### PR TITLE
makemessages: Remove line numbers from .po files

### DIFF
--- a/locale/ar/LC_MESSAGES/django.po
+++ b/locale/ar/LC_MESSAGES/django.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 19:27+0000\n"
 "Last-Translator: Anders Kaseorg <andersk@mit.edu>\n"
 "Language-Team: Arabic <https://hosted.weblate.org/projects/zulip/django/ar/"
@@ -27,50 +27,50 @@ msgstr ""
 "&& n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "غير مسموح للمستعملين الزائرين"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "منظمة غير صالحة"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr "القنوات العامة"
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr "القنوات الخاصة"
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr "الرسائل المباشرة"
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr "الرسائل المباشرة للمجموعة"
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr "القناة مطلوبة للرسم البياني: {chart_name}"
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr "اسم الرسم البياني غير معروف: {chart_name}"
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr "وقت البدء متأخر عن وقت الانتهاء. البدء: {start}, الانتهاء: {end}"
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr "No analytics data available. Please contact your server administrator."
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -83,7 +83,7 @@ msgstr ""
 "المستخدمين غير النشطين]({deactivate_user_help_page_link}) للسماح للمستخدمين "
 "الجدد بالانضمام."
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -94,7 +94,7 @@ msgstr ""
 "({billing_page_link}) أو [قم بتعطيل المستخدمين غير النشطين]"
 "({deactivate_user_help_page_link}) للسماح لأكثر من مستخدم واحد بالانضمام."
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -105,7 +105,7 @@ msgstr ""
 "({billing_page_link}) أو [قم بتعطيل المستخدمين غير النشطين]"
 "({deactivate_user_help_page_link}) للسماح لأكثر من مستخدمين بالانضمام."
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -116,7 +116,7 @@ msgstr ""
 "({billing_page_link}) أو [قم بتعطيل المستخدمين غير النشطين]"
 "({deactivate_user_help_page_link}) للسماح لأكثر من ثلاثة مستخدمين بالانضمام."
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -125,28 +125,27 @@ msgid ""
 "({billing_page_link}) is greater than the current number of users."
 msgstr ""
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr ""
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr "تم إلغاء التسجيل"
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr "ريموت سيرفر غير صالح"
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
@@ -154,7 +153,7 @@ msgid ""
 msgstr ""
 "عليك أن تشتري رخص لكل المستخدمين النشطين في منظمتك ({min_licenses} كحد أدنى)."
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
@@ -163,86 +162,86 @@ msgstr ""
 "الفواتير المتخطية {max_licenses} رخصة لا يمكن معالجتها في هذه الصفحة. لإكمال "
 "التحديث, من فضلك اتصل ب {email}."
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr "لا يوجد طريقة دفع مسجلة"
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr "{brand} تنتهي في {last4}"
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr "Unknown payment method. Please contact {email}."
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr "هناك خطأ ما. الرجاء التواصل {email}."
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "هناك خطأ ما. الرجاء إعادة تحميل الصفحة."
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr "هناك خطأ ما. الرجاء الإنتظار لبضع دقائق و إعادة المحاولة."
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr "يرجى إضافة بطاقة ائتمان قبل بدء الفترة التجريبية المجانية"
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr "يرجى إضافة بطاقة ائتمان لجدولة الترقية"
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
 msgstr "غير قادر على تحديث الخطة. انتهت صلاحية الخطة واستبدلت بخطة جديدة."
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr "غير قادر على تحديث الخطة. انتهت الخطة."
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr "لا يمكن تحديث التراخيص في فترة الفوترة الحالية لخطة التجربة المجانية"
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
 msgstr "غير قادر على تحديث التراخيص يدويًا. خطتك على إدارة الترخيص التلقائي."
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr "خطتك موجودة بالفعل على تراخيص {licenses} في فترة الفوترة الحالية."
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr "لا يمكنك تقليل التراخيص في فترة الفوترة الحالية."
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
 msgstr "لا يمكن تغيير التراخيص لدورة الفوترة القادمة لخطة تم تخفيضها"
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
 "licenses."
 msgstr "تمت جدولة خطتك بالفعل للتجديد مع تراخيص {licenses_at_next_renewal}."
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
@@ -250,27 +249,27 @@ msgid ""
 msgstr ""
 "لقد قمت بالفعل بشراء {licenses_at_next_renewal}  رخصة لفترة الفوترة القادمة."
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr "لا شيء لتغييره."
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr "لا يوجد زبون لهذه المنظمة!"
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr "الجلسة غير موجودة"
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr "لم يتم العثور على القصد من الدفع"
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr "قم بتقديم stripe_session_id أو stripe_invoice_id"
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -285,58 +284,56 @@ msgstr ""
 " إذا يمكنك {begin_link}وضع زوليب كراعي في موقعك{end_link}, سوف نكون في غاية "
 "الامتنان!"
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr "المعلمة \"مؤكدة\" مطلوبة"
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr "انتهت صلاحية رمز الوصول للفوترة."
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr "رمز الوصول للفوترة غير صالح."
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
 "{support_email}"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr "حساب المستخدم غير موجود بعد."
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr "يجب عليك قبول شروط الخدمة للمتابعة."
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr "معرّف منظمة زوليب غير مسجل في نظام إدارة الفواتير الخاص ب زوليب."
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr "مفتاح منظمة زوليب غير صالح/متوافق مع معرّف منظمة زوليب"
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr "لقد تم تعطيل تسجيل الخادم الخاص بك."
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "خطأ"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr "لم يتم العثور على الصفحة (404)"
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
@@ -345,11 +342,11 @@ msgstr ""
 "إذا كان هذا الخطأ غير متوقع, بإمكانك <a href=\"mailto:"
 "%(support_email)s\">التواصل مع الدعم</a>."
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr "ممنوع الوصول (403)"
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
@@ -357,11 +354,11 @@ msgstr ""
 "تعذر إكمال طلبك بسبب أن متصفحك لم يرسل بيانات الاعتماد المطلوبة للمصادقة علي "
 "دخولك. لحل هذه المشكلة:"
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr "تأكد أن متصفحك يسمح بالكوكيز لهذا الموقع."
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
@@ -369,22 +366,21 @@ msgstr ""
 "تحقق من أي إعدادات الخصوصية للمتصفح أو الإمتدادات التي تمنع ال Referer "
 "headers و قم بإلغائها لهذا الموقع."
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr "الطريقة غير مسموح بها (405)"
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr "خطأ في الخادم الداخلي"
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
 msgstr ""
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -392,13 +388,13 @@ msgid ""
 "a> with any questions."
 msgstr ""
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -414,7 +410,7 @@ msgstr ""
 "في الوقت الراهن, تستطيع أن <a href=\"mailto:%(support_email)s\">تتواصل\n"
 " مع مديرين هذا الخادم</a>للدعم."
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
@@ -424,136 +420,134 @@ msgstr ""
 "href=\"%(troubleshooting_url)s\">دليل زوليب لاستكشاف أخطاء الخادم وإصلاحها</"
 "a>."
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr "تحليلات ل %(target_name)s| زوليب"
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr "Analytics are fully available 24 hours after organization creation."
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr "Zulip analytics for %(target_name)s"
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr "ملخص المنظمة"
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr "عدد المستخدمين"
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr "المستخدمون النشطون خلال آخر 15 يومًا"
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr "عدد الضيوف"
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr "إجمالي عدد الرسائل"
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr "عدد الرسائل في آخر 30 يومًا"
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr "تخزين الملفات قيد الاستخدام"
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "المستخدمين الفاعلين"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr "الأنشطة اليومية"
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr "15 day actives"
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr "إجمالي المستخدمين"
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "المستخدمين"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr "الرسائل المرسلة عن طريق نوع المستلم"
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "أنا"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "الجميع"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "الاسبوع الماضي"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "الشهر الماضي"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "العام الماضي"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "كل الوقت"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr "الرسائل المرسلة بمرور الوقت"
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "يوميا"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "أسبوعيا"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr "تراكمي"
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "البشر"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "الروبوتات"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr "الرسائل المقروءة بمرور الوقت"
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr "الرسائل المرسلة من قبل العميل"
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr "اخر تحديث"
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
@@ -561,15 +555,15 @@ msgstr ""
 "التحديث الكامل لجميع الرسوم البيانية يحدث مرة واحدة في اليوم. يتم تحديث "
 "الرسم البياني ”الرسائل المرسلة بمرور الوقت“ مرة كل ساعة."
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr "تم تغيير البريد الإكتروني"
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr "البريد الإلكتروني قد تغير!"
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
@@ -578,21 +572,21 @@ msgstr ""
 "هذا يؤكد أن عنوان البريد الإلكتروني لحساب \"زوليب\" الخاص بك قد تغير من "
 "%(old_email_html_tag)s إلى %(new_email_html_tag)s"
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr "تأكيد عنوان بريدك الإلكتروني"
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr "رابط التأكيد غير موجود"
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr "عذرًا. لم نتمكن من العثور على رابط التأكيد الخاص بك في النظام."
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
@@ -601,27 +595,27 @@ msgstr ""
 "علي أي حال, تواصل معنا عن طريق %(support_email_html_tag)s و سنقوم بحل هذا "
 "الأمر في وقت قصير."
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr "رابط التأكيد منتهي الصلاحية أو معطل"
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr "عذرًا. انتهت صلاحية رابط التأكيد أو تم تعطيله."
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr "يرجى الاتصال بمسؤول مؤسستك للحصول على ارتباط جديد."
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr "رابط التأكيد غير صحيح"
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr "عذرًا. رابط التأكيد غير صحيح."
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
@@ -629,72 +623,55 @@ msgstr ""
 "تأكد من نسخ الرابط بشكل صحيح في متصفحك. إذا كنت لا تزال تواجه هذه الصفحة ، "
 "فمن المحتمل أن يكون هذا خطأنا. آسفون."
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr "الفواتير"
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr "غلق"
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr "لا أهتم"
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr "تخفيض"
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "إلغاء"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr "تأكيد"
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr "إلغاء التحديث"
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr "حالة الفواتير"
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr "الغاء تسجيل السيرفر؟"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr "إدارة الخطة غير متاحة"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -705,7 +682,7 @@ msgid ""
 "server."
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
@@ -713,7 +690,7 @@ msgstr ""
 "لنقل الخطة من هذا الخادم لهذه المنظمة, أو لأسئلة أخرى, <a href=\"mailto:"
 "{{ support_email }}\">اتصل بالدعم</a>."
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
@@ -721,7 +698,7 @@ msgstr ""
 "إدارة الخطة لهذا الخادم غير متاحة بسبب أن هناك منظمة واحدة علي الأقل مستضافة "
 "علي هذا الخادم ولديها خطة نشطة بالفعل."
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -732,737 +709,247 @@ msgstr ""
 "billing\">تسجيل الدخول</a> لإدراة الخطة لمنظمتك, أو <a href='mailto:"
 "%(support_email)s'>اتصل بالدعم </a> لأي أسئلة."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr "حد معدل تجاوز"
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr "تم تجاوز حد المعدل."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 "الخادم الخاص بك تخطي الحد المسموح لعدد المرات التي يمكن فيها تنفيذ هذا الأمر."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, fuzzy, python-format
 #| msgid "You can try again in %(retry_after)s seconds."
 msgid "You can try again in %(retry_after_string)s."
 msgstr "يمكنك المحاولة مرة أخرى في %(retry_after)s ثانية."
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr "تحديث"
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr "أرسل الفاتورة و ابدأ التجرية المجانية"
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr "أرسل الفاتورة"
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr "مجلد المجتمعات المفتوحة"
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr "تصفية حسب الفئة"
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "الجميع"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr "فئات"
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr "10.000 رسالة"
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr "غير محدود"
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr "مسنود"
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr "تدار ذاتيا"
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr "للمؤسسات التي تضم ما يصل إلى 10 مستخدمين"
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr "25 مستخدمًا كحد أدنى"
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr "غير متاح"
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr "مجتمع تنمية \"زوليب\""
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr "انضم كمستخدم"
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr "انضم كمضيف ذاتي"
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr "انضم كمساهم"
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "إنشاء منظمة"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr ""
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr "إستضافة ذاتية لـ\"زوليب\""
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr "طلب رعاية"
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr "تسعير التعليم"
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr "عرض السعر"
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr "\"زوليب\" للأعمال"
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Zulip guide for open-source projects"
 msgid "Zulip for open source"
 msgstr "دليل زوليب للمشاريع مفتوحة المصدر"
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "start a conversation"
 msgid "Screenshot of Zulip conversation"
 msgstr "ابدأ محادثة"
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Messages sent over time"
 msgid "Message with code"
 msgstr "الرسائل المرسلة بمرور الوقت"
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr "رابط"
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr "اتصل بالدعم"
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr "من"
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr "منظمة"
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr "موضوع"
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr "رسالة"
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr "إرسال"
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr "شكراً لاتصالك بنا"
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr "شكراً لاتصالك بنا!"
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr "سنكون على اتصال بك قريبا."
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
@@ -1470,13 +957,13 @@ msgstr ""
 "تستطيع إيجاد إجابات الأسئلة المتكررة في <a href=\"/help/\">مركز مساعدة "
 "زوليب</a>."
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 #, fuzzy
 #| msgid "Getting started"
 msgid "Get started"
 msgstr "ابدء"
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
@@ -1485,51 +972,50 @@ msgstr ""
 "يتم الآن استضافة دردشة الفريق هذه على سحابة \"زوليب\". رجاءً أقبل <a "
 "href=\"https://zulip.com/policies/terms\">شروط خدمة \"زوليب\"</a> للاستمرار."
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr "أو ، بدلاً من ذلك، استخدم أحد هواتفك الاحتياطية:"
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr "كحل أخير ، يمكنك استخدام رمز النسخ الاحتياطي:"
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr "استخدم رمز النسخ الاحتياطي"
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr "اقبل شروط الخدمة"
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr "مرحبا بكم في زوليب"
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "بريد الالكتروني"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr ""
 "اشترك لي في نشرة \"زوليب\" الإخبارية منخفضة الحركة (القليل من رسائل بريد "
 "إلكتروني في السنة)."
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr "استمر"
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr "أكد عنوان بريدك الألكتروني"
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1539,7 +1025,7 @@ msgstr ""
 "لإكمال عميلة التسجيل, تفقد حسابك البريدي (<span class=\"user_email semi-"
 "bold\">%(email)s</span>) للحصول علي رسالة تأكيد من زوليب."
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
@@ -1547,67 +1033,66 @@ msgstr ""
 "إن لم ترى بريد إلكتروني تأكيدي في الصندوق الوارد أو مجلد الرسائل المزعجة, "
 "نستطيع <a href=\"#\" id=\"resend_email_link\">إعادة ارساله</a>."
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr ""
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
 msgstr ""
 "إذا لم تختفي تلك الرسالة, جرب <a class=\"reload-lnk\">إعادة تحميل</a> الصفحة."
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr "تعذر تحميل زوليب. جرب <a class=\"reload-lnk\">إعادة تحميل</a> الصفحة."
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr "لا يوجد محادثات متوافقة مع هذه التصفيات."
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr "هذا الجزء لا يزال يحمل الرسايل."
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr "أعرض المزيد"
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr "انتهت مكالمة الفيديو"
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr "تستطيع غلق هذه النافذة الآن."
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr "خطأ اعدادات"
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
@@ -1615,7 +1100,7 @@ msgstr ""
 "أنت تحاول تسجيل الدخول باستخدام LDAP بدون إنشاء منظمة أولًا. رجاءً استخدم "
 "EmailAuthBackend لإنشاء منظمتك ثم أعد المحاولة مرة أخرى."
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1625,73 +1110,71 @@ msgstr ""
 "هذا الخادم لم يتم إعداده لاستخدام دفع الاشعارات, لمعرفة كيفية تفعيل تلك "
 "الخدمة, من فضلك اقرأ <a href=\"%(doc_url)s\">الوثيقة</a>."
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr "حساب غير موجود"
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr "حساب \"زوليب\" غير موجود."
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, fuzzy, python-format
 #| msgid "Your account email: %(email)s"
 msgid "No account found for %(email)s."
 msgstr "حساب بريدك الإلكتروني: %(email)s"
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr "تسجيل الدخول بحساب آخر"
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr "استمر في التسجيل"
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Must be a demo organization."
 msgid "Try Zulip in a demo organization"
 msgstr "يجب أن تكون منظمة تجريبية."
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Try Zulip now"
 msgid "Try Zulip"
 msgstr "جرب زوليب الآن"
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "إنشاء منظمة جديدة"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr "أنشئ منظمة \"زوليب\" جديدة"
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr "أدخل عنوان بريدك الالكتروني"
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr "البريد الإلكتروني الخاص بك"
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
@@ -1701,11 +1184,11 @@ msgstr ""
 "import-from-mattermost\">Mattermost</a>, أو <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr "كيف سمعت أول مرة عن زوليب؟"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
@@ -1713,42 +1196,41 @@ msgstr ""
 "هذه القيمة تستخدم فقط إذا اخترت خطة عند التسجيل, في هذه الحالة سترسل إلي "
 "فريق زوليب."
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr "حدد اختيار"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr "من فضلك صف"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr "أين رأيت الإعلان؟"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr "أي منظمة؟"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr "نوع المنظمة"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr "لغة المنظمة"
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 #, fuzzy
 #| msgid ""
 #| "\n"
@@ -1768,80 +1250,76 @@ msgstr ""
 "import-from-mattermost\">Mattermost</a>, أو <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>"
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 #, fuzzy
 #| msgid "Private, shared history"
 msgid "Import chat history?"
 msgstr "سجل خاص ومشترك"
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr "اسم المنظمة"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "Organization URL"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr "استخدم %(external_host)s"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "أو"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "سجل"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "سجل في Zulip"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr "أنت بحاجة إلى دعوة للانضمام إلى هذه المنظمة."
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr "سجل عن طريق %(identity_provider)s"
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr "لديك حساب؟"
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "تسجيل الدخول"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr "ضبط خصوصية البريد الإلكتروني"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
 msgstr "زوليب يسمح لك باختيار الأدوار التي يمكنها رؤية عنوان بريدك الإلكتروني."
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
@@ -1849,11 +1327,11 @@ msgstr ""
 "هل تريد تغيير اعدادات الخصوصية لبريدك الإلكتروني من الاعداد الأولي لهذه "
 "المنظمة؟"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr "من يستطيع أن يصل لبريدك الإلكتروني"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1864,103 +1342,102 @@ msgstr ""
 "configure-email-visibility\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">الانضمام</a>."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr "مديرون هذه المنظمة سيكونون قادرين على رؤية هذا البريد الإلكتروني"
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
 msgstr ""
 "مديرون و مشرفون هذه المنظمة سيكونون قادرين على رؤية هذا البريد الإلكتروني"
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr "لا أحد في منظمة زوليب هذه سيتمكن من رؤية هذا البريد الإلكتروني"
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 "المستخدمون الآخرون في منظمة زوليب هذه سيتمكنون من رؤية هذا البريد الإلكتروني"
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "تغيير"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr "تسجيل"
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr "أنشئ منظمتك"
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr "أنشئ حسابك"
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr "<p>ادخل تفاصيل حسابك لإكمال التسجيل.</p>"
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr "منظمتك"
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr "الحساب الخاص بك"
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr "لا تستورد الإعدادات"
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr "استيراد الإعدادات من حساب \"زوليب\" موجود"
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr "اسمك الكامل"
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "الاسم"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr "هكذا يبدو حسابك في زوليب"
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "كلمة السر"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr "أدخل كلمة مرور الدليل النشط LDAP."
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr "يُستخدم هذا لتطبيقات الجوال والأدوات الأخرى التي تتطلب كلمة مرور."
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr "قوة كلمة السر"
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr "ماالذي تهتم به؟"
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
@@ -1969,15 +1446,15 @@ msgstr ""
 "أوافق على <a href=\"%(root_domain_url)s/policies/terms\" target=\"_blank\" "
 "rel=\"noopener noreferrer\">شروط الخدمة </a>."
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr "منظمة معطلة"
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr "تم نقل المنظمة"
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
@@ -1986,7 +1463,7 @@ msgstr ""
 "هذه المنظمة نقلت إلى <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -1994,7 +1471,7 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid ""
@@ -2002,7 +1479,7 @@ msgid ""
 "deleted."
 msgstr "تم تعطيل هذه المنظمة"
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2017,7 +1494,7 @@ msgstr ""
 "في الوقت الراهن, تستطيع أن <a href=\"mailto:%(support_email)s\">تتواصل مع "
 "زوليب للدعم</a>."
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2033,13 +1510,13 @@ msgstr ""
 "في الوقت الراهن, تستطيع أن <a href=\"mailto:%(support_email)s\">تتواصل\n"
 " مع مديرين هذا الخادم</a>للدعم."
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid "This organization has been deactivated."
 msgstr "تم تعطيل هذه المنظمة"
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -2048,14 +1525,14 @@ msgstr ""
 "إذا كنت مالك هذه المنظمة, تستطيع <a href=\"mailto:"
 "%(support_email)s\">التواصل مع زوليب للدعم</a> لإعادة تفعيل المنظمة."
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -2066,15 +1543,15 @@ msgstr ""
 "%(support_email)s\">التواصل مع مديرين خادم زوليب هذا</a> لإعادة تفعيل "
 "المنظمة."
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr "انهاء تسجيل الدخول إلى تطبيق سطح المكتب"
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr "إنهاء تسجيل دخول سطح المكتب"
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
@@ -2082,109 +1559,108 @@ msgstr ""
 "استخدم متصفح الويب الخاص بك لإنهاء تسجيل الدخول، ثم ارجع إلى هنا للصق رمز "
 "تسجيل الدخول الخاص بك."
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr "لصق الرمز هنا"
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr "إنهاء"
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr "رمز غير صحيح."
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr "تم قبول الرمز. جارٍ تسجيل دخولك…"
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr "تسجيل الدخول إلى تطبيق سطح المكتب"
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 "انسخ رمز تسجيل الدخول هذا وارجع إلى تطبيق \"زوليب\" لإنهاء تسجيل الدخول:"
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "نسخ"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr "يمكنك بعد ذلك إغلاق هذه النافذة."
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr "أو، استمر في متصفحك."
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr "مستخدم مجهول"
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr "أصحاب"
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "المسؤولين"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr "الوسطاء"
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr "المستخدمون الضيوف"
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "المستخدمون العاديون"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr "أعد توجيه رسائل البريد الإلكتروني إلى حساب بريد إلكتروني"
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "اغلاق"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "تحديث"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr "\"زوليب\""
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr "موجز"
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
 "<b>%(realm_name)s</b>."
 msgstr "تهانين! لقد قمت بإنشاء منظمة زوليب جديدة: <b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr "مرحبًا بك في Zulip!"
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr "لقد قمت بالانضمام إلي منظمة زوليب <b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
@@ -2193,43 +1669,43 @@ msgstr ""
 "سوف تستخدم البيانات التالية لتسجيل الدخول إلى زوليب للويب و تطبيقات <a "
 "href=\"%(apps_page_link)s\">الهاتف و سطح المكتب</a>:"
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr "عنوان URL للمنظمة: %(organization_url)s"
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr "اسم المستخدم: %(ldap_username)s"
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr "استخدم حساب LDAP الخاص بك لتسجيل الدخول"
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr "حساب بريدك الإلكتروني: %(email)s"
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr "اذهب إلى المنظمة"
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
 "href=\"%(getting_user_started_link)s\">getting started guide</a>!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2237,7 +1713,7 @@ msgid ""
 "Zulip</a>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
@@ -2246,28 +1722,28 @@ msgstr ""
 "لديك أسئلة؟ <a href=\"mailto:%(support_email)s\">تواصل معنا</a> — نحب أن "
 "نساعد!"
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr "%(realm_name)s على Zulip: تفاصيل منظمتك الجديدة"
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr "%(realm_name)s على Zulip: تفاصيل حسابك الجديد"
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr "تهانينا, لقد قمت بإنشاء منظمة زوليب جديدة: %(realm_name)s"
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr "لقد انضممت إلى منظمة Zulip %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
@@ -2276,31 +1752,31 @@ msgstr ""
 "سوف تقوم باستخدام المعلومات القادمة لتسجيل الدخول إلى زوليب ويب, الهاتف و "
 "تطبيقات سطح المكتب (%(apps_page_link)s):"
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
 "(%(getting_user_started_link)s)!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
 "(%(getting_organization_started_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr "أسئلة؟ تواصل معنا على %(support_email)s — نحب أن نساعد!"
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2309,17 +1785,17 @@ msgstr ""
 "إذا لديك أي أسئلة, من فضلك تواصل مع مديرين خادم زوليب هذا على "
 "%(support_email)s"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr "مرحبا،"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2330,12 +1806,12 @@ msgstr ""
 "زوليب التجريبية الخاص بك على %(realm_url)s. لتأكيد هذا و تعيين كلمة مرور "
 "لهذا الحساب, من فضلك اضغط أدناه:"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr "تأكيد و تعيين كلمة مرور"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2343,14 +1819,14 @@ msgid ""
 msgstr ""
 "إذا لم تطلب هذا التغيير ، يرجى الاتصال بنا على الفور على %(support_email)s."
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 #, fuzzy
 #| msgid "Verify your new email address for your demo Zulip organization"
 msgid "Verify your email address for your Zulip demo organization"
 msgstr "قم بتأكيد بريدك الإلكتروني الجديد لمنظمة زوليب التجريبية الخاصة بك"
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2358,8 +1834,8 @@ msgid ""
 msgstr ""
 "إذا لم تطلب هذا التغيير ، يرجى الاتصال بنا على الفور على <%(support_email)s>."
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2369,33 +1845,33 @@ msgstr ""
 "تلقينا طلبًا لتغيير عنوان البريد الإلكتروني لحساب زوليب على %(realm_url)s من "
 "%(old_email)s إلى %(new_email)s. لتأكيد هذا التغيير ، رجاءً انقر أدناه:"
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr "تأكيد تغيير البريد الإلكتروني"
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr "قم بتأكيد بريدك الإلكتروني الجديد ل %(organization_host)s"
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr "لقد طلبت منظمة زوليب جديدة:"
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr "نوع المنظمة: %(organization_type)s"
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr "لقد قمت مؤخرًا بالتسجيل في Zulip. رائع!"
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
@@ -2403,53 +1879,53 @@ msgstr ""
 "اضغط على الزر في الأسفل لإنشاء المنظمة و تسجيل حسابك. سوف تكون قادرا على "
 "تعديل المعلومات التي في الأعلى إذا تريد"
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr "انقر فوق الزر أدناه لإكمال التسجيل."
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr "اكمل التسجيل"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr "قم بإنشاء منظمة \"زوليب\" الخاصة بك"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr "قم بتفعيل حساب Zulip الخاص بك"
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr "انقر فوق الرابط أدناه لإكمال التسجيل."
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
 "— we'd love to help!"
 msgstr "هل لديك أسئلة أو تعليق؟ اتصل بنا على %(support_email)s — نحب أن نساعد!"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr "إدارة تفضيلات البريد الإلكتروني"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr "إلغاء الاشتراك من رسائل البريد الإلكتروني التسويقية"
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
@@ -2458,17 +1934,17 @@ msgstr ""
 "حسابك في زوليب على <a href=\"%(realm_url)s\">%(realm_url)s</a> تم تعطيله, و "
 "لن يمكنك من تسجيل الدخول بعد الآن"
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr "قدم المسؤولون التعليق التالي:"
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr "إشعار تعطيل الحساب على %(realm_name)s"
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
@@ -2477,11 +1953,11 @@ msgstr ""
 "تم تعطيل حساب زوليب الخاص بك على %(realm_url)s, و لن تستطيع تسجيل الدخول بعد "
 "الآن"
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr "قنوات جديدة"
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2489,22 +1965,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because your organization has "
@@ -2520,8 +1996,8 @@ msgstr ""
 "class=\"content_disabled_help_link\" href=\"%(help_url)s\">إظهار محتوى "
 "الرسائل في إشعارات البريد الإلكتروني</a>."
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because you have disabled <a "
@@ -2536,40 +2012,40 @@ msgstr ""
 "class=\"content_disabled_help_link\" href=\"%(alert_notif_url)s\">محتوى "
 "الرسائل الذي يظهر في إشعارات البريد الإلكتروني</a>."
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, fuzzy, python-format
 #| msgid "Click here to log in to Zulip and catch up."
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr "انقر هنا لتسجيل الدخول إلى Zulip واللحاق بالآخرين."
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr "إلغاء الاشتراك من ملخص رسائل البريد الإلكتروني"
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr "ملخص Zulip ل %(realm_name)s"
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2586,8 +2062,8 @@ msgstr ""
 "محتوى الرسائل في إشعارات البريد الإلكتروني.\n"
 "انظر %(hide_content_url)s للمزيد من التفاصيل.\n"
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2603,33 +2079,31 @@ msgstr ""
 "يظهر في إشعارات البريد الإلكتروني.\n"
 "انظر %(alert_notif_url)s للمزيد من التفاصيل.\n"
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, fuzzy, python-format
 #| msgid "Click here to log in to Zulip and catch up: %(organization_url)s."
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr "اضغط هنا لتسجيل الدخول إلى زوليب: %(organization_url)s"
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr "إدارة تفضيلات البريد الإلكتروني:"
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr "إلغاء الاشتراك من ملخص رسائل البريد الإلكتروني:"
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr "أسماك السباحة"
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr "شكرا على طلبك!"
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
@@ -2638,8 +2112,7 @@ msgstr ""
 "يحتوي عنوان بريدك الإلكتروني %(email)s على حسابات لدى منظمات زوليب السحابية "
 "التالية:"
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
@@ -2648,7 +2121,7 @@ msgstr ""
 "يحتوي عنوان بريدك الإلكتروني %(email)s على حسابات مع منظمات \"زوليب\" "
 "التالية التي تستضيفها %(external_host)s:"
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
@@ -2657,19 +2130,15 @@ msgstr ""
 "إذا كنت تواجه مشكلة في تسجيل الدخول, يمكنك <a "
 "href=\"%(help_reset_password_link)s\">إعادة تعيين كلمة المرور</a>"
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr "لقد قمت بطلب قائمة من حسابات زوليب لهذا البريد الإلكتروني"
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr "للأسف, لم يتم العثور علي حساب زوليب سحابي."
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
@@ -2678,7 +2147,7 @@ msgstr ""
 "للأسف, لم يتم العثور على حسابات في منظمات زوليب المستضافة بواسطة "
 "%(external_host)s"
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2686,38 +2155,35 @@ msgid ""
 "to find your account."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr "إن لم تتعرف علي هذا الطلب, بإمكانك تجاهل هذا البريد الإلكتروني."
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr "حسابات \"زوليب\" الخاصة بك"
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr "لم يتم العثور علي حساب زوليب."
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr "إذا كنت تواجه مشاكل تسجيل دخول, تستطيع إعادة تعيين كلمة المرور."
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
 "try another way to find your account (%(help_logging_in_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr "أهلًا،"
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
@@ -2726,17 +2192,17 @@ msgstr ""
 "%(referrer_name)s يريدك أن تنضم إليهم على Zulip &mdash; أداة اتصال الفريق "
 "المصممة للإنتاجية."
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr "للبدء، انقر فوق الزر أدناه."
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr "%(referrer_full_name)s دعاك للانضمام إلى %(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
@@ -2745,17 +2211,17 @@ msgstr ""
 "%(referrer_full_name)s (%(referrer_email)s) يريدوك أن تنضم إليهم على "
 "\"زوليب\" - أداة اتصال الفريق المصممة للإنتاجية."
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr "للبدء ، انقر فوق الرابط أدناه."
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr "أهلا مجددا،"
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
@@ -2764,13 +2230,13 @@ msgstr ""
 "هذا تذكير ودي بأن %(referrer_name)s يريدك أن تنضم إليهم على \"زوليب\" - أداة "
 "اتصال الفريق المصممة للإنتاجية."
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr "هذا هو آخر تذكير ستتلقاه بخصوص هذه الدعوة."
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
@@ -2779,12 +2245,12 @@ msgstr ""
 "تنتهي هذه الدعوة في غضون يومين. إذا انتهت صلاحية الدعوة، فستحتاج أن تطلب من "
 "%(referrer_name)s دعوة أخرى."
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr "تذكير: انضم إلى %(referrer_name)s على %(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2794,14 +2260,14 @@ msgstr ""
 "هذا تذكير ودي بأن %(referrer_name)s (%(referrer_email)s) يريدوك أن تنضم "
 "إليهم على \"زوليب\" - أداة اتصال الفريق المصممة للإنتاجية."
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at <a href=\"mailto:%(email)s\">%(email)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
@@ -2810,59 +2276,57 @@ msgstr ""
 "هل لديك أسئلة أو تعليق؟ <a href=\"mailto:%(email)s\">اتصل بنا</a> — نحب أن "
 "نساعد!"
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr "أنت تتلقى هذا لأنه تم الإشارة إليك بشكل شخصي"
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr "أنت تتلقى هذا لأنه تم الإشارة إلى %(mentioned_user_group_name)s@"
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
 "#%(channel_name)s > %(topic_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr "أنت تتلقى هذا لأنه تم الإشارة إلى الجميع في %(channel_name)s#"
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
 msgstr ""
 "أنت تتلقى هذا لأن إشعارات البريد الإلكتروني مفعلة للمواضيع التي تتابعها"
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 msgstr "أنت تتلقى هذا لأن إشعارات البريد الإلكتروني مفعلة ل #%(channel_name)s"
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2870,21 +2334,21 @@ msgid ""
 "preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
@@ -2893,43 +2357,43 @@ msgstr ""
 "لا تقم بالرد على هذا البريد. خادم \"زوليب\" هذا غير مهيء لقبول رسائل البريد "
 "القادمة (<a href=\"%(url)s\">مساعدة</a>)."
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr "الرسائل المباشرة للمجموعة مع %(direct_message_group_display_name)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr "الرسائل المباشرة مع %(sender_str)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr "رسائل جديدة"
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 "قم بالرد على هذه الرسالة الإلكترونية مباشرة، أو اعرضها في %(realm_name)s "
 "زوليب:"
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr "أعرض أو رد في %(realm_name)sزوليب:"
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr "الرد في %(realm_name)s Zulip:"
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
@@ -2937,7 +2401,7 @@ msgstr ""
 "لا تقم بالرد على هذا البريد. خادم \"زوليب\" هذا غير مهيء لقبول رسائل البريد "
 "الإلكتروني القادمة. مساعدة:"
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2948,22 +2412,22 @@ msgstr ""
 "%(new_email)s. إذا لم تطلب هذا التغيير، يرجى الاتصال بنا على الفور على "
 "%(support_email)s."
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr "الأفضل،"
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr "فريق \"زوليب\""
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr "تم تغيير بريد \"زوليب\" الإلكتروني لـ %(realm_name)s"
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2974,7 +2438,7 @@ msgstr ""
 "%(new_email)s. إذا لم تطلب هذا التغيير، يرجى الاتصال بنا على الفور "
 "على<%(support_email)s> ."
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
@@ -2982,46 +2446,46 @@ msgstr ""
 "المنظمة: %(organization_url)s الوقت: %(login_time)s البريد الإلكتروني: "
 "%(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr "لقد لاحظنا تسجيل دخول حديث لحساب \"زوليب\" التالي."
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr "المنظمة: %(organization_link)s"
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr "البريد الالكتروني: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr "الوقت: %(login_time)s"
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr "الجهاز: %(device_browser)s على %(device_os)s"
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr "عنوان IP: %(device_ip)s"
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr "إذا كان هذا أنت ، عظيم! لا يوجد شيء آخر عليك القيام به."
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3032,31 +2496,31 @@ msgstr ""
 "<a href=\"%(reset_link)s\">إعادة تعيين كلمة المرور</a> أو الاتصال بنا على "
 "الفور على %(support_email)s."
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr "شكرا،"
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr "أمن Zulip"
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr "إلغاء الاشتراك من إشعارات تسجيل الدخول"
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr "تسجيل دخول جديد من %(device_browser)s على %(device_os)s"
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr "منظمة: %(organization_url)s"
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3067,7 +2531,7 @@ msgstr ""
 "إعادة تعيين كلمة المرور الخاصة بك على%(reset_link)s أو قم بالاتصال بنا "
 "مباشرة على %(support_email)s."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -3075,7 +2539,7 @@ msgid ""
 "Zulip</a> to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
@@ -3083,7 +2547,7 @@ msgstr ""
 "خلاف ذلك, إليك بعض النصائح التي كثيرا ما نسمعها من العملاء لتقييم <i>أي "
 "منتج</i> للدردشة الجماعية:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
@@ -3092,12 +2556,12 @@ msgstr ""
 "<a href=\"%(invite_users)s\"><b>قم بدعوة زملائك</b></a> للاستكشاف معك و "
 "مشاركة وجهات نظرهم الفريدة."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr "استخدم التطبيق نفسه لتتحدث عن انطباعاتك."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -3105,7 +2569,7 @@ msgid ""
 "experience how a new chat app will help your team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -3115,46 +2579,46 @@ msgstr ""
 "صُمِّم زوليب <a href=\"%(why_zulip)s\">ليمكنك من التواصل الفعال</a>, و نأمل أن "
 "تقوم هذه النصائح من جعل فريقك يشعر بهذا"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr "إلغاء الاشتراك من رسائل البريد الترحيبية ل %(realm_name)s"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr "اختيار تطبيق الدردشة لفريقك"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
 msgstr "قم بدعوة زملائك للاستكشاف معك و مشاركة وجهات نظرهم الفريدة"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
 "team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
@@ -3162,8 +2626,8 @@ msgstr ""
 "صُمِّم زوليب ليمكنك من التواصل الفعال, و نأمل أن تقوم هذه النصائح من جعل فريقك "
 "يشعر بهذا"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
@@ -3172,77 +2636,77 @@ msgstr ""
 "أثناء بدايتك مع زوليب, نود أن نساعدك في اكتشاف كيف يمكن أن يعمل زوليب ملائما "
 "لإحتياجاتك. اقرأ هذا الدليل لميزات زوليب للمنظمات مثل منظمتك!"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr "عرض دليل زوليب للشركات"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr "عرض دليل زوليب للمشاريع مفتوحة المصدر."
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr "عرض دليل زوليب للتعليم"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr "عرض دليل زوليب للبحث"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr "عرض دليل زوليب للأحداث و المؤتمرات"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr "عرض دليل زوليب لغير الربح"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr "عرض دليل زوليب للمجتمعات"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr "دليل زوليب للشركات"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr "دليل زوليب للمشاريع مفتوحة المصدر"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr "دليل زوليب للتعليم"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr "دليل زوليب للبحث"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr "دليل زوليب للأحداث و المؤتمرات"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr "دليل زوليب لغير الربح"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr "دليل زوليب للمجتمعات"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
 msgstr "إليك بعض النصائح لجعل محادثات زوليب الخاصة بك منظمة باستخدام المواضيع"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
@@ -3250,19 +2714,19 @@ msgstr ""
 "في زوليب, <b>القنوات</b> تحدد من يستقبل رسالة. <b>المواضيع</b> تحدد حول ماذا "
 "تتحدث الرسالة"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr "القنوات و المواضيع في تطبيق زوليب"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3270,11 +2734,11 @@ msgid ""
 "about…?”"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr "أمثلة من المواضيع القصيرة"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3283,23 +2747,23 @@ msgid ""
 "href=\"%(move_channels_link)s\">move a topic to a different channel</a>."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr "اذهب إلى \"زوليب\""
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr "اجعل محادثاتك منظمة باستخدام المواضيع."
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3308,8 +2772,8 @@ msgid ""
 "(%(move_channels_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
@@ -3318,15 +2782,15 @@ msgstr ""
 "شخص ما (ربما أنت) قام بطلب كلمة مرور جديدة لحساب زوليب %(email)s على "
 "%(realm_url)s"
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr "انقر فوق الزر أدناه لإعادة تعيين كلمة المرور الخاصة بك."
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr "إعادة تعيين كلمة المرور"
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3336,18 +2800,18 @@ msgstr ""
 "كان لديك حساب سابقًا على %(organization_url)s، ولكن تم تعطيله. يمكنك الاتصال "
 "بمسؤول المنظمة <a href=\"%(help_link)s\">لإعادة تفعيل حسابك</a>."
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr "ليس لديك حساب في تلك المنظمة على Zulip."
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr "لديك حسابات نشطة في المنظمة (المنظمات) التالية."
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
@@ -3355,23 +2819,23 @@ msgstr ""
 "يمكنك محاولة تسجيل الدخول أو إعادة تعيين كلمة المرور الخاصة بك في المنظمة "
 "(المنظمات) أعلاه."
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 "إذا لم تتعرف على هذا النشاط ، فيمكنك تجاهل هذا البريد الإلكتروني بأمان."
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr "طلب إعادة تعيين كلمة المرور لـ %(realm_name)s"
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr "انقر فوق الرابط أدناه لإعادة تعيين كلمة المرور الخاصة بك."
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
@@ -3380,7 +2844,7 @@ msgstr ""
 "لقد كان لديك حساب سابقًا على %(realm_url)s, لكن تم تعطيله. يمكنك الاتصال بأحد "
 "مديري المنظمة لإعادة تفعيل حسابك"
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3390,7 +2854,7 @@ msgstr ""
 "منظمتك، %(organization_name_with_link)s، تم تخفيضها لسحابة \"زوليب\" خطة "
 "مجانية بسبب الفواتير غير المدفوعة. تم إلغاء الفواتير غير المسددة."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
@@ -3399,7 +2863,7 @@ msgstr ""
 "للمتابعة في خطة معيار سحابة زوليب، رجاءً قم بالترقية مرة أخرى بالذهاب إلى "
 "%(upgrade_url)s."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
@@ -3408,8 +2872,8 @@ msgstr ""
 "إذا كنت تظن أنه هذا كان خطأ أو تحتاج للمزيد من التفاصيل، رجاءً تواصل معنا على "
 "%(support_email)s."
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "You have deactivated your Zulip organization, %(realm_name)s, on "
@@ -3420,8 +2884,8 @@ msgid ""
 msgstr ""
 "لقد قمت بتعطيل منظمة زوليب الخاصة بك, %(realm_name)s, في %(localized_date)s"
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "Your Zulip organization, %(realm_name)s, was deactivated by "
@@ -3433,8 +2897,8 @@ msgstr ""
 "تم تعطيل منظمة زوليب الخاصة بك, %(realm_name)s, بواسطة "
 "%(deactivating_owner)s في %(localized_date)s"
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "Your Zulip organization, %(realm_name)s, was deactivated on "
@@ -3444,8 +2908,8 @@ msgid ""
 "%(localized_date)s."
 msgstr "تم تعطيل منظمة زوليب الخاصة بك, %(realm_name)s, في %(localized_date)s"
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
@@ -3453,8 +2917,8 @@ msgid ""
 msgstr ""
 "لقد قمت بتعطيل منظمة زوليب الخاصة بك, %(realm_name)s, في %(localized_date)s"
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
@@ -3463,49 +2927,49 @@ msgstr ""
 "تم تعطيل منظمة زوليب الخاصة بك, %(realm_name)s, بواسطة "
 "%(deactivating_owner)s في %(localized_date)s"
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr "تم تعطيل منظمة زوليب الخاصة بك, %(realm_name)s, في %(localized_date)s"
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr ""
 "إذا لديك أية أسئلة أو مخاوف, من فضلك قم بالرد على هذا البريد في أسرع وقت ممكن"
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr "منظمة زوليب %(realm_name)s تم تعطيلها"
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr "أعزائي المسؤولين السابقين في %(realm_name)s،"
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "One of your administrators requested reactivation of the previously "
@@ -3517,8 +2981,8 @@ msgstr ""
 "أحد المديرين قام بطلب إعادة تفعيل منظمة زوليب التي تم تعطيلها مسبقاً, "
 "المستضافة على %(realm_url)s."
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
@@ -3527,16 +2991,16 @@ msgstr ""
 "أحد المديرين قام بطلب إعادة تفعيل منظمة زوليب التي تم تعطيلها مسبقاً, "
 "المستضافة على %(realm_url)s."
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr "انقر فوق الزر أدناه لإعادة تفعيل منظمتك."
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr "إعادة تفعيل المنظمة"
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
@@ -3544,21 +3008,21 @@ msgstr ""
 "إذا كان الطلب خاطئًا ، فلا يمكنك اتخاذ أي إجراء وستنتهي صلاحية هذا الرابط في "
 "غضون 24 ساعة."
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Reactivate your Zulip organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "أعد تفعيل منظمة \"زوليب\" الخاصة بك"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr "أعد تفعيل منظمة \"زوليب\" الخاصة بك"
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr "انقر الرابط أدناه لإعادة تفعيل منظمتك."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3567,20 +3031,20 @@ msgstr ""
 "إما أنت, أو شخص بالنيابة عنك, قام بطلب رابط تسجيل دخول لإدارة خطة زوليب ل "
 "<b>%(remote_server_hostname)s</b>"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, fuzzy
 #| msgid "Click the link below to log in."
 msgid "Click the button below to log in."
 msgstr "اضغط على الرابط أدناه لتسجيل الدخول"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr "هذا الرابط سوف يصبح منتهي الصلاحية خلال %(validity_in_hours)s ساعات"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
@@ -3589,11 +3053,11 @@ msgstr ""
 "أسئلة؟ <a href=\"%(billing_help_link)s\">اعرف المزيد</a> أو تواصل مع "
 "%(billing_contact_email)s"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr "تسجيل الدخول إلى إدارة خطة زوليب"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3602,12 +3066,12 @@ msgstr ""
 "إما أنت, أو شخص بالنيابة عنك, قام بطلب رابط تسجيل دخول لإدارة خطة زوليب ل "
 "%(remote_server_hostname)s"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr "اضغط على الرابط أدناه لتسجيل الدخول"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
@@ -3616,7 +3080,7 @@ msgstr ""
 "أسئلة؟ اعرف المزيد من %(billing_help_link)s أو تواصل مع "
 "%(billing_contact_email)s"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
@@ -3625,16 +3089,16 @@ msgstr ""
 "اضغط الزر أدناه لتأكيد بريدك الإلكتروني و تسجيل الدخول لإدارة خطة زوليب ل "
 "<b>%(remote_realm_host)s</b>"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr "تأكيد و تسجيل الدخول"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr "تأكيد البريد الإلكتروني لإدارة خطة زوليب"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
@@ -3643,285 +3107,285 @@ msgstr ""
 "اضغط الزر أدناه لتأكيد بريدك الإلكتروني و تسجيل الدخول لإدارة خطة زوليب ل "
 "%(remote_realm_host)s"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the <a href=\"%(plans_link)s\">Zulip Community plan</a>."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
 "website</a>, we would really appreciate it!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
 msgstr ""
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr "البحث عن حساباتك"
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr "ابحث عن حسابات Zulip الخاصة بك"
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
 "accounts for another email address</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr "عنوان البريد الإلكتروني"
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "Find accounts"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr "المنتج"
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr "لماذا Zulip"
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr "ميزات"
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr "الخطط والتسعير"
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Zulip Cloud status"
 msgid "Zulip Cloud"
 msgstr "حالة سحابة زوليب"
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr "الاستضافة الذاتية"
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr "حماية"
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "إدماجات"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr "تطبيقات سطح المكتب & الهاتف المحمول"
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr "منظمة جديدة"
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr "حلول"
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr "اعمال"
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr "تعليم"
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr "بحث"
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr "الأحداث و المؤتمرات"
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr "مشاريع مفتوحة المصدر"
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr "مجتمعات"
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr "قصص العملاء"
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr "المجتمعات المفتوحة"
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr "مصادر"
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr "ابدء"
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr "مركز المساعدة"
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr "الدردشة مع الجماعة"
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr "حالة سحابة زوليب"
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr "تثبيت خادم \"زوليب\""
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr "ترقية خادم \"زوليب\""
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr "المساهمة"
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr "دليل المساهمة"
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr "مجتمع التطوير"
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr "ترجمة"
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr "GitHub"
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr "معلومات عنا"
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr "فريق"
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "سجل"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr "القيم"
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr "وظائف"
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr "مدونة"
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr "دعم \"زوليب\""
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr "Mastodon"
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Values"
 msgid "Bluesky"
 msgstr "القيم"
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr "مشغل بواسطة <a href=\"https://zulip.com\">زوليب</a>"
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr "شروط الخدمة"
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr "سياسة الخصوصية"
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr "سمات الموقع"
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr "أكثر من %(integrations_count_display)s إدماجات أصلية."
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 #, fuzzy
 #| msgid ""
 #| "And hundreds more through <a href=\"/integrations/doc/zapier\">Zapier</a> "
@@ -3933,51 +3397,47 @@ msgstr ""
 "ومئات أخرى من خلال <a href=\"/integrations/doc/zapier\">Zapier</a> و <a "
 "href=\"/integrations/doc/ifttt\">IFTTT</a>."
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr "إدماجات البحث"
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr "إدماجات مخصصة"
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr "واردات الويب هوك"
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr "روبوتات تفاعلية"
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr "REST API"
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr "بريد إلكتروني غير صالح"
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr "بريد إلكتروني غير مسموح"
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr "البريد الإلكتروني الذي تحاول التسجيل به غير صالح."
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3985,7 +3445,7 @@ msgid ""
 "emails with your email domain."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3993,7 +3453,7 @@ msgid ""
 "disposable email addresses."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4003,24 +3463,24 @@ msgstr ""
 "المنظمة التي تحاول الانضمام إليها, <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a>, لا تسمح بالتسجيل باستخدام بريد إلكتروني يحتوي على \"+\""
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr "من فضلك قم بالتسجيل باستخدام بريد إلكتروني صالح."
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr "من فضلك قم بالتسجيل باستخدام بريد إلكتروني مسموح."
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr "لم يتم العثور علي منظمة"
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr "لا توجد منظمة زوليب على <b>%(current_url)s</b>"
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -4028,7 +3488,7 @@ msgid ""
 "%(support_email)s\">contact Zulip support</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -4036,92 +3496,92 @@ msgid ""
 "%(support_email)s\">contact this Zulip server's administrators</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
 "management for your Zulip server."
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr "جلسة تسجيل الدخول غير صالحة أو منتهية الصلاحية"
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr "جلسة تسجيل الدخول غير صالحة أو منتهية الصلاحية."
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr "تسجيل الدخول إلى زوليب"
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 "لقد قمت فعلاً بالتسجيل باستخدام عنوان البريد الإلكتروني هذا. رجاءً قم بتسجيل "
 "الدخول أدناه."
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr "البريد الإلكتروني أو اسم المستخدم"
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "اسم المستخدم"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr "نسيت رقمك السري؟"
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr "سجّل الدخول باستخدام %(identity_provider)s"
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr "عرض من غير حساب"
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 "لا تملك حسابا حتى الآن؟ أنت بحاجة إلى أن تتم دعوتك للانضمام إلى هذه المنظمة."
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr "لا توجد رخص متاحة"
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr "المنظمة لا تستطيع استقبال أعضاء جدد الآن"
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> because all Zulip Cloud licenses are in use."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr "تخطى إلى المحتوى الأساسي"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -4130,34 +3590,33 @@ msgid ""
 "or misconfiguration."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 #, fuzzy
 #| msgid "No organization found"
 msgid "Demo organizations disabled"
 msgstr "لم يتم العثور علي منظمة"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr "مطلوب التحديث"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr "قم بتنزيل أحدث إصدار."
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, fuzzy
 #| msgid ""
 #| "Your server has exceeded the limit for how\n"
@@ -4168,12 +3627,11 @@ msgstr ""
 "الخادم الخاص بك تخطي الحد المسموح\n"
 " لعدد المرات التي يمكن فيها تنفيذ هذا الأمر."
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr "رابط إنشاء المنظمة مطلوب"
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -4181,12 +3639,11 @@ msgid ""
 "organization for more information."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr "رابط إنشاء المنظمة منتهي الصلاحية أو غير صالح"
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
@@ -4194,11 +3651,11 @@ msgstr ""
 "للأسف, هذ ليس رابط صالح لإنشاء منظمة. من فضلك <a href=\"/new/\">احصل على "
 "رابط جديد</a> و حاول مرة أخرى"
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr "تسجيل خادم زوليب غير متوقع"
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -4206,17 +3663,16 @@ msgid ""
 "Zulip support</a> for assistance in resolving this issue."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr "متصفح غير مدعوم"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr "%(browser_name)sغير مدعوم بواسطة زوليب"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
@@ -4225,7 +3681,7 @@ msgstr ""
 "زوليب يدعم <a href=\"%(supported_browsers_page_link)s\">المتصفحات الحديثة</"
 "a> مثل فايرفوكس, كروم, و مايكروسوفت إيدج"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
@@ -4233,25 +3689,24 @@ msgstr ""
 "بإمكانك أيضاً استخدام <a href=\"%(apps_page_link)s\">تطبيق زوليب لسطح المكتب "
 "</a>."
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr "الحساب معطل"
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Invalid organization"
 msgid "Finalize organization import"
 msgstr "منظمة غير صالحة"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Organization moved"
 msgid "Organization import completed!"
 msgstr "تم نقل المنظمة"
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -4259,56 +3714,55 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Select your account"
 msgstr "أنشئ حسابك"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Create new account"
 msgstr "أنشئ حسابك"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr "تم تفعيل المنظمة بنجاح"
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr "تم إعادة تفعيل منظمتك بنجاح."
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr "رابط إعادة تفعيل المنظمة منتهي الصلاحية أو غير صالح"
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr "انتهت صلاحية رابط إعادة تفعيل المنظمة أو أنه غير صالح."
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr "سجّل الدخول إلى منظمتك"
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr "ألا تعرف عنوان URL لمنظمتك؟"
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr "اعثر على منظمتك."
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr "التالي"
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4316,24 +3770,24 @@ msgid ""
 "have one yet."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 #, fuzzy
 #| msgid "Self-host Zulip"
 msgid "Self-hosting Zulip?"
 msgstr "إستضافة ذاتية لـ\"زوليب\""
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">log in to manage plans and billing.</a>"
 msgstr ""
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr "اعد تعيين كلمة المرور"
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
@@ -4341,64 +3795,64 @@ msgstr ""
 "نسيت كلمة المرور؟ لا مشكلة, سنرسل رابط لإعادة تعيين كلمة المرور إلي البريد "
 "الإلكتروني المستخدم في التسجيل."
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr "أرسل رابط إعادة التعيين"
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr "أعد تعيين كلمة مرور جديدة"
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "تأكيد كلمة السر"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr "عذرًا، الرابط الذي قدمته غير صالح أو تم استخدامه بالفعل."
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr "تم تعيين كلمة مرور جديدة بنجاح"
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr "لقد قمت بتعيين كلمة مرور جديدة!"
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr ""
 "الرجاء <a href=\"%(login_url)s\">تسجيل الدخول</a> باستخدام كلمة المرور "
 "الجديدة الخاصة بك."
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr "تم إرسال بريد إلكتروني لإعادة تعيين كلمة المرور"
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr "تم إرسال إعادة تعيين كلمة المرور!"
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr "تحقق من بريدك الإلكتروني في بضع دقائق لإنهاء العملية."
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 #, fuzzy
 #| msgid "Export still in progress"
 msgid "Import progress"
 msgstr "التصدير لا يزال قيد التنفيذ"
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4406,7 +3860,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4415,60 +3869,60 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 #, fuzzy
 #| msgid ""
 #| "Nobody in this Zulip organization will be able to see this email address."
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr "لا أحد في منظمة زوليب هذه سيتمكن من رؤية هذا البريد الإلكتروني"
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4476,7 +3930,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4484,22 +3938,22 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr "اختر حساب للمصادقة"
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr "<h1 class=\"get-started\">حدد حساب</h1>"
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 "يحتوي حسابك على GitHub أيضًا على عناوين بريد إلكتروني مرتبطة به لم يتم التحقق "
 "منها."
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
@@ -4507,15 +3961,15 @@ msgstr ""
 "لاستخدام واحدة من هذه لتسجيل الدخول إلى \"زوليب\"، يجب عليك أولًا <a "
 "href=\"https://github.com/settings/emails\">التحقق منها بواسطة GitHub.</a>"
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr "خطأ في إلغاء الاشتراك من البريد الإلكتروني"
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr "طلب إلغاء اشتراك بريد إلكتروني غير معروف"
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
@@ -4523,7 +3977,7 @@ msgstr ""
 "أهلا ! يبدو أنك حاولت إلغاء الاشتراك من شيء ما, ولكننا لا نستطيع التعرف علي "
 "الرابط."
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4534,12 +3988,11 @@ msgstr ""
 "%(support_email)s\">ارسل لنا عبر البريد الإلكتروني</a> و سوف نقوم بمعالجة "
 "هذا الأمر!"
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr "تم تحديث إعدادات البريد الإلكتروني"
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
@@ -4548,7 +4001,7 @@ msgstr ""
 "لقد قمت بإلغاء الاشتراك بنجاح من زوليب %(subscription_type)s لرسائل البريد "
 "الإلكتروني ل <a href=\"%(realm_url)s\">%(realm_name)s</a>."
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
@@ -4557,113 +4010,111 @@ msgstr ""
 "تستطيع إلغاء هذا التغيير أو مراجعة تفضيلاتك من <a href=\"%(realm_url)s/"
 "#settings/notifications\">إعدادات الإشعارات</a>."
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr "تعيين أمر غير صالح."
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr "أسئلة و نقاش عن استخدام زوليب."
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr "التجربة مع زوليب هنا. :test_tube:"
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr "لمحادثات الفرق الكبيرة"
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr "الاشتراكات"
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr "{user} انضم لهذه المنظمة."
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr "تم قبول دعوتك من قبل {user} للانضمام إلى \"زوليب\"!"
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 #, fuzzy
 #| msgid "Cannot deactivate the only {entity}."
 msgid "Cannot reactivate a deleted user"
 msgstr "لا يمكن تعطيل {entity} فقط."
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr "حقل الـ ID {id} غير موجود."
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr ""
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr ""
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr ""
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
@@ -4671,7 +4122,7 @@ msgstr ""
 "لحماية المستخدمين، يحد \"زوليب\" من عدد الدعوات التي يمكنك إرسالها في يوم "
 "واحد. نظرًا لأنك وصلت إلى الحد الأقصى، لم يتم إرسال دعوات."
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
@@ -4679,76 +4130,76 @@ msgstr ""
 "حسابك جديد جدًا بحيث لا يمكن إرسال دعوات لهذه المنظمة. اسأل مسؤول المنظمة، أو "
 "مستخدم أكثر خبرة."
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 "لم يتم التحقق من صحة بعض رسائل البريد الإلكتروني، لذلك لم نرسل أي دعوات."
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr "لم نتمكن من دعوة أي شخص."
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr "لا شيء لتغييره"
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr "الرسائل المباشرة لا يمكن نقلها إلى القنوات"
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr "الرسائل المباشرة لا يمكن أن تحتوي على مواضيع"
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr "propagate_mode غير صالح بدون تعديل الموضوع"
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr ""
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr "لا يمكن تعديل محتوى الرسالة أثناء تغيير القناة"
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr "لا يمكن تعديل الأدوات."
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr "لقد أوقفت منظمتك تعديل الرسائل"
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr "ليس لديك إذن لتعديل هذه الرسالة"
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr "انقضت المهلة الزمنية لتعديل هذه الرسالة"
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr "قام {user} بوضع علامة تم الحل على هذا الموضوع."
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr "قام {user} بوضع علامة على هذا الموضوع على أنه لم يتم حله."
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr "تم نقل هذا الموضوع إلى {new_location} بواسطة {user}."
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr "رسالة نُقلت من هذا الموضوع إلى {new_location} بواسطة {user}."
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
@@ -4757,18 +4208,18 @@ msgstr ""
 "{changed_messages_count} تم نقل رسائل من هذا الموضوع إلى {new_location} "
 "بواسطة {user}."
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr "تم نقل هذا الموضوع هنا من {old_location} بواسطة {user}."
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
@@ -4776,69 +4227,66 @@ msgid ""
 msgstr ""
 "{changed_messages_count} تم نقل رسائل هنا من {old_location} بواسطة {user}."
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 #, fuzzy
 #| msgid "You do not have permission to post in this channel."
 msgid "You don't have permission to resolve topics in this channel."
 msgstr "ليس لديك الإذن للإرسال في هذه القناة"
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr "ليس لديك إذن بنقل هذه الرسالة"
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr ""
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr "الرسالة(الرسائل) غير صالحة"
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr "تعذر تقديم الرسالة"
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr "قناة واحدة هي المتوقعة"
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr "نوع بيانات غير صالح للقناة"
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr "نوع البيانات غير صالح للمستلمين"
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 "قد تحتوي قوائم المستلمين على رسائل بريد إلكتروني أو معرفات ID للمستخدم، ولكن "
 "ليس كليهما."
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
@@ -4847,7 +4295,7 @@ msgstr ""
 "البوت الخاص بك {bot_identity} حاول إرسال رسال إلى مُعرِّف القناة {channel_id}, "
 "و لكن لا يوجد قناة بهذا المُعرِّف"
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4857,36 +4305,36 @@ msgstr ""
 "البوت الخاص بك {bot_identity} حاول إرسال رسالة إلي القناة {channel_name}, و "
 "لكن تلك القناة غير موجودة. اضغط [هنا]({new_channel_link}) لإنشائها."
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
 "The channel exists but does not have any subscribers."
 msgstr ""
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr ""
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr "الأدوات: أرسل مبرمج الـ API محتوى JSON غير صالح"
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr "الأدوات: {error_msg}"
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4894,64 +4342,62 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr "يوجد بالفعل رمز تعبيري مخصص بهذا الاسم."
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr "صيغة الصورة غير صالحة"
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
 "authentication method."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr ""
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr "الرسالة المجدولة بالفعل تم ارسالها"
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder could not be sent."
 msgstr "الرمز غير موجود"
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr "لا يمكن ارسال الرسالة في الوقت المجدول."
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
@@ -4959,47 +4405,47 @@ msgid ""
 msgstr ""
 "الرسالة المجدولة لتصل في {delivery_datetime} لم يتم ارسالها بسبب هذا الخطأ:"
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr "[عرض الرسائل المجدولة](#scheduled)"
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr "المنظمة مفعَّلة بالفعل"
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, fuzzy, python-brace-format
 #| msgid "Channel {channel_name} un-archived."
 msgid "Channel #**{channel_name}** has been archived."
 msgstr "منظمة {channel_name} غير مؤرشفة."
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr "المنظمة ليست معطلة حاليا"
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr "منظمة باسم {channel_name} بالفعل موجودة"
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr ""
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, fuzzy, python-brace-format
 #| msgid "Channel {channel_name} un-archived."
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr "منظمة {channel_name} غير مؤرشفة."
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
 "**{old_policy}** to **{new_policy}**."
 msgstr ""
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -5008,51 +4454,49 @@ msgid ""
 "* **New**: {new_setting_description}\n"
 msgstr ""
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr "بدون وصف."
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr "{user} قام بتغيير الوصف لهذه القناة."
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr "الوصف القديم"
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr "الوصف الجديد"
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr "أبديًا"
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr "{number_of_days} أيام"
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 msgstr ""
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr "سيتم الآن الاحتفاظ بالرسائل في هذه القناة للأبد."
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -5063,150 +4507,139 @@ msgid ""
 "{summary_line}"
 msgstr ""
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr "لا يمكنك إرفاق رسالة فرعية بهذه الرسالة."
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr "مُعرِّف مستخدم غير صالح {user_id}"
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr ""
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr "إذن غير كاف"
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr "الـ API هذا غير صالح لروبوتات الويب هوك الواردة."
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr "الحساب غير مرتبط بهذا المجال الفرعي"
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr "لا تقبل نقطة النهاية هذه طلبات الروبوت."
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr "يجب أن يكون مسؤول الخادم"
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr "تتطلب نقطة النهاية هذه مصادقة HTTP الأساسية."
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr "رأس المصادقة غير صالح للمصادقة الأساسية"
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr "رأس المصادقة مفقود للمصادقة الأساسية"
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr "يمكن لروبوتات الويب هوك الوصول إلى الويب هوك فقط"
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr ""
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
 "organization administrator to reactivate it."
 msgstr "تم تعطيل حسابك {username}. يرجى الاتصال بمسؤول منظمتك لإعادة تفعيله."
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr "كلمة المرور ضعيفة للغاية."
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr "يجب أن يكون النطاق الفرعي بطول 3 أو أكبر."
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr "لا يمكن أن يبدأ النطاق الفرعي أو ينتهي بـ '-'."
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr "يمكن أن يحتوي النطاق الفرعي على أحرف صغيرة وأرقام و'-' فقط."
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr "رجاءً استخدم عنوان بريدك الإلكتروني الحقيقي."
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr "المنظمة التي تحاول الانضمام إليها باستخدام {email} غير موجودة."
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr "يرجى طلب دعوة لـ {email} من مسؤول المنظمة."
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
@@ -5215,11 +4648,11 @@ msgstr ""
 "عنوان بريدك الإلكتروني {email}، ليس في أحد المجالات المسموح لها بالتسجيل في "
 "حسابات هذه المنظمة."
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr "غير مسموح بعناوين البريد الإلكتروني التي تحتوي على + في هذه المنظمة."
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
@@ -5229,41 +4662,40 @@ msgstr ""
 "التي تملكها قيد الاستخدام. رجاءً تواصل مع الشخص الذي دعاك واطلب منه زيادة عدد "
 "التراخيص، ثم حاول مرة أخرى."
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 #, fuzzy
 #| msgid "Embedded bots are not enabled."
 msgid "Challenges are not enabled."
 msgstr "لم يتم تمكين الروبوتات المضمنة."
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "كلمة مرور جديدة"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr "تأكيد كلمة السر الجديدة"
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "You're making too many attempts to sign in. Try again in "
 "{retry_after_string} or contact your organization administrator for help."
 msgstr ""
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
@@ -5271,92 +4703,90 @@ msgstr ""
 "تم تعطيل كلمة المرور الخاصة بك لأنها ضعيفة للغاية. أعد تعيين كلمة المرور "
 "الخاصة بك لإنشاء كلمة مرور جديدة."
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr "رمز"
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr "رجاءً إدخال 10 رسائل بريد إلكتروني على الأكثر."
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr "لم نتمكن من العثور على منظمة \"زوليب\" تلك."
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr ""
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr "موضوع مفقود"
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr "لا يمكن الإرسال إلى عدة قنوات"
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr "قناة مفقودة"
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr "يجب أن تملك الرسالة مستلمين"
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr "نوع الرسالة غير صالح"
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr "مرفق غير صالح"
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr "حدث خطأ أثناء حذف المرفق. رجاءً حاول مرة أخرى في وقت لاحق."
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr "يجب أن تحتوي الرسالة على مستلمين!"
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Channel name can't be empty."
 msgid "Channel folder name can't be empty."
 msgstr "اسم القناة يجب أن لا يكون فارغ"
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Channel named {channel_name} already exists"
 msgid "Channel folder name already in use"
 msgstr "منظمة باسم {channel_name} بالفعل موجودة"
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Invalid channel ID"
 msgid "Invalid channel folder ID"
 msgstr "مُعرف قناة غير صالح"
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 #, fuzzy
 #| msgid "Confirm your email address"
 msgid "Configure owner account email address."
 msgstr "أكد عنوان بريدك الألكتروني"
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| " Congratulations, you have created a new demo Zulip organization. Note "
@@ -5372,72 +4802,72 @@ msgstr ""
 "تلقائيا بعد 30 يوما. اعرف المزيد عن المنظمات التجريبية من هنا: "
 "%(demo_organizations_help_link)s"
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a date"
 msgid "{var_name} is not Base64 encoded"
 msgstr "{var_name} ليس تاريخًا"
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 #, fuzzy
 #| msgid "Invalid emoji code."
 msgid "Invalid `device_id`"
 msgstr "شِفرة رمز تعبيري غير صالحة."
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr ""
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr "لا يمكن أن يكون المجال فارغًا."
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr "يجب أن يحتوي المجال على نقطة واحدة على الأقل (.)"
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr "المجال طويل جدًا"
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr "لا يمكن أن يبدأ المجال أو ينتهي بنقطة (.)"
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr "'.' المتتابعة ليست مسموحة."
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr "لا يمكن أن تبدأ المجالات الفرعية أو تنتهي بـ '-'."
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr "يمكن أن يحتوي المجال فقط على أحرف وأرقام و '.' و '-'."
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr "يجب ألا يكون الطابع الزمني سالبًا."
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr "يجب ألا يحتوي الموضوع على وحدات فارغة"
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr "قام المستخدم بتعطيل مزامنة المسودات."
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr "المسودة غير موجودة"
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5445,633 +4875,631 @@ msgid ""
 "{error_message}"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr "بريد إلكتروني بدون موضوع"
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr "افتح \"زوليب\" لرؤية محتوى المفسد"
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr "إشعارات {service_name}"
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr "عنوان غير صحيح."
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr "خارج المجال الخاص بك."
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr "عناوين البريد الإلكتروني التي تحتوي على + غير مسموح بها."
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr "محجوز لروبوتات النظام."
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr "{email} لديه حساب بالفعل"
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr "لديه حساب بالفعل."
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr "تم تعطيل الحساب."
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr ""
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr "رمز تعبيري مخصص غير صالح."
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr "اسم رمز تعبيري مخصص غير صالح."
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr "تم تعطيل هذا الرمز التعبيري المخصص."
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr "شِفرة رمز تعبيري غير صالحة."
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr "اسم رمز تعبيري غير صالح."
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr "نوع رمز تعبيري غير صالح."
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr "يجب أن يكون مسؤول منظمة أو مؤلف رموز تعبيرية"
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr ""
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
 msgstr ""
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr "اسم الرمز التعبيري مفقود"
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr "تعذر تخصيص قائمة انتظار الحدث"
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr "لم يتم تسجيل الدخول: يلزم مصادقة API أو جلسة المستخدم"
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, fuzzy, python-brace-format
 #| msgid "Channel named {channel_name} already exists"
 msgid "Channel '{channel_name}' already exists"
 msgstr "منظمة باسم {channel_name} بالفعل موجودة"
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr "صاحب المنظمة"
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr "المستعمل"
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr "لا يمكن تعطيل {entity} فقط."
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr "Markdown غير صالح يتضمن البيان: {include_statement}"
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr "JSON تالف"
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr "يجب أن يكون مسؤول منظمة"
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr "يجب أن يكون صاحب منظمة"
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Must be an organization owner"
 msgid "Must be a bot user"
 msgstr "يجب أن يكون صاحب منظمة"
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr "اسم المستخدم أو كلمة المرور غير صحيحة"
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr "تم تعطيل هذه المنظمة"
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr "تم تعطيل تسجيل خدمة إرسال الإشعارات إلى الهاتف لخادمك"
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr "تم تعطيل مصادقة كلمة المرور في هذه المنظمة"
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr "تم تعطيل كلمة مرورك ويجب إعادة تعيينها"
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr "مفتاح API غير صالح"
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr "مفتاح API مشوه"
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
 "webhook; ignoring"
 msgstr ""
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr "تعذر تحليل الطلب: هل أنشأ {webhook_name} هذا الحدث؟"
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr "المجال الفرعي غير صالح"
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr "الرسائل المابشرة معطلة في هذه المنظمة"
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr "هذه المحادثة لا تحتوي على أي مستخدم مسموح له بالتحدث فيها"
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr "تم رفض الوصول"
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} most recent messages in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr "التفاعل موجود بالفعل."
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr "رد الفعل غير موجود."
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
 msgstr ""
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr "منظمة غير مسجلة"
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr ""
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr ""
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr ""
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr "وقت الوصول المجدول يجب أن يكون في المستقبل."
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Already has an account."
 msgid "Atlassian account ID"
 msgstr "لديه حساب بالفعل."
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Behance username"
 msgstr "اسم أو اسم مستخدم سيئ"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 msgid "Bitbucket username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Codeberg username"
 msgstr "اسم أو اسم مستخدم سيئ"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Dribbble username"
 msgstr "البريد الإلكتروني أو اسم المستخدم"
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Facebook username"
 msgstr "اسم أو اسم مستخدم سيئ"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "GitLab username"
 msgstr "البريد الإلكتروني أو اسم المستخدم"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Instagram username"
 msgstr "اسم أو اسم مستخدم سيئ"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Mastodon"
 msgid "Mastodon profile"
 msgstr "Mastodon"
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Medium username"
 msgstr "اسم أو اسم مستخدم سيئ"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Pinterest username"
 msgstr "اسم أو اسم مستخدم سيئ"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Reddit username"
 msgstr "البريد الإلكتروني أو اسم المستخدم"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 msgid "Snapchat username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Threads username"
 msgstr "اسم أو اسم مستخدم سيئ"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "TikTok username"
 msgstr "البريد الإلكتروني أو اسم المستخدم"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Twitch username"
 msgstr "البريد الإلكتروني أو اسم المستخدم"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "اسم المستخدم"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr "نوع الحساب الخارجي غير صالح"
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr "أطر عمل الدمج"
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 #, fuzzy
 #| msgid "Video call ended"
 msgid "Video calling"
 msgstr "انتهت مكالمة الفيديو"
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr "الدمج المستمر"
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr "دعم العملاء"
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr "تعيين"
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr "وسائل الترفيه"
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr "تواصل"
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr "المالية"
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr ""
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr "تسويق"
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr "متنوع"
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr ""
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr "ادارة مشروع"
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr "إنتاجية"
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr "التحكم في الإصدار"
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr "يجب ألا تكون الرسالة فارغة"
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr "يجب ألا تحتوي الرسالة على وحدات فارغة"
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{fullname} moderation"
 msgstr "ذكرك {full_name}:"
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr "مشغل تضيق العرض غير صالح: {desc}"
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr ""
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr ""
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr "الوسيط 'anchor' مفقود."
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 #, fuzzy
 #| msgid "Missing 'anchor' argument."
 msgid "Missing 'anchor_date' argument."
 msgstr "الوسيط 'anchor' مفقود."
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr "مذيع غير صالح"
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr ""
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 #, fuzzy
 #| msgid "Confirmation link does not exist"
 msgid "Navigation view does not exist."
 msgstr "رابط التأكيد غير موجود"
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6079,7 +5507,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6087,7 +5515,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6095,7 +5523,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6103,7 +5531,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| " Congratulations, you have created a new demo Zulip organization. Note "
@@ -6120,14 +5548,14 @@ msgstr ""
 "تلقائيا بعد 30 يوما. اعرف المزيد عن المنظمات التجريبية من هنا: "
 "%(demo_organizations_help_link)s"
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
 "them in your [Inbox](/#inbox).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6135,7 +5563,7 @@ msgid ""
 "({navigation_tour_video_url}) for a quick app overview.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6150,14 +5578,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -6165,7 +5593,7 @@ msgid ""
 "and edit your [profile information](/help/edit-your-profile).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -6176,7 +5604,7 @@ msgid ""
 "experience in your [Preferences](#settings/preferences).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6187,7 +5615,7 @@ msgid ""
 "[Browse and subscribe to channels]({settings_link}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -6204,7 +5632,7 @@ msgid ""
 "discussed.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -6213,7 +5641,7 @@ msgid ""
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -6225,7 +5653,7 @@ msgid ""
 "times, and more.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "\n"
@@ -6246,7 +5674,7 @@ msgstr ""
 "اقرأ [ دليل بداية الاستخدام](/help/getting-started-with-zulip),\n"
 "أو تصفح [مركز المساعدة](/help/) لتعرف المزيد!\n"
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6254,7 +5682,7 @@ msgid ""
 "get help, try one of the following messages: {bot_commands}\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6266,13 +5694,13 @@ msgid ""
 "({move_content_another_channel_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6286,12 +5714,11 @@ msgid ""
 "and above.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr "أهلا بك في زوليب!"
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -6299,14 +5726,14 @@ msgid ""
 "no matter how many other conversations are going on.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
 "conversations with unread messages.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -6314,7 +5741,7 @@ msgid ""
 "the `+` button next to its name.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -6322,13 +5749,13 @@ msgid ""
 "can we chat about…?”\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6336,7 +5763,7 @@ msgid ""
 "({format_message_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6356,127 +5783,127 @@ msgid ""
 "```\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
 "teammates.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
 "conversation.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr "نقل الرسائل"
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr "التجارب"
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr "ابدأ محادثة"
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr "التحييات"
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr "JSON غير صالح في الرد"
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr "تنسيق الرد غير صالح"
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr "رمز فارغ أو طوله غير صالح"
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr "رمز APNS غير صالح"
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr ""
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr "الرمز غير موجود"
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr "{full_name} المذكور @{user_group_name}:"
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr "ذكرك {full_name}:"
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr "ذكر {full_name} الجميع:"
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "رسالة جديدة"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr "اختبار الإشعار"
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 #, fuzzy
 #| msgid "Invalid API key"
 msgid "Invalid `push_key`"
 msgstr "مفتاح API غير صالح"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
@@ -6487,1119 +5914,1098 @@ msgstr[3] ""
 msgstr[4] ""
 msgstr[5] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr "المستخدم غير مخول لهذا الاستعلام"
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr "'{email}' لم يعد يستخدم \"زوليب\"."
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr ""
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr "{var_name} طويل جدًا (الحد: {max_length} حرفًا)"
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder does not exist"
 msgstr "الرمز غير موجود"
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr ""
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr "لا يمكن الاختيار بين الوسيطين '{var_name1}' و '{var_name2}'"
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr "الوسيط '{var_name}' مفقود"
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr "قيمة سيئة لـ '{var_name}': {bad_value}"
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr "رسالة مجدولة غير موجودة"
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr ""
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr ""
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr ""
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr "ليس لديك الإذن للإرسال في هذه القناة"
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 #, fuzzy
 #| msgid "You do not have permission to post in this channel."
 msgid "You do not have permission to create new topics in this channel."
 msgstr "ليس لديك الإذن للإرسال في هذه القناة"
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr "مُعرف قناة غير صالح"
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr ""
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr "اسم القناة يجب أن لا يكون فارغ"
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr ""
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr ""
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr "بيانات المشترك غير متوفرة لهذه القناة"
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr "تعذر فك تشفير الصورة؛ هل قمت بتحميل ملف صورة؟"
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr "حجم الصورة يتجاوز الحد."
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr "صورة فاسدة أو مقصوصة"
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr "{var_name} ليس قيمة منطقية"
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} does not have a length"
 msgid "{var_name} does not have the expected format"
 msgstr "{var_name} لا يحتوي على طول"
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr "{var_name} ليس تاريخًا"
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr "{var_name} ليس dict"
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr "{var_name} غير صالح"
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr "{var_name} ليس عددًا عشريًا"
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr "{var_name} صغير جدًا"
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr "{var_name} ليس عددًا صحيحًا"
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr "{var_name} ليس JSON صالح"
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr "{var_name} كبير جدًا"
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr "{var_name} ليست قائمة"
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr "{var_name} طويل جدًا (الحد: {max_length} حرفًا)"
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr "{var_name} قصير جدا"
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr "{var_name} ليس نص"
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr "{var_name} لديه صيغة غير صالحة"
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr "{var_name} ليس بطول {length}"
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr "{var_name} طويل جدًا (الحد: {max_length} حرفًا)"
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr "{var_name} طويل جدًا (الحد: {max_length} حرفًا)"
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr "{var_name} لا يمكن أن يكون فارغًا."
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr "غير صالح {var_name}: {msg}"
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr "{var_name} مجال مفقود: {msg}"
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr "حمولة مشوهة"
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr "ليس في قائمة القيم الممكنة"
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr "ليس عنوان URL"
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr "{var_name} ليست شِفرة لون hex صالحة"
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid {var_name}"
 msgid "Invalid {setting_name}"
 msgstr "{var_name} غير صالح"
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr "قد يتجاوز التحميل حصة التحميل الخاصة بمنظمتك."
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr "حجم الصورة يتخطى المسموح"
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr ""
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr "مجموعة مستخدم غير صالحة"
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid user group ID: {group_id}"
 msgid "Invalid user group ID: {user_group_id}"
 msgstr "مُعرِّف مجموعة غير صالح: {group_id}"
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr ""
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr "مُعرِّف مجموعة غير صالح: {group_id}"
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr ""
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr ""
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr "لم يقم العميل بتمرير أي قيم جديدة."
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr "يجب أن يمرر العميل emoji_name إذا مرر إما emoji_code أو reaction_type."
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr "الاسم طويل جدًا!"
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 #, fuzzy
 #| msgid "Message must not be empty"
 msgid "Name must not be empty!"
 msgstr "يجب ألا تكون الرسالة فارغة"
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr "أحرف غير صالحة في الاسم!"
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr "تنسيق غير صحيح!"
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr ""
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr ""
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr "اسم أو اسم مستخدم سيئ"
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr ""
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr ""
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr ""
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr "بيانات التكوين غير صالحة!"
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr "نوع الروبوت غير صالح"
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr "نوع الواجهة غير صالح"
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr ""
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr "لا يوجد مثل هذا الروبوت"
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr "لا يوجد مثل هذا المستخدم"
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr "تم تعطيل المستخدم"
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr "{item} لا يمكن أن يكون فارغًا."
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr "{var_name} له طول غير صحيح {length} ؛ يجب أن يكون {target_length}"
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a string"
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr "{var_name} ليس نص"
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr "{container} يجب أن يحتوي بالضبط على {length} عنصرًا"
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr "المفتاح {key_name} مفقود من {var_name}"
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr ""
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr "{var_name} ليس allowed_type"
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr "{variable} != {expected_value} ({value} خطأ)"
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr "{var_name} ليس عنوان URL"
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr ""
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr "'{item}' لا يمكن أن يكون فارغًا."
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr ""
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr "'{value}' ليس اختيارًا صالحًا لـ '{field_name}'."
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr "{var_name} ليس نص أو قائمة أعداد صحيحة"
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr "{var_name} ليس نص أو عددًا صحيحًا"
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr "{var_name} لا يحتوي على طول"
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr "{var_name} مفقود"
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr "رأس حدث HTTP مفقود '{header}'"
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr "يجب أن يكون هناك شرطة مائلة في البداية في zcommand."
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr "أمر غير موجود: {command}"
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr "خطأ CSRF : {reason}"
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr "التاريخ"
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr "حساب خارجي"
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr "الضمائر"
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr "لا أحد"
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr ""
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "أعضاء"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr "الجميع على الانترنت"
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Invalid characters in emoji name"
 msgid "Invalid auto-conversion field: empty field name."
 msgstr "أحرف غير صالحة في اسم الرموز التعبيرية"
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr ""
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr "خطأ غير معروف في التعبير العادي"
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 msgid "Example input does not match the linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in alternative URL template is not present in linkifier "
 "pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in linkifier pattern is not present in alternative URL "
 "template."
 msgstr ""
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr "رموز Unicode التعبيرية"
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "رموز تعبيرية مخصصة"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr "رموز \"زوليب\" التعبيرية الإضافية"
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr "أحرف غير صالحة في اسم الرموز التعبيرية"
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr "أحرف غير صالحة في لغة pygments"
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr ""
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr "صندوق الرمل"
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr "عام"
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr "أحداث القناة"
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr "تحديثات زوليب"
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr "متوفر على سحابة \"زوليب\" الأساسية. قم بالترقية للوصول."
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr ""
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr ""
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr ""
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr "الويب العامة"
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "عامة"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr "سجل خاص ومشترك"
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr "سجل خاص ومحمي"
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr "المشرفون والوسطاء والأعضاء والضيوف"
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr "المشرفون والوسطاء والأعضاء"
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr "المشرفون والوسطاء"
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr "المديرون فقط"
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr "مستخدم غير معروف"
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr "صاحب المنظمة"
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr "مسؤول المنظمة"
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr "الوسيط"
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "عضو"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "ضيف"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr "عنوان IP غير معروف"
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr "نظام تشغيل غير معروف"
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr "متصفح غير معروف"
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr "وسيط 'queue_id' مفقود"
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr "وسيط 'last_event_id' مفقود"
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr "تم بالفعل إزالة حدث أحدث من {event_id}!"
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr "الحدث {event_id} لم يكن في قائمة الانتظار هذه"
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr ""
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 #, fuzzy
 #| msgid "Failed to create Zoom call"
 msgid "Failed to generate challenge"
 msgstr "فشل إنشاء مكالمة Zoom"
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr ""
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr "لم يتم تمرير رمز ويب JSON في الطلب"
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr "رمز ويب JSON سيء"
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr ""
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr "المجال الفرعي مطلوب"
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr "كلمة المرور غير صحيحة."
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr "رأس وكيل المستخدم مفقود من الطلب"
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr "لا يمكن أن يكون التصنيف فارغًا."
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr "يجب أن يحتوي الحقل على خيار واحد على الأقل."
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 #, fuzzy
 #| msgid "Presence is not supported for bot users."
 msgid "Field type not supported for use for user matching."
 msgstr "الحضور غير مدعوم لمستخدمي الروبوتات."
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr "نوع الحقل غير صالح."
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr "يمكن إظهار فقط خانتين مخصصتين من الملف الشخصي في ملخص الملف الشخصي."
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr "يوجد بالفعل حقل بهذا التصنيف."
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr "لا يمكن تحديث الحقل المخصص الافتراضي."
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr "نقطة النهاية غير متوفرة في الإنتاج."
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr "لم يتم تمكين DevAuthBackend."
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr ""
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr "قاعدة البيانات فارغة"
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr ""
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr ""
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr ""
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr ""
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr "لا توجد مثل هذه الدعوة"
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 #, fuzzy
 #| msgid "Confirmation link expired or deactivated"
 msgid "Invitation already used or deactivated."
 msgstr "رابط التأكيد منتهي الصلاحية أو معطل"
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr ""
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr ""
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr "يجب عليك تحديد عنوان بريد إلكتروني واحد على الأقل."
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
@@ -7607,106 +7013,104 @@ msgstr ""
 "بعض هذه العناوين تستخدم \"زوليب\" بالفعل، لذلك لم نرسل لهم دعوة. لقد أرسلنا "
 "دعوات إلى أي شخص آخر!"
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr "تم تعطيل سجل تعديل الرسائل في هذه المؤسسة"
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr "ليس لديك إذن بحذف هذه الرسالة"
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr "انقضت المهلة المحددة لحذف هذه الرسالة"
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr "تم حذف الرسالة بالفعل"
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr ""
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr ""
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr ""
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Organization creation link required"
 msgid "An explanation is required."
 msgstr "رابط إنشاء المنظمة مطلوب"
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Zephyr mirroring is not allowed in this organization"
 msgid "Message reporting is not enabled in this organization."
 msgstr "لا يسمح بالنسخ المتطابق لـ Zephyr في هذه المنظمة"
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr "المرسل مفقود"
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr "النسخ المتطابق غير مسموح به مع IDs المستخدم المستلم"
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr "رسالة معكوسة غير صالحة"
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr ""
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr ""
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr ""
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr "لا يمكنك كتم نفسك"
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr "تم كتم صوت المستخدم بالفعل"
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr "المستخدم ليس مكتومًا"
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 #, fuzzy
 #| msgid "Reaction already exists."
 msgid "Navigation view already exists."
 msgstr "التفاعل موجود بالفعل."
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7714,572 +7118,570 @@ msgid ""
 "later. Is this a good time?\n"
 msgstr ""
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr "الحضور غير مدعوم لمستخدمي الروبوتات."
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr "لا يوجد بيانات التواجد لـ {user_id_or_email}"
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 #, fuzzy
 #| msgid "You do not have permission to post in this channel."
 msgid "You do not have permission to manage plans and billing."
 msgstr "ليس لديك الإذن للإرسال في هذه القناة"
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr ""
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr ""
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr ""
 "يجب أن يكون أحد الوسطاء التاليين على الأقل موجود: emoji_name ، emoji_code"
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr "مؤشرات القراءة معطلة في هذه المنظمة"
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr "لغة غير صالحة '{language}'"
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr "يجب تمكين طريقة مصادقة واحدة على الأقل."
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr ""
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr ""
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr "يجب أن تكون منظمة تجريبية."
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr ""
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr "يعد النطاق {domain} جزءًا من منظمتك بالفعل."
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr "لم يتم العثور على إدخال للمجال {domain}."
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr "يجب عليك تحميل ملف واحد بالضبط."
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr ""
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 #, fuzzy
 #| msgid "Disposable email addresses are not allowed in this organization"
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr "عناوين البريد الإلكتروني المؤقتة غير مسموح بها في هذه المنظمة"
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr "تم تجاوز حد المعدل."
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr "ID تصدير البيانات غير صالح"
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr "تم حذف التصدير بالفعل"
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr "فشل التصدير, لا يوجد شيء لحذفه"
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr "التصدير لا يزال قيد التنفيذ"
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr "يجب عليك تحميل أيقونة واحدة بالضبط."
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr "الرابط غير موجود."
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr "يجب عليك تحميل شعار واحد بالضبط."
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid characters in pygments language"
 msgid "Invalid character in language: {character}"
 msgstr "أحرف غير صالحة في لغة pygments"
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid language '{language}'"
 msgid "Language '{language}' is not allowed."
 msgstr "لغة غير صالحة '{language}'"
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr "مكان تجربة شِفرة غير صالح"
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr ""
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "moving messages"
 msgid "Importing messages…"
 msgstr "نقل الرسائل"
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "Your full name"
 msgid "Your name"
 msgstr "اسمك الكامل"
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr ""
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr ""
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr "القنوات الخاصة لا يمكن جعلها افتراضية."
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr "يجب عليك تمرير \"new_description\" أو \"new_group_name\"."
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr "قيمة غير صالحة لـ \"op\". حدد \"add\" أو \"remove\"."
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr "إعدادات غير صالحة"
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr ""
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr "القناة لديها هذا الاسم بالفعل"
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr "لا شيء لفعله. حدد واحدًا على الأقل من \"add\" أو \"delete\"."
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr ""
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr ""
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr "تعذر الوصول إلى قناة ({channel_name})."
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr "قنوات جديدة"
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
 "**"
 msgstr ""
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr ""
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr ""
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr ""
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr "json غير صالح للرسالة الفرعية"
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr ""
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr ""
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr "فارغ 'to' القائمة"
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr ""
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr "<p>هذا الملف غير موجود أو تم حذفه</p>"
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr "<p>أنت غير مصرح لك لعرض هذا الملف.</p>"
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr "رمز غير صالح"
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr "اسم الملف غير صالح"
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr "يجب عليك تحديد ملف للتحميل"
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr "يمكنك فقط تحميل ملف واحد في كل مرة"
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr "لم يتم توفير بيانات جديدة"
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 msgstr ""
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr "المستخدم {user_id} عضو بالفعل في هذه المجموعة"
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr ""
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
 "subgroups."
 msgstr ""
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr "تم تعطيل تغييرات الصورة الرمزية في هذه المنظمة."
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr "تم تعطيل تغييرات عنوان البريد الإلكتروني في هذه المنظمة."
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr "default_language غير صالحة"
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr ""
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr ""
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr "تتم إدارة كلمة مرورك لـ \"زوليب\" في LDAP"
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr "كلمة مرور خاطئة!"
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, fuzzy, python-brace-format
 #| msgid "You can try again in %(retry_after)s seconds."
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr "يمكنك المحاولة مرة أخرى في %(retry_after)s ثانية."
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr "كلمة المرور الجديدة ضعيفة للغاية!"
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr "يجب عليك تحميل صورة رمزية واحدة بالضبط."
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr "الموضوع ليس صامتًا"
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr "لا يمكن نعطيل مالك المنظمة الوحيد"
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Nobody in this Zulip organization will be able to see this email address."
 msgid "User is not allowed to delete other user's messages."
 msgstr "لا أحد في منظمة زوليب هذه سيتمكن من رؤية هذا البريد الإلكتروني"
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr "لا يمكن إزالة إذن المالك من مالك المنظمة الوحيد."
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr ""
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr ""
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
@@ -8291,25 +7693,25 @@ msgstr ""
 "لا يمكن إنشاء روبوتات حتى يتم تكوين FAKE_EMAIL_DOMAIN بشكل صحيح.\n"
 " يرجى الاتصال بمسؤول الخادم الخاص بك."
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 #, fuzzy
 #| msgid "Channel named {channel_name} already exists"
 msgid "Email address already in use"
 msgstr "منظمة باسم {channel_name} بالفعل موجودة"
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr "فشل في تغيير المالك ، لا يوجد مثل هذا المستخدم"
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr "فشل في تغيير المالك، تم تعطيل المستخدم"
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr "فشل في تغيير المالك، لا تستطيع الروبوتات امتلاك روبوتات أخرى"
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
@@ -8317,291 +7719,291 @@ msgstr ""
 "لا يمكن إنشاء روبوتات حتى يتم تكوين FAKE_EMAIL_DOMAIN بشكل صحيح.\n"
 " يرجى الاتصال بمسؤول الخادم الخاص بك."
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr "لم يتم تمكين الروبوتات المضمنة."
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr "اسم الروبوت المضمن غير صالح."
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr ""
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr "البريد الإلكتروني '{email}' غير مسموح به في هذه المنظمة"
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr "عناوين البريد الإلكتروني المؤقتة غير مسموح بها في هذه المنظمة"
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom access token"
 msgid "Invalid {provider_name} access token"
 msgstr "رمز وصول لـ Zoom غير صالح"
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} call"
 msgstr "فشل إنشاء مكالمة Zoom"
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Zoom credentials have not been configured"
 msgid "{provider_name} credentials have not been configured"
 msgstr "لم يتم تكوين بيانات اعتماد Zoom"
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom credentials"
 msgid "Invalid {provider_name} credentials"
 msgstr "بيانات اعتماد Zoom غير صالحة"
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error connecting to the BigBlueButton server."
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr "خطأ في الاتصال بخادم BigBlueButton."
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error authenticating to the BigBlueButton server."
 msgid "Error authenticating to the {provider_name} server"
 msgstr "خطأ في المصادقة مع خادم BigBlueButton."
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "BigBlueButton server returned an unexpected error."
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr "أرجع خادم BigBlueButton خطأ غير متوقع."
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom session identifier"
 msgid "Invalid {provider_name} session identifier"
 msgstr "معرّف جلسة Zoom غير صالح"
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr ""
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} public room."
 msgstr "فشل إنشاء مكالمة Zoom"
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr "توقيع غير صالح."
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{full_name}'s Zulip room"
 msgstr "ذكرك {full_name}:"
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr "حمولة غير صالحة"
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr "طلب ويب هوك غير معروف"
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr "الموضوع لا يمكن أن يكون فارغًا"
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr "المحتوى لا يمكن أن يكون فارغًا"
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr ""
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr "إدخال JSON تالف"
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr ""
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr "خطأ: إعداد channel_map_to_topics بخلاف 0 أو 1"
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr ""
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
 "({export_settings_link})."
 msgstr ""
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr ""
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr ""
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr ""
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr ""
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr "المجال الفرعي غير صالح لحارس إرسال الإشعارات"
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr "يجب التحقق من الصحة باستخدام مفتاح API لخادم \"زوليب\" صالح"
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr "UUID غير صالح"
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr "نوع الرمز غير صالح"
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr ""
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr ""
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr ""
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr ""
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
 "try again later or reach out to {support_email} for assistance."
 msgstr ""
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr ""
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr ""
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr "ios_app_id مفقود"
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr "user_id أو user_uuid مفقود"
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
 "server: {reason}"
 msgstr ""
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr ""
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr ""
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr ""
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr "البيانات خارج الترتيب."
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr ""
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr ""
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr "تحتاج إلى إعادة تعيين كلمة المرور الخاصة بك."
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr "إعداد id_token مفقود"
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 #, fuzzy
 #| msgid "Missing id_token parameter"
 msgid "Missing idp param"
 msgstr "إعداد id_token مفقود"
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr "OTP غير صحيح"
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr "لا يمكن استخدام كل من mobile_flow_otp و desktop_flow_otp معًا."
 

--- a/locale/be/LC_MESSAGES/django.po
+++ b/locale/be/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 18:57+0000\n"
 "Last-Translator: Alex Vandiver <alexmv@zulip.com>\n"
 "Language-Team: Belarusian <https://hosted.weblate.org/projects/zulip/django/"
@@ -22,54 +22,54 @@ msgstr ""
 "(n%100>=11 && n%100<=14)? 2 : 3);\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "Не дазваляецца гасцявым карыстальнікам"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "Няправільная арганізацыя"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr "Публічны канал"
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr "Прыватныя каналы"
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr "Асабістыя паведамленні"
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr "Групавыя асабістыя паведамленні"
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr "Не знойдзены канал для дыяграмы: {chart_name}"
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr "Невядомая назва дыяграмы: {chart_name}"
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr ""
 "Стартавы час павінен быць пазней за канчатковы час. Старт: {start}, Канец: "
 "{end}"
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr ""
 "Няма даступных дадзеных аналітыкі. Калі ласка, звяжыцеся з адміністратарам "
 "сервера."
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -83,7 +83,7 @@ msgstr ""
 "({deactivate_user_help_page_link}), каб дазволіць новым карыстальнікам "
 "далучыцца."
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -95,7 +95,7 @@ msgstr ""
 "карыстальнікаў]({deactivate_user_help_page_link}), каб дазволіць больш чым "
 "аднаму карыстальніку далучыцца."
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -107,7 +107,7 @@ msgstr ""
 "неактыўных карыстальнікаў]({deactivate_user_help_page_link}), каб дазволіць "
 "больш за двух карыстальнікаў далучыцца."
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -119,7 +119,7 @@ msgstr ""
 "неактыўных карыстальнікаў]({deactivate_user_help_page_link}), каб дазволіць "
 "больш за тры карыстальнікам далучыцца."
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -128,28 +128,27 @@ msgid ""
 "({billing_page_link}) is greater than the current number of users."
 msgstr ""
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr ""
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr "Рэгістрацыя адключана"
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr "Няправільны удалены сервер."
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
@@ -158,7 +157,7 @@ msgstr ""
 "Вам неабходна набыць ліцэнзіі для ўсіх актыўных карыстальнікаў у вашай "
 "арганізацыі (мінімум {min_licenses})."
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
@@ -167,64 +166,64 @@ msgstr ""
 "Рахункі з больш чым {max_licenses} ліцэнзіямі не могуць быць апрацаваныя з "
 "гэтай старонкі. Каб завяршыць абнаўленне, калі ласка, звяжыцеся з {email}."
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr "Няма спосабу аплаты ў файле."
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr "{brand} заканчваецца на {last4}"
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr "Невядомы спосаб аплаты. Калі ласка, звяжыцеся па {email}."
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr "Нешта пайшло не так. Калі ласка, звяжыцеся з {email}."
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "Нешта пайшло не так. Калі ласка, перазагрузіце старонку."
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr ""
 "Нешта пайшло не так. Калі ласка, пачакайце некалькі секунд і паспрабуйце "
 "зноў."
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 "Калі ласка, дадайце крэдытную карту перад пачаткам бясплатнага прабнага "
 "перыяду."
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr "Дадайце крэдытную карту, каб запланаваць паляпшэнне."
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
 msgstr ""
 "Немагчыма абнаўленне плану. План скончыўся і быў заменены новым планам."
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr "Немагчыма абнавіць план. План скончыўся."
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 "Немагчыма абнавіць ліцэнзіі ў дзейным білінгавым перыядзе для бясплатнага "
 "спробнага плану."
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
@@ -232,57 +231,57 @@ msgstr ""
 "Немажліва абнаўляць ліцэнзіі ўручную. Ваш план знаходзіцца на аўтаматычным "
 "кіраванні ліцэнзіямі."
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
 msgstr ""
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
 "licenses."
 msgstr ""
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
 "billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr ""
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr ""
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr ""
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -292,100 +291,97 @@ msgid ""
 "we would really appreciate it!"
 msgstr ""
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
 "{support_email}"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr ""
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "Памылка"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr ""
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
 "%(support_email)s\">contact support</a>."
 msgstr ""
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr ""
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
 msgstr ""
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr ""
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
 msgstr ""
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr ""
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr ""
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
 msgstr ""
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -393,289 +389,270 @@ msgid ""
 "a> with any questions."
 msgstr ""
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
 "a> for support."
 msgstr ""
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
 "href=\"%(troubleshooting_url)s\">Zulip server troubleshooting guide</a>."
 msgstr ""
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr ""
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr ""
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr ""
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr ""
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr ""
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr ""
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr ""
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr ""
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr ""
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr ""
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr ""
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr ""
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr ""
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr ""
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr ""
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "Я"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr ""
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "Мінулы тыдзень"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "Мінулы месяц"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "Мінулы год"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "Увесь час"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr ""
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr ""
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr ""
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr ""
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr ""
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr ""
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr ""
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr ""
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr ""
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
 "%(old_email_html_tag)s to %(new_email_html_tag)s"
 msgstr ""
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr ""
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
 msgstr ""
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "Скасаваць"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr ""
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr ""
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -686,19 +663,19 @@ msgid ""
 "server."
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -706,788 +683,297 @@ msgid ""
 "%(support_email)s'>contact support</a> with any questions."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, python-format
 msgid "You can try again in %(retry_after_string)s."
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr ""
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr ""
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr ""
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr ""
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr ""
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr ""
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr ""
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr ""
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr ""
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr ""
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr ""
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr ""
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr ""
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr ""
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 msgid "Zulip for open source"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 msgid "Message with code"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr "Паведамлення"
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
 msgstr ""
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 msgid "Get started"
 msgstr ""
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
 "continue."
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "Электронная пошта"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1495,78 +981,77 @@ msgid ""
 "from Zulip."
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
 msgstr ""
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr ""
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr ""
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr ""
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr ""
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr ""
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr ""
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr ""
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
 msgstr ""
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1574,212 +1059,205 @@ msgid ""
 "href=\"%(doc_url)s\">documentation</a>."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, python-format
 msgid "No account found for %(email)s."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Create a new organization"
 msgid "Try Zulip in a demo organization"
 msgstr "Стварыць новую арганізацыю"
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 msgid "Try Zulip"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "Стварыць новую арганізацыю"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr "Ваша электронная пошта"
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 #, fuzzy
 #| msgid "Private, shared history"
 msgid "Import chat history?"
 msgstr "Прыватная, агульная гісторыя"
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "URL арганізацыі"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "OR"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "Уваход"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1787,123 +1265,122 @@ msgid ""
 "noreferrer\">after you join</a>."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "Змяніць"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "Пароль"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr ""
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">Terms of Service</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr ""
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr ""
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -1911,47 +1388,47 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 msgid ""
 "This organization has been deactivated, and all organization data has been "
 "deleted."
 msgstr ""
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
 "inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
 "administrators</a> to inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "Registration is deactivated"
 msgid "This organization has been deactivated."
 msgstr "Рэгістрацыя адключана"
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
 "%(support_email)s\">contact Zulip support</a> to reactivate it."
 msgstr ""
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -1959,165 +1436,164 @@ msgid ""
 "reactivate it."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "Капіяваць"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "Закрыць"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr ""
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr ""
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
 "<b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
 "href=\"%(apps_page_link)s\">mobile and desktop</a> apps:"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
 "href=\"%(getting_user_started_link)s\">getting started guide</a>!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2125,83 +1601,83 @@ msgid ""
 "Zulip</a>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
 "to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
 "desktop apps (%(apps_page_link)s):"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
 "(%(getting_user_started_link)s)!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
 "(%(getting_organization_started_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2209,32 +1685,32 @@ msgid ""
 "password for this account, please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "%(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 msgid "Verify your email address for your Zulip demo organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "<%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2242,113 +1718,113 @@ msgid ""
 "please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
 "— we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
 "deactivated, and you will no longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr ""
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2356,22 +1832,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because your organization <a "
@@ -2379,8 +1855,8 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to <a "
@@ -2388,39 +1864,39 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr ""
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because your organization hides "
@@ -2428,81 +1904,74 @@ msgid ""
 "details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to hide "
 "message content in email notifications. See %(help_url)s for more details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr ""
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
 "organizations:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
 "organizations hosted by %(external_host)s:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
 "href=\"%(help_reset_password_link)s\">reset your password</a>."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
 "%(external_host)s."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2510,97 +1979,94 @@ msgid ""
 "to find your account."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
 "try another way to find your account (%(help_logging_in_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
 "communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr ""
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
 "-- the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
 "Zulip &mdash; the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
 "to ask %(referrer_name)s for another one."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2608,72 +2074,70 @@ msgid ""
 "productivity."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at <a href=\"mailto:%(email)s\">%(email)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
 "%(email)s\">Contact us</a> — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
 "#%(channel_name)s > %(topic_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2681,68 +2145,68 @@ msgid ""
 "preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails (<a href=\"%(url)s\">help</a>)."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2750,22 +2214,22 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2773,52 +2237,52 @@ msgid ""
 "immediately at <%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2826,31 +2290,31 @@ msgid ""
 "contact us immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2858,7 +2322,7 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -2866,25 +2330,25 @@ msgid ""
 "Zulip</a> to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
 "with you and share their unique perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -2892,7 +2356,7 @@ msgid ""
 "experience how a new chat app will help your team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -2900,148 +2364,148 @@ msgid ""
 "action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
 "team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
 "organizations like yours!"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3049,11 +2513,11 @@ msgid ""
 "about…?”"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3062,23 +2526,23 @@ msgid ""
 "href=\"%(move_channels_link)s\">move a topic to a different channel</a>."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3087,23 +2551,23 @@ msgid ""
 "(%(move_channels_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
 "%(email)s on %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3111,46 +2575,46 @@ msgid ""
 "href=\"%(help_link)s\">reactivate your account</a>."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
 "You can contact an organization administrator to reactivate your account."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3158,541 +2622,537 @@ msgid ""
 "have been voided."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
 "to %(upgrade_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip demo organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip demo organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Create a new organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "Стварыць новую арганізацыю"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for <b>%(remote_server_hostname)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 msgid "Click the button below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for %(remote_server_hostname)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
 "management for <b>%(remote_realm_host)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
 "management for %(remote_realm_host)s."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the <a href=\"%(plans_link)s\">Zulip Community plan</a>."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
 "website</a>, we would really appreciate it!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
 msgstr ""
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
 "accounts for another email address</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr ""
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "Знайсці ўліковыя запісы"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr ""
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr ""
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr ""
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 msgid "Zulip Cloud"
 msgstr ""
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr ""
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr ""
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr ""
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr ""
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr ""
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr ""
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr ""
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr ""
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr ""
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr ""
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr ""
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr ""
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr ""
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr ""
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr ""
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr ""
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr ""
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr ""
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr ""
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr ""
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr ""
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr ""
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr ""
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr ""
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr ""
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr ""
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "Гісторыя"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr ""
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr ""
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr ""
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr ""
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr ""
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 msgid "Bluesky"
 msgstr ""
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr ""
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr ""
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr ""
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 msgid ""
 "And hundreds more through <a href=\"/integrations/zapier\">Zapier</a> and <a "
 "href=\"/integrations/ifttt\">IFTTT</a>."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3700,7 +3160,7 @@ msgid ""
 "emails with your email domain."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3708,7 +3168,7 @@ msgid ""
 "disposable email addresses."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3716,24 +3176,24 @@ msgid ""
 "emails that contain \"+\"."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3741,7 +3201,7 @@ msgid ""
 "%(support_email)s\">contact Zulip support</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3749,89 +3209,89 @@ msgid ""
 "%(support_email)s\">contact this Zulip server's administrators</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
 "management for your Zulip server."
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr ""
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr ""
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr ""
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "Імя карыстальніка"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr ""
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr ""
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr ""
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> because all Zulip Cloud licenses are in use."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -3840,44 +3300,42 @@ msgid ""
 "or misconfiguration."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 #, fuzzy
 #| msgid "Registration is deactivated"
 msgid "Demo organizations disabled"
 msgstr "Рэгістрацыя адключана"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -3885,22 +3343,21 @@ msgid ""
 "organization for more information."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -3908,46 +3365,44 @@ msgid ""
 "Zulip support</a> for assistance in resolving this issue."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
 "a> like Firefox, Chrome, and Edge."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Invalid organization"
 msgid "Finalize organization import"
 msgstr "Няправільная арганізацыя"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 msgid "Organization import completed!"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -3955,54 +3410,53 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 msgid "Select your account"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create a new organization"
 msgid "Create new account"
 msgstr "Стварыць новую арганізацыю"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr ""
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4010,81 +3464,81 @@ msgid ""
 "have one yet."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 msgid "Self-hosting Zulip?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">log in to manage plans and billing.</a>"
 msgstr ""
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr ""
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
 msgstr ""
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr ""
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr ""
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr ""
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr ""
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr ""
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4092,7 +3546,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4101,57 +3555,57 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr ""
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4159,7 +3613,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4167,40 +3621,40 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4208,300 +3662,294 @@ msgid ""
 "away!"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
 "href=\"%(realm_url)s/#settings/notifications\">notification settings</a>."
 msgstr ""
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr ""
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr ""
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr ""
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr ""
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr ""
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr ""
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr ""
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 msgid "Cannot reactivate a deleted user"
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr ""
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr ""
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr ""
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr ""
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
 msgstr ""
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
 msgstr ""
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr ""
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr ""
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr ""
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr ""
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr ""
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr ""
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr ""
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr ""
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr ""
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr ""
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
 "{new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
 "{user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to resolve topics in this channel."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr ""
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr ""
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr ""
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr ""
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr ""
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
 "but there is no channel with that ID."
 msgstr ""
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4509,36 +3957,36 @@ msgid ""
 "it."
 msgstr ""
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
 "The channel exists but does not have any subscribers."
 msgstr ""
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr ""
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr ""
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr ""
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4546,107 +3994,105 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
 "authentication method."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr ""
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 msgid "Reminder could not be sent."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
 "the following error:"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr ""
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr ""
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr ""
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr ""
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr ""
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
 "**{old_policy}** to **{new_policy}**."
 msgstr ""
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -4655,51 +4101,49 @@ msgid ""
 "* **New**: {new_setting_description}\n"
 msgstr ""
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr ""
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr ""
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr ""
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr ""
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr ""
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr ""
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 msgstr ""
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr ""
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -4710,283 +4154,269 @@ msgid ""
 "{summary_line}"
 msgstr ""
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr ""
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr ""
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr ""
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr ""
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr ""
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr ""
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr ""
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr ""
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr ""
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr ""
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr ""
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
 "organization administrator to reactivate it."
 msgstr ""
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr ""
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr ""
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr ""
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr ""
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr ""
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr ""
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr ""
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
 "to register for accounts in this organization."
 msgstr ""
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr ""
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 msgid "Challenges are not enabled."
 msgstr ""
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr ""
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr ""
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "You're making too many attempts to sign in. Try again in "
 "{retry_after_string} or contact your organization administrator for help."
 msgstr ""
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
 msgstr ""
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr ""
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr ""
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr ""
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr ""
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr ""
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr ""
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr ""
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr ""
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr ""
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr ""
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr ""
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name can't be empty."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 msgid "Invalid channel folder ID"
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 msgid "Configure owner account email address."
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4995,69 +4425,69 @@ msgid ""
 "organization]({convert_demo}).\n"
 msgstr ""
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, python-brace-format
 msgid "{var_name} is not Base64 encoded"
 msgstr ""
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 msgid "Invalid `device_id`"
 msgstr ""
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr ""
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr ""
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr ""
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr ""
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr ""
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr ""
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr ""
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr ""
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr ""
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr ""
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5065,607 +4495,605 @@ msgid ""
 "{error_message}"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr ""
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr ""
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr ""
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr ""
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr ""
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr ""
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr ""
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr ""
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr ""
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr ""
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr ""
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr ""
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr ""
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
 msgstr ""
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr ""
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr ""
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr ""
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr ""
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr ""
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr ""
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr ""
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr ""
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 msgid "Must be a bot user"
 msgstr ""
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr ""
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr ""
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr ""
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
 "webhook; ignoring"
 msgstr ""
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr ""
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr ""
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr ""
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr ""
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} most recent messages in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr ""
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr ""
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
 msgstr ""
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr ""
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr ""
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr ""
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr ""
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr ""
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Find accounts"
 msgid "Atlassian account ID"
 msgstr "Знайсці ўліковыя запісы"
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 msgid "Behance username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 msgid "Bitbucket username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 msgid "Codeberg username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 msgid "Dribbble username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 msgid "Facebook username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "GitLab username"
 msgstr "Імя карыстальніка"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 msgid "Instagram username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 msgid "Mastodon profile"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "Medium username"
 msgstr "Імя карыстальніка"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 msgid "Pinterest username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "Reddit username"
 msgstr "Імя карыстальніка"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 msgid "Snapchat username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 msgid "Threads username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "TikTok username"
 msgstr "Імя карыстальніка"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "Twitch username"
 msgstr "Імя карыстальніка"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "Імя карыстальніка"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr ""
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr ""
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 msgid "Video calling"
 msgstr ""
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr ""
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr ""
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr ""
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr ""
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr ""
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr ""
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr ""
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr ""
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr ""
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr ""
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr ""
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr ""
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr ""
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr ""
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "{fullname} moderation"
 msgstr ""
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr ""
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr ""
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor_date' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr ""
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 msgid "Navigation view does not exist."
 msgstr ""
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5673,7 +5101,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5681,7 +5109,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5689,7 +5117,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5697,7 +5125,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5707,14 +5135,14 @@ msgid ""
 "a permanent organization]({convert_demo_organization_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
 "them in your [Inbox](/#inbox).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5722,7 +5150,7 @@ msgid ""
 "({navigation_tour_video_url}) for a quick app overview.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5737,14 +5165,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -5752,7 +5180,7 @@ msgid ""
 "and edit your [profile information](/help/edit-your-profile).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -5763,7 +5191,7 @@ msgid ""
 "experience in your [Preferences](#settings/preferences).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5774,7 +5202,7 @@ msgid ""
 "[Browse and subscribe to channels]({settings_link}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -5791,7 +5219,7 @@ msgid ""
 "discussed.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -5800,7 +5228,7 @@ msgid ""
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -5812,7 +5240,7 @@ msgid ""
 "times, and more.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5822,7 +5250,7 @@ msgid ""
 "or browse the [help center](/help/) to learn more!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5830,7 +5258,7 @@ msgid ""
 "get help, try one of the following messages: {bot_commands}\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5842,13 +5270,13 @@ msgid ""
 "({move_content_another_channel_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5862,12 +5290,11 @@ msgid ""
 "and above.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr ""
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -5875,14 +5302,14 @@ msgid ""
 "no matter how many other conversations are going on.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
 "conversations with unread messages.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -5890,7 +5317,7 @@ msgid ""
 "the `+` button next to its name.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -5898,13 +5325,13 @@ msgid ""
 "can we chat about…?”\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5912,7 +5339,7 @@ msgid ""
 "({format_message_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5932,125 +5359,125 @@ msgid ""
 "```\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
 "teammates.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
 "conversation.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr ""
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr ""
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr ""
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr ""
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 msgid "Invalid `push_key`"
 msgstr ""
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
@@ -6059,1199 +5486,1176 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr ""
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr ""
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr ""
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 msgid "Reminder does not exist"
 msgstr ""
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr ""
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr ""
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr ""
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr ""
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr ""
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr ""
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr ""
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr ""
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 msgid "You do not have permission to create new topics in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr ""
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr ""
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr ""
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr ""
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr ""
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr ""
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} does not have the expected format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr ""
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr ""
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr ""
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {user_group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr ""
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr ""
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr ""
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr ""
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr ""
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 msgid "Name must not be empty!"
 msgstr ""
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr ""
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr ""
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr ""
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr ""
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr ""
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr ""
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr ""
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr ""
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr ""
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr ""
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr ""
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr ""
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr ""
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr ""
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr ""
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr ""
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr ""
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr ""
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr ""
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr ""
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr ""
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr ""
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr ""
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr ""
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr ""
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr ""
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr ""
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr ""
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr ""
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr ""
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr ""
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr ""
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr ""
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr ""
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr ""
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr ""
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr ""
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: empty field name."
 msgstr ""
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr ""
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr ""
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 msgid "Example input does not match the linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in alternative URL template is not present in linkifier "
 "pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in linkifier pattern is not present in alternative URL "
 "template."
 msgstr ""
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr ""
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr ""
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr ""
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr ""
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr ""
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr ""
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr ""
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr ""
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr ""
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr ""
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr ""
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr ""
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr ""
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr "Прыватная, агульная гісторыя"
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr "Прыватная, абароненая гісторыя"
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr ""
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr ""
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr ""
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr ""
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr ""
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr ""
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr ""
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr "Мадэратар"
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "Удзельнік"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "Госць"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr ""
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr ""
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr ""
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr ""
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 msgid "Failed to generate challenge"
 msgstr ""
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr ""
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr ""
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr ""
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr ""
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr ""
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr ""
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for use for user matching."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr ""
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr ""
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr ""
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr ""
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr ""
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr ""
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr ""
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr ""
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 #, fuzzy
 #| msgid "Registration is deactivated"
 msgid "Invitation already used or deactivated."
 msgstr "Рэгістрацыя адключана"
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr ""
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr ""
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr ""
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
 msgstr ""
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr ""
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr ""
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr ""
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr ""
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr ""
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr ""
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr ""
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr ""
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 msgid "Message reporting is not enabled in this organization."
 msgstr ""
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr ""
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr ""
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr ""
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr ""
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr ""
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr ""
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr ""
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr ""
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr ""
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 msgid "Navigation view already exists."
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7259,561 +6663,559 @@ msgid ""
 "later. Is this a good time?\n"
 msgstr ""
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr ""
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr ""
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 msgid "You do not have permission to manage plans and billing."
 msgstr ""
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr ""
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr ""
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr ""
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr ""
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr ""
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr ""
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr ""
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr ""
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr ""
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr ""
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr ""
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr ""
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr ""
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr ""
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr ""
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr ""
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr ""
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr ""
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr ""
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Invalid character in language: {character}"
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Language '{language}' is not allowed."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr ""
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr ""
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "Direct messages"
 msgid "Importing messages…"
 msgstr "Асабістыя паведамленні"
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "Your email"
 msgid "Your name"
 msgstr "Ваша электронная пошта"
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr ""
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr ""
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr ""
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr ""
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr ""
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr "Няправільныя параметры"
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr ""
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr ""
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr ""
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr ""
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr ""
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr ""
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr ""
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
 "**"
 msgstr ""
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr ""
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr ""
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr ""
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr ""
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr ""
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr ""
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr ""
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr ""
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr ""
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr ""
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr ""
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr ""
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr ""
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 msgstr ""
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr ""
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr ""
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
 "subgroups."
 msgstr ""
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr ""
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr ""
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr ""
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr ""
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr ""
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr ""
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr ""
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr ""
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr ""
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr ""
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 msgid "User is not allowed to delete other user's messages."
 msgstr ""
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr ""
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr ""
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "No analytics data available. Please contact your server administrator."
@@ -7824,300 +7226,300 @@ msgstr ""
 "Няма даступных дадзеных аналітыкі. Калі ласка, звяжыцеся з адміністратарам "
 "сервера."
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 msgid "Email address already in use"
 msgstr ""
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr ""
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr ""
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr ""
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 msgstr ""
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr ""
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr ""
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr ""
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr ""
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr ""
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} access token"
 msgstr ""
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} call"
 msgstr ""
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} credentials have not been configured"
 msgstr ""
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} credentials"
 msgstr ""
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr ""
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error authenticating to the {provider_name} server"
 msgstr ""
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr ""
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} session identifier"
 msgstr ""
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr ""
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} public room."
 msgstr ""
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr ""
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{full_name}'s Zulip room"
 msgstr ""
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr ""
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr ""
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr ""
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr ""
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr ""
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr ""
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr ""
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr ""
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr ""
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
 "({export_settings_link})."
 msgstr ""
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr ""
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr ""
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr ""
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr ""
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr ""
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr ""
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr ""
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr ""
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr ""
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr ""
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr ""
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr ""
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
 "try again later or reach out to {support_email} for assistance."
 msgstr ""
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr ""
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr ""
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr ""
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr ""
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
 "server: {reason}"
 msgstr ""
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr ""
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr ""
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr ""
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr ""
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr ""
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr ""
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr ""
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr ""
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 msgid "Missing idp param"
 msgstr ""
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr ""
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr ""

--- a/locale/bg/LC_MESSAGES/django.po
+++ b/locale/bg/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 19:38+0000\n"
 "Last-Translator: Alex Vandiver <alexmv@zulip.com>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/zulip/django/"
@@ -23,52 +23,52 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "Не е позволено за потребители без акаунт"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "Невалидна организация"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr "Публични канали"
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr "Затворени канали"
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr "Лични съобщения"
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr "Групови лични съобщения"
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr "Липсва канал за диаграма: {chart_name}"
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr "Неизвестно име на диаграма: {chart_name}"
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr "Началното време е по-късно от крайното. Начало: {start}, Край: {end}"
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr ""
 "Няма налични данни за анализ. Моля свържете се с вашия администратор на "
 "сървъра."
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -81,7 +81,7 @@ msgstr ""
 "[деактивирайте неактивните потребители]({deactivate_user_help_page_link}), "
 "за да позволите на нови потребители да се присъединят."
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -93,7 +93,7 @@ msgstr ""
 "неактивните потребители]({deactivate_user_help_page_link}), за да могат да "
 "се присъединят повече от един членове."
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -105,7 +105,7 @@ msgstr ""
 "неактивните потребители]({deactivate_user_help_page_link}), за да могат да "
 "се присъединят повече от двама членове."
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -117,7 +117,7 @@ msgstr ""
 "неактивните потребители]({deactivate_user_help_page_link}), за да могат да "
 "се присъединят повече от трима членове."
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -126,28 +126,27 @@ msgid ""
 "({billing_page_link}) is greater than the current number of users."
 msgstr ""
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr ""
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr "Регистрацията е деактивирана"
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr "Невалиден отдалечен сървър."
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
@@ -156,7 +155,7 @@ msgstr ""
 "Трябва да закупите лицензи за всички активни потребители във вашата "
 "организация (минимум {min_licenses})."
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
@@ -166,60 +165,60 @@ msgstr ""
 "тази страница. За да завършите надграждането на плана, моля, свържете се с "
 "{email}."
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr "Във файла липсва метод на плащане."
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr "{brand}, завършваща на {last4}"
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr "Неизвестен начин на плащане. Моля, свържете се с {email}."
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr "Нещо се обърка. Моля, свържете се с {email}."
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "Възникна грешка. Моля рестартирайте страницата."
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr "Възникна грешка. Моля изчакайте няколко секунди и опитайте отново."
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 "Моля, добавете кредитна карта, преди да започнете безплатната пробна версия."
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr "Моля, добавете кредитна карта, за да планирате надграждане."
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
 msgstr "Надграждането на плана е неуспешно. Плана е изтекъл и е заменен с нов."
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr "Актуализирането на плана е неуспешно. Планът е прекратен."
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 "Не можете да актуализирате лицензи в текущия период на таксуване за "
 "безплатния пробен план."
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
@@ -227,18 +226,18 @@ msgstr ""
 "Ръчното актуализиране на лизенците е неуспешно. Вашият план е на автоматично "
 "лизензно управление."
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr ""
 "Вашият план вече е на {licenses} лиценза в текущия период на таксуване."
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr "Не можете да намалите броя на лицензите в текущия период на таксуване."
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
@@ -246,7 +245,7 @@ msgstr ""
 "Не можете да промените лицензите на следващия цикъл на таксуване на план, "
 "който е в процес на понижаване."
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
@@ -255,34 +254,34 @@ msgstr ""
 "Вашият план вече е планиран за подновяване с {licenses_at_next_renewal} "
 "лицензи."
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
 "billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr "Няма нищо за променяне."
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr "Няма клиент за тази организация!"
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr "Сесията не е открита"
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr "Сесията за таксуване не е открита"
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr ""
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -297,58 +296,56 @@ msgstr ""
 "Ще ви бъдем много благодарни ако можете да {begin_link}добавите Zulip като "
 "спонсор във вашия уебсайт{end_link}!"
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr "Тоукънът за достъп до таксуването е изтекъл."
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr "Невалиден тоукън за достъп до таксуването."
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
 "{support_email}"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr "Потребителския акаунт все още не съществува."
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr "За да продължите, трябва да приемете Условията за ползване."
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr "Регистрацията на вашия сървър е деактивирана."
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "Грешка"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr "Страницата не е намерена (404)"
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, fuzzy, python-format
 #| msgid ""
 #| "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd "
@@ -360,42 +357,41 @@ msgstr ""
 "Имате въпроси? <a href=\"mailto:%(support_email)s\">Свържете се с нас</a>  — "
 "ще се радваме да ви помогнем!"
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr ""
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
 msgstr ""
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr ""
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
 msgstr ""
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr "Методът не е разрешен (405)"
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr "Грешка на вътрешния сървър"
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
 msgstr ""
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -403,13 +399,13 @@ msgid ""
 "a> with any questions."
 msgstr ""
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, fuzzy, python-format
 #| msgid ""
 #| "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd "
@@ -421,144 +417,142 @@ msgstr ""
 "Имате въпроси? <a href=\"mailto:%(support_email)s\">Свържете се с нас</a>  — "
 "ще се радваме да ви помогнем!"
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
 "href=\"%(troubleshooting_url)s\">Zulip server troubleshooting guide</a>."
 msgstr ""
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr "Анализ на %(target_name)s | Zulip"
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 "Анализите са напълно достъпни 24 часа след създаването на организацията."
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr "Zulip анализ на %(target_name)s"
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr "Резюме на организацията"
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr "Брой потребители"
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr "Потребители, активни през последните 15 дни"
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr "Брой потребители без акаунт"
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr "Общ брой съобщения"
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr "Брой съобщения през последните 30 дни"
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr "Използвано хранилище за файлове"
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "Активни потребители"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr "Ежедневно активни"
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr "Активни в последните 15 дни"
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr "Общо потребители"
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "Потребители"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr "Изпратени съобщения по тип получател"
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "Аз"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "Всички"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "Последна седмица"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "Последен месец"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "Последна година"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "Всичко"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr "Съобщения изпратени през времето"
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "Дневен"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "Седмичен"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr "Натрупан"
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "Хора"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "Ботове"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr "Съобщения прочетени през времето"
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr "Съобщения изпратени от клиент"
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr "Последно обновяване"
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
@@ -566,15 +560,15 @@ msgstr ""
 "Пълно обновяване на всички диаграми се извършва веднъж дневно. Диаграмата "
 "\"съобщения изпратени през времето\" се обновява веднъж на час."
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr "Имейлът е променен"
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr "Е-пощата е променена!"
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
@@ -583,49 +577,49 @@ msgstr ""
 "Това е потвърждение, че имейл адресът на вашия Zulip акаунт е променен от "
 "%(old_email_html_tag)s на %(new_email_html_tag)s"
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr "Потвърждаване на вашия имейл адрес"
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr "Адреса за потвърждаване не съществува"
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr ""
 "Възникна грешка. Не успяхме да намерим линка за потвърждение в системата."
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr "Адреса за потвърждение е изтекъл или е деактивиран"
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr "Линка за потвърждение е изтекъл или е бил деактивиран."
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr "Моля, свържете се с администратора на вашата организация за нов линк."
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr "Адресът за потвърждение е повреден"
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr "Упс. Адресът за потвърждение е повреден."
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
@@ -633,72 +627,55 @@ msgstr ""
 "Уверете се, че сте копирали правилно уеб връзката в браузъра си. Ако все още "
 "се сблъсквате с тази страница, това вероятно е наша грешка. Съжаляваме."
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr "Таксуване"
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr "Затвори прозореца"
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr "Откажи"
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr "Понижи"
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "Откажи"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr "Потвърди"
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr "Отмяна на надграждането"
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr "Статус на таксуване"
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr "Деактивиране на регистрация на сървър?"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr "Управлението на плана не е достъпно"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -709,19 +686,19 @@ msgid ""
 "server."
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -729,736 +706,246 @@ msgid ""
 "%(support_email)s'>contact support</a> with any questions."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, fuzzy, python-format
 #| msgid "You can try again in %(retry_after)s seconds."
 msgid "You can try again in %(retry_after_string)s."
 msgstr "Може да опитате отново след %(retry_after)s секунди."
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr "Надгради"
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr ""
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr "Отвори директорията с общности"
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr "Филтиране по категории"
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "Всички"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr "Категории"
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr "Неограничено"
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr "Поддържан"
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr "Самостоятелно управление"
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr "За организации с до 10 потребителя"
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr "Не е налично"
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr "Общността за разработка на Zulip"
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr "Присъединете се като потребител"
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr "Присъединете се като самостоятелен хостър"
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr "Присъединете се като сътрудник"
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "Създай организация"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr ""
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr "Самостоятелен хостинг на Zulip"
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr "Запитване за спонсорство"
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr "Цени за обучение"
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr "Цени"
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr "Zulip за бизнеси"
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Zulip guide for open-source projects"
 msgid "Zulip for open source"
 msgstr "Ръководството на Zulip за проекти с отворен код"
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Create your Zulip organization"
 msgid "Screenshot of Zulip conversation"
 msgstr "Създайте своята Zulip организация"
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Messages sent over time"
 msgid "Message with code"
 msgstr "Съобщения изпратени през времето"
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr "Свържи"
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr "Свържете се с поддръжката"
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr "От"
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr "Организация"
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr "Тема"
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr "Съобщение"
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr "Изпрати"
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr "Благодарим ви, че се свързахте с нас"
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr "Благодарим ви, че се свързахте с нас!"
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr "Скоро ще се свържем с вас."
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
@@ -1466,11 +953,11 @@ msgstr ""
 "Можете да намерите отговори на често задавани въпроси в нашия <a href=\"/"
 "help/\">Помощен център</a>."
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 msgid "Get started"
 msgstr ""
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
@@ -1480,49 +967,48 @@ msgstr ""
 "href=\"https://zulip.com/policies/terms\">Условията за ползване на Zulip</a> "
 "за да продължите."
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr "Или пък използвайте някой от резервните си телефони:"
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr "В краен случай можете да използвате резервен токен:"
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr "Използвай резервния тоукън"
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr "Съгласете се с Условията за Ползване"
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr "Добре дошли в Zulip"
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "Е-поща"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr "Абонирай ме за Zulip бюлетина с нисък трафик (няколко имейла годишно)."
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr "Продължи"
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr "Потвърдете вашия имейл адрес"
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1533,7 +1019,7 @@ msgstr ""
 "class=\"user_email semi-bold\">%(email)s</span>) за имейл за потвърждение от "
 "Zulip."
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
@@ -1541,30 +1027,30 @@ msgstr ""
 "Ако не намирате имейла за потвърждение във вашите кутия или спам папка ние "
 "можем да го <a href=\"#\" id=\"resend_email_link\">изпратим отново</a>."
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr ""
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
@@ -1572,39 +1058,38 @@ msgstr ""
 "Ако това съобщение не изчезне, опитайте да <a class=\"reload-"
 "lnk\">рестартирате</a>страницата."
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 "Грешка при зареждането на Zulip. Опитайте да <a class=\"reload-"
 "lnk\">презаредите</a> страницата."
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr "Няма разговори, които да отговарят на текущия ви филтър."
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr "Тази визия все още зарежда съобщения."
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr "Зареди още"
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr "Видео разговора завърши"
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr "Може да затворите този прозорец."
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr ""
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
@@ -1613,7 +1098,7 @@ msgstr ""
 "използвайте EmailAuthBackend за да създадете организация, след което "
 "опитайте отново."
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1621,206 +1106,199 @@ msgid ""
 "href=\"%(doc_url)s\">documentation</a>."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr "Акаунта не е намерен"
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr "Zulip акаунта не е намерен."
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, fuzzy, python-format
 #| msgid "Your account email: %(email)s"
 msgid "No account found for %(email)s."
 msgstr "Имейл на вашия акаунт: %(email)s"
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr "Влезте с друг акаунт"
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr "Продължи към регистрация"
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Create your Zulip organization"
 msgid "Try Zulip in a demo organization"
 msgstr "Създайте своята Zulip организация"
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Try Zulip now"
 msgid "Try Zulip"
 msgstr "Пробвай Zulip сега"
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "Създайте нова организация"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr "Създайте нова Zulip организация"
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr "Въвдете вашия адрес за Е-поща"
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr "Вашия имейл"
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr "Тип организация"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr "Език на организацията"
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 #, fuzzy
 #| msgid "Private, shared history"
 msgid "Import chat history?"
 msgstr "Лична, споделена история"
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr "Име на организацията"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "Уеб адрес на Организация"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr "Изполвай %(external_host)s"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "ИЛИ"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "Регистрация"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "Регистрация със Zulip"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr "Необходима ви е покана за да се включите в тази организация."
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr "Регистритайте се с %(identity_provider)s"
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr "Вече имате акаунт?"
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "Вход"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr "Конфигуриране на имейл поверителността"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
 msgstr ""
 "Zulip ви дава контрол над това кои роли в организацията могат да виждат ваши."
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
@@ -1828,11 +1306,11 @@ msgstr ""
 "Искате ли да промените настройките за поверителност на имейла си вместо да "
 "използвате конфигурацията по подразбиране на тази организация?"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr "Кой има достъп до вашия имейл адрес"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1843,7 +1321,7 @@ msgstr ""
 "configure-email-visibility\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">след като влезете</a>."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
@@ -1851,7 +1329,7 @@ msgstr ""
 "Администраторите на тази Zulip организация ще могат да виждат този имейл "
 "адрес."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
@@ -1859,12 +1337,12 @@ msgstr ""
 "Този имейл адрес ще бъде видим от администраторите и модераторите на тази "
 "Zulip организация."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr "Никой в тази Zulip организация няма да може да види този имейл адрес."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
@@ -1872,80 +1350,79 @@ msgstr ""
 "Другите потребители в тази Zulip организация ше могат да виждат този имейл "
 "адрес."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "Промени"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr "Регистрация"
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr "Създайте свойта организация"
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr "Създайте своя акаунт"
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr "<p>Въведете данните на акаунта си, за да завършите регистрацията.</p>"
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr "Вашата организация"
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr "Вашия акаунт"
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr "Импортиране на настройките от съществуващ Zulip акаунт"
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "Име"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "Парола"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 "Това се използва за мобилни приложения и други инструменти които изискват "
 "парола."
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr "Сложност на парола"
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr ""
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
@@ -1954,22 +1431,22 @@ msgstr ""
 "Съгласен съм с <a href=\"%(root_domain_url)s/policies/terms\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">Условията за ползване</a>."
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr "Деактивирана организация"
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr ""
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -1977,47 +1454,47 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 msgid ""
 "This organization has been deactivated, and all organization data has been "
 "deleted."
 msgstr ""
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
 "inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
 "administrators</a> to inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "Your server registration has been deactivated."
 msgid "This organization has been deactivated."
 msgstr "Регистрацията на вашия сървър е деактивирана."
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
 "%(support_email)s\">contact Zulip support</a> to reactivate it."
 msgstr ""
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, fuzzy, python-format
 #| msgid ""
 #| "If you have any questions, please contact this Zulip server's "
@@ -2030,15 +1507,15 @@ msgstr ""
 "Ако имате въпроси, моля, свържете се с администраторите на този Zulip сървър "
 "на %(support_email)s."
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr "Завършете входа в десктоп приложението"
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
@@ -2046,93 +1523,92 @@ msgstr ""
 "Използвайте уеб браузъра си, за да завършите входа в системата, след което "
 "се върнете тук, за да поставите предоставения тоукън за вход."
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr "Поставете тоукъна тук"
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr "Завърши"
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr "Неправилен тоукън."
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr "Тоукъна е приет. Влизате в системата…"
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr "Вход в десктоп приложението"
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 "Копирайте този тоукън за вход и се върнете в Zulip приложението, за да "
 "завършите входа в системата:"
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "копие"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr "След това можете да затворите този прозорец."
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr "Или продължете в браузъра си."
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr "Анонимен потребител"
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr "Собственици"
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "Администратори"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr "Модератори"
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr "Потребители без акаунт"
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "Нормални потребители"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr "Препращане на имейли към имейл акаунт"
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "Затвори"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "Обнови"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr "Zulip"
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr "Дайджест"
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
@@ -2140,17 +1616,17 @@ msgid ""
 msgstr ""
 "Поздравления, вие създадохте нова Zulip организация: <b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr "Добре дошли в Zulip!"
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr "Вие се присъединихте към Zulip организацията <b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
@@ -2159,43 +1635,43 @@ msgstr ""
 "Използвайте следната информация, за да влезете в системата в Zulip уебсайта "
 "и в<a href=\"%(apps_page_link)s\">мобилното и компютърното</a> приложение:"
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr "URL на организацията: %(organization_url)s"
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr "Вашето потребителско име: %(ldap_username)s"
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr "Използвайте вашия LDAP акаунт, за да влезете"
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr "Имейл на вашия акаунт: %(email)s"
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr "Към организацията"
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
 "href=\"%(getting_user_started_link)s\">getting started guide</a>!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2203,7 +1679,7 @@ msgid ""
 "Zulip</a>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
@@ -2212,28 +1688,28 @@ msgstr ""
 "Имате въпроси? <a href=\"mailto:%(support_email)s\">Свържете се с нас</a> — "
 "ще се радваме да ви помогнем!"
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr "%(realm_name)s в Zulip: Детайли за вашата нова организация"
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr "%(realm_name)s в Zulip: Детайли за новия ви акаунт"
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr "Поздравления, вие създадохте нова Zulip организация: %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr "Вие се присъединихте към Zulip организацията %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
@@ -2242,33 +1718,33 @@ msgstr ""
 "Използвайте следната информация, за да влезете в системата в сайта, и в "
 "мобилното и десктоп приложенията на Zulip (%(apps_page_link)s):"
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
 "(%(getting_user_started_link)s)!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
 "(%(getting_organization_started_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 "Имате въпроси? Свържете се с нас на %(support_email)s — с удоволствие ще ви "
 "помогнем!"
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2277,17 +1753,17 @@ msgstr ""
 "Ако имате въпроси, моля, свържете се с администраторите на този Zulip сървър "
 "на %(support_email)s."
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr "Здравейте,"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2295,12 +1771,12 @@ msgid ""
 "password for this account, please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr "Потвърждаване и задаване на парола"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2309,14 +1785,14 @@ msgstr ""
 "Ако не сте поискали тази промяна, моля, свържете се с нас незабавно на "
 "%(support_email)s."
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 #, fuzzy
 #| msgid "Verify your new email address for your demo Zulip organization"
 msgid "Verify your email address for your Zulip demo organization"
 msgstr "Потвърдете новия си имейл адрес за вашата демо Zulip организация"
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2325,8 +1801,8 @@ msgstr ""
 "Ако не сте поискали тази промяна, моля, свържете се с нас незабавно на "
 "<%(support_email)s>."
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2334,33 +1810,33 @@ msgid ""
 "please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr "Потвърди смяна на имейл"
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr "Потвърдете новия си имейл адрес за %(organization_host)s"
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr "Вие изпратихте заявка за нова Zulip организация:"
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr "Тип организация: %(organization_type)s"
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr "Вие наскоро сте се регистрирали за Zulip. Страхотно!"
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
@@ -2369,33 +1845,33 @@ msgstr ""
 "регистрирате профила си. Ако желаете, ще можете да актуализирате "
 "информацията по-горе."
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr "Натиснете бутона по-долу, за да завършите регистрацията."
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr "Завърши регистрацията"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr "Създайте своята Zulip организация"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr "Активирайте своя Zulip акаунт"
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr "Натиснете линка по-долу, за да завършите регистрацията."
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
@@ -2404,48 +1880,48 @@ msgstr ""
 "Имате въпроси или мнения които искате да споделите? Свържете се с нас на "
 "%(support_email)s — ще се радваме да ви помогнем!"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr "Променете вашите имейл предпочитания"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr "Отписване от маркетинг имейли"
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
 "deactivated, and you will no longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr "Администраторите предоставиха следния коментар:"
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr "Уведомление за деактивиране на акаунт на %(realm_name)s"
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr "Нови канали"
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2453,22 +1929,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because your organization has "
@@ -2484,8 +1960,8 @@ msgstr ""
 "class=\"content_disabled_help_link\" href=\"%(help_url)s\">съдържанието на "
 "съобщения в имейл известията</a>."
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because you have disabled <a "
@@ -2501,40 +1977,40 @@ msgstr ""
 "href=\"%(alert_notif_url)s\">съдържанието на съобщения в имейл известията</"
 "a>."
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, fuzzy, python-format
 #| msgid "Click here to log in to Zulip and catch up."
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr "Кликнете тук, за да влезете в Zulip и да наваксате."
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr "Отписване от дайджест имейли"
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr "Zulip дайджест за %(realm_name)s"
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2551,8 +2027,8 @@ msgstr ""
 "съдържанието на съобщения в имейл известията.\n"
 "Вижте %(hide_content_url)s за подробности.\n"
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2568,42 +2044,39 @@ msgstr ""
 "съобщения в имейл известията.\n"
 "Вижте %(alert_notif_url)s за подробности.\n"
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, fuzzy, python-format
 #| msgid "Click here to log in to Zulip and catch up: %(organization_url)s."
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr ""
 "Кликнете тук, за да влезете в Zulip и да наваксате: %(organization_url)s."
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr "Променете вашите имейл предпочитания:"
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr "Отписване от дайджест имейли:"
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr "Благодарим ви за заявката!"
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
 "organizations:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
@@ -2612,33 +2085,29 @@ msgstr ""
 "Вашия имейл адрес %(email)s има акаунти със следните Zulip организации "
 "хостнати от %(external_host)s:"
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
 "href=\"%(help_reset_password_link)s\">reset your password</a>."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
 "%(external_host)s."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2646,38 +2115,35 @@ msgid ""
 "to find your account."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr "Вашите Zulip акаунти"
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
 "try another way to find your account (%(help_logging_in_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr "Здравейте,"
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
@@ -2686,19 +2152,19 @@ msgstr ""
 "%(referrer_name)s ви кани да се присъедините към Zulip &mdash; инструмента "
 "за комуникация в екип, предназначен за повишаване на продуктивността."
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr "За да започнете, кликнете върху бутона по-долу."
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 "%(referrer_full_name)s ви покани да се присъедините към "
 "%(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
@@ -2708,17 +2174,17 @@ msgstr ""
 "Zulip -- инструмента за комуникация в екип, предназначен за повишаване на "
 "продуктивността."
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr "За да започнете, кликнете на линка по-долу."
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr "Здравейте отново,"
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
@@ -2728,13 +2194,13 @@ msgstr ""
 "към Zulip &mdash; инструмента за комуникация в екип, предназначен за "
 "повишаване на продуктивността."
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr "Това е последното напомняне, което ще получите за тази покана."
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
@@ -2743,13 +2209,13 @@ msgstr ""
 "Срокът на валидност на тази покана изтича след два дни. Ако срокът на "
 "поканата изтече, ще трябва да поискате нова от%(referrer_name)s."
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr ""
 "Напомняне: Присъединете се към %(referrer_name)s в %(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2760,7 +2226,7 @@ msgstr ""
 "кани да се присъедините към Zulip - инструмента за комуникация в екип, "
 "предназначен за повишаване на продуктивността."
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2769,7 +2235,7 @@ msgstr ""
 "Ако имате някакви въпроси, моля, свържете се с администраторите на този "
 "Zulip сървър на <a href=\"mailto:%(email)s\">%(email)s</a>."
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
@@ -2778,22 +2244,20 @@ msgstr ""
 "Имате въпроси или мнения които искате да споделите? <a href=\"mailto:"
 "%(email)s\">Свържете се с нас</a> — ще се радваме да ви помогнем!"
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr "Получавате това, защото вие бяхте споменати лично."
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr "Получавате това, защото @%(mentioned_user_group_name)s беше спомената."
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
@@ -2802,22 +2266,22 @@ msgstr ""
 "Получавате това, защото всички участници в темата бяха споменати в "
 "#%(channel_name)s > %(topic_name)s."
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr "Вие получавате това, защото всеки в #%(channel_name)s беше споменат."
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
@@ -2825,8 +2289,8 @@ msgstr ""
 "Получавате това съобщение, защото сте включили имейл известия за темите, "
 "които следвате."
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
@@ -2834,7 +2298,7 @@ msgid ""
 msgstr ""
 "Получавате това, защото сте включили имейл известия за #%(channel_name)s."
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2845,7 +2309,7 @@ msgstr ""
 "%(realm_name)s Zulip</a>, или кликнете <a href=\"%(notif_url)s\">управление "
 "на имейл предпочитанията</a>."
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
@@ -2855,7 +2319,7 @@ msgstr ""
 "или кликнете <a href=\"%(notif_url)s\">управление на имейл предпочитанията</"
 "a>."
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
@@ -2865,7 +2329,7 @@ msgstr ""
 "кликнете <a href=\"%(notif_url)s\">конфигуриране на имейл предпочитанията</"
 "a>."
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
@@ -2874,42 +2338,42 @@ msgstr ""
 "Не отговаряйте на този имейл. Този Zulip сървър не е устроен за да приема "
 "входящи имейли (<a href=\"%(url)s\">помощ</a>)."
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr "Групови съобщения с %(direct_message_group_display_name)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr "Лични съобщения с %(sender_str)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr "Нови съобщения"
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 "Отговорете на този имейл директно или го прегледайте в %(realm_name)s Zulip:"
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr "Прегледайте или отговорете в %(realm_name)s Zulip:"
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr "Отговорете в %(realm_name)s Zulip:"
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
@@ -2917,7 +2381,7 @@ msgstr ""
 "Не отговаряйте на този имейл. Този Zulip сървър не е конфигуриран за да "
 "получава имейли. Помощ:"
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2928,22 +2392,22 @@ msgstr ""
 "%(new_email)s. Ако не сте заявили тази промяна, моля, свържете се с нас "
 "незабавно на %(support_email)s."
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr "Zulip екип"
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr "Zulip имейлът за %(realm_name)s е променен"
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2954,53 +2418,53 @@ msgstr ""
 "%(new_email)s. Ако не сте заявили тази промяна, моля, свържете се с нас "
 "незабавно на <%(support_email)s>."
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 msgstr ""
 "Организация: %(organization_url)s Време: %(login_time)s Имейл: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr "Забелязахме скорошно влизане в следния Zulip акаунт."
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr "Организация: %(organization_link)s"
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr "Е-поща: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr "Време: %(login_time)s"
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr "Устройство: %(device_browser)s с %(device_os)s."
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr "IP адрес: %(device_ip)s"
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr "Ако това бяхте вие, чудесно! Няма нищо друго което трябва да правите."
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3011,31 +2475,31 @@ msgstr ""
 "компрометиран, моля, <a href=\"%(reset_link)s\">възстановете паролата си</a> "
 "или се свържете с нас незабавно на %(support_email)s."
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr "Благодаря,"
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr "Zulip Поверителност"
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr "Отписване от известията за вход"
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr "Ново влизане от %(device_browser)s на %(device_os)s"
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr "Организация: %(organization_url)s"
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3046,7 +2510,7 @@ msgstr ""
 "компрометиран, моля, възстановете паролата си на %(reset_link)s или се "
 "свържете с нас незабавно на %(support_email)s."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -3054,7 +2518,7 @@ msgid ""
 "Zulip</a> to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
@@ -3062,7 +2526,7 @@ msgstr ""
 "В противен случай, ето няколко съвета за оценяване на <i>продукти</i> за "
 "комуникация в екип, които често чуваме от клиенти:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
@@ -3071,13 +2535,13 @@ msgstr ""
 "<a href=\"%(invite_users)s\"><b>Поканете членовете на вашия екип</b></a> за "
 "да разгледат Zulip заедно с вас и за да споделят техните перспективи."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr ""
 "Използвайте самото приложение, за да разговаряте за вашите впечатления."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -3089,7 +2553,7 @@ msgstr ""
 "единственият начин, по който наистина можете да разберете колко може едно "
 "ново приложение за чат да помогне на екипа ви да общува ефикасно."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -3100,27 +2564,27 @@ msgstr ""
 "комуникация</a>, и се надяваме, че тези съвети ще помогнат на екипа ви да го "
 "изпита в действие."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr "Отписване от имейли за добре дошли за %(realm_name)s"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr "Избиране на правилното чат приложение за вашия екип"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
@@ -3128,7 +2592,7 @@ msgstr ""
 "В противен случай, ето няколко съвета за оценяване на продукти за "
 "комуникация в екип, които често чуваме от клиенти:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
@@ -3136,7 +2600,7 @@ msgstr ""
 "Поканете членовете на вашия екип за да разгледат Zulip заедно с вас и за да "
 "споделят техните гледни точки."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
@@ -3146,7 +2610,7 @@ msgstr ""
 "инструменти за чат. Това е единственият начин наистина да разберете колко "
 "може едно ново приложение за чат да помогне на екипа ви да общува ефикасно."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
@@ -3154,8 +2618,8 @@ msgstr ""
 "Zulip е създаден така, че да позволява ефективна комуникация, и се надяваме, "
 "че тези съвети ще помогнат на екипа ви да го изпита в действие."
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
@@ -3165,71 +2629,71 @@ msgstr ""
 "как може да използвате програмата най-ефективно за вашите нужди. Разгледайте "
 "нашия наръчник с основните функции на Zulip за организации като вашата!"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr "Вижте ръководството на Zulip за бизнеси"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr "Погледнете ръководството на Zulip за проекти с отворен код"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr "Вижте ръководството на Zulip за образование"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr "Вижте ръководството на Zulip за проучвания"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr "Вижте ръководството на Zulip за събития и конференции"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr "Вижте ръководството на Zulip за нестопански организации"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr "Вижте ръководството на Zulip за общности"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr "Ръководството на Zulip за бизнеси"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr "Ръководството на Zulip за проекти с отворен код"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr "Ръководството на Zulip за образование"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr "Ръководството на Zulip за проучвания"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr "Наръчник на Zulip за събития и конференции"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr "Ръководството на Zulip за нестопански организации"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr "Ръководството на Zulip за общности"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
@@ -3237,7 +2701,7 @@ msgstr ""
 "Ето няколко съвета, които ще ви помогнат да организирате разговорите ви в "
 "Zulip по теми."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
@@ -3245,8 +2709,8 @@ msgstr ""
 "Във Zulip, <b>каналите</b> определят кой получава дадено съобщение. "
 "<b>Темите</b> показват на каква тема е съобщението."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
@@ -3255,12 +2719,12 @@ msgstr ""
 "виждате всяко съобщение с контекст, независимо от това колко различни "
 "дискусии се водят в момента."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr "Канали и теми в мобилното приложение на Zulip"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3272,11 +2736,11 @@ msgstr ""
 "подходящо име на темата се опитайте да завършите изречението: \"Здравейте, "
 "можем ли да говорим за...?\""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr "Примери за кратки теми"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3289,17 +2753,17 @@ msgstr ""
 "съобщения</a>, да <a href=\"%(rename_topics_link)s\">преименувате теми</a>, "
 "или да <a href=\"%(move_channels_link)s\">преместите тема в друг канал</a>."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr "Към Zulip"
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr "Организирайте разговорите си с помощтта на темите"
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
@@ -3307,7 +2771,7 @@ msgstr ""
 "В Zulip каналите определят кой ще получи съобщението. Темите показват за "
 "какво се отнася съобщението."
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3320,23 +2784,23 @@ msgstr ""
 "преименувате теми (%(rename_topics_link)s), или да преместите тема в друг "
 "канал (%(move_channels_link)s)."
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
 "%(email)s on %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr "Кликнете бутона по-долу, за да възстановите паролата си."
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr "Възстановяване на парола"
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3347,18 +2811,18 @@ msgstr ""
 "Можете да се свържете с администраторите на организацията, за да <a "
 "href=\"%(help_link)s\">реактивирате акаунта си</a>."
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr "Нямате акаунт в тази Zulip организация."
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr "Имате активни акаунти в следната организация(и)."
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
@@ -3366,30 +2830,30 @@ msgstr ""
 "Можете да опитате да влезете или да възстановите паролата си в "
 "организацията(ите) по-горе."
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 "Ако не разпознавате тази активност, можете спокойно да игнорирате този имейл."
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr "Кликнете върху линка по-долу, за да възстановите паролата си."
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
 "You can contact an organization administrator to reactivate your account."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3400,7 +2864,7 @@ msgstr ""
 "безплатния Zulip Cloud План заради неплатени фактури. Неплатените фактури са "
 "анулирани."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
@@ -3409,7 +2873,7 @@ msgstr ""
 "За да продължите да използвате стандартния Zulip Cloud план, моля надградете "
 "плана отново на %(upgrade_url)s."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
@@ -3418,8 +2882,8 @@ msgstr ""
 "Ако смятате, че е станала грешка, или се нуждаете от повече информация, "
 "моля, свържете се с нас на %(support_email)s."
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid "You've joined the Zulip organization %(realm_name)s."
 msgid ""
@@ -3427,104 +2891,104 @@ msgid ""
 "%(localized_date)s."
 msgstr "Вие се присъединихте към Zulip организацията %(realm_name)s."
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip demo organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr "кликнете бутона по-долу, за да активирате отново организацията си."
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr "Реактивиране на организацията"
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
@@ -3532,21 +2996,21 @@ msgstr ""
 "Ако заявката е била погрешна, не е нужно да предприемете никакви действия, "
 "тази връзка сама ще изтече след 24 часа."
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Create your Zulip organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "Създайте своята Zulip организация"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr "Кликнете линка по-долу, за да активирате отново организацията си."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3555,20 +3019,20 @@ msgstr ""
 "Вие или някой от ваше име, е поискал линк за вход в системата, с цел да "
 "управлява Zulip плана на <b>%(remote_server_hostname)s</b>."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, fuzzy
 #| msgid "Click the link below to log in."
 msgid "Click the button below to log in."
 msgstr "Кликнете върху линка по-долу за да влезете в системата."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr "Този линк че спре да бъде валиден след %(validity_in_hours)s часа."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
@@ -3577,11 +3041,11 @@ msgstr ""
 "Имате въпроси? <a href=\"%(billing_help_link)s\">Научете повече</a> или се "
 "свържете с %(billing_contact_email)s."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr "Влезте в управлението на Zulip плана"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3590,12 +3054,12 @@ msgstr ""
 "Вие или някой от ваше име, е поискал линк за вход в системата, с цел да "
 "управлява Zulip плана на %(remote_server_hostname)s."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr "Кликнете върху линка по-долу за да влезете в системата."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
@@ -3604,7 +3068,7 @@ msgstr ""
 "Имате въпроси? Научете повече на %(billing_help_link)s или се свържете с "
 "%(billing_contact_email)s."
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
@@ -3613,16 +3077,16 @@ msgstr ""
 "Кликнете върху бутона по-долу за да потвърдите имейла си и за да влезете в "
 "управление на Zulip плана на <b>%(remote_realm_host)s</b>."
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr "Потвърдете имейл за управление на Zulip плана"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
@@ -3631,7 +3095,7 @@ msgstr ""
 "Натиснете линка по-долу за да потвърдите вашия имейл и за да влезете в "
 "управление на вашия Zulip план за %(remote_realm_host)s."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
@@ -3640,7 +3104,7 @@ msgstr ""
 "Вашата заявка за Zulip спонсорство е одобрена! Вашата организация е "
 "надградена до плана <a href=\"%(plans_link)s\">Zulip Общност</a>."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
@@ -3649,12 +3113,12 @@ msgstr ""
 "Ще ви бъдем много благодарни ако можете да <a "
 "href=\"%(link_to_zulip)s\">добавите Zulip като спонсор във вашия уебсайт</a>!"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr "Одобрено спонсорство на Общностния Zulip план за %(billing_entity)s!"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
@@ -3662,261 +3126,261 @@ msgstr ""
 "Вашата заявка за спонсорство на Zulip е одобрена! Вашата организация е "
 "надградена до плана \"Zulip Общност\"."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
 msgstr ""
 "Много ще оценим ако можете да включите Zulip като спонсор във вашия уебсайт!"
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr "Намерете вашите акаунти"
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr "Намери своите Zulip акаунти"
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
 "accounts for another email address</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr "Имейл адрес"
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "Намери акаунти"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr "Продукт"
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr "Защо Zulip"
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr "Възможности"
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr "Планове и цени"
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Zulip"
 msgid "Zulip Cloud"
 msgstr "Zulip"
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr ""
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr "Поверителност"
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "Интеграция"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr "Десктоп и мобилни приложения"
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr "Нова организация"
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr "Решения"
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr "Бизнес"
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr "Образование"
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr "Проучвания"
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr "Събития и конференции"
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr ""
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr "Обшности"
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr ""
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr "Отворени общности"
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr "Ресурси"
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr ""
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr "Център за помощ"
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr "Чат на общността"
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr ""
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr "Допринасяне"
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr ""
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr ""
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr "Превеждане"
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr "GitHub"
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr "За нас"
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr "Екип"
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "история"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr "Ценности"
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr "Работа"
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr "Блог"
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr "Подкрепи Zulip"
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr ""
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr ""
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Values"
 msgid "Bluesky"
 msgstr "Ценности"
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr ""
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr "Условия за Ползване"
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr "Правила за поверителност"
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 #, fuzzy
 #| msgid ""
 #| "And hundreds more through <a href=\"/integrations/doc/zapier\">Zapier</a> "
@@ -3928,51 +3392,47 @@ msgstr ""
 "И стотици още през <a href=\"/integrations/doc/zapier\">Zapier</a> и <a "
 "href=\"/integrations/doc/ifttt\">IFTTT</a>."
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr "Търсене на интеграции"
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr "Интерактивни ботове"
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr "Невалиден имейл"
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr "Имейл адресът, с който се опитвате да се регистрирате, не е валиден."
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3980,7 +3440,7 @@ msgid ""
 "emails with your email domain."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3988,7 +3448,7 @@ msgid ""
 "disposable email addresses."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3996,24 +3456,24 @@ msgid ""
 "emails that contain \"+\"."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr "Моля, регистрирайте се с валиден имейл адрес."
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr "Моля, регистрирайте се с позволен имейл адрес."
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -4021,7 +3481,7 @@ msgid ""
 "%(support_email)s\">contact Zulip support</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -4029,75 +3489,75 @@ msgid ""
 "%(support_email)s\">contact this Zulip server's administrators</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
 "management for your Zulip server."
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr ""
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr ""
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 "Вече имате регистрирация с този имейл адрес. Моля, влезте в профила си по-"
 "долу."
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr "Адрес за Е-поща или потербителско име"
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "Потребителско име"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr ""
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr ""
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr ""
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 "Все още нямате акуант? Трябва ви покана за да можете да се присъедините към "
 "тази организация."
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr "Организацията не може да приема нови членове в момента"
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> because all Zulip Cloud licenses are in use."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
@@ -4105,19 +3565,19 @@ msgstr ""
 "Свържете се с лицето, което ви е поканило, и го помолете да увеличи броя на "
 "лицензите, след което опитайте отново."
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr "Грешка в поддомейна за удостоверяване"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr "Поддомейн за автентикация"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -4126,44 +3586,42 @@ msgid ""
 "or misconfiguration."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 #, fuzzy
 #| msgid "New organization"
 msgid "Demo organizations disabled"
 msgstr "Нова организация"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr "Необходима е актуализация"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -4171,22 +3629,21 @@ msgid ""
 "organization for more information."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr "Адреса за създаване на организация е изтекъл или е невалиден"
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, fuzzy, python-format
 #| msgid ""
 #| "Your organization is registered to a different Zulip server. Please "
@@ -4199,48 +3656,46 @@ msgstr ""
 "Вашата организация е регистрирана към друг Zulip сървър. Моля, свържете се с "
 "екипа на Zulip за съдействие при разрешаването на този проблем."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr "Браузъра не се поддържа"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
 "a> like Firefox, Chrome, and Edge."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr "Акаунта е деактивиран"
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Invalid organization"
 msgid "Finalize organization import"
 msgstr "Невалидна организация"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Organization type"
 msgid "Organization import completed!"
 msgstr "Тип организация"
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -4248,58 +3703,57 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Select your account"
 msgstr "Създайте своя акаунт"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Create new account"
 msgstr "Създайте своя акаунт"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr "Организацията е реактивирана успешно"
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr "Вашата организация успешно е активирана отново."
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr ""
 "Адресът за повторно активиране на организацията е невалиден или е изтекъл"
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr ""
 "Линка за повторно активиране на организацията е изтекъл или не е валиден."
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr "Намерете вашата организация."
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr "Следващ"
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4307,24 +3761,24 @@ msgid ""
 "have one yet."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 #, fuzzy
 #| msgid "Self-host Zulip"
 msgid "Self-hosting Zulip?"
 msgstr "Самостоятелен хостинг на Zulip"
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">log in to manage plans and billing.</a>"
 msgstr ""
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr "Възстновете паролата си"
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
@@ -4332,62 +3786,62 @@ msgstr ""
 "Забравили сте паролата си? Няма проблем, ние ще изпратим линк за "
 "възстановяване на парола на имейла, с който сте се регистрирали."
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "Потвърдете паролата"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr ""
 "Съжаляваме, връзката която предоставихте е невалидна или вече е използвана."
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr ""
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr ""
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr "Моля <a href=\"%(login_url)s\">влезте</a> в системата с новата парола."
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr "Възстановяване на паролата Ви изпрати писмо!"
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr ""
 "Проверете електронната си поща след няколко минути, за да завършите процеса."
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr ""
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4395,7 +3849,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4404,60 +3858,60 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 #, fuzzy
 #| msgid ""
 #| "Nobody in this Zulip organization will be able to see this email address."
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr "Никой в тази Zulip организация няма да може да види този имейл адрес."
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4465,7 +3919,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4473,21 +3927,21 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 "Вашият GitHub акаунт също има непотвърдени имейл адреси асоциирани с него."
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
@@ -4495,15 +3949,15 @@ msgstr ""
 "За да използвате някое от тези, за да влезете в Zulip, първо трябва да го <a "
 "href=\"https://github.com/settings/emails\">потвърдите в GitHub.</a>"
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
@@ -4511,7 +3965,7 @@ msgstr ""
 "Здравейте! Изглежда, че сте се опитали да се отпишете от нещо, но ние не "
 "разпознаваме URL адреса."
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4522,131 +3976,128 @@ msgstr ""
 "<a href=\"mailto:%(support_email)s\">изпратете имейл</a> и ние ще ви "
 "помогнем!"
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
 "href=\"%(realm_url)s/#settings/notifications\">notification settings</a>."
 msgstr ""
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr ""
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr ""
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr ""
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr ""
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr ""
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr ""
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr "{user} прие поканата ви за присъединяване към Zulip!"
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 msgid "Cannot reactivate a deleted user"
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr ""
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr "Невалидно име на групата на началния канал '{group_name}'"
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr ""
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 "'{channel_name}' е начален канал и не може да бъде добавен в '{group_name}'"
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr ""
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr ""
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
@@ -4655,7 +4106,7 @@ msgstr ""
 "да изпратите в рамките на един ден. Тъй като вие сте достигнали лимита, не "
 "са изпратени още покани."
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
@@ -4664,87 +4115,87 @@ msgstr ""
 "Помолете някой от администраторите на организацията или някой по-опитен "
 "потребител."
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr "Някои имейли не бяха валидирани, така че не изпратихме покани."
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr "Не успяхме да поканим никого."
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr ""
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr "Личните съобщения не могат да се преместват в канали."
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr ""
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr ""
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr ""
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr "Уиджетите не могат да се редактират."
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr "Вашата организация е изключила редактирането на съобщения"
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr "Нямате разрешение да редактирате това съобщение"
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr "Срокът за редактиране на това съобщение е изтекъл"
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr "{user} е отбелязал тази тема като разрешена."
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr "{user} е отбелязал тази тема като неразрешена."
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr "Тази тема беше преместена в {new_location} от {user}."
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr "{user} премести съобщение от тази тема в {new_location}."
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
 "{new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr "Тази тема беше преместена тук от {old_location} от {user}."
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
@@ -4752,7 +4203,7 @@ msgstr ""
 "[Едно съобщение]({message_link}) беше преместено тук от {old_location} от "
 "{user}."
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
@@ -4761,76 +4212,73 @@ msgstr ""
 "{changed_messages_count} съобщения бяха преместени тук от {old_location} от "
 "{user}."
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 #, fuzzy
 #| msgid "You don't have permission to delete this message"
 msgid "You don't have permission to resolve topics in this channel."
 msgstr "Нямате разрешение да изтриете това съобщение"
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr "Срокът за редактиране на това съобщение е изтекъл."
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr "Нямате разрешение да преместите това съобщение"
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr ""
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr ""
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr ""
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr ""
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 "Списъците на получателите могат да съдържат или имейли, или потребителски "
 "номера, не и двете."
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
 "but there is no channel with that ID."
 msgstr ""
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4838,36 +4286,36 @@ msgid ""
 "it."
 msgstr ""
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
 "The channel exists but does not have any subscribers."
 msgstr ""
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr "Нямате разрешение за достъп до някои от получателите."
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr ""
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr "Уиджети: {error_msg}"
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4875,64 +4323,62 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
 "authentication method."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr ""
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder could not be sent."
 msgstr "Този тоукън не съществува"
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr "Съобщението не можа да бъде изпратено в планираното време."
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
@@ -4941,45 +4387,45 @@ msgstr ""
 "Съобщението, което бяхте посочили да се изпрати на {delivery_datetime}, не "
 "беше изпратено поради следната грешка:"
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr ""
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr ""
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr ""
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr ""
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr ""
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
 "**{old_policy}** to **{new_policy}**."
 msgstr ""
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -4988,51 +4434,49 @@ msgid ""
 "* **New**: {new_setting_description}\n"
 msgstr ""
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr "Няма описание."
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr ""
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr "Старо описание"
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr "Ново описание"
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr "Завинаги"
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr ""
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 msgstr ""
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr ""
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -5043,99 +4487,89 @@ msgid ""
 "{summary_line}"
 msgstr ""
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr "Не можете да прикачите подсъобщение към това съобщение."
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr ""
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr ""
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr ""
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr "Този API не е достъпен за входящи уебхуук ботове."
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr "Акаунтът не е свързан с този поддомейн"
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr ""
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr ""
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr "Тази крайна точка изисква основно HTTP удостоверяване ."
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr "Невалиден оторизационен хедър за основна автентикация"
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr "Липсва оторизационен хедър за основна автентикация"
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr "Уебхук ботовете имат достъп само до уебхукове"
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr ""
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
@@ -5144,53 +4578,52 @@ msgstr ""
 "Вашият акаунт {username} е деактивиран. Моля, свържете се с администратора "
 "на вашата организация, за да го активирате отново."
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr ""
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr "Поддомейнът трябва да е с дължина 3 или повече."
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr "Поддомейнът не може да започва или завършва с '-'."
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr "Поддомейна може да съдържа само малки букви, цифри и тирета."
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr "Поддомейнът е резервиран. Моля, изберете друг."
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr "Моля, използвайте истинския си имейл адрес."
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr ""
 "Организацията, към която се опитвате да се присъедините използвайки {email}, "
 "не съществува."
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr "Моля, поискайте покана за {email} от администратора на организацията."
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
@@ -5199,11 +4632,11 @@ msgstr ""
 "Вашият имейл адрес, {email}, не е сред домейните, които са разрешени за "
 "регистрация в тази организация."
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr "Имейл адреси, съдържащи +, не са разрешени в тази организация."
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
@@ -5214,32 +4647,31 @@ msgstr ""
 "е поканило, и го помолете да увеличи броя на лицензите, след което опитайте "
 "отново."
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 msgid "Challenges are not enabled."
 msgstr ""
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "Нова парола"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr ""
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "You're making too many attempts to sign in. Try again in {seconds} "
@@ -5251,7 +4683,7 @@ msgstr ""
 "Правите твърде много опити да влезете. Опитайте отново след {seconds} "
 "секунди или се свържете с администратора на вашата организация за помощ."
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
@@ -5259,91 +4691,89 @@ msgstr ""
 "Вашата парола е деактивирана, тъй като е твърде слаба. Възстановете паролата "
 "си, за да създадете нова."
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr "Тоукън"
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr "Съвет: Можете да въведете няколко имейл адреса със запетаи между тях."
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr "Моля, въведете най-много 10 имейла."
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr "Не успяхме да намерим тази Zulip организация."
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr ""
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr ""
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr ""
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr ""
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr "Съобщението трябва да има получатели"
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr ""
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr "Невалиден файл"
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr ""
 "Възникна грешка при изтриването на прикачения файл. Моля, опитайте отново по-"
 "късно."
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr "Съобщението трябва да има получатели!"
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "User group name can't be empty!"
 msgid "Channel folder name can't be empty."
 msgstr "Името на групата не може да бъде празно!"
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid character in topic, at position {position}!"
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr "Невалиден символ в темата, на позиция {position}!"
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 msgid "Invalid channel folder ID"
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 #, fuzzy
 #| msgid "Confirm your email address"
 msgid "Configure owner account email address."
 msgstr "Потвърдете вашия имейл адрес"
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| " Congratulations, you have created a new demo Zulip organization. Note "
@@ -5359,72 +4789,72 @@ msgstr ""
 "тази организация ще бъде изтрита автоматично след 30 дни. Научете повече за "
 "демо организациите тук: %(demo_organizations_help_link)s!"
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a valid hex color code"
 msgid "{var_name} is not Base64 encoded"
 msgstr "{var_name} не е валиден шестнадесетичен код за цвят"
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 #, fuzzy
 #| msgid "Invalid email"
 msgid "Invalid `device_id`"
 msgstr "Невалиден имейл"
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr ""
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr "Домейнът не може да бъде празен."
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr "Домейнът трябва да съдържа поне една точка (.)"
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr "Домейнът е твърде дълъг"
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr "Домейнът не може да започва или завършва с точка (.)"
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr ""
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr "Поддомейните не могат да започват или завършват с '-'."
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr "Домейнът може да съдържа само букви, цифри и символите \".\" и \"-\"."
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr ""
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr "Темата не трябва да съдържа нулеви байтове"
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr ""
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr "Тази чернова не съществува"
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5432,86 +4862,86 @@ msgid ""
 "{error_message}"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr "Отворете Zulip, за да видите съдържанието на спойлера"
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr "{service_name} известия"
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr "Невалиден адрес."
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr "Извън вашия домейн."
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr "Имейл адреси, съдържащи +, не са разрешени."
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr "Запазено за системни ботове."
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr ""
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr "Вече има акаунт."
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr "Акаунта е деактивиран."
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr ""
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr ""
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr "Този персонализиранo емоджи е деактивирано."
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr ""
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr "Невалидно име на емоджи."
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr "Невалиден тип емоджи."
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr "Трябва да сте администратор на организация или автор на емоджита"
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr "Имената на емоджитата трябва да завършват с буква или цифра."
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
@@ -5519,179 +4949,177 @@ msgstr ""
 "Имената на емоджитата могат да съдържат само малки английски букви, цифри, "
 "интервали, тирета и долни черти."
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr "Липсва име на емоджито"
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr ""
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr ""
 "Не сте влезли в системата: Изисква се API удостоверяване или потребителска "
 "сесия"
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr ""
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr "собственик на организацията"
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr "потребител"
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr ""
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr ""
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr ""
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Number of users"
 msgid "Must be a bot user"
 msgstr "Брой потребители"
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr "Вашето потребителско име или парола са неправилни"
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr ""
 "Регистрацията на услугата зa мобилни известия за вашия сървър е деактивирана"
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr ""
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr "Вашата парола е деактивирана и трябва да бъде променена"
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
 "webhook; ignoring"
 msgstr ""
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 "Преработването на заявката е неуспешно: {webhook_name} ли генерира това "
 "събитие?"
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr "Невалиден поддомейн"
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr "Личните съобщения за изключени в тази организация."
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr ""
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr "Достъпа е отказан"
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
@@ -5700,15 +5128,15 @@ msgstr ""
 "Имате разрешение да местите само поседните {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} съобщения в тази тема."
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr ""
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr ""
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
@@ -5716,358 +5144,358 @@ msgstr ""
 "Вашата организация е регистрирана към друг Zulip сървър. Моля, свържете се с "
 "екипа на Zulip за съдействие при разрешаването на този проблем."
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr ""
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr ""
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr ""
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr ""
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr "Планираното време за изпращане трябва да е в бъдещето."
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Already has an account."
 msgid "Atlassian account ID"
 msgstr "Вече има акаунт."
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Behance username"
 msgstr "Twitter потребителско име"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Bitbucket username"
 msgstr "GitHub потребителско име"
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Codeberg username"
 msgstr "Twitter потребителско име"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Dribbble username"
 msgstr "GitHub потребителско име"
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Facebook username"
 msgstr "Адрес за Е-поща или потербителско име"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr "GitHub потребителско име"
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "GitLab username"
 msgstr "GitHub потребителско име"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Instagram username"
 msgstr "Twitter потребителско име"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 msgid "Mastodon profile"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Medium username"
 msgstr "GitHub потребителско име"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Pinterest username"
 msgstr "Twitter потребителско име"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Reddit username"
 msgstr "GitHub потребителско име"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Snapchat username"
 msgstr "GitHub потребителско име"
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Threads username"
 msgstr "Twitter потребителско име"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "TikTok username"
 msgstr "Twitter потребителско име"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Twitch username"
 msgstr "Twitter потребителско име"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "Потребителско име"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr ""
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr ""
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 #, fuzzy
 #| msgid "Video call ended"
 msgid "Video calling"
 msgstr "Видео разговора завърши"
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr ""
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr "Oбслужване на клиенти"
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr ""
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr "Развлечения"
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr "Комуникация"
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr ""
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr "Човешки ресурси"
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr "Маркетинг"
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr "Разни"
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr "Мониторинг"
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr ""
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr "Продуктивност"
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr ""
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr ""
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr "Съобщението не трябва да съдържа нулеви байтове"
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "{fullname} moderation"
 msgstr ""
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr ""
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr ""
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor_date' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr ""
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 #, fuzzy
 #| msgid "Confirmation link does not exist"
 msgid "Navigation view does not exist."
 msgstr "Адреса за потвърждаване не съществува"
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6075,7 +5503,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6083,7 +5511,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6091,7 +5519,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6099,7 +5527,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| " Congratulations, you have created a new demo Zulip organization. Note "
@@ -6116,14 +5544,14 @@ msgstr ""
 "тази организация ще бъде изтрита автоматично след 30 дни. Научете повече за "
 "демо организациите тук: %(demo_organizations_help_link)s!"
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
 "them in your [Inbox](/#inbox).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6131,7 +5559,7 @@ msgid ""
 "({navigation_tour_video_url}) for a quick app overview.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6146,14 +5574,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -6161,7 +5589,7 @@ msgid ""
 "and edit your [profile information](/help/edit-your-profile).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -6172,7 +5600,7 @@ msgid ""
 "experience in your [Preferences](#settings/preferences).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6183,7 +5611,7 @@ msgid ""
 "[Browse and subscribe to channels]({settings_link}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -6200,7 +5628,7 @@ msgid ""
 "discussed.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -6209,7 +5637,7 @@ msgid ""
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -6221,7 +5649,7 @@ msgid ""
 "times, and more.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6231,7 +5659,7 @@ msgid ""
 "or browse the [help center](/help/) to learn more!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6239,7 +5667,7 @@ msgid ""
 "get help, try one of the following messages: {bot_commands}\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6251,13 +5679,13 @@ msgid ""
 "({move_content_another_channel_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6271,12 +5699,11 @@ msgid ""
 "and above.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr ""
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -6284,14 +5711,14 @@ msgid ""
 "no matter how many other conversations are going on.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
 "conversations with unread messages.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -6299,7 +5726,7 @@ msgid ""
 "the `+` button next to its name.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -6307,13 +5734,13 @@ msgid ""
 "can we chat about…?”\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6321,7 +5748,7 @@ msgid ""
 "({format_message_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6341,1247 +5768,1226 @@ msgid ""
 "```\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
 "teammates.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
 "conversation.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr ""
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr ""
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr ""
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr ""
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr "Този тоукън не съществува"
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "Ново съобщение"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr "Устройството не е разпознато"
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 #, fuzzy
 #| msgid "Invalid token"
 msgid "Invalid `push_key`"
 msgstr "Невалиден тоукън"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr "Потребителят не е оторизиран за тази заявка"
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr "'{email}' вече не използва Zulip."
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr "Не можете да изпращате лични съобщения извън вашата организация."
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr "{var_name} е твърде дълго (лимит: {max_length} символа)"
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder does not exist"
 msgstr "Този тоукън не съществува"
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr ""
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr ""
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr ""
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr ""
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr ""
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr ""
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr ""
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr ""
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 #, fuzzy
 #| msgid "You don't have permission to delete this message"
 msgid "You do not have permission to create new topics in this channel."
 msgstr "Нямате разрешение да изтриете това съобщение"
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr ""
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr ""
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr ""
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr ""
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr ""
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr "Невалиден символ в темата, на позиция {position}!"
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr "Не можахме да декодираме изображението; вие изображение ли качихте?"
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr ""
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} does not have a length"
 msgid "{var_name} does not have the expected format"
 msgstr "{var_name} няма дължина"
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr "Невалиден {var_name}"
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr "{var_name} е твърде малко"
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr "{var_name} е твърде голямо"
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr "{var_name} е твърде дълго (лимит: {max_length} символа)"
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr "{var_name} е твърде кратко."
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr "{var_name} е твърде дълго (лимит: {max_length} символа)"
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr "{var_name} е твърде дълго (лимит: {max_length} символа)"
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr "{var_name} не е валиден шестнадесетичен код за цвят"
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr "Невалиден {setting_name}"
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr ""
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr ""
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr ""
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {user_group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr ""
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 "Настройката '{setting_name}' не може да бъде зададена в групата 'role:"
 "internet'."
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 "Настройката '{setting_name}' не може да бъде зададена в групата 'role:"
 "nobody'."
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 "Настройката '{setting_name}' не може да бъде зададена в групата 'role:"
 "everyone'."
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 "Настройката '{setting_name}' не може да бъде зададена в групата "
 "'{group_name}'."
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr "Името на групата не може да бъде празно!"
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr ""
 "Името на потребителската група не може да надвишава {max_length} символa."
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr "Името на потребителската група не може да започва с '{prefix}'."
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr ""
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr "Името е твърде дълго!"
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 msgid "Name must not be empty!"
 msgstr ""
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr ""
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr "Невалиден формат!"
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr ""
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr ""
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr ""
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr ""
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr ""
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr ""
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr ""
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr "Невалиден вид бот"
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr "Невалиден тип интерфейс"
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr ""
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr "Няма такъв бот"
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr "Няма такъв потребител"
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr "Потребителя е деактивиран"
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr ""
 "{var_name} има неправилна дължина {length}; трябва да бъде {target_length}"
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr ""
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr "{container} трябва да има точно {length} елемента"
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr "Ключът {key_name} липсва в {var_name}"
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr ""
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr ""
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr ""
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr ""
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr ""
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr "Полето не трябва да има дублиращи се опции."
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr "'{value}' не е валиден избор за '{field_name}'."
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr ""
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr ""
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr "{var_name} няма дължина"
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr "HTTP хедъра за събития '{header}' липсва"
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr ""
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr "Няма такава команда: {command}"
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr ""
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr "Потребителят с ID {user_id} е бот"
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr "Външен акаунт"
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr "Местоимения"
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr "Никой"
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr ""
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "Членове"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr "Всички в интернет"
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Invalid characters in emoji name"
 msgid "Invalid auto-conversion field: empty field name."
 msgstr "В името на емоджито има невалидни символи"
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr ""
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr ""
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr "Невалиден URL шаблон."
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 msgid "Example input does not match the linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in alternative URL template is not present in linkifier "
 "pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in linkifier pattern is not present in alternative URL "
 "template."
 msgstr ""
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr ""
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "Персонализирано емоджи"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr ""
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr "В името на емоджито има невалидни символи"
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr ""
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr ""
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr ""
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr ""
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr ""
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr "Предлага се в стандартния Zulip Cloud план. Надградете за достъп."
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr "Предлага се в плана Zulip Cloud Plus. Надградете за достъп."
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr "Разрешаване на GIF файлове с рейтинг G (Обща аудитория)"
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr "Разрешаване на GIF файлове с рейтинг PG (Насоки за родители)"
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr "Разрешаване на GIF-ове с рейтинг PG-13 (Parental guidance - под 13)"
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr ""
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr "Уеб-публичен"
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "Публичен"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr "Лична, споделена история"
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr "Лична, защитена история"
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr "Администратори, модератори, членове и гости"
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr "Администратори, модератори и членове"
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr "Админи и модератори"
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr "Само администратори"
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr "Неизвестен потребител"
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr "Собственик на организацията"
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr "Администратор на организацията"
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr "Модератор"
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "Потребител"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "Гост"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr "Непознат IP адрес"
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr "неизвестна операционна система"
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr "Неизвестен браузър"
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr "Събитие, по-ново от {event_id}, вече е било изрязано!"
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr "Събитието {event_id} не е в този списък"
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr ""
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 msgid "Failed to generate challenge"
 msgstr ""
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr "JWT удостоверяването не е разрешено за тази организация"
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr ""
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr ""
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr ""
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr "Нужен е поддомейн"
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr "Грешна парола."
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr "В полето трябва да има поне един избор."
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for use for user matching."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr "Поле с този етикет вече съществува."
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr ""
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr ""
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr ""
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr ""
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr ""
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr ""
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr ""
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr ""
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 #, fuzzy
 #| msgid "Invitation has already been revoked"
 msgid "Invitation already used or deactivated."
 msgstr "Поканата вече е отказана"
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr "Поканата вече е отказана"
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr ""
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr "Трябва да посочите поне един имейл адрес."
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
@@ -7589,106 +6995,104 @@ msgstr ""
 "Някои от тези адреси вече използват Zulip, затова не им изпратихме покана. "
 "Изпратихме покани на всички останали!"
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr ""
 "Историята на редактиране на съобщенията е деактивирана в тази организация"
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr "Нямате разрешение да изтриете това съобщение"
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr "Срокът за изтриване на това съобщение е изтекъл"
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr ""
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr ""
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr ""
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr ""
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr ""
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Message edit history is disabled in this organization"
 msgid "Message reporting is not enabled in this organization."
 msgstr ""
 "Историята на редактиране на съобщенията е деактивирана в тази организация"
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr ""
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr ""
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr ""
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr ""
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr ""
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr ""
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr ""
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr ""
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr ""
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 #, fuzzy
 #| msgid "A field with that label already exists."
 msgid "Navigation view already exists."
 msgstr "Поле с този етикет вече съществува."
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7696,575 +7100,573 @@ msgid ""
 "later. Is this a good time?\n"
 msgstr ""
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr ""
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr ""
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 #, fuzzy
 #| msgid "You don't have permission to delete this message"
 msgid "You do not have permission to manage plans and billing."
 msgstr "Нямате разрешение да изтриете това съобщение"
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr ""
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr ""
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr ""
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr "Разписките за прочитане са изключени в тази организация."
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr ""
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr "Трябва да е активиран поне един метод за удостоверяване."
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr ""
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr ""
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr ""
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr "Домейнът {domain} вече е част от вашата организация."
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr "Каченият файл е по-голям от позволения лимит, който е {max_size} MiB"
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 #, fuzzy
 #| msgid "JWT authentication is not enabled for this organization"
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr "JWT удостоверяването не е разрешено за тази организация"
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr ""
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr ""
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr ""
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr ""
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr ""
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr ""
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr ""
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid characters in emoji name"
 msgid "Invalid character in language: {character}"
 msgstr "В името на емоджито има невалидни символи"
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Language '{language}' is not allowed."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr ""
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr ""
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "Direct messages"
 msgid "Importing messages…"
 msgstr "Лични съобщения"
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "Your email"
 msgid "Your name"
 msgstr "Вашия имейл"
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr ""
 "Изисква се да изберете получател при актуализиране на типа на планираното "
 "съобщение."
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr ""
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr "Невалиден DSN"
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr ""
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr ""
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr ""
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr "Невалидни параметри"
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr ""
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr ""
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr ""
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, fuzzy, python-brace-format
 #| msgid "{user_full_name} added you to the group {group_name}."
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr "{user_full_name} ви добави към групата {group_name}."
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr ""
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr ""
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr ""
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
 "**"
 msgstr ""
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr ""
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr ""
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr ""
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr ""
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr ""
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr ""
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr ""
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr "Потребителят е деактивирал известията за писане за лични съобщения"
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr "<p>Този файл не съществува или е бил изтрит.</p>"
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr "<p>Нямате разрешение да преглеждате този файл. </p>"
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr "Невалиден тоукън"
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr "Невалидно име на файл"
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr "Трябва да посочите файл, който да качите"
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr "Можете да качвате само по един файл наведнъж"
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr ""
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 msgstr ""
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr "{user_full_name} ви добави към групата {group_name}."
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr "{user_full_name} ви премахна от групата {group_name}."
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr "Потребителят {user_id} вече е член на тази група"
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr "В тази потребителска група няма член '{user_id}'"
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr "Потребителската група {group_id} вече е подгрупа на тази група."
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
 "subgroups."
 msgstr ""
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr "Потребителската група {group_id} не е подгрупа на тази група."
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr "Промените на аватара са изклю в тази организация."
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr "Промен на имейл адреси са забранени в тази организация."
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr ""
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr ""
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr ""
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr "Вашата Zulip парола се управлява в LDAP"
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr "Грешна парола!"
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, fuzzy, python-brace-format
 #| msgid "You're making too many attempts! Try again in {seconds} seconds."
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr "Правите твърде много опити! Опитайте отново след {seconds} секунди."
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr "Новата парола е твърде слаба!"
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr ""
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr ""
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr ""
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Nobody in this Zulip organization will be able to see this email address."
 msgid "User is not allowed to delete other user's messages."
 msgstr "Никой в тази Zulip организация няма да може да види този имейл адрес."
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 "Разрешението за собственик не може да бъде премахнато от единствения "
 "собственик на организацията."
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr ""
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr ""
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
@@ -8277,27 +7679,27 @@ msgstr ""
 "конфигуриран.\n"
 "Моля, свържете се с администратора на вашия сървър."
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 #, fuzzy
 #| msgid "Email address"
 msgid "Email address already in use"
 msgstr "Имейл адрес"
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr "Неуспешна смяна на собственика, няма такъв потребител"
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr "Неуспешна смяна на собственика, потребителят е деактивиран"
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr ""
 "Промяната на собственик е неуспешна, ботовете не могат да притежават други "
 "ботове"
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
@@ -8306,132 +7708,132 @@ msgstr ""
 "конфигуриран.\n"
 "Моля, свържете се с администратора на вашия сървър."
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr ""
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr ""
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr ""
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr "Имейл '{email}' не е разрешен в тази организация"
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr "Еднократните имейл адреси не са разрешени в тази организация"
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid billing access token."
 msgid "Invalid {provider_name} access token"
 msgstr "Невалиден тоукън за достъп до таксуването."
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} call"
 msgstr ""
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} credentials have not been configured"
 msgstr ""
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid {var_name}"
 msgid "Invalid {provider_name} credentials"
 msgstr "Невалиден {var_name}"
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr ""
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error authenticating to the {provider_name} server"
 msgstr ""
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr ""
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} session identifier"
 msgstr ""
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr ""
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} public room."
 msgstr ""
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr ""
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{full_name}'s Zulip room"
 msgstr ""
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 "Проектите, използващи този доставчик на система за контрол на версиите, не "
 "се поддържат"
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr ""
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr ""
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr ""
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr ""
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr ""
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr ""
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr ""
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr ""
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr ""
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
@@ -8440,153 +7842,153 @@ msgstr ""
 "Експортирането на данни е завършено. [Преглед и изтегляне на експортирани "
 "данни]({export_settings_link})."
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr ""
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr ""
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr ""
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr ""
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr ""
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr "Трябва да се валидира със валиден API ключ за Zulip сървър"
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr "Невалидно UUID"
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr ""
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr ""
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr ""
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr ""
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr ""
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
 "try again later or reach out to {support_email} for assistance."
 msgstr ""
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr ""
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr ""
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr "Липсва ios_app_id"
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr ""
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
 "server: {reason}"
 msgstr ""
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr "Вашият план не позволява изпращането на известия."
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr ""
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr ""
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr ""
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr ""
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr ""
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr ""
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr ""
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 #, fuzzy
 #| msgid "Missing ios_app_id"
 msgid "Missing idp param"
 msgstr "Липсва ios_app_id"
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr "Невалидно OTP"
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr ""
 

--- a/locale/bn/LC_MESSAGES/django.po
+++ b/locale/bn/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 19:09+0000\n"
 "Last-Translator: Alex Vandiver <alexmv@zulip.com>\n"
 "Language-Team: Bengali <https://hosted.weblate.org/projects/zulip/django/bn/"
@@ -20,50 +20,50 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr ""
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr ""
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr ""
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr ""
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr ""
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr ""
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -72,7 +72,7 @@ msgid ""
 "users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -80,7 +80,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than one user to join."
 msgstr ""
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -88,7 +88,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than two users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -96,7 +96,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than three users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -105,148 +105,147 @@ msgid ""
 "({billing_page_link}) is greater than the current number of users."
 msgstr ""
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr ""
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr ""
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
 "(minimum {min_licenses})."
 msgstr ""
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
 "page. To complete the upgrade, please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr ""
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr ""
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr ""
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr ""
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr ""
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr ""
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
 msgstr ""
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
 msgstr ""
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
 "licenses."
 msgstr ""
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
 "billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr ""
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr ""
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr ""
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -256,100 +255,97 @@ msgid ""
 "we would really appreciate it!"
 msgstr ""
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
 "{support_email}"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr ""
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr ""
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr ""
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
 "%(support_email)s\">contact support</a>."
 msgstr ""
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr ""
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
 msgstr ""
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr ""
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
 msgstr ""
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr ""
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr ""
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
 msgstr ""
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -357,289 +353,270 @@ msgid ""
 "a> with any questions."
 msgstr ""
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
 "a> for support."
 msgstr ""
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
 "href=\"%(troubleshooting_url)s\">Zulip server troubleshooting guide</a>."
 msgstr ""
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr ""
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr ""
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr ""
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr ""
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr ""
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr ""
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr ""
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr ""
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr ""
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr ""
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr ""
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr ""
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr ""
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr ""
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr ""
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr ""
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr ""
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr ""
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr ""
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr ""
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr ""
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr ""
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr ""
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr ""
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr ""
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr ""
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr ""
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr ""
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr ""
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr ""
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
 "%(old_email_html_tag)s to %(new_email_html_tag)s"
 msgstr ""
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr ""
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
 msgstr ""
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "বাতিল"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr ""
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr ""
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -650,19 +627,19 @@ msgid ""
 "server."
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -670,788 +647,297 @@ msgid ""
 "%(support_email)s'>contact support</a> with any questions."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, python-format
 msgid "You can try again in %(retry_after_string)s."
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr ""
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr ""
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr ""
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr ""
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr ""
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr ""
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr ""
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr ""
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr ""
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr ""
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr ""
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr ""
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr ""
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr ""
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 msgid "Zulip for open source"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 msgid "Message with code"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
 msgstr ""
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 msgid "Get started"
 msgstr ""
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
 "continue."
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "ই-মেইল"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1459,78 +945,77 @@ msgid ""
 "from Zulip."
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
 msgstr ""
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr ""
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr ""
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr ""
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr ""
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr ""
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr ""
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr ""
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
 msgstr ""
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1538,210 +1023,203 @@ msgid ""
 "href=\"%(doc_url)s\">documentation</a>."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, python-format
 msgid "No account found for %(email)s."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Create a new organization"
 msgid "Try Zulip in a demo organization"
 msgstr "নতুন সংস্থা তৈরি করুন"
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 msgid "Try Zulip"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "নতুন সংস্থা তৈরি করুন"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid "Import chat history?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "অথবা"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "সাইন-আপ"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1749,123 +1227,122 @@ msgid ""
 "noreferrer\">after you join</a>."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "পরিবর্তন"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr ""
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">Terms of Service</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr ""
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr ""
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -1873,45 +1350,45 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 msgid ""
 "This organization has been deactivated, and all organization data has been "
 "deleted."
 msgstr ""
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
 "inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
 "administrators</a> to inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 msgid "This organization has been deactivated."
 msgstr ""
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
 "%(support_email)s\">contact Zulip support</a> to reactivate it."
 msgstr ""
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -1919,165 +1396,164 @@ msgid ""
 "reactivate it."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "কপি"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "বন্ধ করুন"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr ""
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr ""
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
 "<b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
 "href=\"%(apps_page_link)s\">mobile and desktop</a> apps:"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
 "href=\"%(getting_user_started_link)s\">getting started guide</a>!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2085,83 +1561,83 @@ msgid ""
 "Zulip</a>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
 "to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
 "desktop apps (%(apps_page_link)s):"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
 "(%(getting_user_started_link)s)!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
 "(%(getting_organization_started_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2169,32 +1645,32 @@ msgid ""
 "password for this account, please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "%(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 msgid "Verify your email address for your Zulip demo organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "<%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2202,113 +1678,113 @@ msgid ""
 "please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
 "— we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
 "deactivated, and you will no longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr ""
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2316,22 +1792,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because your organization <a "
@@ -2339,8 +1815,8 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to <a "
@@ -2348,39 +1824,39 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr ""
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because your organization hides "
@@ -2388,81 +1864,74 @@ msgid ""
 "details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to hide "
 "message content in email notifications. See %(help_url)s for more details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr ""
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
 "organizations:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
 "organizations hosted by %(external_host)s:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
 "href=\"%(help_reset_password_link)s\">reset your password</a>."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
 "%(external_host)s."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2470,97 +1939,94 @@ msgid ""
 "to find your account."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
 "try another way to find your account (%(help_logging_in_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
 "communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr ""
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
 "-- the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
 "Zulip &mdash; the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
 "to ask %(referrer_name)s for another one."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2568,72 +2034,70 @@ msgid ""
 "productivity."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at <a href=\"mailto:%(email)s\">%(email)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
 "%(email)s\">Contact us</a> — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
 "#%(channel_name)s > %(topic_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2641,68 +2105,68 @@ msgid ""
 "preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails (<a href=\"%(url)s\">help</a>)."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2710,22 +2174,22 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2733,52 +2197,52 @@ msgid ""
 "immediately at <%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2786,31 +2250,31 @@ msgid ""
 "contact us immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2818,7 +2282,7 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -2826,25 +2290,25 @@ msgid ""
 "Zulip</a> to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
 "with you and share their unique perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -2852,7 +2316,7 @@ msgid ""
 "experience how a new chat app will help your team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -2860,148 +2324,148 @@ msgid ""
 "action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
 "team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
 "organizations like yours!"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3009,11 +2473,11 @@ msgid ""
 "about…?”"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3022,23 +2486,23 @@ msgid ""
 "href=\"%(move_channels_link)s\">move a topic to a different channel</a>."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3047,23 +2511,23 @@ msgid ""
 "(%(move_channels_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
 "%(email)s on %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3071,46 +2535,46 @@ msgid ""
 "href=\"%(help_link)s\">reactivate your account</a>."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
 "You can contact an organization administrator to reactivate your account."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3118,541 +2582,537 @@ msgid ""
 "have been voided."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
 "to %(upgrade_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip demo organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip demo organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Create a new organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "নতুন সংস্থা তৈরি করুন"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for <b>%(remote_server_hostname)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 msgid "Click the button below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for %(remote_server_hostname)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
 "management for <b>%(remote_realm_host)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
 "management for %(remote_realm_host)s."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the <a href=\"%(plans_link)s\">Zulip Community plan</a>."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
 "website</a>, we would really appreciate it!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
 msgstr ""
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
 "accounts for another email address</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr ""
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "অ্যাকাউন্ট খুজুন"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr ""
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr ""
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr ""
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 msgid "Zulip Cloud"
 msgstr ""
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr ""
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr ""
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr ""
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr ""
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr ""
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr ""
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr ""
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr ""
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr ""
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr ""
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr ""
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr ""
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr ""
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr ""
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr ""
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr ""
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr ""
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr ""
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr ""
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr ""
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr ""
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr ""
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr ""
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr ""
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr ""
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr ""
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "ইতিহাস"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr ""
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr ""
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr ""
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr ""
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr ""
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 msgid "Bluesky"
 msgstr ""
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr ""
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr ""
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr ""
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 msgid ""
 "And hundreds more through <a href=\"/integrations/zapier\">Zapier</a> and <a "
 "href=\"/integrations/ifttt\">IFTTT</a>."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3660,7 +3120,7 @@ msgid ""
 "emails with your email domain."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3668,7 +3128,7 @@ msgid ""
 "disposable email addresses."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3676,24 +3136,24 @@ msgid ""
 "emails that contain \"+\"."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3701,7 +3161,7 @@ msgid ""
 "%(support_email)s\">contact Zulip support</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3709,89 +3169,89 @@ msgid ""
 "%(support_email)s\">contact this Zulip server's administrators</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
 "management for your Zulip server."
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr ""
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr ""
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr ""
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr ""
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr ""
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr ""
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr ""
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> because all Zulip Cloud licenses are in use."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -3800,42 +3260,40 @@ msgid ""
 "or misconfiguration."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 msgid "Demo organizations disabled"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -3843,22 +3301,21 @@ msgid ""
 "organization for more information."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -3866,44 +3323,42 @@ msgid ""
 "Zulip support</a> for assistance in resolving this issue."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
 "a> like Firefox, Chrome, and Edge."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 msgid "Finalize organization import"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 msgid "Organization import completed!"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -3911,54 +3366,53 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 msgid "Select your account"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create a new organization"
 msgid "Create new account"
 msgstr "নতুন সংস্থা তৈরি করুন"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr ""
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -3966,81 +3420,81 @@ msgid ""
 "have one yet."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 msgid "Self-hosting Zulip?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">log in to manage plans and billing.</a>"
 msgstr ""
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr ""
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
 msgstr ""
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr ""
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr ""
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr ""
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr ""
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr ""
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4048,7 +3502,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4057,57 +3511,57 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr ""
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4115,7 +3569,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4123,40 +3577,40 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4164,300 +3618,294 @@ msgid ""
 "away!"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
 "href=\"%(realm_url)s/#settings/notifications\">notification settings</a>."
 msgstr ""
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr ""
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr ""
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr ""
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr ""
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr ""
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr ""
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr ""
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 msgid "Cannot reactivate a deleted user"
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr ""
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr ""
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr ""
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr ""
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
 msgstr ""
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
 msgstr ""
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr ""
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr ""
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr ""
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr ""
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr ""
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr ""
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr ""
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr ""
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr ""
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr ""
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
 "{new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
 "{user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to resolve topics in this channel."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr ""
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr ""
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr ""
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr ""
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr ""
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
 "but there is no channel with that ID."
 msgstr ""
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4465,36 +3913,36 @@ msgid ""
 "it."
 msgstr ""
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
 "The channel exists but does not have any subscribers."
 msgstr ""
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr ""
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr ""
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr ""
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4502,107 +3950,105 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
 "authentication method."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr ""
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 msgid "Reminder could not be sent."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
 "the following error:"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr ""
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr ""
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr ""
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr ""
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr ""
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
 "**{old_policy}** to **{new_policy}**."
 msgstr ""
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -4611,51 +4057,49 @@ msgid ""
 "* **New**: {new_setting_description}\n"
 msgstr ""
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr ""
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr ""
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr ""
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr ""
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr ""
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr ""
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 msgstr ""
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr ""
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -4666,283 +4110,269 @@ msgid ""
 "{summary_line}"
 msgstr ""
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr ""
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr ""
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr ""
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr ""
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr ""
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr ""
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr ""
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr ""
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr ""
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr ""
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr ""
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
 "organization administrator to reactivate it."
 msgstr ""
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr ""
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr ""
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr ""
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr ""
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr ""
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr ""
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr ""
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
 "to register for accounts in this organization."
 msgstr ""
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr ""
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 msgid "Challenges are not enabled."
 msgstr ""
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr ""
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr ""
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "You're making too many attempts to sign in. Try again in "
 "{retry_after_string} or contact your organization administrator for help."
 msgstr ""
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
 msgstr ""
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr ""
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr ""
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr ""
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr ""
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr ""
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr ""
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr ""
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr ""
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr ""
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr ""
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr ""
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name can't be empty."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 msgid "Invalid channel folder ID"
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 msgid "Configure owner account email address."
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4951,69 +4381,69 @@ msgid ""
 "organization]({convert_demo}).\n"
 msgstr ""
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, python-brace-format
 msgid "{var_name} is not Base64 encoded"
 msgstr ""
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 msgid "Invalid `device_id`"
 msgstr ""
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr ""
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr ""
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr ""
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr ""
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr ""
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr ""
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr ""
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr ""
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr ""
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr ""
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5021,595 +4451,593 @@ msgid ""
 "{error_message}"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr ""
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr ""
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr ""
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr ""
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr ""
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr ""
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr ""
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr ""
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr ""
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr ""
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr ""
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr ""
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr ""
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
 msgstr ""
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr ""
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr ""
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr ""
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr ""
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr ""
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr ""
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr ""
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr ""
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 msgid "Must be a bot user"
 msgstr ""
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr ""
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr ""
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr ""
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
 "webhook; ignoring"
 msgstr ""
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr ""
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr ""
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr ""
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr ""
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} most recent messages in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr ""
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr ""
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
 msgstr ""
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr ""
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr ""
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr ""
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr ""
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr ""
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Find accounts"
 msgid "Atlassian account ID"
 msgstr "অ্যাকাউন্ট খুজুন"
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 msgid "Behance username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 msgid "Bitbucket username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 msgid "Codeberg username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 msgid "Dribbble username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 msgid "Facebook username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 msgid "GitLab username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 msgid "Instagram username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 msgid "Mastodon profile"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 msgid "Medium username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 msgid "Pinterest username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 msgid "Reddit username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 msgid "Snapchat username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 msgid "Threads username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 msgid "TikTok username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 msgid "Twitch username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 msgid "X username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr ""
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr ""
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 msgid "Video calling"
 msgstr ""
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr ""
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr ""
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr ""
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr ""
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr ""
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr ""
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr ""
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr ""
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr ""
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr ""
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr ""
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr ""
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr ""
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr ""
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "{fullname} moderation"
 msgstr ""
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr ""
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr ""
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor_date' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr ""
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 msgid "Navigation view does not exist."
 msgstr ""
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5617,7 +5045,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5625,7 +5053,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5633,7 +5061,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5641,7 +5069,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5651,14 +5079,14 @@ msgid ""
 "a permanent organization]({convert_demo_organization_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
 "them in your [Inbox](/#inbox).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5666,7 +5094,7 @@ msgid ""
 "({navigation_tour_video_url}) for a quick app overview.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5681,14 +5109,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -5696,7 +5124,7 @@ msgid ""
 "and edit your [profile information](/help/edit-your-profile).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -5707,7 +5135,7 @@ msgid ""
 "experience in your [Preferences](#settings/preferences).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5718,7 +5146,7 @@ msgid ""
 "[Browse and subscribe to channels]({settings_link}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -5735,7 +5163,7 @@ msgid ""
 "discussed.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -5744,7 +5172,7 @@ msgid ""
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -5756,7 +5184,7 @@ msgid ""
 "times, and more.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5766,7 +5194,7 @@ msgid ""
 "or browse the [help center](/help/) to learn more!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5774,7 +5202,7 @@ msgid ""
 "get help, try one of the following messages: {bot_commands}\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5786,13 +5214,13 @@ msgid ""
 "({move_content_another_channel_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5806,12 +5234,11 @@ msgid ""
 "and above.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr ""
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -5819,14 +5246,14 @@ msgid ""
 "no matter how many other conversations are going on.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
 "conversations with unread messages.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -5834,7 +5261,7 @@ msgid ""
 "the `+` button next to its name.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -5842,13 +5269,13 @@ msgid ""
 "can we chat about…?”\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5856,7 +5283,7 @@ msgid ""
 "({format_message_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5876,1324 +5303,1301 @@ msgid ""
 "```\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
 "teammates.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
 "conversation.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr ""
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr ""
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr ""
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr ""
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 msgid "Invalid `push_key`"
 msgstr ""
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr ""
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr ""
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr ""
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 msgid "Reminder does not exist"
 msgstr ""
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr ""
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr ""
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr ""
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr ""
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr ""
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr ""
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr ""
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr ""
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 msgid "You do not have permission to create new topics in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr ""
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr ""
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr ""
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr ""
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr ""
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr ""
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} does not have the expected format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr ""
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr ""
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr ""
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {user_group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr ""
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr ""
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr ""
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr ""
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr ""
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 msgid "Name must not be empty!"
 msgstr ""
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr ""
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr ""
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr ""
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr ""
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr ""
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr ""
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr ""
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr ""
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr ""
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr ""
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr ""
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr ""
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr ""
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr ""
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr ""
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr ""
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr ""
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr ""
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr ""
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr ""
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr ""
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr ""
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr ""
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr ""
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr ""
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr ""
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr ""
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr ""
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr ""
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr ""
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr ""
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr ""
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr ""
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr ""
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr ""
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr ""
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr ""
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Invalid characters in emoji name"
 msgid "Invalid auto-conversion field: empty field name."
 msgstr "ইমোজির নামে অকার্যকর অক্ষর"
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr ""
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr ""
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 msgid "Example input does not match the linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in alternative URL template is not present in linkifier "
 "pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in linkifier pattern is not present in alternative URL "
 "template."
 msgstr ""
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr "ইউনিকোড ইমোজি"
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "কাস্টম ইমোজি"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr "যুলিপের অতিরিক্ত ইমোজি"
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr "ইমোজির নামে অকার্যকর অক্ষর"
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr ""
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr ""
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr ""
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr ""
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr ""
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr ""
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr ""
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr ""
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr ""
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr ""
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr ""
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr ""
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr ""
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr ""
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr ""
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr ""
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr ""
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr ""
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr ""
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr ""
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr ""
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr ""
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr ""
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr ""
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr ""
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr ""
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 msgid "Failed to generate challenge"
 msgstr ""
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr ""
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr ""
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr ""
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr ""
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr ""
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr ""
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for use for user matching."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr ""
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr ""
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr ""
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr ""
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr ""
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr ""
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr ""
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr ""
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 msgid "Invitation already used or deactivated."
 msgstr ""
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr ""
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr ""
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr ""
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
 msgstr ""
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr ""
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr ""
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr ""
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr ""
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr ""
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr ""
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr ""
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr ""
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 msgid "Message reporting is not enabled in this organization."
 msgstr ""
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr ""
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr ""
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr ""
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr ""
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr ""
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr ""
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr ""
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr ""
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr ""
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 msgid "Navigation view already exists."
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7201,857 +6605,855 @@ msgid ""
 "later. Is this a good time?\n"
 msgstr ""
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr ""
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr ""
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 msgid "You do not have permission to manage plans and billing."
 msgstr ""
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr ""
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr ""
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr ""
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr ""
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr ""
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr ""
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr ""
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr ""
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr ""
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr ""
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr ""
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr ""
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr ""
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr ""
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr ""
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr ""
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr ""
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr ""
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr ""
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid characters in emoji name"
 msgid "Invalid character in language: {character}"
 msgstr "ইমোজির নামে অকার্যকর অক্ষর"
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Language '{language}' is not allowed."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr ""
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr ""
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 msgid "Importing messages…"
 msgstr ""
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 msgid "Your name"
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr ""
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr ""
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr ""
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr ""
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr ""
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr ""
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr ""
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr ""
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr ""
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr ""
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr ""
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr ""
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr ""
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
 "**"
 msgstr ""
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr ""
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr ""
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr ""
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr ""
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr ""
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr ""
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr ""
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr ""
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr ""
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr ""
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr ""
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr ""
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr ""
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 msgstr ""
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr ""
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr ""
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
 "subgroups."
 msgstr ""
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr ""
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr ""
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr ""
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr ""
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr ""
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr ""
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr ""
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr ""
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr ""
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr ""
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 msgid "User is not allowed to delete other user's messages."
 msgstr ""
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr ""
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr ""
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 msgid ""
 "Can't change bot email until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 msgstr ""
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 msgid "Email address already in use"
 msgstr ""
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr ""
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr ""
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr ""
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 msgstr ""
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr ""
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr ""
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr ""
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr ""
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr ""
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} access token"
 msgstr ""
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} call"
 msgstr ""
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} credentials have not been configured"
 msgstr ""
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} credentials"
 msgstr ""
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr ""
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error authenticating to the {provider_name} server"
 msgstr ""
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr ""
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} session identifier"
 msgstr ""
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr ""
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} public room."
 msgstr ""
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr ""
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{full_name}'s Zulip room"
 msgstr ""
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr ""
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr ""
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr ""
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr ""
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr ""
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr ""
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr ""
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr ""
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr ""
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
 "({export_settings_link})."
 msgstr ""
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr ""
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr ""
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr ""
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr ""
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr ""
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr ""
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr ""
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr ""
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr ""
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr ""
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr ""
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr ""
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
 "try again later or reach out to {support_email} for assistance."
 msgstr ""
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr ""
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr ""
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr ""
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr ""
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
 "server: {reason}"
 msgstr ""
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr ""
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr ""
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr ""
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr ""
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr ""
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr ""
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr ""
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr ""
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 msgid "Missing idp param"
 msgstr ""
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr ""
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr ""

--- a/locale/bqi/LC_MESSAGES/django.po
+++ b/locale/bqi/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 19:46+0000\n"
 "Last-Translator: Alex Vandiver <alexmv@zulip.com>\n"
 "Language-Team: Luri (Bakhtiari) <https://hosted.weblate.org/projects/zulip/"
@@ -20,50 +20,50 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr ""
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr ""
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr ""
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr ""
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr ""
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr ""
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -72,7 +72,7 @@ msgid ""
 "users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -80,7 +80,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than one user to join."
 msgstr ""
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -88,7 +88,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than two users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -96,7 +96,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than three users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -105,148 +105,147 @@ msgid ""
 "({billing_page_link}) is greater than the current number of users."
 msgstr ""
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr ""
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr ""
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
 "(minimum {min_licenses})."
 msgstr ""
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
 "page. To complete the upgrade, please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr ""
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr ""
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr ""
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr ""
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr ""
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr ""
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
 msgstr ""
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
 msgstr ""
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
 "licenses."
 msgstr ""
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
 "billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr ""
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr ""
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr ""
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -256,100 +255,97 @@ msgid ""
 "we would really appreciate it!"
 msgstr ""
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
 "{support_email}"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr ""
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "xatā"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr ""
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
 "%(support_email)s\">contact support</a>."
 msgstr ""
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr ""
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
 msgstr ""
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr ""
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
 msgstr ""
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr ""
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr "xatā mêni,mên sêrvêr"
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
 msgstr ""
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -357,289 +353,270 @@ msgid ""
 "a> with any questions."
 msgstr ""
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
 "a> for support."
 msgstr ""
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
 "href=\"%(troubleshooting_url)s\">Zulip server troubleshooting guide</a>."
 msgstr ""
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr ""
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr ""
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr ""
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr ""
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr ""
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr ""
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr ""
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr ""
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr ""
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr ""
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr ""
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr ""
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr ""
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "mêntorā"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr ""
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "mo"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "poy"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "haftê dindâyi"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "borčê dindâyi"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "sālê dindâyi"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "poy zamovā"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr ""
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr ""
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "haftêyi"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr ""
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "āďumiyal"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "robātā"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr ""
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr ""
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr "vê ru kerdên dindâyi"
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr "imêyl ālêšt vâbi!"
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
 "%(old_email_html_tag)s to %(new_email_html_tag)s"
 msgstr ""
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr ""
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
 msgstr ""
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "raď kerdên"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr ""
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr ""
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -650,19 +627,19 @@ msgid ""
 "server."
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -670,788 +647,297 @@ msgid ""
 "%(support_email)s'>contact support</a> with any questions."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, python-format
 msgid "You can try again in %(retry_after_string)s."
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr ""
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr ""
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr ""
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "poy"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr "kêtên kerdêyal"
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr ""
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr ""
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr ""
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr ""
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr ""
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "vorkêlê sāzêmow"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr ""
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr ""
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr ""
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr ""
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 msgid "Zulip for open source"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 msgid "Message with code"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr "ling"
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
 msgstr ""
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 msgid "Get started"
 msgstr ""
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
 "continue."
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "imêyl"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1459,78 +945,77 @@ msgid ""
 "from Zulip."
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
 msgstr ""
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr ""
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr ""
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr ""
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr ""
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr ""
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr ""
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr ""
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
 msgstr ""
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1538,212 +1023,205 @@ msgid ""
 "href=\"%(doc_url)s\">documentation</a>."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr "hêsāvê mêntori zulip nê najost."
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, python-format
 msgid "No account found for %(email)s."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Create organization"
 msgid "Try Zulip in a demo organization"
 msgstr "vorkêlê sāzêmow"
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Why Zulip"
 msgid "Try Zulip"
 msgstr "sičê Zulip?"
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid "Import chat history?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr "nome sāzêmow"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "sabtê nom"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "sabtê nom mênê Zulip"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "avoďên"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1751,123 +1229,122 @@ msgid ""
 "noreferrer\">after you join</a>."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "ālêštkâri"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr "hêsāvê isā"
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "nom"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "razm"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr "qoďratê razm"
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr ""
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">Terms of Service</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr ""
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr ""
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -1875,45 +1352,45 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 msgid ""
 "This organization has been deactivated, and all organization data has been "
 "deleted."
 msgstr ""
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
 "inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
 "administrators</a> to inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 msgid "This organization has been deactivated."
 msgstr ""
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
 "%(support_email)s\">contact Zulip support</a> to reactivate it."
 msgstr ""
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -1921,165 +1398,164 @@ msgid ""
 "reactivate it."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "dîvowdārow"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "mêntorā ma'muli"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "bastên"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr ""
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr "Zulip"
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
 "<b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
 "href=\"%(apps_page_link)s\">mobile and desktop</a> apps:"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
 "href=\"%(getting_user_started_link)s\">getting started guide</a>!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2087,83 +1563,83 @@ msgid ""
 "Zulip</a>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
 "to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
 "desktop apps (%(apps_page_link)s):"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
 "(%(getting_user_started_link)s)!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
 "(%(getting_organization_started_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2171,32 +1647,32 @@ msgid ""
 "password for this account, please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "%(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 msgid "Verify your email address for your Zulip demo organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "<%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2204,113 +1680,113 @@ msgid ""
 "please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
 "— we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
 "deactivated, and you will no longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr ""
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2318,22 +1794,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because your organization <a "
@@ -2341,8 +1817,8 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to <a "
@@ -2350,39 +1826,39 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr ""
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because your organization hides "
@@ -2390,81 +1866,74 @@ msgid ""
 "details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to hide "
 "message content in email notifications. See %(help_url)s for more details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr ""
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
 "organizations:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
 "organizations hosted by %(external_host)s:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
 "href=\"%(help_reset_password_link)s\">reset your password</a>."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
 "%(external_host)s."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2472,97 +1941,94 @@ msgid ""
 "to find your account."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
 "try another way to find your account (%(help_logging_in_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
 "communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr ""
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
 "-- the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
 "Zulip &mdash; the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
 "to ask %(referrer_name)s for another one."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2570,72 +2036,70 @@ msgid ""
 "productivity."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at <a href=\"mailto:%(email)s\">%(email)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
 "%(email)s\">Contact us</a> — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
 "#%(channel_name)s > %(topic_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2643,68 +2107,68 @@ msgid ""
 "preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails (<a href=\"%(url)s\">help</a>)."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2712,22 +2176,22 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr "timê Zulip"
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2735,52 +2199,52 @@ msgid ""
 "immediately at <%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2788,31 +2252,31 @@ msgid ""
 "contact us immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2820,7 +2284,7 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -2828,25 +2292,25 @@ msgid ""
 "Zulip</a> to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
 "with you and share their unique perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -2854,7 +2318,7 @@ msgid ""
 "experience how a new chat app will help your team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -2862,148 +2326,148 @@ msgid ""
 "action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
 "team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
 "organizations like yours!"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3011,11 +2475,11 @@ msgid ""
 "about…?”"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3024,23 +2488,23 @@ msgid ""
 "href=\"%(move_channels_link)s\">move a topic to a different channel</a>."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr "ra'ďên vê Zulip"
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3049,23 +2513,23 @@ msgid ""
 "(%(move_channels_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
 "%(email)s on %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3073,46 +2537,46 @@ msgid ""
 "href=\"%(help_link)s\">reactivate your account</a>."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
 "You can contact an organization administrator to reactivate your account."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3120,541 +2584,537 @@ msgid ""
 "have been voided."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
 "to %(upgrade_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip demo organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip demo organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip demo organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for <b>%(remote_server_hostname)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 msgid "Click the button below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for %(remote_server_hostname)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
 "management for <b>%(remote_realm_host)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
 "management for %(remote_realm_host)s."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the <a href=\"%(plans_link)s\">Zulip Community plan</a>."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
 "website</a>, we would really appreciate it!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
 msgstr ""
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
 "accounts for another email address</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr "ādrês imêyl"
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "jostên hêsāvā mêntori"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr ""
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr "sičê Zulip?"
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr ""
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr ""
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Zulip"
 msgid "Zulip Cloud"
 msgstr "Zulip"
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr ""
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr ""
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "ya jur kerdênā"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr ""
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr "sāzêmowê nu"
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr ""
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr ""
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr ""
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr ""
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr ""
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr ""
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr ""
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr ""
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr ""
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr ""
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr ""
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr ""
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr ""
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr ""
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr ""
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr ""
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr ""
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr ""
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr ""
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr ""
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr "tim"
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr ""
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr ""
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr ""
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr ""
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr ""
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr ""
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 msgid "Bluesky"
 msgstr ""
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr ""
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr ""
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr ""
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 msgid ""
 "And hundreds more through <a href=\"/integrations/zapier\">Zapier</a> and <a "
 "href=\"/integrations/ifttt\">IFTTT</a>."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr "API rêst"
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3662,7 +3122,7 @@ msgid ""
 "emails with your email domain."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3670,7 +3130,7 @@ msgid ""
 "disposable email addresses."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3678,24 +3138,24 @@ msgid ""
 "emails that contain \"+\"."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3703,7 +3163,7 @@ msgid ""
 "%(support_email)s\">contact Zulip support</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3711,89 +3171,89 @@ msgid ""
 "%(support_email)s\">contact this Zulip server's administrators</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
 "management for your Zulip server."
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr ""
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr ""
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr "imêyl yā nomê mêntori"
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "nomê mêntori"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr ""
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr ""
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr ""
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> because all Zulip Cloud licenses are in use."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -3802,44 +3262,42 @@ msgid ""
 "or misconfiguration."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 #, fuzzy
 #| msgid "New organization"
 msgid "Demo organizations disabled"
 msgstr "sāzêmowê nu"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -3847,22 +3305,21 @@ msgid ""
 "organization for more information."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -3870,48 +3327,46 @@ msgid ""
 "Zulip support</a> for assistance in resolving this issue."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
 "a> like Firefox, Chrome, and Edge."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create organization"
 msgid "Finalize organization import"
 msgstr "vorkêlê sāzêmow"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Organization name"
 msgid "Organization import completed!"
 msgstr "nome sāzêmow"
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -3919,56 +3374,55 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Your account"
 msgid "Select your account"
 msgstr "hêsāvê isā"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Already has an account."
 msgid "Create new account"
 msgstr "zê zitar ya hêsāv mêntori dāre."
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr ""
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -3976,81 +3430,81 @@ msgid ""
 "have one yet."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 msgid "Self-hosting Zulip?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">log in to manage plans and billing.</a>"
 msgstr ""
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr ""
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
 msgstr ""
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "taiďê razm"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr ""
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr ""
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr ""
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr ""
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr ""
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4058,7 +3512,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4067,57 +3521,57 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr ""
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4125,7 +3579,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4133,40 +3587,40 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4174,302 +3628,296 @@ msgid ""
 "away!"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr "sāmovā imêyl vê ru vâbin"
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
 "href=\"%(realm_url)s/#settings/notifications\">notification settings</a>."
 msgstr ""
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr ""
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr ""
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr ""
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr ""
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr ""
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr ""
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr ""
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 msgid "Cannot reactivate a deleted user"
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr "fildê nomê mêntori {id} nê najost."
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr ""
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr ""
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr ""
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
 msgstr ""
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
 msgstr ""
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr ""
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr "ālêštkâriyî nî"
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr ""
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr ""
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr ""
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr ""
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr ""
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr "sāzêmov isā,ālêštê payum nê bîkênêš kerde"
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr "isā dasrasi si ālêštê i payumê nê nađârin"
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr ""
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
 "{new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
 "{user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 #, fuzzy
 #| msgid "You don't have permission to edit this message"
 msgid "You don't have permission to resolve topics in this channel."
 msgstr "isā  dasrasi si ālêštê i payumê nê nađârin"
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr ""
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr ""
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr "payom (ā) nazêbāl"
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr ""
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr ""
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
 "but there is no channel with that ID."
 msgstr ""
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4477,36 +3925,36 @@ msgid ""
 "it."
 msgstr ""
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
 "The channel exists but does not have any subscribers."
 msgstr ""
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr ""
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr ""
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr ""
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4514,109 +3962,107 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
 "authentication method."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr ""
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder could not be sent."
 msgstr "nêšovêi nî"
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
 "the following error:"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr ""
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr ""
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr ""
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr ""
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr ""
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
 "**{old_policy}** to **{new_policy}**."
 msgstr ""
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -4625,51 +4071,49 @@ msgid ""
 "* **New**: {new_setting_description}\n"
 msgstr ""
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr ""
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr ""
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr ""
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr ""
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr ""
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr ""
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 msgstr ""
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr ""
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -4680,285 +4124,271 @@ msgid ""
 "{summary_line}"
 msgstr ""
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr ""
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr ""
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr ""
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr "dasrasi kâfi nađārin"
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr ""
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr ""
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr ""
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr ""
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr ""
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr ""
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr ""
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
 "organization administrator to reactivate it."
 msgstr ""
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr ""
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr ""
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr ""
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr ""
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr ""
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr ""
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr ""
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
 "to register for accounts in this organization."
 msgstr ""
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr ""
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 msgid "Challenges are not enabled."
 msgstr ""
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "razmê nu"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr ""
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "You're making too many attempts to sign in. Try again in "
 "{retry_after_string} or contact your organization administrator for help."
 msgstr ""
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
 msgstr ""
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr ""
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr ""
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr ""
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr ""
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr "sartālî nî"
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr ""
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr ""
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr ""
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr "no'ê payom zêbāl nî"
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr ""
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr ""
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Domain can't be empty."
 msgid "Channel folder name can't be empty."
 msgstr "dāmana natarê pati bu."
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 msgid "Invalid channel folder ID"
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 msgid "Configure owner account email address."
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4967,69 +4397,69 @@ msgid ""
 "organization]({convert_demo}).\n"
 msgstr ""
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, python-brace-format
 msgid "{var_name} is not Base64 encoded"
 msgstr ""
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 msgid "Invalid `device_id`"
 msgstr ""
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr ""
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr "dāmana natarê pati bu."
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr ""
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr ""
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr ""
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr ""
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr ""
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr ""
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr ""
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr ""
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5037,623 +4467,621 @@ msgid ""
 "{error_message}"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr ""
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr "ādrês zêbāl nî."
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr "dar zê dāmanê isā hêď."
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr ""
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr ""
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr ""
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr "zê zitar ya hêsāv mêntori dāre."
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr ""
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr ""
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr ""
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr ""
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr ""
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr ""
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
 msgstr ""
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr ""
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr ""
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr ""
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr ""
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr "mêntor"
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr ""
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr "JSON êštêvā"
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr ""
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 msgid "Must be a bot user"
 msgstr ""
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr ""
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr ""
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr ""
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr "kilitê API êštêvā"
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
 "webhook; ignoring"
 msgstr ""
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr ""
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr ""
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr ""
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr "dasrasi ma'dud"
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} most recent messages in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr ""
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr ""
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
 msgstr ""
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr ""
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr ""
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr ""
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr ""
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr ""
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Already has an account."
 msgid "Atlassian account ID"
 msgstr "zê zitar ya hêsāv mêntori dāre."
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Behance username"
 msgstr "imêyl yā nomê mêntori"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 msgid "Bitbucket username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Codeberg username"
 msgstr "imêyl yā nomê mêntori"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Dribbble username"
 msgstr "imêyl yā nomê mêntori"
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Facebook username"
 msgstr "imêyl yā nomê mêntori"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "GitLab username"
 msgstr "imêyl yā nomê mêntori"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Instagram username"
 msgstr "imêyl yā nomê mêntori"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 msgid "Mastodon profile"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Medium username"
 msgstr "imêyl yā nomê mêntori"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Pinterest username"
 msgstr "imêyl yā nomê mêntori"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Reddit username"
 msgstr "imêyl yā nomê mêntori"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 msgid "Snapchat username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Threads username"
 msgstr "imêyl yā nomê mêntori"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "TikTok username"
 msgstr "imêyl yā nomê mêntori"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Twitch username"
 msgstr "imêyl yā nomê mêntori"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "nomê mêntori"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr ""
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr ""
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 msgid "Video calling"
 msgstr ""
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr ""
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr "lādêrâri muštiri"
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr ""
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr ""
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr ""
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr "mâli"
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr ""
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr ""
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr ""
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr ""
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr ""
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr ""
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr ""
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr "payum navā pati bu"
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "{fullname} moderation"
 msgstr ""
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr ""
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr ""
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor_date' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr ""
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Navigation view does not exist."
 msgstr "nêšovêi nî"
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5661,7 +5089,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5669,7 +5097,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5677,7 +5105,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5685,7 +5113,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5695,14 +5123,14 @@ msgid ""
 "a permanent organization]({convert_demo_organization_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
 "them in your [Inbox](/#inbox).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5710,7 +5138,7 @@ msgid ""
 "({navigation_tour_video_url}) for a quick app overview.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5725,14 +5153,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -5740,7 +5168,7 @@ msgid ""
 "and edit your [profile information](/help/edit-your-profile).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -5751,7 +5179,7 @@ msgid ""
 "experience in your [Preferences](#settings/preferences).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5762,7 +5190,7 @@ msgid ""
 "[Browse and subscribe to channels]({settings_link}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -5779,7 +5207,7 @@ msgid ""
 "discussed.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -5788,7 +5216,7 @@ msgid ""
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -5800,7 +5228,7 @@ msgid ""
 "times, and more.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5810,7 +5238,7 @@ msgid ""
 "or browse the [help center](/help/) to learn more!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5818,7 +5246,7 @@ msgid ""
 "get help, try one of the following messages: {bot_commands}\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5830,13 +5258,13 @@ msgid ""
 "({move_content_another_channel_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5850,12 +5278,11 @@ msgid ""
 "and above.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr ""
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -5863,14 +5290,14 @@ msgid ""
 "no matter how many other conversations are going on.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
 "conversations with unread messages.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -5878,7 +5305,7 @@ msgid ""
 "the `+` button next to its name.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -5886,13 +5313,13 @@ msgid ""
 "can we chat about…?”\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5900,7 +5327,7 @@ msgid ""
 "({format_message_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5920,1330 +5347,1307 @@ msgid ""
 "```\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
 "teammates.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
 "conversation.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr ""
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr ""
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr ""
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr ""
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr "nêšovêi nî"
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 #, fuzzy
 #| msgid "Invalid API key"
 msgid "Invalid `push_key`"
 msgstr "kilitê API êštêvā"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr ""
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr ""
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr ""
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder does not exist"
 msgstr "nêšovêi nî"
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr ""
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr ""
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr ""
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr ""
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr ""
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr ""
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr ""
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr ""
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 #, fuzzy
 #| msgid "You don't have permission to edit this message"
 msgid "You do not have permission to create new topics in this channel."
 msgstr "isā  dasrasi si ālêštê i payumê nê nađârin"
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr ""
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr ""
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr ""
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr ""
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr ""
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr ""
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} does not have the expected format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr ""
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr ""
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr ""
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {user_group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr ""
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr ""
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr ""
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr ""
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr "nom qalêve tulâni hêď!"
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 #, fuzzy
 #| msgid "Message must not be empty"
 msgid "Name must not be empty!"
 msgstr "payum navā pati bu"
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr ""
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr ""
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr ""
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr ""
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr ""
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr ""
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr ""
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr ""
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr ""
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr ""
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr ""
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr ""
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr "činow robāti nî"
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr "činow mêntori nî"
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr ""
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr ""
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr ""
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr ""
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr ""
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr ""
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr ""
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr ""
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr ""
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr ""
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr ""
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr ""
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr ""
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr ""
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr ""
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr ""
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr ""
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr ""
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr ""
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr ""
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr ""
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr ""
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr ""
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: empty field name."
 msgstr ""
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr ""
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr ""
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 msgid "Example input does not match the linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in alternative URL template is not present in linkifier "
 "pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in linkifier pattern is not present in alternative URL "
 "template."
 msgstr ""
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr ""
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "êmuji sêfârêši"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr ""
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr ""
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr ""
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr ""
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr ""
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr ""
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr ""
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr ""
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr ""
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr ""
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "poy volâti"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr ""
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr ""
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr ""
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr ""
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr ""
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr ""
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr ""
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr ""
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr "dîvowdārê sāzêmow"
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr ""
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "mêntor"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "mîmow"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr ""
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr ""
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr ""
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr ""
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 msgid "Failed to generate challenge"
 msgstr ""
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr ""
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr ""
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr ""
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr ""
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr ""
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr ""
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for use for user matching."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr ""
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr ""
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr ""
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr ""
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr ""
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr ""
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr ""
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr ""
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 msgid "Invitation already used or deactivated."
 msgstr ""
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr ""
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr ""
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr ""
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
 msgstr ""
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr ""
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr ""
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr ""
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr ""
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr ""
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr ""
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr ""
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr ""
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 msgid "Message reporting is not enabled in this organization."
 msgstr ""
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr "fêšnāko pati hêď"
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr ""
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr ""
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr ""
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr ""
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr ""
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr ""
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr ""
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr ""
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 msgid "Navigation view already exists."
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7251,863 +6655,861 @@ msgid ""
 "later. Is this a good time?\n"
 msgstr ""
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr ""
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr ""
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 #, fuzzy
 #| msgid "You don't have permission to edit this message"
 msgid "You do not have permission to manage plans and billing."
 msgstr "isā  dasrasi si ālêštê i payumê nê nađârin"
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr ""
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr ""
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr ""
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr ""
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr ""
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr ""
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr ""
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr ""
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr ""
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr ""
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr ""
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr ""
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr ""
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr ""
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr ""
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr ""
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr ""
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr ""
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr ""
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Invalid character in language: {character}"
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Language '{language}' is not allowed."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr ""
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr ""
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 msgid "Importing messages…"
 msgstr ""
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 msgid "Your name"
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr ""
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr ""
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr ""
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr ""
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr ""
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr ""
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr ""
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr ""
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr ""
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr ""
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr ""
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr ""
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr ""
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
 "**"
 msgstr ""
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr ""
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr ""
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr ""
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr ""
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr ""
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr ""
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr ""
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr ""
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr ""
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr ""
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr ""
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr ""
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr ""
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 msgstr ""
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr ""
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr ""
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
 "subgroups."
 msgstr ""
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr ""
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr ""
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr ""
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr ""
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr "razm zêbāl nî!"
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr ""
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr ""
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr ""
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr ""
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr ""
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 msgid "User is not allowed to delete other user's messages."
 msgstr ""
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr ""
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr ""
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 msgid ""
 "Can't change bot email until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 msgstr ""
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 #, fuzzy
 #| msgid "Email address"
 msgid "Email address already in use"
 msgstr "ādrês imêyl"
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr ""
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr ""
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr ""
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 msgstr ""
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr ""
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr ""
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr ""
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr ""
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr ""
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} access token"
 msgstr ""
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} call"
 msgstr ""
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} credentials have not been configured"
 msgstr ""
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} credentials"
 msgstr ""
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr ""
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error authenticating to the {provider_name} server"
 msgstr ""
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr ""
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} session identifier"
 msgstr ""
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr ""
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} public room."
 msgstr ""
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr ""
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{full_name}'s Zulip room"
 msgstr ""
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr ""
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr ""
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr "sartāl natare pati bu"
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr ""
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr ""
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr ""
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr ""
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr ""
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr ""
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
 "({export_settings_link})."
 msgstr ""
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr ""
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr ""
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr ""
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr ""
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr ""
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr ""
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr ""
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr ""
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr ""
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr ""
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr ""
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr ""
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
 "try again later or reach out to {support_email} for assistance."
 msgstr ""
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr ""
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr ""
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr ""
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr ""
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
 "server: {reason}"
 msgstr ""
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr ""
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr ""
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr ""
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr ""
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr ""
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr ""
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr ""
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr ""
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 #, fuzzy
 #| msgid "Missing sender"
 msgid "Missing idp param"
 msgstr "fêšnāko pati hêď"
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr "OTP êštêvā hêď"
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr ""
 

--- a/locale/ca/LC_MESSAGES/django.po
+++ b/locale/ca/LC_MESSAGES/django.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 19:28+0000\n"
 "Last-Translator: Alex Vandiver <alexmv@zulip.com>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/zulip/django/ca/"
@@ -22,50 +22,50 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "No permès per a usuaris convidats"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "Organització no vàlida"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr ""
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr ""
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr ""
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr "Sense dades d'analytics. Parleu amb l'administrador."
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -74,7 +74,7 @@ msgid ""
 "users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -82,7 +82,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than one user to join."
 msgstr ""
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -90,7 +90,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than two users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -98,7 +98,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than three users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -107,148 +107,147 @@ msgid ""
 "({billing_page_link}) is greater than the current number of users."
 msgstr ""
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr ""
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr ""
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
 "(minimum {min_licenses})."
 msgstr ""
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
 "page. To complete the upgrade, please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr ""
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr ""
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "Alguna cosa ha fallat. Recarregueu la pàgina."
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr "Alguna cosa ha fallat. Espereu uns segons i torneu a provar-ho."
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr ""
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr ""
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
 msgstr ""
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
 msgstr ""
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
 "licenses."
 msgstr ""
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
 "billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr ""
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr ""
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr ""
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -258,100 +257,97 @@ msgid ""
 "we would really appreciate it!"
 msgstr ""
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
 "{support_email}"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr ""
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "Error"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr ""
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
 "%(support_email)s\">contact support</a>."
 msgstr ""
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr ""
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
 msgstr ""
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr ""
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
 msgstr ""
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr ""
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr "Error intern del servidor"
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
 msgstr ""
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -359,289 +355,270 @@ msgid ""
 "a> with any questions."
 msgstr ""
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
 "a> for support."
 msgstr ""
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
 "href=\"%(troubleshooting_url)s\">Zulip server troubleshooting guide</a>."
 msgstr ""
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr ""
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr ""
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr ""
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr ""
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr ""
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr ""
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr ""
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr ""
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr ""
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "Usuaris actius"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr ""
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr ""
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr ""
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "Usuaris"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr ""
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "Jo"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr ""
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "Darrera setmana"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "Darrer mes"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "Darrer any"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr ""
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr ""
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "Diàriament"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "Setmanalment"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr ""
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "Humans"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "Bots"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr ""
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr ""
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr ""
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
 "%(old_email_html_tag)s to %(new_email_html_tag)s"
 msgstr ""
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr ""
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
 msgstr ""
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "Cancel·la"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr ""
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr ""
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -652,19 +629,19 @@ msgid ""
 "server."
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -672,788 +649,297 @@ msgid ""
 "%(support_email)s'>contact support</a> with any questions."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, python-format
 msgid "You can try again in %(retry_after_string)s."
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr ""
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr ""
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr "Filtra per categories"
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "Tots"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr ""
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr ""
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr ""
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr ""
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr ""
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "Crea una organització"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr ""
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr ""
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr ""
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr ""
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 msgid "Zulip for open source"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 msgid "Message with code"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr "Enllaç"
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr "Contacta amb l'equip de suport"
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr "Missatge"
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
 msgstr ""
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 msgid "Get started"
 msgstr ""
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
 "continue."
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "Correu electrònic"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1461,78 +947,77 @@ msgid ""
 "from Zulip."
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
 msgstr ""
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr ""
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr ""
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr ""
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr ""
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr ""
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr ""
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr ""
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
 msgstr ""
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1540,212 +1025,205 @@ msgid ""
 "href=\"%(doc_url)s\">documentation</a>."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr "No s'ha trobat el compte de Zulip."
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, python-format
 msgid "No account found for %(email)s."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Log in to your organization"
 msgid "Try Zulip in a demo organization"
 msgstr "Inicia la sessió en la meva organització"
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Why Zulip"
 msgid "Try Zulip"
 msgstr "Per què Zulip"
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "Crea una nova organització"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr "Crea una nova organització de Zulip"
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr "Introduïu la vostra adreça electrònica"
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid "Import chat history?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr "Nom d'organització"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "URL d'organització"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "OR"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "Crea un compte"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "Crea un compte de Zulip"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr "Crea un compte amb %(identity_provider)s"
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "Inicia la sessió"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1753,123 +1231,122 @@ msgid ""
 "noreferrer\">after you join</a>."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "Change"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr "Compte d'usuari"
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr "No importes la configuració"
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "Nom"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "Contrasenya"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr "Seguretat de la contrasenya"
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr ""
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">Terms of Service</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr "L'organització s'ha desactivat"
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr ""
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -1877,45 +1354,45 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 msgid ""
 "This organization has been deactivated, and all organization data has been "
 "deleted."
 msgstr ""
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
 "inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
 "administrators</a> to inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 msgid "This organization has been deactivated."
 msgstr ""
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
 "%(support_email)s\">contact Zulip support</a> to reactivate it."
 msgstr ""
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -1923,165 +1400,164 @@ msgid ""
 "reactivate it."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr "Finalitza l'inici de sessió d'escriptori"
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "Copia"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "Administradors"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr "Usuaris convidats"
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "Usuaris normals"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "Tancar"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "Actualitza"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr "Zulip"
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
 "<b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr "Us donem la benvinguda a Zulip!"
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
 "href=\"%(apps_page_link)s\">mobile and desktop</a> apps:"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr "URL de l'organització: %(organization_url)s"
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
 "href=\"%(getting_user_started_link)s\">getting started guide</a>!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2089,83 +1565,83 @@ msgid ""
 "Zulip</a>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
 "to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
 "desktop apps (%(apps_page_link)s):"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
 "(%(getting_user_started_link)s)!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
 "(%(getting_organization_started_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2173,32 +1649,32 @@ msgid ""
 "password for this account, please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "%(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 msgid "Verify your email address for your Zulip demo organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "<%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2206,113 +1682,113 @@ msgid ""
 "please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr "Us heu registrat a Zulip fa poc. Fantàstic!"
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
 "— we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr "Administra les preferències de correu electrònic"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
 "deactivated, and you will no longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr ""
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2320,22 +1796,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because your organization <a "
@@ -2343,8 +1819,8 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to <a "
@@ -2352,39 +1828,39 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr ""
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because your organization hides "
@@ -2392,82 +1868,75 @@ msgid ""
 "details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to hide "
 "message content in email notifications. See %(help_url)s for more details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, fuzzy, python-format
 #| msgid "Log in to your organization"
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr "Inicia la sessió en la meva organització"
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr "Administra les preferències de correu electrònic:"
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr ""
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
 "organizations:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
 "organizations hosted by %(external_host)s:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
 "href=\"%(help_reset_password_link)s\">reset your password</a>."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
 "%(external_host)s."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2475,97 +1944,94 @@ msgid ""
 "to find your account."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
 "try another way to find your account (%(help_logging_in_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
 "communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr ""
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
 "-- the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
 "Zulip &mdash; the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
 "to ask %(referrer_name)s for another one."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2573,72 +2039,70 @@ msgid ""
 "productivity."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at <a href=\"mailto:%(email)s\">%(email)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
 "%(email)s\">Contact us</a> — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
 "#%(channel_name)s > %(topic_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2646,68 +2110,68 @@ msgid ""
 "preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails (<a href=\"%(url)s\">help</a>)."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2715,22 +2179,22 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr "L'equip de Zulip"
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2738,7 +2202,7 @@ msgid ""
 "immediately at <%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
@@ -2746,46 +2210,46 @@ msgstr ""
 "Organització: %(organization_url)s Hora: %(login_time)s E-mail: "
 "%(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr "Organització: %(organization_link)s"
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr "Correu electrònic: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2793,31 +2257,31 @@ msgid ""
 "contact us immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr "Organització: %(organization_url)s"
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2825,7 +2289,7 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -2833,25 +2297,25 @@ msgid ""
 "Zulip</a> to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
 "with you and share their unique perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -2859,7 +2323,7 @@ msgid ""
 "experience how a new chat app will help your team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -2867,148 +2331,148 @@ msgid ""
 "action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
 "team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
 "organizations like yours!"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3016,11 +2480,11 @@ msgid ""
 "about…?”"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3029,23 +2493,23 @@ msgid ""
 "href=\"%(move_channels_link)s\">move a topic to a different channel</a>."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3054,23 +2518,23 @@ msgid ""
 "(%(move_channels_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
 "%(email)s on %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3078,46 +2542,46 @@ msgid ""
 "href=\"%(help_link)s\">reactivate your account</a>."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
 "You can contact an organization administrator to reactivate your account."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3125,543 +2589,539 @@ msgid ""
 "have been voided."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
 "to %(upgrade_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip demo organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip demo organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr "Reactiva l'organització"
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Reactivate organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "Reactiva l'organització"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for <b>%(remote_server_hostname)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 msgid "Click the button below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for %(remote_server_hostname)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
 "management for <b>%(remote_realm_host)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
 "management for %(remote_realm_host)s."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the <a href=\"%(plans_link)s\">Zulip Community plan</a>."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
 "website</a>, we would really appreciate it!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
 msgstr ""
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
 "accounts for another email address</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr ""
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "Cerca comptes"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr ""
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr "Per què Zulip"
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr "Característiques"
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr ""
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Zulip"
 msgid "Zulip Cloud"
 msgstr "Zulip"
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr ""
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr ""
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "Integracions"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr "Aplicacions d'escriptori i mòbils"
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr "Nova organització"
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr ""
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr ""
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr ""
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr ""
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr ""
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr ""
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr ""
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr ""
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr ""
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr ""
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr ""
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr "Centre d'ajuda"
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr "Xat de la comunitat"
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr ""
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr ""
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr ""
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr ""
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr ""
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr ""
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr ""
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr "Equip"
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "Historial"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr ""
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr ""
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr ""
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr ""
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr ""
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 msgid "Bluesky"
 msgstr ""
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr ""
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr "Condicions del servei"
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr "Política de privacitat"
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 msgid ""
 "And hundreds more through <a href=\"/integrations/zapier\">Zapier</a> and <a "
 "href=\"/integrations/ifttt\">IFTTT</a>."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr "API REST"
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3669,7 +3129,7 @@ msgid ""
 "emails with your email domain."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3677,7 +3137,7 @@ msgid ""
 "disposable email addresses."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3685,24 +3145,24 @@ msgid ""
 "emails that contain \"+\"."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3710,7 +3170,7 @@ msgid ""
 "%(support_email)s\">contact Zulip support</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3718,89 +3178,89 @@ msgid ""
 "%(support_email)s\">contact this Zulip server's administrators</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
 "management for your Zulip server."
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr ""
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr "Inicia la sessió en Zulip"
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr "E-mail o nom d'usuari"
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "Nom d'usuari"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr ""
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr ""
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr ""
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> because all Zulip Cloud licenses are in use."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -3809,44 +3269,42 @@ msgid ""
 "or misconfiguration."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 #, fuzzy
 #| msgid "New organization"
 msgid "Demo organizations disabled"
 msgstr "Nova organització"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -3854,22 +3312,21 @@ msgid ""
 "organization for more information."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -3877,48 +3334,46 @@ msgid ""
 "Zulip support</a> for assistance in resolving this issue."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
 "a> like Firefox, Chrome, and Edge."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Invalid organization"
 msgid "Finalize organization import"
 msgstr "Organització no vàlida"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Organization name"
 msgid "Organization import completed!"
 msgstr "Nom d'organització"
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -3926,56 +3381,55 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Your account"
 msgid "Select your account"
 msgstr "Compte d'usuari"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create a new organization"
 msgid "Create new account"
 msgstr "Crea una nova organització"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr ""
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr "Inicia la sessió en la meva organització"
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -3983,81 +3437,81 @@ msgid ""
 "have one yet."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 msgid "Self-hosting Zulip?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">log in to manage plans and billing.</a>"
 msgstr ""
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr "Restableix la contrasenya"
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
 msgstr ""
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "Confirmeu la contrasenya"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr ""
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr ""
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr ""
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr ""
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr ""
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4065,7 +3519,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4074,57 +3528,57 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr ""
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4132,7 +3586,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4140,40 +3594,40 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4181,300 +3635,294 @@ msgid ""
 "away!"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr "S'ha actualitzat la configuració de correu electrònic"
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
 "href=\"%(realm_url)s/#settings/notifications\">notification settings</a>."
 msgstr ""
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr ""
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr ""
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr ""
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr ""
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr ""
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr ""
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr ""
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 msgid "Cannot reactivate a deleted user"
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr ""
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr ""
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr ""
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr ""
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
 msgstr ""
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
 msgstr ""
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr ""
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr ""
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr ""
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr ""
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr ""
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr ""
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr ""
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr ""
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr ""
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr ""
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
 "{new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
 "{user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to resolve topics in this channel."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr ""
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr ""
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr ""
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr ""
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr ""
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
 "but there is no channel with that ID."
 msgstr ""
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4482,36 +3930,36 @@ msgid ""
 "it."
 msgstr ""
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
 "The channel exists but does not have any subscribers."
 msgstr ""
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr ""
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr ""
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr ""
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4519,107 +3967,105 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
 "authentication method."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr ""
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 msgid "Reminder could not be sent."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
 "the following error:"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr ""
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr ""
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr ""
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr ""
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr ""
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
 "**{old_policy}** to **{new_policy}**."
 msgstr ""
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -4628,51 +4074,49 @@ msgid ""
 "* **New**: {new_setting_description}\n"
 msgstr ""
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr ""
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr ""
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr ""
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr ""
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr ""
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr ""
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 msgstr ""
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr ""
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -4683,286 +4127,272 @@ msgid ""
 "{summary_line}"
 msgstr ""
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr ""
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr ""
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr ""
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr ""
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr ""
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr ""
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr ""
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr ""
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr ""
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr ""
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr ""
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
 "organization administrator to reactivate it."
 msgstr ""
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr ""
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr ""
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr ""
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr ""
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr ""
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr ""
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr ""
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
 "to register for accounts in this organization."
 msgstr ""
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr ""
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 msgid "Challenges are not enabled."
 msgstr ""
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr ""
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr ""
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "You're making too many attempts to sign in. Try again in "
 "{retry_after_string} or contact your organization administrator for help."
 msgstr ""
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
 msgstr ""
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr ""
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr ""
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr ""
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr ""
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr ""
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr ""
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr ""
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr ""
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr ""
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr "Fitxer adjunt no vàlid"
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr ""
 "S'ha produït un error a l'adjuntar el fitxer. Torneu a intentar-ho més tard."
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name can't be empty."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 msgid "Invalid channel folder ID"
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 #, fuzzy
 #| msgid "Enter your email address"
 msgid "Configure owner account email address."
 msgstr "Introduïu la vostra adreça electrònica"
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4971,69 +4401,69 @@ msgid ""
 "organization]({convert_demo}).\n"
 msgstr ""
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, python-brace-format
 msgid "{var_name} is not Base64 encoded"
 msgstr ""
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 msgid "Invalid `device_id`"
 msgstr ""
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr ""
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr ""
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr ""
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr ""
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr ""
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr ""
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr ""
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr ""
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr ""
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr ""
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5041,621 +4471,619 @@ msgid ""
 "{error_message}"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr ""
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr "Adreça no vàlida."
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr ""
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr ""
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr ""
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr ""
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr ""
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr ""
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr ""
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr ""
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr ""
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr ""
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr ""
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
 msgstr ""
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr ""
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr ""
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr ""
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr ""
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr "propietari d'organització"
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr ""
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr ""
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr ""
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr ""
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 msgid "Must be a bot user"
 msgstr ""
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr ""
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr ""
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr ""
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr "Clau d'API no vàlida"
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr "Clau d'API malformada"
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
 "webhook; ignoring"
 msgstr ""
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr ""
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr ""
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr ""
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr ""
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} most recent messages in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr ""
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr ""
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
 msgstr ""
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr ""
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr ""
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr ""
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr ""
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr ""
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Find accounts"
 msgid "Atlassian account ID"
 msgstr "Cerca comptes"
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Behance username"
 msgstr "E-mail o nom d'usuari"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 msgid "Bitbucket username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Codeberg username"
 msgstr "E-mail o nom d'usuari"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Dribbble username"
 msgstr "E-mail o nom d'usuari"
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Facebook username"
 msgstr "E-mail o nom d'usuari"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "GitLab username"
 msgstr "E-mail o nom d'usuari"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Instagram username"
 msgstr "E-mail o nom d'usuari"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 msgid "Mastodon profile"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Medium username"
 msgstr "E-mail o nom d'usuari"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Pinterest username"
 msgstr "E-mail o nom d'usuari"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Reddit username"
 msgstr "E-mail o nom d'usuari"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 msgid "Snapchat username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Threads username"
 msgstr "E-mail o nom d'usuari"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "TikTok username"
 msgstr "E-mail o nom d'usuari"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Twitch username"
 msgstr "E-mail o nom d'usuari"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "Nom d'usuari"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr ""
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr ""
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 msgid "Video calling"
 msgstr ""
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr ""
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr "Atenció al client"
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr ""
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr ""
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr ""
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr ""
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr ""
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr ""
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr ""
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr ""
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr ""
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr ""
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr ""
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr ""
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "{fullname} moderation"
 msgstr ""
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr "Operador de filtratge no vàlid: {desc}"
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr ""
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr ""
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor_date' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr ""
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 msgid "Navigation view does not exist."
 msgstr ""
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5663,7 +5091,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5671,7 +5099,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5679,7 +5107,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5687,7 +5115,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5697,14 +5125,14 @@ msgid ""
 "a permanent organization]({convert_demo_organization_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
 "them in your [Inbox](/#inbox).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5712,7 +5140,7 @@ msgid ""
 "({navigation_tour_video_url}) for a quick app overview.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5727,14 +5155,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -5742,7 +5170,7 @@ msgid ""
 "and edit your [profile information](/help/edit-your-profile).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -5753,7 +5181,7 @@ msgid ""
 "experience in your [Preferences](#settings/preferences).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5764,7 +5192,7 @@ msgid ""
 "[Browse and subscribe to channels]({settings_link}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -5781,7 +5209,7 @@ msgid ""
 "discussed.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -5790,7 +5218,7 @@ msgid ""
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -5802,7 +5230,7 @@ msgid ""
 "times, and more.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5812,7 +5240,7 @@ msgid ""
 "or browse the [help center](/help/) to learn more!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5820,7 +5248,7 @@ msgid ""
 "get help, try one of the following messages: {bot_commands}\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5832,13 +5260,13 @@ msgid ""
 "({move_content_another_channel_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5852,12 +5280,11 @@ msgid ""
 "and above.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr ""
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -5865,14 +5292,14 @@ msgid ""
 "no matter how many other conversations are going on.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
 "conversations with unread messages.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -5880,7 +5307,7 @@ msgid ""
 "the `+` button next to its name.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -5888,13 +5315,13 @@ msgid ""
 "can we chat about…?”\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5902,7 +5329,7 @@ msgid ""
 "({format_message_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5922,1329 +5349,1306 @@ msgid ""
 "```\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
 "teammates.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
 "conversation.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr ""
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr ""
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr ""
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr ""
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "Missatge nou"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 #, fuzzy
 #| msgid "Invalid API key"
 msgid "Invalid `push_key`"
 msgstr "Clau d'API no vàlida"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr ""
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr ""
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr ""
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 msgid "Reminder does not exist"
 msgstr ""
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr ""
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr ""
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr ""
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr ""
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr ""
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr ""
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr ""
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr ""
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 msgid "You do not have permission to create new topics in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr ""
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr ""
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr ""
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr ""
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr ""
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr ""
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} does not have the expected format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid attachment"
 msgid "Invalid {setting_name}"
 msgstr "Fitxer adjunt no vàlid"
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr ""
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr ""
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr ""
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {user_group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr ""
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr ""
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr ""
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr ""
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr ""
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 msgid "Name must not be empty!"
 msgstr ""
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr ""
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr ""
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr ""
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr ""
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr ""
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr ""
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr ""
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr ""
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr ""
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr ""
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr ""
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr ""
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr ""
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr ""
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr ""
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr ""
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr ""
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr ""
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr ""
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr ""
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr ""
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr ""
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr ""
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr ""
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr ""
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr ""
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr ""
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr ""
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr ""
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr ""
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr ""
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr ""
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr ""
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr ""
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr ""
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "Membres"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr ""
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: empty field name."
 msgstr ""
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr ""
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr ""
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 msgid "Example input does not match the linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in alternative URL template is not present in linkifier "
 "pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in linkifier pattern is not present in alternative URL "
 "template."
 msgstr ""
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr ""
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "Emojis personalitzats"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr ""
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr ""
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr ""
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr ""
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr ""
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr ""
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr ""
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr ""
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr ""
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr ""
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "Públic"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr ""
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr ""
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr ""
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr ""
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr ""
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr ""
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr ""
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr "Propietari d'organització"
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr "Administrador d'organització"
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr ""
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "Membre"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "Convidat"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr ""
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr ""
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr ""
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr ""
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 msgid "Failed to generate challenge"
 msgstr ""
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr ""
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr ""
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr ""
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr ""
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr ""
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr ""
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for use for user matching."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr "El camp personalitzat predeterminat no es pot actualitzar."
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr ""
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr ""
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr ""
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr ""
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr ""
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr ""
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr ""
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr ""
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 msgid "Invitation already used or deactivated."
 msgstr ""
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr ""
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr ""
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr ""
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
 msgstr ""
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr ""
 "L'historial d'edicions de missatge està desactivat en aquesta organització"
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr ""
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr ""
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr ""
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr ""
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr ""
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr ""
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr ""
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Message edit history is disabled in this organization"
 msgid "Message reporting is not enabled in this organization."
 msgstr ""
 "L'historial d'edicions de missatge està desactivat en aquesta organització"
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr ""
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr ""
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr ""
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr ""
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr ""
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr ""
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr ""
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr ""
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr ""
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 msgid "Navigation view already exists."
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7252,145 +6656,145 @@ msgid ""
 "later. Is this a good time?\n"
 msgstr ""
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr ""
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr ""
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 msgid "You do not have permission to manage plans and billing."
 msgstr ""
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr ""
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr ""
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr ""
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr ""
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr ""
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr ""
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr ""
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr ""
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr ""
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr ""
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr ""
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 #, fuzzy
 #| msgid "Message edit history is disabled in this organization"
 msgid ""
@@ -7398,414 +6802,412 @@ msgid ""
 msgstr ""
 "L'historial d'edicions de missatge està desactivat en aquesta organització"
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr ""
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr ""
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr ""
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr ""
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr ""
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr ""
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr ""
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Invalid character in language: {character}"
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Language '{language}' is not allowed."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr ""
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr ""
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 msgid "Importing messages…"
 msgstr ""
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 msgid "Your name"
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr ""
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr ""
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr ""
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr ""
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr ""
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr ""
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr ""
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr ""
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr ""
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr ""
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr ""
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr ""
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr ""
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
 "**"
 msgstr ""
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr ""
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr ""
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr ""
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr ""
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr ""
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr ""
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr ""
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr ""
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr ""
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr ""
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr ""
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr ""
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr ""
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 msgstr ""
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr ""
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr ""
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
 "subgroups."
 msgstr ""
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr "default_language no vàlida"
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr ""
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr ""
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr ""
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr ""
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr ""
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr ""
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr ""
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr "El tema no està silenciat"
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr ""
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 msgid "User is not allowed to delete other user's messages."
 msgstr ""
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr ""
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr ""
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "No analytics data available. Please contact your server administrator."
@@ -7814,301 +7216,301 @@ msgid ""
 "Please contact your server administrator."
 msgstr "Sense dades d'analytics. Parleu amb l'administrador."
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 msgid "Email address already in use"
 msgstr ""
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr ""
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr ""
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr ""
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 msgstr ""
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr ""
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr ""
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr ""
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr ""
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr ""
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} access token"
 msgstr ""
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} call"
 msgstr ""
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} credentials have not been configured"
 msgstr ""
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} credentials"
 msgstr ""
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr ""
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error authenticating to the {provider_name} server"
 msgstr ""
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr ""
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} session identifier"
 msgstr ""
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr ""
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} public room."
 msgstr ""
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr ""
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{full_name}'s Zulip room"
 msgstr ""
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr ""
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr ""
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr ""
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr ""
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr ""
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr ""
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr ""
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr ""
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr ""
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
 "({export_settings_link})."
 msgstr ""
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr ""
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr ""
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr ""
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr ""
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr ""
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr ""
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr ""
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr ""
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr ""
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr ""
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr ""
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr ""
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
 "try again later or reach out to {support_email} for assistance."
 msgstr ""
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr ""
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr ""
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr ""
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr ""
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
 "server: {reason}"
 msgstr ""
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr ""
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr ""
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr ""
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr ""
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr ""
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr ""
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr ""
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr ""
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 msgid "Missing idp param"
 msgstr ""
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr ""
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr ""
 

--- a/locale/cs/LC_MESSAGES/django.po
+++ b/locale/cs/LC_MESSAGES/django.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-04-13 16:12+0000\n"
 "Last-Translator: Pavel Fric <pavelfric@yahoo.com>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/zulip/django/cs/>\n"
@@ -28,52 +28,52 @@ msgstr ""
 "<= 4 && n % 1 == 0) ? 1: (n % 1 != 0 ) ? 2 : 3;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "Není povoleno pro hosty"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "Neplatná organizace"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr "Veřejné kanály"
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr "Soukromé kanály"
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr "Přímé zprávy"
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr "Seskupit přímé zprávy"
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr "Chybějící kanál pro graf:: {chart_name}"
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr "Neznámý název grafu: {chart_name}"
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr "Čas začátku je později než čas konce. Začátek: {start}, konec: {end}"
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr ""
 "Žádná analytická data nejsou k dispozici. Spojte se, prosím, se správcem "
 "serveru."
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -86,7 +86,7 @@ msgstr ""
 "vašich licencí]({billing_page_link}) nebo [deaktivujte neaktivní uživatele]"
 "({deactivate_user_help_page_link})."
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -98,7 +98,7 @@ msgstr ""
 "({billing_page_link}) nebo [deaktivujte neaktivní uživatele]"
 "({deactivate_user_help_page_link})."
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -110,7 +110,7 @@ msgstr ""
 "({billing_page_link}) nebo [deaktivujte neaktivní uživatele]"
 "({deactivate_user_help_page_link})."
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -122,7 +122,7 @@ msgstr ""
 "({billing_page_link}) nebo [deaktivujte neaktivní uživatele]"
 "({deactivate_user_help_page_link})."
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -135,30 +135,29 @@ msgstr ""
 "ujistěte se, že [počet licencí pro aktuální a následující zúčtovací období]"
 "({billing_page_link}) je vyšší než aktuální počet uživatelů."
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr ""
 "Vaše organizace nemá dostatek licencí pro Zulip. Pozvánky nebyly odeslány."
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
 msgstr ""
 "Vaše organizace nemá dostatek licencí pro Zulip, aby mohla změnit roli hosta."
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr "Registrace je vypnuta"
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr "Neplatný vzdálený server."
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
@@ -167,7 +166,7 @@ msgstr ""
 "Musíte zakoupit licence pro všechny činné uživatele ve vaší organizaci "
 "(minimum {min_licenses})."
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
@@ -176,42 +175,42 @@ msgstr ""
 "Účty s více než {max_licenses} licencemi nelze zpracovat z této stránky. Pro "
 "dokončení povýšení se, prosím, spojte s {email}."
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr "Žádná platební metoda v záznamu."
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr "{brand} končí za {last4}"
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr "Neznámá platební metoda. Spojte se, prosím, s {email}."
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr "Nastala chyba. Spojte se, prosím, s {email}."
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "Něco se nepodařilo. Načtěte prosím stránku znovu."
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr "Něco se nepodařilo. Počkejte prosím několik sekund a zkuste to znovu."
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr "Před zahájením bezplatné zkušební verze přidejte kreditní kartu."
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr "Pro naplánování aktualizace přidejte prosím kreditní kartu."
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
@@ -219,18 +218,18 @@ msgstr ""
 "Aktualizace platebního plánu se nezdařila. Plán již vypršel a byl nahrazen "
 "novým."
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr "Aktualizace platebního plánu se nezdařila. Plán již byl ukončen."
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 "Nelze aktualizovat licence v aktuálním zúčtovacím období pro bezplatný "
 "zkušební plán."
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
@@ -238,7 +237,7 @@ msgstr ""
 "Ruční aktualizace licencí se nezdařila. Váš platební plán má nastavenu "
 "automatickou správu licencí."
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
@@ -246,18 +245,18 @@ msgstr ""
 "Váš aktuální platební plán již využívá {licenses} licencí v aktuálním "
 "zúčtovacím období."
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr "Nelze snížit počet licencí v aktuálním zúčtovacím období."
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
 msgstr ""
 "Nelze změnit licence pro příští zúčtovací cyklus u plánu, který je ponižován."
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
@@ -266,7 +265,7 @@ msgstr ""
 "Váš platební plán je již nastaven aby v dalším zúčtovacím období obnovil "
 "{licenses_at_next_renewal} licencí."
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
@@ -275,27 +274,27 @@ msgstr ""
 "Na další zúčtovací období jste již zakoupili licence "
 "{licenses_at_next_renewal}."
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr "Není co měnit."
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr "Pro tuto organizaci neexistuje žádný zákazník!"
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr "Relace nebyla nalezena"
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr "Záměr platby nenalezen"
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr "Vložte stripe_session_id nebo stripe_invoice_id"
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -310,20 +309,19 @@ msgstr ""
 "Pokud byste mohli {begin_link} uvést společnost Zulip jako sponzora na svých "
 "webových stránkách{end_link}, budeme vám velmi vděčni!"
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr "Parametr 'confirmed' je povinný"
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr "Platnost přístupového dokladu pro fakturaci vypršela."
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr "Neplatný fakturační přístupový doklad."
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
@@ -332,39 +330,38 @@ msgstr ""
 "Nepodařilo se sladit fakturační údaje mezi serverem a oblastí. Spojte se, "
 "prosím, s {support_email}"
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr "Uživatelský účet zatím neexistuje."
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr "Chcete-li pokračovat, musíte souhlasit s podmínkami služby."
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 "Toto zulip_org_id není registrováno v systému správy účtů společnosti Zulip."
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr "Neplatný zulip_org_key pro toto zulip_org_id."
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr "Registrace vašeho serveru byla vypnuta."
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "Chyba"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr "Stránka nebyla nalezena (404)"
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
@@ -373,11 +370,11 @@ msgstr ""
 "Pokud jste tuto chybu nečekali, můžete <a href=\"mailto:"
 "%(support_email)s\">kontaktovat podporu</a>."
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr "Přístup odepřen (403)"
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
@@ -385,32 +382,31 @@ msgstr ""
 "Váš požadavek nebylo možné zpracovat, protože váš prohlížeč neodeslal "
 "přihlašovací údaje potřebné k ověření vašeho přístupu. Pro vyřešení problému:"
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr ""
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
 msgstr ""
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr "Metoda není povolena (405)"
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr "Vnitřní chyba serveru"
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
 msgstr ""
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -418,13 +414,13 @@ msgid ""
 "a> with any questions."
 msgstr ""
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, fuzzy, python-format
 #| msgid ""
 #| "If you have any questions, please contact this Zulip server's "
@@ -436,143 +432,141 @@ msgstr ""
 "V případě jakýchkoli dotazů se obraťte na správce tohoto serveru Zulip na "
 "%(support_email)s."
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
 "href=\"%(troubleshooting_url)s\">Zulip server troubleshooting guide</a>."
 msgstr ""
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr "Rozbor pro %(target_name)s | Zulip"
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr "Analytikové jsou plně dostupní 24 hodin po vytvoření organizace."
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr "Analytika Zulipu pro %(target_name)s"
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr "Přehled organizace"
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr "Počet uživatelů"
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr "Uživatelé činní v posledních 15 dnech"
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr "Počet hostů"
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr "Celkový počet zpráv"
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr "Počet zpráv za posledních 30 dní"
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr "Používané úložiště souborů"
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "Aktivní uživatelé"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr "Aktivní denně"
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr "Aktivní v posledních 15 dnech"
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr "Celkem uživatelů"
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "Uživatelé"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr "Odeslané zprávy podle typu příjemce"
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "Já"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "Každý"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "Poslední týden"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "Poslední měsíc"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "Poslední rok"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "Za celou dobu"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr "Zprávy odeslané v průběhu času"
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "Denní"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "Týdenní"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr "Kumulativní"
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "Lidé"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "Roboti"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr "Zprávy přečtené v průběhu času"
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr "Zprávy odeslané klientem"
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr "Poslední aktualizace"
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
@@ -580,15 +574,15 @@ msgstr ""
 "Plná aktualizace všech grafů se dělá jednou denně. Graf “zpráv odeslaných v "
 "průběhu času” je obnovován jednou za hodinu."
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr "Adresa elektronické pošty změněna"
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr "E-mail změněn!"
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
@@ -597,48 +591,48 @@ msgstr ""
 "Toto potvrzuje, že e-mailová adresa pro váš Zulip účet se změnila z "
 "%(old_email_html_tag)s na %(new_email_html_tag)s"
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr "Potvrzuje se adresa elektronické pošty"
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr "Potvrzovací odkaz neexistuje"
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr "Jejda. V systému jsme nenašli váš potvrzovací odkaz."
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr "Platnost potvrzovacího odkazu vypršela nebo byl vypnut"
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr "Jejda. Platnost potvrzovacího odkazu vypršela nebo byl vypnut."
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr "Požádejte správce vaší organizace o nový odkaz."
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr "Potvrzovací odkaz je chybný"
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr "Jejda. Potvrzovací odkaz je poškozen."
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
@@ -647,72 +641,55 @@ msgstr ""
 "s touto stránkou stále setkáváte, je to pravděpodobně naše chyba. Omlouváme "
 "se."
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr "Fakturace"
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr "Zavřít okno"
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr "Nevadí"
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr "Ponížit"
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "Zrušit"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr "Potvrdit"
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr "Zrušit povýšení"
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr "Stav vyúčtování"
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr "Vypnout registraci serveru?"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr "Správa plánu není dostupná"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -723,19 +700,19 @@ msgid ""
 "server."
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -743,736 +720,246 @@ msgid ""
 "%(support_email)s'>contact support</a> with any questions."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr "Překročen mez rychlosti."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, fuzzy, python-format
 #| msgid "You can try again in %(retry_after)s seconds."
 msgid "You can try again in %(retry_after_string)s."
 msgstr "Můžete to zkusit znovu za %(retry_after)s sekund."
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr "Povýšit"
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr ""
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr "Otevřít adresář společenství"
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr "Filtrovat podle kategorie"
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "Vše"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr "Kategorie"
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr "10,000 zpráv"
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr "Neomezeno"
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr "Podporováno"
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr "Vlastní správa"
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr "Pro organizace s až 10 uživateli"
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr "nejméně 25 uživatelů"
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr "Nedostupné"
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr "Vývojářská komunita Zulipu"
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr "Zapojit se jako uživatel"
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr "Zapojit se jako provozovatel na vlastní infrastruktuře"
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr "Zapojit se jako přispěvatel"
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "Vytvořit organizaci"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr ""
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr "Vlastní hostování Zulipu"
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr "Požádejte o sponzorství"
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr "Ceny za vzdělávání"
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr "Zobrazit ceny"
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr "Zulip pro podnikání"
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Zulip guide for open-source projects"
 msgid "Zulip for open source"
 msgstr "Průvodce Zulipem pro projekty s otevřeným zdrojovým kódem"
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Create your Zulip organization"
 msgid "Screenshot of Zulip conversation"
 msgstr "Vytvořte svou organizaci Zulip"
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Messages sent over time"
 msgid "Message with code"
 msgstr "Zprávy odeslané v průběhu času"
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr "Odkaz"
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr "Spojit se s podporou"
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr "Od"
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr "Organizace"
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr "Předmět"
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr "Zpráva"
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr "Odeslat"
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr "Děkujeme, že jste se na nás obrátili"
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr "Děkujeme, že jste se na nás obrátili!"
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr "Brzy se vám ozveme."
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
@@ -1480,13 +967,13 @@ msgstr ""
 "Odpovědi na často kladené otázky naleznete ve <a href=\"/help/\">středisku "
 "nápovědy pro Zulip</a>."
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 #, fuzzy
 #| msgid "Getting started"
 msgid "Get started"
 msgstr "Začínáme"
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
@@ -1496,50 +983,49 @@ msgstr ""
 "prosím, přijměte <a href=\"https://zulip.com/policies/terms\">podmínky "
 "služby Zulip</a>."
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr "Nebo můžete použít jeden z vaších záložních telefonů:"
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr "Poslední možností je použití elektronického klíče zálohy:"
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr "Použít elektronický klíč zálohy"
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr "Přijmout podmínky užití"
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr "Vítejte v Zulipu"
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "E-mail"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr ""
 "Přihlašte se k odběru občasného zpravodaje Zulip (několik e-mailů ročně)."
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr "Pokračovat"
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr "Potvrďte svoji adresu elektronické pošty"
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1550,78 +1036,77 @@ msgstr ""
 "class=\"user_email semi-bold\">%(email)s</span>) pro potvrzovací e-mail od "
 "Zulipu."
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
 msgstr ""
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr ""
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr "Vašim filtrům neodpovídají žádné rozhovory."
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr "Toto zobrazení stále ještě nahrává zprávy."
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr "Nahrát další"
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr "Videohovor ukončen"
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr "Nyní můžete toto okno zavřít."
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr "Chyba nastavení"
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
 msgstr ""
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1629,199 +1114,192 @@ msgid ""
 "href=\"%(doc_url)s\">documentation</a>."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr "Účet nenalezen"
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr "Nebyl nalezen Zulip účet."
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, fuzzy, python-format
 #| msgid "Your account email: %(email)s"
 msgid "No account found for %(email)s."
 msgstr "Váš e-mailový účet: %(email)s"
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr "Přihlásit se pomocí jiného účtu"
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr "Pokračovat na registrací"
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Must be a demo organization."
 msgid "Try Zulip in a demo organization"
 msgstr "Musí to být ukázková organizace."
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Try Zulip now"
 msgid "Try Zulip"
 msgstr "Vyzkoušejte Zulip hned teď"
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "Vytvořit novou organizaci"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr "Vytvořit novou Zulip organizaci"
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr "Zadejte svůj e-mail"
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr "Vaše e-mailová adresa"
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr "Druh organizace"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 #, fuzzy
 #| msgid "Private, shared history"
 msgid "Import chat history?"
 msgstr "Soukromá, sdílená historie"
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr "Název organizace"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "Adresa organizace"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr "Použít %(external_host)s"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "NEBO"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "Zaregistrovat se"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "Zaregistrovat se do Zulipu"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr "Pro připojení k této organizaci potřebujete pozvánku."
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr "Přihlásit se pomocí %(identity_provider)s"
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr "Již máte účet."
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "Přihlásit se"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr "Nastavit soukromí adresy elektronické pošty"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
@@ -1829,7 +1307,7 @@ msgstr ""
 "Zulip umožňuje řídit, které role v organizaci mohou zobrazit vaši e-mailovou "
 "adresu."
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
@@ -1837,11 +1315,11 @@ msgstr ""
 "Chcete změnit nastavení soukromí vašeho e-mailu oproti výchozímu nastavení "
 "pro tuto organizaci?"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr "Kdo může přistupovat k vaší adrese elektronické pošty"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1852,102 +1330,101 @@ msgstr ""
 "configure-email-visibility\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">poté, co se připojíte</a>."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "Změnit"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr "Registrace"
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr "Vytvořte si organizaci"
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr "Vytvořte si účet"
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr "<p>Zadejte údaje o svém účtu a dokončete registraci.</p>"
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr "Vaše organizace"
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr "Váš účet"
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr "Neimportovat nastavení"
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr "Import nastavení z existujícího Zulip účtu"
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "Jméno"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "Heslo"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr "Zadejte vaše heslo do LDAP/Active directory."
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 "Tohle se použije pro mobilní aplikace a další nástroje, které vyžadují heslo."
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr "Síla hesla"
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr "O co se zajímáte?"
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
@@ -1956,22 +1433,22 @@ msgstr ""
 "Souhlasím s <a href=\"%(root_domain_url)s/policies/terms\" target=\"_blank\" "
 "rel=\"noopener noreferrer\">podmínkami užití</a>."
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr "Vypnutá organizace"
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr ""
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -1979,7 +1456,7 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid ""
@@ -1987,7 +1464,7 @@ msgid ""
 "deleted."
 msgstr "Tato organizace byla vypnuta"
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2003,20 +1480,20 @@ msgstr ""
 "%(support_email)s\">kontaktovat podporu Zulipu</a>.\n"
 "                "
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
 "administrators</a> to inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid "This organization has been deactivated."
 msgstr "Tato organizace byla vypnuta"
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2032,14 +1509,14 @@ msgstr ""
 "%(support_email)s\">kontaktovat podporu Zulipu</a>.\n"
 "                "
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2056,15 +1533,15 @@ msgstr ""
 "%(support_email)s\">kontaktovat podporu Zulipu</a>.\n"
 "                "
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr "Dokončit přihlášení aplikace pro počítače"
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr "Dokončit přihlášení počítače"
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
@@ -2072,93 +1549,92 @@ msgstr ""
 "Použijte prohlížeč internetu na dokončení přihlášení se, potom jděte zpět "
 "sem pro vložení svého přihlašovacího elektronického klíče."
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr "Vložit elektronický klíč zde"
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr "Dokončit"
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr "Nesprávný elektronický klíč."
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr "Elektronický klíč přijat. Jste přihlašován…"
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr "Přihlášení do aplikace pro počítače"
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 "Zkopírujte tento přihlašovací elektronický klíč a vraťte se do svého Zulipu "
 "pro dokončení přihlášení:"
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "Kopírovat"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr "Potom toto okno můžete zavřít."
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr "Nebo pokračovat v prohlížeči."
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr "Anonym"
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr "Vlastníci"
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "Správci"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr "Moderátoři"
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr "Hosté"
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "Normální uživatelé"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "Zavřít"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "Obnovit"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr "Zulip"
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr "Přehled"
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
@@ -2167,17 +1643,17 @@ msgstr ""
 "Vytvořili jste novou organizaci na Zulipu blahopřejeme: <b>%(realm_name)s</"
 "b>."
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr "Vítejte v Zulipu!"
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr "Připojil/a jste se k organizaci na Zulipu <b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
@@ -2186,43 +1662,43 @@ msgstr ""
 "Následující informaci použijete pro přihlášení se do webové, <a "
 "href=\"%(apps_page_link)s\">mobilní a desktopové aplikace</a> Zulip:"
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr "Adresa organizace: %(organization_url)s"
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr "Vaše uživatelské jméno: %(ldap_username)s"
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr "Pro přihlášení použijte váš LDAP účet"
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr "Váš e-mailový účet: %(email)s"
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr "Přejít na organizaci"
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
 "href=\"%(getting_user_started_link)s\">getting started guide</a>!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2230,36 +1706,36 @@ msgid ""
 "Zulip</a>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
 "to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr "%(realm_name)s na Zulipu: podrobnosti o vaší nové organizaci"
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr "%(realm_name)s na Zulipu: podrobnosti o vašem novém účtu"
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr ""
 "Vytvořili jste novou organizaci na Zulipu, blahopřejeme: %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr "Připojil/a jste se k organizaci na Zulipu %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
@@ -2268,31 +1744,31 @@ msgstr ""
 "Následující informaci použijete pro přihlášení se do webové, mobilní a "
 "desktopové aplikace Zulip (%(apps_page_link)s):"
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
 "(%(getting_user_started_link)s)!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
 "(%(getting_organization_started_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2301,17 +1777,17 @@ msgstr ""
 "V případě jakýchkoli dotazů se obraťte na správce tohoto serveru Zulip na "
 "%(support_email)s."
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr "Ahoj,"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2319,12 +1795,12 @@ msgid ""
 "password for this account, please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2333,14 +1809,14 @@ msgstr ""
 "Pokud jste tuto změnu neiniciovali, neprodleně se s námi spojte "
 "na%(support_email)s."
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 #, fuzzy
 #| msgid "Create your Zulip organization"
 msgid "Verify your email address for your Zulip demo organization"
 msgstr "Vytvořte svou organizaci Zulip"
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2349,8 +1825,8 @@ msgstr ""
 "Pokud jste nedali podnět k této změně, neprodleně se s námi spojte na "
 "<%(support_email)s>."
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2358,65 +1834,65 @@ msgid ""
 "please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr "Potvrdit změnu e-mailu"
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr "Nedávno jste se přihlásil/a k Zulipu. Skvělé!"
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr "Klepněte na tlačítko níže pro dokončení registrace."
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr "Dokončit registraci"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr "Vytvořte svou organizaci Zulip"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr "Zapněte váš Zulip účet"
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr "Klepněte na odkaz níže pro dokončení registrace."
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
@@ -2425,48 +1901,48 @@ msgstr ""
 "Máte dotazy nebo připomínky? Spojte se s námi na adrese %(support_email)s — "
 "rádi vám pomůžeme!"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr "Spravovat nastavení e-mailů"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr "Zrušit odběr obchodních e-mailů"
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
 "deactivated, and you will no longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr "Správci poskytli následující vysvětlení:"
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr "Nové kanály"
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2474,22 +1950,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because your organization has "
@@ -2506,8 +1982,8 @@ msgstr ""
 "href=\"%(help_url)s\">objevování se obsahu zpráv v oznámeních elektronickou "
 "poštou</a>."
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because you have disabled <a "
@@ -2522,40 +1998,40 @@ msgstr ""
 "class=\"content_disabled_help_link\" href=\"%(alert_notif_url)s\">objevování "
 "se obsahu zpráv v oznámeních elektronickou poštou</a>."
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, fuzzy, python-format
 #| msgid "Click here to log in to Zulip and catch up."
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr "Zde klepněte pro přihlášení k programu Zulip."
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr "Zrušit odběr shrnujících e-mailů"
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr "Shrnutí Zulipu pro %(realm_name)s"
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2572,8 +2048,8 @@ msgstr ""
 "zakázala objevování se obsahu zpráv v oznámeních elektronickou poštou.\n"
 "Na další podrobnosti se podívejte v %(hide_content_url)s .\n"
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2589,41 +2065,38 @@ msgstr ""
 "objevování se obsahu zpráv v oznámeních elektronickou poštou.\n"
 "Na další podrobnosti se podívejte v %(alert_notif_url)s.\n"
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, fuzzy, python-format
 #| msgid "Log in to your organization"
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr "Přihlašte se do vaší organizace"
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr "Spravovat nastavení e-mailů:"
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr "Zrušit odběr shrnujících e-mailů:"
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr "Plavající ryba"
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr "Díky za váš požadavek!"
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
 "organizations:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
@@ -2632,33 +2105,29 @@ msgstr ""
 "Vaše e-mailová adresa %(email)s má účty u následujících organizací Zulipu "
 "hostovaných %(external_host)s:"
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
 "href=\"%(help_reset_password_link)s\">reset your password</a>."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
 "%(external_host)s."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2666,38 +2135,35 @@ msgid ""
 "to find your account."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr "Vaše účty Zulip"
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
 "try another way to find your account (%(help_logging_in_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr "Ahoj,"
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
@@ -2706,17 +2172,17 @@ msgstr ""
 "%(referrer_name)s vás zve, abyste se k němu připojili na Zulipu &mdash; "
 "nástroji pro týmovou komunikaci vytvořeném pro zlepšení produktivity."
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr "Začněte klepnutím na tlačítko níže."
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr "%(referrer_full_name)s vás zve do %(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
@@ -2726,17 +2192,17 @@ msgstr ""
 "připojili na Zulipu -- nástroji pro týmovou komunikaci vytvořeném pro "
 "zlepšení produktivity."
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr "Začněte klepnutím na odkaz níže."
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr "Ještě jednou ahoj,"
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
@@ -2746,15 +2212,15 @@ msgstr ""
 "připojili na Zulipu &mdash; nástroji pro týmovou komunikaci vytvořeném pro "
 "zlepšení produktivity."
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr ""
 "Tohle je poslední upomínka, kterou od nás v souvislosti s touto pozvánkou "
 "dostanete."
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
@@ -2763,12 +2229,12 @@ msgstr ""
 "Toto pozvání vyprší za dva dny. Pokud pozvání vyprší, musíte "
 "požádat%(referrer_name)s o další."
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr "Upomínka: připojit se k %(referrer_name)s na %(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2779,72 +2245,70 @@ msgstr ""
 "abyste se k němu připojili na Zulipu -- nástroji pro týmovou komunikaci "
 "vytvořeném pro zlepšení produktivity."
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at <a href=\"mailto:%(email)s\">%(email)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
 "%(email)s\">Contact us</a> — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr "Dostáváte ji, protože jste byl osobně zmíněn."
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr "Toto jste dostal, protože @%(mentioned_user_group_name)s byl zmíněn."
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
 "#%(channel_name)s > %(topic_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2852,21 +2316,21 @@ msgid ""
 "preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
@@ -2875,43 +2339,43 @@ msgstr ""
 "Neodpovídejte na tento elektronický dopis. Tento server Zulipu není nastaven "
 "na přijímání příchozí elektronické pošty (<a href=\"%(url)s\">nápověda</a>)."
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr "Skupinové PM s %(direct_message_group_display_name)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr "PM s %(sender_str)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr "Nové zprávy"
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 "Odpovědět na tento elektronický dopis přímo, nebo jej zobrazit v "
 "%(realm_name)s Zulipu:"
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr "Zobrazit nebo odpovědět v %(realm_name)s Zulipu:"
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr "Odpovědět v %(realm_name)s Zulipu:"
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
@@ -2919,7 +2383,7 @@ msgstr ""
 "Neodpovídejte na tento elektronický dopis. Tento server Zulipu není nastaven "
 "na přijímání příchozí elektronické pošty. Nápověda:"
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2930,22 +2394,22 @@ msgstr ""
 "Pokud jste tuto změnu nevyžádal/a, neprodleně nás kontaktujte na "
 "%(support_email)s."
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr "S pozdravem,"
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr "Vývojáři Zulipu"
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr "Zulip e-mail změněn pro %(realm_name)s"
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2956,53 +2420,53 @@ msgstr ""
 "Pokud jste tuto změnu nevyžádal/a, neprodleně nás kontaktujte na "
 "<%(support_email)s>."
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 msgstr ""
 "Organizace: %(organization_url)s Čas: %(login_time)s E-mail: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr "Zaznamenali jsme nedávné přihlášení pro následující Zulip účet."
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr "Organizace: %(organization_link)s"
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr "E-mail: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr "Čas: %(login_time)s"
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr "Zařízení: %(device_browser)s na %(device_os)s."
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr "IP adresa: %(device_ip)s"
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr "Pokud jste to byl/a vy tak je to v pořádku. Nemusíte dělat nic jiného."
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3013,31 +2477,31 @@ msgstr ""
 "zkompromitován, prosím, <a href=\"%(reset_link)s\">změňte si heslo</a> ebo "
 "se s námi neprodleně spojte na adrese %(support_email)s."
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr "Díky,"
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr "Zulip Security"
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr "Zrušit odběr oznámení o přihlášení"
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr "Nové přihlášení z%(device_browser)s na %(device_os)s"
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr "Organizace: %(organization_url)s"
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3048,7 +2512,7 @@ msgstr ""
 "zkompromitován, prosím, změňte si heslo na %(reset_link)s nebo se s námi "
 "neprodleně spojte na %(support_email)s."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -3056,25 +2520,25 @@ msgid ""
 "Zulip</a> to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
 "with you and share their unique perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -3082,7 +2546,7 @@ msgid ""
 "experience how a new chat app will help your team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -3090,53 +2554,53 @@ msgid ""
 "action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
 "team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
@@ -3146,71 +2610,71 @@ msgstr ""
 "vyhovovat vašim potřebám. Podívejte se na tohoto průvodce klíčovými funkcemi "
 "systému Zulip pro organizace, jako je ta vaše!"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr "Zobrazit průvodce Zulipem pro podniky"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr "Zobrazit průvodce Zulipem pro projekty s otevřeným zdrojovým kódem"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr "Zobrazit průvodce Zulipem pro vzdělávání"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr "Zobrazit průvodce Zulipem pro výzkum"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr "Zobrazit průvodce Zulipem pro události a konference"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr "Zobrazit průvodce Zulipem pro neziskové organizace"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr "Zobrazit průvodce Zulipem pro společenství"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr "Průvodce Zulipem pro podniky"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr "Průvodce Zulipem pro projekty s otevřeným zdrojovým kódem"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr "Průvodce Zulipem pro vzdělávání"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr "Průvodce Zulipem pro výzkum"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr "Průvodce Zulipem pro události a konference"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr "Průvodce Zulipem pro neziskové organizace"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr "Průvodce Zulipem pro společenství"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
@@ -3218,14 +2682,14 @@ msgstr ""
 "Zde je několik rad, jak udržovat konverzace na Zulipu uspořádané pomocí "
 "témat."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
@@ -3233,12 +2697,12 @@ msgstr ""
 "Pomocí témat můžete číst Zulip po jedné konverzaci. Každou zprávu uvidíte v "
 "souvislosti bez ohledu na to, kolik různých diskusí právě probíhá."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3246,11 +2710,11 @@ msgid ""
 "about…?”"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr "Příklady krátkých témat"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3259,23 +2723,23 @@ msgid ""
 "href=\"%(move_channels_link)s\">move a topic to a different channel</a>."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr "Jít na Zulip"
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr "Udržujte rozhovory uspořádány pomocí témat"
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3284,23 +2748,23 @@ msgid ""
 "(%(move_channels_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
 "%(email)s on %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr "Klepněte na tlačítko níže pro změnu vašeho hesla."
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr "Resetovat heslo"
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3311,49 +2775,49 @@ msgstr ""
 "spojit se správcem organizace pro <a href=\"%(help_link)s\">opětovné zapnutí "
 "vašeho účtu</a>."
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr "V této Zulip organizaci nemáte účet."
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr "Máte aktivní účty v těchto organizacích."
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
 msgstr ""
 "Můžete se zkusit přihlásit, nebo resetovat vaše heslo v organizacích výše."
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 "Pokud nerozpoznáváte tuto aktivitu, v klidu, nemusíte si tohoto e-mailu "
 "všímat."
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr "Požadavek na reset hesla pro %(realm_name)s"
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr "Klepněte na odkaz níže pro resetování vašeho hesla."
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
 "You can contact an organization administrator to reactivate your account."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3364,7 +2828,7 @@ msgstr ""
 "Zulip. Plán zdarma kvůli nezaplaceným fakturám. Nezaplacené faktury byly "
 "prohlášeny za neplatné."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
@@ -3373,7 +2837,7 @@ msgstr ""
 "Chcete-li pokračovat v plánu Zulip Cloud Standard, povyšte znovu na adrese "
 "%(upgrade_url)s."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
@@ -3382,8 +2846,8 @@ msgstr ""
 "Pokud si myslíte, že se jedná o chybu nebo potřebujete další podrobnosti, "
 "spojte se s námi na adrese %(support_email)s."
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "You have deactivated your Zulip organization, %(realm_name)s, on "
@@ -3394,8 +2858,8 @@ msgid ""
 msgstr ""
 "Vypnuli jste svou organizaci Zulip, %(realm_name)s, na %(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "You have deactivated your Zulip organization, %(realm_name)s, on "
@@ -3406,8 +2870,8 @@ msgid ""
 msgstr ""
 "Vypnuli jste svou organizaci Zulip, %(realm_name)s, na %(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "You have deactivated your Zulip organization, %(realm_name)s, on "
@@ -3418,8 +2882,8 @@ msgid ""
 msgstr ""
 "Vypnuli jste svou organizaci Zulip, %(realm_name)s, na %(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
@@ -3427,80 +2891,80 @@ msgid ""
 msgstr ""
 "Vypnuli jste svou organizaci Zulip, %(realm_name)s, na %(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr "Drazí bývalí správci %(realm_name)s,"
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip demo organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr "Klepněte níže pro opětovné zapnutí vaší organizace."
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr "Znovu zapnout organizaci"
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
@@ -3508,372 +2972,372 @@ msgstr ""
 "Pokud se to stalo omylem, nemusíte nic dělat a tento odkaz za 24 hodin "
 "přestane fungovat."
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Reactivate your Zulip organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "Znovu zapnout vaši organizaci v Zulipu"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr "Znovu zapnout vaši organizaci v Zulipu"
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr "Klepněte na odkaz níže pro opětovné zapnutí vaší organizace."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for <b>%(remote_server_hostname)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, fuzzy
 #| msgid "Click the button below to complete registration."
 msgid "Click the button below to log in."
 msgstr "Klepněte na tlačítko níže pro dokončení registrace."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for %(remote_server_hostname)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
 "management for <b>%(remote_realm_host)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
 "management for %(remote_realm_host)s."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the <a href=\"%(plans_link)s\">Zulip Community plan</a>."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
 "website</a>, we would really appreciate it!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
 msgstr ""
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr "Najděte své účty"
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr "Najděte své účty Zulip"
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
 "accounts for another email address</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr "E-mailová adresa"
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "Najít účty"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr "Produkt"
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr "Proč Zulip"
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr "Funkce"
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr "Ceník a plány"
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Zulip"
 msgid "Zulip Cloud"
 msgstr "Zulip"
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr "Vlastní hostování"
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr "Bezpečnost"
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "Doplňky"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr "Aplikace pro počítače a telefony"
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr "Nová organizace"
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr "Řešení"
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr "Podnikání"
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr "Vzdělávání"
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr "Výzkum"
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr "Události a konference"
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr "Projekty s otevřeným zdrojovým kódem"
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr "Společenství"
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr "Příběhy zákazníků"
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr "Otevřená společenství"
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr "Zdroje"
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr "Začínáme"
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr "Centrum nápovědy"
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr "Komunitní chat"
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr ""
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr "Instalace serveru Zulip"
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr "Povýšení serveru Zulip"
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr "Příspívání"
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr "Průvodce pro přispěvatele"
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr "Vývojářská komunita"
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr "Překlad"
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr "GitHub"
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr "O nás"
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr "Tým"
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "Historie"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr "Hodnoty"
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr "Pracovní místa"
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr "Blog"
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr "Podpořte Zulip"
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr ""
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr ""
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Values"
 msgid "Bluesky"
 msgstr "Hodnoty"
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr "Poháněno <a href=\"https://zulip.com\">Zulipem</a>"
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr "Podmínky užití služby"
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr "Zásady ochrany osobních údajů"
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr "Přisuzování internetových stránek"
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr "Více než %(integrations_count_display)s nativních doplňků."
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 #, fuzzy
 #| msgid ""
 #| "And hundreds more through <a href=\"/integrations/doc/zapier\">Zapier</a> "
@@ -3885,52 +3349,48 @@ msgstr ""
 "A stovky dalších od <a href=\"/integrations/doc/zapier\">Zapier</a> a <a "
 "href=\"/integrations/doc/ifttt\">IFTTT</a>."
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr "Hledat doplňky"
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr "Vlastní doplňky"
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr "Příchozí zpětná volání HTTP"
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr "Interaktivní roboti"
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr "REST API"
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr "Neplatný e-mail"
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr "E-mail není povolen"
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr ""
 "Adresa elektronické pošty, kterou se pokoušíte zaregistrovat, není platná."
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3938,7 +3398,7 @@ msgid ""
 "emails with your email domain."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3946,7 +3406,7 @@ msgid ""
 "disposable email addresses."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3954,24 +3414,24 @@ msgid ""
 "emails that contain \"+\"."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr "Zaregistrujte se, prosím, pomocí platné adresy elektronické pošty."
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr "Zaregistrujte se, prosím, pomocí povolené adresy elektronické pošty."
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3979,7 +3439,7 @@ msgid ""
 "%(support_email)s\">contact Zulip support</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3987,90 +3447,90 @@ msgid ""
 "%(support_email)s\">contact this Zulip server's administrators</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
 "management for your Zulip server."
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr "Neplatné nebo vypršené sezení přihlášení"
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr "Neplatné nebo vypršelé sezení přihlášení."
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr "Přihlásit se do Zulipu"
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr "S tímto e-mailem již jste zaregistrován. Přihlašte se prosím níže."
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr "E-mail nebo uživatelské jméno"
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "Uživatelské jméno"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr "Zapomněl/a jste heslo?"
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr "Přihlásit se pomocí %(identity_provider)s"
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr "Zobrazení bez účtu"
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 "Ještě nemáte účet? Pro připojení k této organizaci potřebujete pozvánku."
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr "Žádné dostupné licence"
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> because all Zulip Cloud licenses are in use."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr "Chyba subdomény pro ověřování"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr "Subdoména pro ověřování"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -4079,44 +3539,42 @@ msgid ""
 "or misconfiguration."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 #, fuzzy
 #| msgid "New organization"
 msgid "Demo organizations disabled"
 msgstr "Nová organizace"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr "Požadována aktualizace"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr "Stáhnout nejnovější vydání."
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr "Požadován odkaz na vytvoření organizace"
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -4124,22 +3582,21 @@ msgid ""
 "organization for more information."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr "Odkaz na vytvoření organizace vypršel nebo není platný"
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -4147,49 +3604,47 @@ msgid ""
 "Zulip support</a> for assistance in resolving this issue."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr "Nepodporovaný prohlížeč"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, fuzzy, python-format
 #| msgid "Presence is not supported for bot users."
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr "Zobrazení přítomnosti není podporováno pro robotické uživatele."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
 "a> like Firefox, Chrome, and Edge."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr "Účet je vypnut"
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Invalid organization"
 msgid "Finalize organization import"
 msgstr "Neplatná organizace"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Organization type"
 msgid "Organization import completed!"
 msgstr "Druh organizace"
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -4197,56 +3652,55 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Select your account"
 msgstr "Vytvořte si účet"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Create new account"
 msgstr "Vytvořte si účet"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr ""
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr "Vaše organizace byla znovu zapnuta."
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr "Odkaz na opětovnou aktivaci organizace buď vypršel, nebo je neplatný."
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr "Přihlašte se do vaší organizace"
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr "Neznáte URL vaší organizace?"
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr "Vyhledat vaši organizaci."
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr "Další"
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4254,24 +3708,24 @@ msgid ""
 "have one yet."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 #, fuzzy
 #| msgid "Self-host Zulip"
 msgid "Self-hosting Zulip?"
 msgstr "Vlastní hostování Zulipu"
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">log in to manage plans and billing.</a>"
 msgstr ""
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr "Nastavit heslo znovu"
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
@@ -4279,60 +3733,60 @@ msgstr ""
 "Zapomněli jste heslo? Žádný problém, zašleme vám odkaz pro obnovení hesla na "
 "e-mail, který jste uvedli při registraci."
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr "Odeslat odkaz na reset hesla"
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr "Nastavte nové heslo"
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "Potvrdit heslo"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr "Je nám líto, vámi zadaný odkaz je neplatný nebo již byl použit."
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr ""
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr ""
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr "<a href=\"%(login_url)s\">Přihlašte se</a> prosím svým novým heslem."
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr "E-mail s postupem pro reset hesla byl odeslán!"
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr "Zkontrolujte svoji e-mailovou schránku pro dokončení resetu hesla."
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr ""
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4340,7 +3794,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4349,57 +3803,57 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr ""
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4407,7 +3861,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4415,21 +3869,21 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr "<h1 class=\"get-started\">Vybrat účet</h1>"
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 "Váš účet u GitHub má také s ním spojené neověřené adresy elektronické pošty."
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
@@ -4437,21 +3891,21 @@ msgstr ""
 "Pro použití jednoho z těchto přihlášení do Zulipu je nejprve musíte <a "
 "href=\"https://github.com/settings/emails\">ověřit pomocí GitHub.</a>"
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr "Požadavek na zrušení odběru z neznámého e-mailu"
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4459,132 +3913,129 @@ msgid ""
 "away!"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr "Nastavení e-mailu aktualizováno"
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
 "href=\"%(realm_url)s/#settings/notifications\">notification settings</a>."
 msgstr ""
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr "Chybný \"mapping\" pořadí."
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr ""
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr ""
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr ""
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr "přihlášení"
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr ""
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr "{user} přijal vaše pozvání, aby se připojil k Zulipu!"
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 #, fuzzy
 #| msgid "Cannot deactivate the only {entity}."
 msgid "Cannot reactivate a deleted user"
 msgstr "Nelze vypnout jedinou {entity}."
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr "Toto pole nesmíte měnit. Pro jeho aktualizaci se obraťte na správce."
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr "Pole s id {id} nebylo nalezeno."
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr ""
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr ""
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr ""
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
@@ -4592,7 +4043,7 @@ msgstr ""
 "Kvůli ochraně uživatelů omezuje Zulip počet pozvánek, které můžete poslat za "
 "jeden den. Protože jste dosáhli meze, nebyly odeslány žádné pozvánky."
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
@@ -4601,77 +4052,77 @@ msgstr ""
 "vám pro tuto chvíli není povoleno. Poproste správce organizace, nebo "
 "nějakého zkušenějšího uživatele."
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 "Platnost některých e-mailů se nepodařilo ověřit a proto jsme raději žádné "
 "pozvánky neposlali."
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr "Nepodařilo se nám pozvat nikoho."
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr "Nic k upravení"
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr ""
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr ""
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr "Neplatný propagate_mode bez úpravy tématu"
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr ""
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr "Grafické součásti nelze upravovat."
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr "Vaše organizace vypnula upravy zpráv"
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr "Nemáte oprávnění k upravení této zprávy"
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr "Časová lhůta pro upravení této zprávy vypršela"
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr "{user} označil toto téma jako vyřešené."
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr "{user} označil toto téma jako nevyřešené."
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr "Toto téma sem bylo přesunuto {user} do {new_location}."
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr "Zpráva byla {user} přesunuta z tohoto tématu do {new_location}."
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
@@ -4680,18 +4131,18 @@ msgstr ""
 "{changed_messages_count} zpráv bylo {user} přesunuto z tohoto tématu do "
 "{new_location}."
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr "Toto téma sem bylo přesunuto {user} z {old_location}."
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
@@ -4699,75 +4150,72 @@ msgid ""
 msgstr ""
 "{changed_messages_count} zpráv sem bylo {user} přesunuto z {old_location}."
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 #, fuzzy
 #| msgid "You do not have permission to post in this channel."
 msgid "You don't have permission to resolve topics in this channel."
 msgstr "Nemáte oprávnění vkládat příspěvky do tohoto kanálu."
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr "Nemáte oprávnění k přesunutí této zprávy"
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr ""
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr "Neplatná zpráva/y"
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr "Nelze zpracovat zprávu"
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr "Neplatný datový typ pro příjemce"
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 "Seznamy příjemců mohou obsahovat adresy nebo uživatelská ID, ale ne obojí."
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
 "but there is no channel with that ID."
 msgstr ""
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4775,36 +4223,36 @@ msgid ""
 "it."
 msgstr ""
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
 "The channel exists but does not have any subscribers."
 msgstr ""
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr ""
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr "\"Widgety\": programátor API odeslal neplatný JSON"
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr "Součástky: {error_msg}"
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4812,109 +4260,107 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr "Vlastní obrázeček s tímto názvem již existuje."
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
 "authentication method."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr ""
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder could not be sent."
 msgstr "Elektronický klíč neexistuje"
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
 "the following error:"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr ""
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr ""
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr ""
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr ""
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr ""
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
 "**{old_policy}** to **{new_policy}**."
 msgstr ""
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -4923,51 +4369,49 @@ msgid ""
 "* **New**: {new_setting_description}\n"
 msgstr ""
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr "Žádný popis."
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr ""
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr "Starý popis"
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr "Nový popis"
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr "Navždy"
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr ""
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 msgstr ""
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr ""
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -4978,99 +4422,89 @@ msgid ""
 "{summary_line}"
 msgstr ""
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr "K této zprávě nelze připojit dílčí zprávu."
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr ""
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr ""
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr "Nedostatečná oprávnění"
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr "Toto API není dostupné pro roboty využívající příchozí \"webhooky\"."
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr "Účet není spojen s subdoménou"
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr "Tento \"endpoint\" nepřijímá požadavky robotů."
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr "Musí být správce serveru"
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr "Tento \"endpoint\" vyžaduje HTTP základní autentizaci."
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr "Neplatná autorizační hlavička pro \"basic auth\""
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr "Chybějící autorizační hlavička pro \"basic auth\""
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr "\"Webhook\" roboti můžou používat pouze \"webhooky\""
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr ""
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
@@ -5079,51 +4513,50 @@ msgstr ""
 "Váš účet {username} byl vypnut. Chcete-li jej znovu zapnout, spojte se se "
 "správcem své organizace."
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr "Heslo je příliš slabé."
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr "Subdomény musí mít délku 3 nebo větší."
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr "Subdomény nemohou začínat nebo končit na '-'."
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr "Subdoména může obsahovat jen malá písmena, čísla a '-'."
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr "Použijte prosím váš skutečný e-mail."
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr "Organizace, ke které se pokoušíte pomocí {email} připojit, neexistuje."
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr "Vyžádejte si, prosím, pozvánku pro {email} od správce organizace."
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
@@ -5132,11 +4565,11 @@ msgstr ""
 "Váš e-mail {email} není součástí ani jedné domény, které jsou pro tuto "
 "organizaci povoleny."
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr "E-mailové adresy obsahující + nejsou pro tuto organizaci povoleny."
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
@@ -5146,41 +4579,40 @@ msgstr ""
 "Zulip jsou používány. Spojte se, prosím, s osobou, která vás pozvala, a "
 "požádejte ji, aby zvýšila počet licencí, pak to zkuste znovu."
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 #, fuzzy
 #| msgid "Embedded bots are not enabled."
 msgid "Challenges are not enabled."
 msgstr "Přidaní roboti nejsou povoleni."
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "Nové heslo"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr "Potvrzení nového hesla"
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "You're making too many attempts to sign in. Try again in "
 "{retry_after_string} or contact your organization administrator for help."
 msgstr ""
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
@@ -5188,90 +4620,88 @@ msgstr ""
 "Vaše heslo bylo vypnuto, protože je příliš slabé. Chcete-li vytvořit nové, "
 "zadejte své heslo znovu."
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr "Elektronický klíč"
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr "Zadejte prosím maximálně 10 e-mailů."
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr "Tuhle organizaci se nám na Zulipu nepodařilo najít."
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr ""
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr "Chybějící téma"
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr ""
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr ""
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr "Zpráva musí mít příjemce"
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr "Neplatný typ zprávy"
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr "Neplatná příloha"
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr "Při mazání přílohy se vyskytla chyba. Zkuste to, prosím, znovu."
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr "Zpráva musí mít příjemce!"
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Content can't be empty"
 msgid "Channel folder name can't be empty."
 msgstr "Obsah nemůže být prázdný"
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Invalid channel ID"
 msgid "Invalid channel folder ID"
 msgstr "Neplatný identifikátor kanálu"
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 #, fuzzy
 #| msgid "Confirm your email address"
 msgid "Configure owner account email address."
 msgstr "Potvrďte svoji adresu elektronické pošty"
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| " Congratulations, you have created a new demo Zulip organization. Note "
@@ -5287,72 +4717,72 @@ msgstr ""
 "bude automaticky smazána za 30 dní. Zjistěte více o ukázkových organizacích "
 "zde: %(demo_organizations_help_link)s!"
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a date"
 msgid "{var_name} is not Base64 encoded"
 msgstr "{var_name} není datum"
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 #, fuzzy
 #| msgid "Invalid emoji code."
 msgid "Invalid `device_id`"
 msgstr "Neplatný kód obrázečku."
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr ""
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr "Doména nemůže být prázdná."
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr "Doména musí mít alespoň jednu tečku (.)"
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr "Doména je příliš dlouhá"
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr "Doména nemůže začínat nebo končit tečkou (.)"
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr "Po sobě jdoucí '.' nejsou povoleny."
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr "Subdomény nemohou začínat nebo končit na '-'."
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr "Doména může obsahovat jen malá písmena, čísla, '.' a '-'."
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr "Časové razítko nesmí být záporné."
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr "Téma nesmí obsahovat nulové bajty"
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr "Uživatel vypnul synchronizaci konceptů."
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr "Návrh neexistuje"
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5360,630 +4790,628 @@ msgid ""
 "{error_message}"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr "Otevřít Zulip a nechat si vyzradit obsah"
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr ""
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr "Neplatná adresa."
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr "Mimo vaši doménu."
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr "E-mailové adresy obsahující + nejsou povoleny."
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr "Vyhrazeno pro systémové roboty."
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr "{email} již má účet"
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr "Již má účet."
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr "Účet byl vypnut."
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr ""
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr "Neplatný vlastní obrázeček."
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr "Neplatný název vlastního obrázečku."
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr "Tento vlastní obrázeček byl vypnut."
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr "Neplatný kód obrázečku."
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr "Neplatný název obrázečku."
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr "Neplatný typ obrázečku."
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr "Musí být správcem organizace nebo tvůrcem obrázečku"
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr ""
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
 msgstr ""
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr "Chybí název obrázečku"
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr "Nepodařilo se přidělit event queue"
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr "Nepřihlášen: API autentikace nebo uživatelská session je vyžadována"
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr ""
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr "Vlastník organizace"
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr "uživatel"
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr "Nelze vypnout jedinou {entity}."
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr "Neplatný markdownový include: {include_statement}"
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr "Nevalidní JSON"
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr "Musí být správcem organizace"
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr "Musí být vlastníkem organizace"
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Must be an organization owner"
 msgid "Must be a bot user"
 msgstr "Musí být vlastníkem organizace"
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr "Vaše uživatelské jméno nebo heslo není správné"
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr "Tato organizace byla vypnuta"
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr "Registrace oznámení po telefonu pro váš server byla vypnuta"
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr "Přihlašování pomocí hesla je v této organizaci vypnuto"
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr "Vaše heslo bylo vypnuto a je třeba je zadat znovu"
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr "Neplatný API klíč"
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr "Špatný API klíč"
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
 "webhook; ignoring"
 msgstr ""
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr "Požadavek nelze zpracovat: Vytvořil {webhook_name} tuto událost?"
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr "Neplatná subdoména"
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr "Přímé zprávy jsou v této organizaci zakázány."
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr "Tento rozhovor nezahrnuje žádné uživatele, kteří ji mohou autorizovat."
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr "Přístup odepřen"
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} most recent messages in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr "Reakce již existuje."
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr "Odpověď neexistuje."
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
 msgstr ""
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr ""
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr ""
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr ""
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr ""
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr ""
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Already has an account."
 msgid "Atlassian account ID"
 msgstr "Již má účet."
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Behance username"
 msgstr "Špatný název nebo uživatelské jméno"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 msgid "Bitbucket username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Codeberg username"
 msgstr "Špatný název nebo uživatelské jméno"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Dribbble username"
 msgstr "E-mail nebo uživatelské jméno"
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Facebook username"
 msgstr "Špatný název nebo uživatelské jméno"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "GitLab username"
 msgstr "E-mail nebo uživatelské jméno"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Instagram username"
 msgstr "Špatný název nebo uživatelské jméno"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 msgid "Mastodon profile"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Medium username"
 msgstr "Špatný název nebo uživatelské jméno"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Pinterest username"
 msgstr "Špatný název nebo uživatelské jméno"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Reddit username"
 msgstr "E-mail nebo uživatelské jméno"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 msgid "Snapchat username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Threads username"
 msgstr "Špatný název nebo uživatelské jméno"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "TikTok username"
 msgstr "E-mail nebo uživatelské jméno"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Twitch username"
 msgstr "E-mail nebo uživatelské jméno"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "Uživatelské jméno"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr "Neplatný vnější typ účtu"
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr "Rámce doplňků"
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 #, fuzzy
 #| msgid "Video call ended"
 msgid "Video calling"
 msgstr "Videohovor ukončen"
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr "Průběžná integrace"
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr "Zákaznická podpora"
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr "Nasazování"
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr "Zábava"
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr "Komunikace"
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr "Finance"
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr ""
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr "Marketing"
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr "Různé"
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr ""
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr "Správa projektu"
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr "Produktivita"
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr "Verzování"
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr "Zpráva nesmí být prázdná"
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr "Zpráva nesmí obsahovat nulové bajty"
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{fullname} moderation"
 msgstr "{full_name} vás zmínil:"
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr "Neplatný zužující operátor: {desc}"
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr ""
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr ""
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr "Chybí argument 'anchor'."
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 #, fuzzy
 #| msgid "Missing 'anchor' argument."
 msgid "Missing 'anchor_date' argument."
 msgstr "Chybí argument 'anchor'."
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr "Neplatná kotva"
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr ""
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 #, fuzzy
 #| msgid "Confirmation link does not exist"
 msgid "Navigation view does not exist."
 msgstr "Potvrzovací odkaz neexistuje"
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5991,7 +5419,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5999,7 +5427,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6007,7 +5435,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6015,7 +5443,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| " Congratulations, you have created a new demo Zulip organization. Note "
@@ -6032,14 +5460,14 @@ msgstr ""
 "bude automaticky smazána za 30 dní. Zjistěte více o ukázkových organizacích "
 "zde: %(demo_organizations_help_link)s!"
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
 "them in your [Inbox](/#inbox).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6047,7 +5475,7 @@ msgid ""
 "({navigation_tour_video_url}) for a quick app overview.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6062,14 +5490,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -6077,7 +5505,7 @@ msgid ""
 "and edit your [profile information](/help/edit-your-profile).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -6088,7 +5516,7 @@ msgid ""
 "experience in your [Preferences](#settings/preferences).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6099,7 +5527,7 @@ msgid ""
 "[Browse and subscribe to channels]({settings_link}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -6116,7 +5544,7 @@ msgid ""
 "discussed.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -6125,7 +5553,7 @@ msgid ""
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -6137,7 +5565,7 @@ msgid ""
 "times, and more.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6147,7 +5575,7 @@ msgid ""
 "or browse the [help center](/help/) to learn more!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6155,7 +5583,7 @@ msgid ""
 "get help, try one of the following messages: {bot_commands}\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6167,13 +5595,13 @@ msgid ""
 "({move_content_another_channel_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6187,12 +5615,11 @@ msgid ""
 "and above.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr ""
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -6200,14 +5627,14 @@ msgid ""
 "no matter how many other conversations are going on.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
 "conversations with unread messages.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -6215,7 +5642,7 @@ msgid ""
 "the `+` button next to its name.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -6223,13 +5650,13 @@ msgid ""
 "can we chat about…?”\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6237,7 +5664,7 @@ msgid ""
 "({format_message_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6257,127 +5684,127 @@ msgid ""
 "```\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
 "teammates.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
 "conversation.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr ""
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr ""
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr ""
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr "Neplatný JSON v odpovědi"
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr "Neplatný formát odpovědi"
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr "Prázdný, nebo nesprávně dlouhý elektronický klíč"
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr "Neplatný elektronický klíč APNS"
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr ""
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr "Elektronický klíč neexistuje"
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr "{full_name} označil/a @{user_group_name}:"
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr "{full_name} vás zmínil:"
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr "{full_name} zmínil všechny:"
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "Nová zpráva"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 #, fuzzy
 #| msgid "Invalid API key"
 msgid "Invalid `push_key`"
 msgstr "Neplatný API klíč"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
@@ -6386,1121 +5813,1100 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr "Uživatel není oprávněn položit tento dotaz"
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr "'{email}' už Zulip nepoužívá."
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr ""
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr "{var_name} je příliš dlouhé (maximálně {max_length} znaků)"
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder does not exist"
 msgstr "Elektronický klíč neexistuje"
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr ""
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr "Nelze se rozhodnout mezi argumenty '{var_name1}' a '{var_name2}'"
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr "Chybí argument '{var_name}'"
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr "Špatná hodnota pro '{var_name}': {bad_value}"
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr ""
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr ""
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr ""
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr ""
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr "Nemáte oprávnění vkládat příspěvky do tohoto kanálu."
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 #, fuzzy
 #| msgid "You do not have permission to post in this channel."
 msgid "You do not have permission to create new topics in this channel."
 msgstr "Nemáte oprávnění vkládat příspěvky do tohoto kanálu."
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr "Neplatný identifikátor kanálu"
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr ""
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr ""
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr ""
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr ""
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr "Nelze dekódovat obrázek; opravdu jste nahráli soubor s obrázkem?"
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr "Obrázek překračuje dovolené limity."
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr "{var_name} není boolean"
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} does not have a length"
 msgid "{var_name} does not have the expected format"
 msgstr "{var_name} nemá délku"
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr "{var_name} není datum"
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr "{var_name} není slovník"
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr "Neplatný {var_name}"
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr "{var_name} není číslo s desetinnou čárkou"
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr "{var_name} je moc malý"
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr "{var_name} není celé číslo"
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr "{var_name} je moc velký"
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr "{var_name} není seznam"
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr "{var_name} je příliš dlouhé (maximálně {max_length} znaků)"
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr "{var_name} není řetězec"
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr "{var_name} je příliš dlouhé (maximálně {max_length} znaků)"
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr "{var_name} je příliš dlouhé (maximálně {max_length} znaků)"
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr "Poškozené užitečné zatížení"
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr "{var_name} není platný hex kód barvy"
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr "Neplatný {setting_name}"
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr ""
 "Nahrání souboru by překročilo kvótu, kterou má vaše organizace nastavenou."
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr ""
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr ""
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr "Neplatná skupina uživatele"
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid user group"
 msgid "Invalid user group ID: {user_group_id}"
 msgstr "Neplatná skupina uživatele"
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr ""
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr ""
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr ""
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr "Klient neposlal žádné nové hodnoty."
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 "Klient musí předat emoji_name, pokud předají buď emoji_code , nebo "
 "reaction_type."
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr "Název je příliš dlouhý!"
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 #, fuzzy
 #| msgid "Message must not be empty"
 msgid "Name must not be empty!"
 msgstr "Zpráva nesmí být prázdná"
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr "Neplatné znaky v názvu!"
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr "Neplatný formát!"
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr ""
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr ""
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr "Špatný název nebo uživatelské jméno"
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr "Neplatný doplněk '{integration_name}'."
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr ""
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr ""
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr "Neplatné nastavení!"
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr "Neplatný typ robota"
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr "Neplatný typ rozhraní"
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr ""
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr "Žádný takový robot"
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr "Žádný takový uživatel"
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr "Uživatel je vypnut"
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr "{item} nemůže být prázdné."
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr "{var_name} má nesprávnou délku {length}; mělo by být {target_length}"
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a string"
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr "{var_name} není řetězec"
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr "{container} má mít přesně {length} položek"
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr "{key_name} klíč chybí v {var_name}"
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr ""
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr "{var_name} není allowed_type"
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr "{variable} != {expected_value} ({value} je chybná)"
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr "{var_name} není adresa (URL)"
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr ""
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr "'{item}' nemůže být prázdné."
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr ""
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr "'{value}' je neplatná možnost pro pole '{field_name}'."
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr "{var_name} není řetězec nebo seznam celých čísel"
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr "{var_name} není řetězec nebo celé číslo"
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr "{var_name} nemá délku"
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr "{var_name} chybí"
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr "Chybí HTTP hlavička události '{header}'"
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr "Zcommand by měl začínat znakem '/'."
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr ""
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr "Chyba CSRF: {reason}"
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr "Datum"
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr "Vnější účet"
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr "Zájmena"
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr "Nikdo"
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr "Řádní členové"
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "Členi"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr "Všichni na internetu"
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Invalid characters in emoji name"
 msgid "Invalid auto-conversion field: empty field name."
 msgstr "Neplatné znaky v názvu obrázečku"
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr ""
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr "Neznámá chyba regulárního výrazu"
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 msgid "Example input does not match the linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in alternative URL template is not present in linkifier "
 "pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in linkifier pattern is not present in alternative URL "
 "template."
 msgstr ""
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr "Unicode obrázeček"
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "Vlastní obrázeček"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr "Další obrázeček Zulipu"
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr "Neplatné znaky v názvu obrázečku"
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr "Neplatné znaky v jazyce segmentů"
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr ""
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr ""
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr ""
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr ""
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr ""
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr "Dostupné v serveru Zulip Standard. Pro přístup povyšte."
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr ""
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr ""
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr ""
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr "Internetový veřejný"
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "Veřejné"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr "Soukromá, sdílená historie"
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr "Soukromá, chráněná historie"
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr "Správci, moderátoři, členové a hosté"
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr "Správci, moderátoři a členové"
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr "Správci a moderátoři"
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr "Pouze správci"
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr "Neznámý uživatel"
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr "Vlastník organizace"
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr "Správce organizace"
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr "Moderátor"
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "Člen"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "Host"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr "Neznámá IP adresa"
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr "neznámý operační systém"
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr "Neznámý prohlížeč"
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr "Chybí argument 'queue_id'"
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr "Chybí argument 'last_event_id'"
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr "Událost novější než {event_id} již byla ořezána!"
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr "Událost {event_id} nebyla v této řadě"
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr ""
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 #, fuzzy
 #| msgid "Failed to create Zoom call"
 msgid "Failed to generate challenge"
 msgstr "Nepodařilo se vytvořit hovor Zoom"
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr ""
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr "V požadavku chybí JSON \"web token\""
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr "Chybný JSON \"web token\""
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr ""
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr "Subdoména je povinná"
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr "Heslo je nesprávné."
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr "V požadavku chybí hlavička uživatelského agenta (User-Agent)"
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr "Štítek nemůže být prázdný."
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr "Políčko musí mít aspoň jednu možnost."
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 #, fuzzy
 #| msgid "Presence is not supported for bot users."
 msgid "Field type not supported for use for user matching."
 msgstr "Zobrazení přítomnosti není podporováno pro robotické uživatele."
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr "Neplatný typ pole."
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr "V přehledu profilu lze zobrazit pouze 2 vlastní profilová pole."
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr "Pole s tímto štítkem již existuje."
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr "Výchozí uživatelské pole nelze aktualizovat."
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr "Koncový bod není v produkci dostupný."
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr "Vývojářská autentizační podpůrná vrstva není zapnuta."
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr ""
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr ""
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr ""
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr ""
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr ""
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr ""
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr "Žádné taková pozvánka"
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 #, fuzzy
 #| msgid "Confirmation link expired or deactivated"
 msgid "Invitation already used or deactivated."
 msgstr "Platnost potvrzovacího odkazu vypršela nebo byl vypnut"
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr ""
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr ""
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr "Musíte zadat alespoň jednu adresu elektronické pošty."
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
@@ -7508,106 +6914,104 @@ msgstr ""
 "Některé z těchto adres již Zulip používají, takže jsme jim pozvánku znovu "
 "neposílali. Odeslali jsme ji ale všem ostatním!"
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr "Historie úprav zprávy je v této organizaci vypnuta"
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr "Nemáte oprávnění smazat tuto zprávu"
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr "Časová lhůta pro smazání této zprávy vypršela"
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr "Tato zpráva je již smazaná"
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr ""
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr ""
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr ""
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Organization creation link required"
 msgid "An explanation is required."
 msgstr "Požadován odkaz na vytvoření organizace"
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Zephyr mirroring is not allowed in this organization"
 msgid "Message reporting is not enabled in this organization."
 msgstr "Zrcadlení Zephyru není v této organizaci povoleno."
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr "Chybí odesílatel"
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr "Zrcadlení není povoleno společně s uživatelskými ID příjemců"
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr "Neplatná zrcadlená zpráva"
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr ""
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr ""
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr ""
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr "Nelze ztlumit sebe"
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr "Uživatel již ztlumen"
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr "Uživatel není ztlumen"
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 #, fuzzy
 #| msgid "Reaction already exists."
 msgid "Navigation view already exists."
 msgstr "Reakce již existuje."
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7615,568 +7019,566 @@ msgid ""
 "later. Is this a good time?\n"
 msgstr ""
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr "Zobrazení přítomnosti není podporováno pro robotické uživatele."
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr "Žádné údaje o přítomnosti pro {user_id_or_email}"
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 #, fuzzy
 #| msgid "You do not have permission to post in this channel."
 msgid "You do not have permission to manage plans and billing."
 msgstr "Nemáte oprávnění vkládat příspěvky do tohoto kanálu."
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr ""
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr ""
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr "Alespoň jedno z následujících musí být uvedeno: emoji_name, emoji_code"
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr ""
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr ""
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr "Alespoň jedna metoda autentizace musí být povolena."
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr ""
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr ""
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr "Musí to být ukázková organizace."
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr ""
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr "Doména {domain} je již součástí vaší organizace."
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr "Nebyl nalezen žádný záznam pro doménu {domain}."
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr "Musíte nahrát přesně jeden soubor."
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr ""
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 #, fuzzy
 #| msgid "Disposable email addresses are not allowed in this organization"
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr "Jednorázové e-maily nejsou v této organizaci povoleny"
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr "Překročeno rychlostní omezení."
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr "Neplatné ID uložení dat"
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr "Uložená data již byla smazána"
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr ""
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr ""
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr "Musíte nahrát přesně jednu ikonu."
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr "Tvůrce odkazů nenalezen."
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr "Musíte nahrát právě jedno logo."
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid characters in pygments language"
 msgid "Invalid character in language: {character}"
 msgstr "Neplatné znaky v jazyce segmentů"
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not an allowed_type"
 msgid "Language '{language}' is not allowed."
 msgstr "{var_name} není allowed_type"
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr "Neplatné hřiště"
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr ""
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "Direct messages"
 msgid "Importing messages…"
 msgstr "Přímé zprávy"
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "Your email"
 msgid "Your name"
 msgstr "Vaše e-mailová adresa"
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr ""
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr ""
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr ""
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr "Je třeba nastavit \"new_description\" nebo \"new_group_name\"."
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr "Neplatná hodnota pro \"op\". Nastavte buď \"add\" nebo \"remove\"."
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr "Neplatné parametry"
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr ""
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr ""
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr "Nic k provedení. Zadejte aspoň jedno z \"add\" nebo \"delete\"."
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr ""
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr ""
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr ""
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr ""
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
 "**"
 msgstr ""
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr ""
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr ""
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr ""
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr "Neplatný JSON pro podzprávu"
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr ""
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr ""
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr "Prázdný 'do' seznamu"
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr ""
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr "<p>Nejste oprávněn zobrazit tento soubor.</p>"
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr "Neplatný elektronický klíč"
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr "Neplatný název souboru"
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr "Musíte zvolit soubor k nahrání"
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr "Najednou můžete nahrát pouze jeden soubor"
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr "Neposkytnuta žádná nová data"
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 msgstr ""
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr "Uživatel {user_id} již je členem této skupiny"
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr ""
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
 "subgroups."
 msgstr ""
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr "Změny avatarů jsou v této organizaci zakázány."
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr "Změny e-mailu jsou v této organizaci zakázány."
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr "Neplatný default_language"
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr ""
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr ""
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr "Vaše heslo pro Zulip je spravováno v LDAPu"
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr "Chybné heslo!"
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, fuzzy, python-brace-format
 #| msgid "You can try again in %(retry_after)s seconds."
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr "Můžete to zkusit znovu za %(retry_after)s sekund."
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr "Nové heslo je příliš slabé!"
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr "Musíte nahrát právě jeden obrázek avatara."
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr "Téma není ztlumeno"
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr "Nelze vypnout jediného vlastníka organizace"
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 msgid "User is not allowed to delete other user's messages."
 msgstr ""
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr "Nelze odstranit vlastnická oprávnění jediného vlastníka organizace."
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr ""
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr ""
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
@@ -8188,25 +7590,25 @@ msgstr ""
 "Roboty nelze vytvářet, dokud FAKE_EMAIL_DOMAIN není správně nastaveno\n"
 "Spojte se, prosím, se správcem serveru."
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 #, fuzzy
 #| msgid "Email address"
 msgid "Email address already in use"
 msgstr "E-mailová adresa"
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr "Nepodařilo se změnit vlastníka, žádný takový uživatel neexistuje"
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr "Nepodařilo se změnit vlastníka, uživatel je vypnut"
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr "Nepodařilo se změnit vlastníka, roboti nemohou vlastnit jiné roboty"
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
@@ -8214,293 +7616,293 @@ msgstr ""
 "Roboty nelze vytvářet, dokud FAKE_EMAIL_DOMAIN není správně nastaveno\n"
 "Spojte se, prosím, se správcem serveru."
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr "Přidaní roboti nejsou povoleni."
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr "Neplatný název přidaného robota."
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr ""
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr "Adresa elektronické pošty '{email}' není v této organizaci povolena"
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr "Jednorázové e-maily nejsou v této organizaci povoleny"
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom access token"
 msgid "Invalid {provider_name} access token"
 msgstr "Neplatný elektronický klíč pro přístup k Zoom"
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} call"
 msgstr "Nepodařilo se vytvořit hovor Zoom"
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Zoom credentials have not been configured"
 msgid "{provider_name} credentials have not been configured"
 msgstr "Přihlašovací údaje Zoom ještě nebyly nastaveny"
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom credentials"
 msgid "Invalid {provider_name} credentials"
 msgstr "Neplatné přihlašovací údaje Zoom"
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error connecting to the BigBlueButton server."
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr ""
 "Chyba při připojování se k serveru BigBlueButton - Velké modré tlačítko."
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error authenticating to the BigBlueButton server."
 msgid "Error authenticating to the {provider_name} server"
 msgstr "Chyba při přihlašování k serveru BigBlueButton - Velké modré tlačítko."
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "BigBlueButton server returned an unexpected error."
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr ""
 "Server BigBlueButton - Velké modré tlačítko, vrátil neočekávanou chybu."
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom session identifier"
 msgid "Invalid {provider_name} session identifier"
 msgstr "Neplatný identifikátor sezení Zoom"
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr ""
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} public room."
 msgstr "Nepodařilo se vytvořit hovor Zoom"
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr "Neplatný podpis."
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{full_name}'s Zulip room"
 msgstr "{full_name} vás zmínil:"
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr "Neplatné užitečné zatížení"
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr "Neznámý požadavek na zpětné volání HTTP, \"webhook request\""
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr "Téma nemůže být prázdné"
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr "Obsah nemůže být prázdný"
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr ""
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr "Neplatný JSON vstup"
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr ""
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr "Chyba: parametr channels_map_to_topics je jiný než 0 nebo 1"
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr ""
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
 "({export_settings_link})."
 msgstr ""
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr ""
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr ""
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr ""
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr ""
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr "Neplatná subdoména pro \"bouncer push\" oznámení"
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr "Musí se prokázat platným Zulip server API klíčem"
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr "Neplatné UUID"
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr "Neplatný typ elektronického klíče"
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr ""
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr ""
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr ""
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr ""
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
 "try again later or reach out to {support_email} for assistance."
 msgstr ""
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr ""
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr ""
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr ""
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr "Chybí uživatelské_id nebo user_uuid"
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
 "server: {reason}"
 msgstr ""
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr ""
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr ""
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr ""
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr "Data nemají správné pořadí."
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr ""
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr ""
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr "Musíte si znovu nastavit heslo."
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr "Chybějící parametr id_token"
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 #, fuzzy
 #| msgid "Missing id_token parameter"
 msgid "Missing idp param"
 msgstr "Chybějící parametr id_token"
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr "Neplatný OTP"
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr "Dohromady nelze použít jak mobile_flow_otp tak desktop_flow_otp."
 

--- a/locale/cy/LC_MESSAGES/django.po
+++ b/locale/cy/LC_MESSAGES/django.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 19:47+0000\n"
 "Last-Translator: Alex Vandiver <alexmv@zulip.com>\n"
 "Language-Team: Welsh <https://hosted.weblate.org/projects/zulip/django/cy/>\n"
@@ -21,53 +21,53 @@ msgstr ""
 "11) ? 2 : 3;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "Ni chaniateir i ddefnyddwyr gwadd"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "Sefydliad annilys"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr ""
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr ""
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr "Negeseuon uniongyrchol"
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr "Grwpio negeseuon uniongyrchol"
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr ""
 "Mae'r amser cychwyn yn hwyrach na'r amser gorffen. Dechreuwch: {start}, "
 "Diwedd: {end}"
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr ""
 "Nid oes data dadansoddeg ar gael. Cysylltwch â gweinyddwr eich gweinydd."
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -80,7 +80,7 @@ msgstr ""
 "({billing_page_link}) neu [deactivate defnyddwyr anactif]"
 "({deactivate_user_help_page_link}) i ganiatáu i ddefnyddwyr newydd ymuno."
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -92,7 +92,7 @@ msgstr ""
 "anactif]({deactivate_user_help_page_link}) i ganiatáu i fwy nag un "
 "defnyddiwr ymuno."
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -104,7 +104,7 @@ msgstr ""
 "anactif]({deactivate_user_help_page_link}) i ganiatáu i fwy na dau "
 "ddefnyddiwr ymuno."
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -116,7 +116,7 @@ msgstr ""
 "anactif]({deactivate_user_help_page_link}) i ganiatáu i fwy na thri "
 "defnyddiwr ymuno."
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -125,78 +125,77 @@ msgid ""
 "({billing_page_link}) is greater than the current number of users."
 msgstr ""
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr ""
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr ""
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
 "(minimum {min_licenses})."
 msgstr ""
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
 "page. To complete the upgrade, please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr ""
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr "{brand} yn gorffen yn {last4}"
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr "Dull talu anhysbys. Cysylltwch â {email}."
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr "Aeth rhywbeth o'i le. Cysylltwch â {email}."
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "Aeth rhywbeth o'i le. Ail-lwythwch y dudalen."
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr ""
 "Aeth rhywbeth o'i le. Arhoswch ychydig eiliadau a rhoi cynnig arall arni."
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr ""
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
@@ -204,16 +203,16 @@ msgstr ""
 "Methu diweddaru'r cynllun. Mae'r cynllun wedi dod i ben a rhoi cynllun "
 "newydd yn ei le."
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr "Methu diweddaru'r cynllun. Mae'r cynllun wedi dod i ben."
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
@@ -221,24 +220,24 @@ msgstr ""
 "Methu diweddaru trwyddedau â llaw. Mae eich cynllun ar reoli trwydded yn "
 "awtomatig."
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr ""
 "Mae eich cynllun eisoes ar drwyddedau {licenses} yn y cyfnod bilio cyfredol."
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr "Ni allwch ostwng y trwyddedau yn y cyfnod bilio cyfredol."
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
 msgstr ""
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
@@ -247,34 +246,34 @@ msgstr ""
 "Disgwylir i'ch cynllun adnewyddu eisoes gyda thrwyddedau "
 "{licenses_at_next_renewal}."
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
 "billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr "Dim byd i newid."
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr "Dim cwsmer i'r sefydliad hwn!"
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr "Ni ddaethpwyd o hyd i sesiwn"
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr "Ni ddarganfuwyd bwriad talu"
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr ""
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -284,100 +283,97 @@ msgid ""
 "we would really appreciate it!"
 msgstr ""
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
 "{support_email}"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr ""
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "Gwall"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr "Tudalen heb ei chanfod (404)"
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
 "%(support_email)s\">contact support</a>."
 msgstr ""
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr ""
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
 msgstr ""
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr ""
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
 msgstr ""
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr "Ni chaniateir y dull (405)"
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr "Gwall gweinydd mewnol"
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
 msgstr ""
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -385,156 +381,154 @@ msgid ""
 "a> with any questions."
 msgstr ""
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
 "a> for support."
 msgstr ""
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
 "href=\"%(troubleshooting_url)s\">Zulip server troubleshooting guide</a>."
 msgstr ""
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr "Dadansoddeg ar gyfer %(target_name)s | Zulip"
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr "Mae dadansoddeg ar gael yn llawn 24 awr ar ôl creu'r sefydliad."
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr "Dadansoddeg Zulip ar gyfer %(target_name)s"
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr "Crynodeb o'r sefydliad"
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr "Nifer ddefnyddwyr"
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr "Defnyddwyr yn weithredol yn ystod y 15 diwrnod diwethaf"
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr "Nifer y gwesteion"
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr "Cyfanswm nifer y negeseuon"
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr "Nifer y negeseuon yn ystod y 30 diwrnod diwethaf"
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr "Storfa ffeiliau yn cael ei defnyddio"
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "Defnyddwyr gweithredol"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr "Actives dyddiol"
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr "Gweithredol 15 diwrnod"
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr "Cyfanswm y defnyddwyr"
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "Defnyddwyr"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr "Negeseuon wedi'u hanfon yn ôl math y derbynnydd"
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "Fi"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "Pawb"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "Wythnos diwethaf"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "Mis diwethaf"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "Blwyddyn diwethaf"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "Trwy'r amser"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr "Negeseuon wedi'u hanfon dros amser"
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "Yn ddyddiol"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "Wythnosol"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr "Cronnus"
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "Bodau dynol"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "Botiau"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr "Negeseuon yn cael eu darllen dros amser"
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr "Negeseuon a anfonwyd gan gleient"
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr "Diweddariad diwethaf"
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
@@ -542,15 +536,15 @@ msgstr ""
 "Mae diweddariad llawn o'r holl graffiau yn digwydd unwaith y dydd. Mae'r "
 "graff “negeseuon a anfonir dros amser” yn cael ei ddiweddaru unwaith yr awr."
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr "E-bost wedi newid"
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr "E-bost wedi newid!"
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
@@ -559,48 +553,48 @@ msgstr ""
 "Mae hyn yn cadarnhau bod y cyfeiriad e-bost ar gyfer eich cyfrif Zulip wedi "
 "newid o %(old_email_html_tag)s i %(new_email_html_tag)s"
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr "Yn cadarnhau eich cyfeiriad e-bost"
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr "Nid yw dolen cadarnhad yn bodoli"
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr "Whoops. Ni allem ddod o hyd i'ch cyswllt cadarnhau yn y system."
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr "Mae'r ddolen gadarnhau wedi dod i ben neu wedi'i dadactifadu"
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr "Whoops. Mae'r ddolen gadarnhau wedi dod i ben neu wedi'i dadactifadu."
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr "Cysylltwch â gweinyddwr eich sefydliad i gael dolen newydd."
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr "Dolen cadarnhad wedi'i gamffurfio"
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr "Whoops. Mae'r cyswllt cadarnhau weid'i gamffurfio."
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
@@ -609,72 +603,55 @@ msgstr ""
 "dal i ddod ar draws y dudalen hon, mae'n debyg mai ein bai ni yw hynny. "
 "Mae'n ddrwg gennym."
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr "Bilio"
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr "Caewch y moddol"
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "Canslo"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr "Cadarnhau"
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr ""
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr "Statws bilio"
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -685,19 +662,19 @@ msgid ""
 "server."
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -705,736 +682,246 @@ msgid ""
 "%(support_email)s'>contact support</a> with any questions."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr "Rhagorwyd ar y terfyn cyfradd."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, fuzzy, python-format
 #| msgid "You can try again in %(retry_after)s seconds."
 msgid "You can try again in %(retry_after_string)s."
 msgstr "Gallwch roi cynnig arall arni mewn %(retry_after)s eiliad."
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr "Uwchraddio"
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr ""
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr "Agor cyfeiriadur cymunedau"
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr "Hidlo yn ôl categori"
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "I gyd"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr "Categorïau"
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr ""
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr "Cymuned ddatblygu Zulip"
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr "Ymunwch fel defnyddiwr"
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr "Ymunwch fel hunan-gwesteiwr"
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr "Ymunwch fel cyfrannwr"
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "Creu sefydliad"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr ""
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr "Zulip hunan-westeiwr"
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr "Gofyn am nawdd"
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr "Prisio addysg"
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr "Gweld prisio"
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr "Zulip am busnes"
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Zulip for business"
 msgid "Zulip for open source"
 msgstr "Zulip am busnes"
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Create your Zulip organization"
 msgid "Screenshot of Zulip conversation"
 msgstr "Creu eich sefydliad Zulip"
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Messages sent over time"
 msgid "Message with code"
 msgstr "Negeseuon wedi'u hanfon dros amser"
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr "Dolen"
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr "Cysylltwch â chefnogaeth"
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr "O"
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr "Trefniadaeth"
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr "Pwnc"
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr "Neges"
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr "Cyflwyno"
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr "Diolch am gysylltu â ni"
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr "Diolch am gysylltu â ni!"
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr "Byddwn mewn cysylltiad â chi yn fuan."
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
@@ -1442,13 +929,13 @@ msgstr ""
 "Gallwch ddod o hyd i atebion i gwestiynau cyffredin yn y <a href=\"/help/"
 "\">Canolfan gymorth Zulip</a>."
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 #, fuzzy
 #| msgid "Getting started"
 msgid "Get started"
 msgstr "Dechrau arni"
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
@@ -1458,51 +945,50 @@ msgstr ""
 "href=\"https://zulip.com/policies/terms\">Delerau Gwasanaeth Zulip</a> i "
 "barhau."
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr "Neu, fel arall, defnyddiwch un o'h ffonau wrth gefn:"
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr "Fel dewis olaf, gallwch ddefnyddio tocyn wrth gefn:"
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr "Defnyddiwch docyn wrth gefn"
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr "Derbyn y Telerau Gwasanaeth"
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr "Croeso i Zulip"
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "E-bost"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr ""
 "Tanysgrifiwch fi i gylchlythyr traffig isel Zulip (ychydig o negeseuon e-"
 "bost y flwyddyn)."
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr "Parhau"
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr "Cadarnhewch eich cyfeiriad e-bost"
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1510,78 +996,77 @@ msgid ""
 "from Zulip."
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
 msgstr ""
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr ""
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr ""
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr ""
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr ""
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr ""
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr ""
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr ""
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
 msgstr ""
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1589,215 +1074,208 @@ msgid ""
 "href=\"%(doc_url)s\">documentation</a>."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr "Ni ddarganfuwyd cyfrif zulip."
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, fuzzy, python-format
 #| msgid "No entry found for domain {domain}."
 msgid "No account found for %(email)s."
 msgstr "Ni ddarganfuwyd cofnod ar gyfer parth {domain}."
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr "Mewngofnodi gyda chyfrif arall"
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr "Parhewch i gofrestru"
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Must be a demo organization."
 msgid "Try Zulip in a demo organization"
 msgstr "Rhaid bod yn sefydliad demo."
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Try Zulip now"
 msgid "Try Zulip"
 msgstr "Rhowch gynnig ar Zulip nawr"
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "Creu sefydliad newydd"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr "Creu sefydliad Zulip newydd"
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr "Rhowch eich cyfeiriad e-bost"
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr "Math o sefydliad"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 #, fuzzy
 #| msgid "Private, shared history"
 msgid "Import chat history?"
 msgstr "Hanes preifat, a rennir"
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr "Enw'r sefydliad"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "URL y sefydliad"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr "Defnyddiwch %(external_host)s"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "NEU"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "Cofrestru"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "Cofrestrwch ar gyfer Zulip"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr "Mae angen gwahoddiad arnoch i ymuno â'r sefydliad hwn."
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr "Cofrestrwch gyda %(identity_provider)s"
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "Mewngofnodi"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1805,105 +1283,104 @@ msgid ""
 "noreferrer\">after you join</a>."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "Newid"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr "Creu eich sefydliad"
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr "Creu eich cyfrif"
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 #, fuzzy
 #| msgid "Click the button below to complete registration."
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr "Cliciwch y botwm isod i gwblhau cofrestriad."
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr "Eich cyfrif"
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr "Peidiwch â mewnforio gosodiadau"
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr "Mewnforio gosodiadau o&#39;r cyfrif Zulip presennol"
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "Enw"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "Cyfrinair"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr "Rhowch eich cyfrinair LDAP / Active Directory."
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 "Defnyddir hwn ar gyfer cymwysiadau symudol ac offer eraill sydd angen "
 "cyfrinair."
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr "Cryfder Cyfrinair"
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr "Beth mae gennych chi ddiddordeb ynddo?"
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
@@ -1912,22 +1389,22 @@ msgstr ""
 "Rwy'n cytuno i'r <a href=\"%(root_domain_url)s/policies/terms\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">Telerau Gwasanaeth</a> ."
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr "Sefydliad wedi'i ddadactifadu"
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr ""
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -1935,7 +1412,7 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid ""
@@ -1943,41 +1420,41 @@ msgid ""
 "deleted."
 msgstr "Mae'r sefydliad hwn wedi'i ddadactifadu"
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
 "inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
 "administrators</a> to inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid "This organization has been deactivated."
 msgstr "Mae'r sefydliad hwn wedi'i ddadactifadu"
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
 "%(support_email)s\">contact Zulip support</a> to reactivate it."
 msgstr ""
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -1985,15 +1462,15 @@ msgid ""
 "reactivate it."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr "Gorffen mewngofnodi bwrdd gwaith"
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
@@ -2001,93 +1478,92 @@ msgstr ""
 "Defnyddiwch eich porwr gwe i orffen mewngofnodi, yna dewch yn ôl yma i "
 "gludo'ch tocyn mewngofnodi."
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr "Gludo tocyn yma"
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr "Gorffen"
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr "Tocyn anghywir."
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr "Derbyniwyd Tocyn. Mewngofnodi i chi…"
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 "Copïwch y tocyn mewngofnodi hwn a'i ddychwelyd i'ch app Zulip i orffen "
 "mewngofnodi:"
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "Copi"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr "Yna gallwch chi gau'r ffenestr hon."
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr "Neu, parhewch yn eich porwr."
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr "Defnyddiwr anhysbys"
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr "Perchnogion"
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "Gweinyddwyr"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr "Cymedrolwyr"
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr "Defnyddwyr gwesteion"
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "Defnyddwyr arferol"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "Cau"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "Diweddariad"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr "Zulip"
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, fuzzy, python-format
 #| msgid "You've joined the Zulip organization %(realm_name)s."
 msgid ""
@@ -2095,61 +1571,61 @@ msgid ""
 "<b>%(realm_name)s</b>."
 msgstr "Rydych chi wedi ymuno â sefydliad Zulip %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr "Croeso i Zulip!"
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, fuzzy, python-format
 #| msgid "You've joined the Zulip organization %(realm_name)s."
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr "Rydych chi wedi ymuno â sefydliad Zulip %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
 "href=\"%(apps_page_link)s\">mobile and desktop</a> apps:"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr "URL y sefydliad: %(organization_url)s"
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr "Defnyddiwch eich cyfrif LDAP i fewngofnodi"
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
 "href=\"%(getting_user_started_link)s\">getting started guide</a>!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2157,83 +1633,83 @@ msgid ""
 "Zulip</a>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
 "to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr "%(realm_name)s ar Zulip: Manylion eich sefydliad newydd"
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr "%(realm_name)s ar Zulip: Manylion eich cyfrif newydd"
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr "Rydych chi wedi ymuno â sefydliad Zulip %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
 "desktop apps (%(apps_page_link)s):"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
 "(%(getting_user_started_link)s)!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
 "(%(getting_organization_started_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr "Helo,"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2241,12 +1717,12 @@ msgid ""
 "password for this account, please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2255,14 +1731,14 @@ msgstr ""
 "Os na ofynasoch am y newid hwn, cysylltwch â ni ar unwaith ar "
 "%(support_email)s."
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 #, fuzzy
 #| msgid "Create your Zulip organization"
 msgid "Verify your email address for your Zulip demo organization"
 msgstr "Creu eich sefydliad Zulip"
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2271,8 +1747,8 @@ msgstr ""
 "Os na ofynasoch am y newid hwn, cysylltwch â ni ar unwaith "
 "yn<%(support_email)s> ."
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2280,113 +1756,113 @@ msgid ""
 "please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr "Cadarnhau newid e-bost"
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr "Fe wnaethoch chi gofrestru ar gyfer Zulip yn ddiweddar. Gwych!"
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr "Cliciwch y botwm isod i gwblhau cofrestriad."
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr "Gorffen cofrestru"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr "Creu eich sefydliad Zulip"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr "Gweithredwch eich cyfrif Zulip"
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr "Cliciwch y ddolen isod i gwblhau cofrestriad."
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
 "— we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr "Rheoli dewisiadau e-bost"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr "Dad-danysgrifio o e-byst marchnata"
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
 "deactivated, and you will no longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr ""
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2394,22 +1870,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because your organization has "
@@ -2425,8 +1901,8 @@ msgstr ""
 "<a class=\"content_disabled_help_link\" href=\"%(help_url)s\">gynnwys neges "
 "anabl yn ymddangos mewn hysbysiadau e-bost</a> ."
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because you have disabled <a "
@@ -2442,40 +1918,40 @@ msgstr ""
 "href=\"%(alert_notif_url)s\">gynnwys neges yn ymddangos mewn hysbysiadau e-"
 "bost</a> ."
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, fuzzy, python-format
 #| msgid "Click here to log in to Zulip and catch up."
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr "Cliciwch yma i fewngofnodi i Zulip a dal i fyny."
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr "Dad-danysgrifio o negeseuon e-bost crynhoad"
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr "Treuliad Zulip ar gyfer %(realm_name)s"
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2492,8 +1968,8 @@ msgstr ""
 "wedi analluogi gynnwys neges yn ymddangos mewn hysbysiadau e-bost. \n"
 "Gweler %(hide_content_url)s i gael mwy o fanylion.\n"
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2509,41 +1985,38 @@ msgstr ""
 "gynnwys neges yn ymddangos mewn hysbysiadau e-bost. Gweler "
 "%(alert_notif_url)s i gael mwy o fanylion.\n"
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, fuzzy, python-format
 #| msgid "Log in to your organization"
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr "Mewngofnodi i'ch sefydliad"
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr "Rheoli dewisiadau e-bost:"
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr "Dad-danysgrifio o negeseuon e-bost crynhoad:"
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr "Pysgod nofio"
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr "Diolch am eich cais!"
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
 "organizations:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
@@ -2552,33 +2025,29 @@ msgstr ""
 "Mae gan eich cyfeiriad e-bost %(email)s gyfrifon gyda'r sefydliadau Zulip "
 "canlynol a gynhelir gan %(external_host)s:"
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
 "href=\"%(help_reset_password_link)s\">reset your password</a>."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
 "%(external_host)s."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2586,38 +2055,35 @@ msgid ""
 "to find your account."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr "Eich cyfrifon Zulip"
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
 "try another way to find your account (%(help_logging_in_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr "Helo,"
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
@@ -2626,19 +2092,19 @@ msgstr ""
 "mae %(referrer_name)s eisiau ichi ymuno â nhw ar Zulip - yr offeryn "
 "cyfathrebu tîm sydd wedi'i gynllunio ar gyfer cynhyrchiant."
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr "I ddechrau, cliciwch y botwm isod."
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 "Mae %(referrer_full_name)s wedi eich gwahodd i ymuno ag "
 "%(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
@@ -2648,17 +2114,17 @@ msgstr ""
 "Zulip - yr offeryn cyfathrebu tîm sydd wedi'i gynllunio ar gyfer "
 "cynhyrchiant."
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr "I ddechrau, cliciwch y ddolen isod."
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr "Helo eto,"
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
@@ -2668,14 +2134,14 @@ msgstr ""
 "ar Zulip - yr offeryn cyfathrebu tîm sydd wedi'i gynllunio ar gyfer "
 "cynhyrchiant."
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr ""
 "Dyma'r nodyn atgoffa olaf y byddwch chi'n ei dderbyn am y gwahoddiad hwn."
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
@@ -2684,13 +2150,13 @@ msgstr ""
 "Daw'r gwahoddiad hwn i ben mewn dau ddiwrnod. Os daw'r gwahoddiad i ben, "
 "bydd angen i chi ofyn i %(referrer_name)s am un arall."
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr ""
 "Nodyn i'ch atgoffa: Ymunwch â %(referrer_name)s yn %(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2701,72 +2167,70 @@ msgstr ""
 "eisiau ichi ymuno â nhw ar Zulip - yr offeryn cyfathrebu tîm sydd wedi'i "
 "gynllunio ar gyfer cynhyrchiant."
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at <a href=\"mailto:%(email)s\">%(email)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
 "%(email)s\">Contact us</a> — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
 "#%(channel_name)s > %(topic_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2774,21 +2238,21 @@ msgid ""
 "preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
@@ -2797,41 +2261,41 @@ msgstr ""
 "Peidiwch ag ymateb i'r e-bost hwn. Nid yw'r gweinydd Zulip hwn wedi'i "
 "ffurfweddu i dderbyn e-byst sy'n dod i mewn ( <a href=\"%(url)s\">help</a> )."
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr "Negeseuon newydd"
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
@@ -2839,7 +2303,7 @@ msgstr ""
 "Peidiwch ag ymateb i'r e-bost hwn. Nid yw'r gweinydd Zulip hwn wedi'i "
 "ffurfweddu i dderbyn e-byst sy'n dod i mewn. Help:"
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2850,22 +2314,22 @@ msgstr ""
 "%(new_email)s. Os na ofynasoch am y newid hwn, cysylltwch â ni ar unwaith ar "
 "%(support_email)s."
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr "Cofion,"
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr "Tîm Zulip"
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr "Newidiodd e-bost Zulip ar gyfer %(realm_name)s"
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2876,56 +2340,56 @@ msgstr ""
 "%(new_email)s. Os na ofynasoch am y newid hwn, cysylltwch â ni ar unwaith "
 "yn<%(support_email)s> ."
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 msgstr ""
 "Sefydliad: %(organization_url)s Amser: %(login_time)s E-bost: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr ""
 "Gwnaethom sylwi ar fewngofnodi diweddar ar gyfer y cyfrif Zulip canlynol."
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr "Sefydliad: %(organization_link)s"
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr "E-bost: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr "Amser: %(login_time)s"
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr "Dyfais: %(device_browser)s ar %(device_os)s."
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr "Cyfeiriad IP: %(device_ip)s"
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr ""
 "Os mai hwn oeddech chi, gwych! Nid oes unrhyw beth arall y mae angen i chi "
 "ei wneud."
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2936,31 +2400,31 @@ msgstr ""
 "fod wedi'i gyfaddawdu, <a href=\"%(reset_link)s\">ailosodwch eich cyfrinair</"
 "a> neu cysylltwch â ni ar unwaith yn %(support_email)s."
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr "Diolch,"
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr "Diogelwch Zulip"
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr "Dad-danysgrifio o hysbysiadau mewngofnodi"
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr "Mewngofnodi newydd o %(device_browser)s ar %(device_os)s"
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr "Sefydliad: %(organization_url)s"
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2971,7 +2435,7 @@ msgstr ""
 "fod wedi'i gyfaddawdu, ailosodwch eich cyfrinair yn %(reset_link)s neu "
 "cysylltwch â ni ar unwaith yn %(support_email)s."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -2979,25 +2443,25 @@ msgid ""
 "Zulip</a> to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
 "with you and share their unique perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -3005,7 +2469,7 @@ msgid ""
 "experience how a new chat app will help your team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -3013,148 +2477,148 @@ msgid ""
 "action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
 "team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
 "organizations like yours!"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3162,11 +2626,11 @@ msgid ""
 "about…?”"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr "Enghreifftiau o bynciau byr"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3175,23 +2639,23 @@ msgid ""
 "href=\"%(move_channels_link)s\">move a topic to a different channel</a>."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr "Ewch i Zulip"
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3200,23 +2664,23 @@ msgid ""
 "(%(move_channels_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
 "%(email)s on %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr "Cliciwch y botwm isod i ailosod eich cyfrinair."
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr "Ailosod cyfrinair"
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3227,18 +2691,18 @@ msgstr ""
 "cael ei ddadactifadu. Gallwch gysylltu â gweinyddwr sefydliad i <a "
 "href=\"%(help_link)s\">ail-greu'ch cyfrif</a> ."
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr "Nid oes gennych gyfrif yn y sefydliad Zulip hwnnw."
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr "Mae gennych gyfrifon gweithredol yn y sefydliad (au) canlynol."
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
@@ -3246,31 +2710,31 @@ msgstr ""
 "Gallwch geisio mewngofnodi neu ailosod eich cyfrinair yn y sefydliad(au) "
 "uchod."
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 "Os nad ydych yn cydnabod y gweithgaredd hwn, gallwch anwybyddu'r e-bost hwn "
 "yn ddiogel."
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr "Cais ailosod cyfrinair ar gyfer %(realm_name)s"
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr "Cliciwch y ddolen isod i ailosod eich cyfrinair."
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
 "You can contact an organization administrator to reactivate your account."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3281,7 +2745,7 @@ msgstr ""
 "gynllun Zulip Cloud Cynllun rhad oherwydd anfonebau di-dâl. Mae'r anfonebau "
 "di-dâl wedi'u gwagio."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
@@ -3290,7 +2754,7 @@ msgstr ""
 "I barhau ar gynllun Zulip Cloud Standard, uwchraddiwch eto trwy fynd i "
 "%(upgrade_url)s."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
@@ -3299,8 +2763,8 @@ msgstr ""
 "Os ydych chi'n credu mai camgymeriad oedd hwn neu angen mwy o fanylion, "
 "estynwch atom ni ar %(support_email)s."
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid "You've joined the Zulip organization %(realm_name)s."
 msgid ""
@@ -3308,104 +2772,104 @@ msgid ""
 "%(localized_date)s."
 msgstr "Rydych chi wedi ymuno â sefydliad Zulip %(realm_name)s."
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr "Annwyl gyn-weinyddwyr %(realm_name)s,"
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip demo organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr "Cliciwch y botwm isod i ail-greu'ch sefydliad."
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr "Ailgychwyn sefydliad"
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
@@ -3413,370 +2877,370 @@ msgstr ""
 "Os oedd y cais mewn camgymeriad, ni allwch gymryd unrhyw gamau a bydd y "
 "ddolen hon yn dod i ben mewn 24 awr."
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Reactivate your Zulip organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "Ailgychwyn eich sefydliad Zulip"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr "Ailgychwyn eich sefydliad Zulip"
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr "Cliciwch y ddolen isod i ail-greu'ch sefydliad."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for <b>%(remote_server_hostname)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, fuzzy
 #| msgid "Click the button below to complete registration."
 msgid "Click the button below to log in."
 msgstr "Cliciwch y botwm isod i gwblhau cofrestriad."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for %(remote_server_hostname)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
 "management for <b>%(remote_realm_host)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
 "management for %(remote_realm_host)s."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the <a href=\"%(plans_link)s\">Zulip Community plan</a>."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
 "website</a>, we would really appreciate it!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
 msgstr ""
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr "Dewch o hyd i&#39;ch cyfrifon Zulip"
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
 "accounts for another email address</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr "Cyfeiriad ebost"
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "Dewch o hyd i gyfrifon"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr "Cynnyrch"
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr "Pam Zulip"
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr "Nodweddion"
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr ""
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Zulip"
 msgid "Zulip Cloud"
 msgstr "Zulip"
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr "Hunan-westeiwr"
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr "Diogelwch"
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "Integreiddiadau"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr "Apiau bwrdd gwaith a symudol"
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr "Sefydliad newydd"
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr "Datrysiadau"
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr "Busnes"
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr "Addysg"
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr "Ymchwil"
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr ""
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr "Prosiectau ffynhonnell agored"
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr "Cymunedau"
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr "Straeon cwsmeriaid"
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr ""
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr ""
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr "Dechrau arni"
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr "Canolfan gymorth"
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr "Sgwrs gymunedol"
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr ""
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr "Gosod gweinydd Zulip"
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr "Uwchraddio gweinydd Zulip"
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr ""
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr ""
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr "Cymuned ddatblygu"
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr "Cyfieithiad"
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr "GitHub"
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr "Amdanom ni"
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr "Tîm"
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "Hanes"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr ""
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr "Swyddi"
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr "Blog"
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr "Cefnogwch Zulip"
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr ""
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr ""
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 msgid "Bluesky"
 msgstr ""
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr ""
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr "Telerau Gwasanaeth"
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr "Polisi preifatrwydd"
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr "Dros %(integrations_count_display)s integreiddiadau brodorol."
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 #, fuzzy
 #| msgid ""
 #| "And hundreds more through <a href=\"/integrations/doc/zapier\">Zapier</a> "
@@ -3788,51 +3252,47 @@ msgstr ""
 "A channoedd yn fwy trwy <a href=\"/integrations/doc/zapier\">Zapier</a> ac "
 "<a href=\"/integrations/doc/ifttt\">IFTTT</a> ."
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr "Chwilio am integreiddiadau"
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr "Integreiddiadau personol"
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr "Webhooks sy'n dod i mewn"
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr "Bots rhyngweithiol"
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr "REST API"
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr "E-bost annilys"
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3840,7 +3300,7 @@ msgid ""
 "emails with your email domain."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3848,7 +3308,7 @@ msgid ""
 "disposable email addresses."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3856,24 +3316,24 @@ msgid ""
 "emails that contain \"+\"."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3881,7 +3341,7 @@ msgid ""
 "%(support_email)s\">contact Zulip support</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3889,93 +3349,93 @@ msgid ""
 "%(support_email)s\">contact this Zulip server's administrators</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
 "management for your Zulip server."
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr "Sesiwn fewngofnodi annilys neu wedi dod i ben."
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr "Mewngofnodi i Zulip"
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 "Rydych chi eisoes wedi cofrestru gyda'r cyfeiriad e-bost hwn. Mewngofnodwch "
 "isod."
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr "E-bost neu enw defnyddiwr"
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "Enw defnyddiwr"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr "Wedi anghofio eich cyfrinair?"
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr "Mewngofnodi gyda %(identity_provider)s"
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr ""
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 "Nid efo cyfrif eto? Mae angen i chi gael eich gwahodd i ymuno â'r sefydliad "
 "hwn."
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> because all Zulip Cloud licenses are in use."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr "Gwall is-barth dilysu"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr "Is-barth dilysu"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -3984,44 +3444,42 @@ msgid ""
 "or misconfiguration."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 #, fuzzy
 #| msgid "New organization"
 msgid "Demo organizations disabled"
 msgstr "Sefydliad newydd"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr "Angen diweddariad"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr "Dadlwythwch y datganiad diweddaraf."
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -4029,22 +3487,21 @@ msgid ""
 "organization for more information."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -4052,49 +3509,47 @@ msgid ""
 "Zulip support</a> for assistance in resolving this issue."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr "Porwr heb gefnogaeth"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, fuzzy, python-format
 #| msgid "Presence is not supported for bot users."
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr "Ni chefnogir presenoldeb ar gyfer defnyddwyr bot."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
 "a> like Firefox, Chrome, and Edge."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr "Mae'r cyfrif yn cael ei ddadactifadu"
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Invalid organization"
 msgid "Finalize organization import"
 msgstr "Sefydliad annilys"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Organization type"
 msgid "Organization import completed!"
 msgstr "Math o sefydliad"
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -4102,56 +3557,55 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Select your account"
 msgstr "Creu eich cyfrif"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Create new account"
 msgstr "Creu eich cyfrif"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr ""
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr "Mae eich sefydliad wedi cael ei ail-creu'n llwyddiannus."
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr "Mae cyswllt adweithio’r sefydliad wedi dod i ben neu nid yw’n ddilys."
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr "Mewngofnodi i'ch sefydliad"
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr "Ddim yn gwybod URL eich sefydliad?"
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr "Dewch o hyd i'ch sefydliad."
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr "Nesaf"
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4159,87 +3613,87 @@ msgid ""
 "have one yet."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 #, fuzzy
 #| msgid "Self-host Zulip"
 msgid "Self-hosting Zulip?"
 msgstr "Zulip hunan-westeiwr"
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">log in to manage plans and billing.</a>"
 msgstr ""
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr "Ailosod eich cyfrinair"
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
 msgstr ""
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr "Anfon dolen ailosod"
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "Cadarnhau cyfrinair"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr ""
 "Mae'n ddrwg gennym, mae'r ddolen a ddarparwyd gennych yn annilys neu wedi'i "
 "defnyddio eisoes."
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr ""
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr ""
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr ""
 "<a href=\"%(login_url)s\">Mewngofnodi</a> gyda'ch cyfrinair newydd os "
 "gwelwch yn dda."
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr "Cyfrinair wedi'i anfon!"
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr "Gwiriwch eich e-bost mewn ychydig funudau i orffen y broses."
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr ""
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4247,7 +3701,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4256,57 +3710,57 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr ""
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4314,7 +3768,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4322,22 +3776,22 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr "<h1 class=\"get-started\">Dewis cyfrif</h1>"
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 "Mae gan eich cyfrif GitHub hefyd gyfeiriadau e-bost heb eu gwirio sy'n "
 "gysylltiedig ag ef."
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
@@ -4345,21 +3799,21 @@ msgstr ""
 "I ddefnyddio un o'r rhain i fewngofnodi i Zulip, yn gyntaf rhaid i chi ei <a "
 "href=\"https://github.com/settings/emails\">wirio gyda GitHub.</a>"
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr "Cais dad-danysgrifio e-bost anhysbys"
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4367,132 +3821,129 @@ msgid ""
 "away!"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr "Diweddarwyd gosodiadau e-bost"
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
 "href=\"%(realm_url)s/#settings/notifications\">notification settings</a>."
 msgstr ""
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr "Mapio archeb annilys."
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr ""
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr ""
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr ""
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr "cofrestriadau"
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr ""
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr "Derbyniodd {user} eich gwahoddiad i ymuno â Zulip!"
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 #, fuzzy
 #| msgid "Cannot deactivate the only {entity}."
 msgid "Cannot reactivate a deleted user"
 msgstr "Methu dadactifadu'r unig {entity}."
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr "Id maes {id} heb ei ddarganfod."
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr ""
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr ""
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr ""
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
@@ -4501,7 +3952,7 @@ msgstr ""
 "gallwch eu hanfon mewn un diwrnod. Oherwydd eich bod wedi cyrraedd y terfyn, "
 "ni anfonwyd unrhyw wahoddiadau."
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
@@ -4509,75 +3960,75 @@ msgstr ""
 "Mae eich cyfrif yn rhy newydd i anfon gwahoddiadau ar gyfer y sefydliad hwn. "
 "Gofynnwch i weinyddwr sefydliad, neu ddefnyddiwr mwy profiadol."
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr "Ni ddilysodd rhai e-byst, felly ni wnaethom anfon unrhyw wahoddiadau."
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr "Nid oeddem yn gallu gwahodd unrhyw un."
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr "Dim byd i newid"
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr ""
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr ""
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr "Propagate_mode annilys heb olygu pwnc"
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr ""
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr "Ni ellir golygu widgets."
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr "Mae eich sefydliad wedi diffodd golygu negeseuon"
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr "Nid oes gennych ganiatâd i olygu'r neges hon"
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr "Mae'r terfyn amser ar gyfer golygu'r neges hon wedi mynd heibio"
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr "Mae {user} wedi nodi'r pwnc hwn fel y'i datryswyd."
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr "Mae {user} wedi nodi'r pwnc hwn fel un heb ei ddatrys."
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr "Symudwyd y pwnc hwn yma i {new_location} gan {user}."
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr "Symudwyd neges o'r pwnc hwn i {new_location} gan {user}."
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
@@ -4586,18 +4037,18 @@ msgstr ""
 "Cafodd {changed_messages_count} neges eu symud o'r pwnc hwn i {new_location} "
 "gan {user}."
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr "Symudwyd y pwnc hwn yma o {old_location} gan {user}."
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
@@ -4605,75 +4056,72 @@ msgid ""
 msgstr ""
 "{changed_messages_count} symudwyd negeseuon yma o {old_location} gan {user}."
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 #, fuzzy
 #| msgid "You don't have permission to delete this message"
 msgid "You don't have permission to resolve topics in this channel."
 msgstr "Nid oes gennych ganiatâd i ddileu'r neges hon"
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr "Nid oes gennych ganiatâd i symud y neges hon"
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr ""
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr "Neges(au) annilys"
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr "Methu rhoi neges"
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr "Math data annilys ar gyfer derbynwyr"
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 "Gall rhestrau derbynwyr gynnwys e-byst neu IDau defnyddiwr, ond nid y ddau."
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
 "but there is no channel with that ID."
 msgstr ""
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4681,36 +4129,36 @@ msgid ""
 "it."
 msgstr ""
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
 "The channel exists but does not have any subscribers."
 msgstr ""
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr ""
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr "Widgets: Anfonodd rhaglennydd API gynnwys JSON annilys"
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr "Widgets: {error_msg}"
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4718,109 +4166,107 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr "Mae emoji personol gyda'r enw hwn eisoes yn bodoli."
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
 "authentication method."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr ""
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder could not be sent."
 msgstr "Nid yw Token yn bodoli"
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
 "the following error:"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr ""
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr ""
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr ""
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr ""
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr ""
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
 "**{old_policy}** to **{new_policy}**."
 msgstr ""
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -4829,51 +4275,49 @@ msgid ""
 "* **New**: {new_setting_description}\n"
 msgstr ""
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr "Dim disgrifiad."
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr ""
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr "Hen disgrifiad"
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr "Disgrifiad newydd"
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr "Am byth"
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr ""
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 msgstr ""
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr ""
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -4884,99 +4328,89 @@ msgid ""
 "{summary_line}"
 msgstr ""
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr "Ni allwch atodi is-asesiad i'r neges hon."
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr ""
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr ""
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr "Caniatâd annigonol"
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr "Nid yw'r API hwn ar gael i bots webhook sy'n dod i mewn."
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr "Nid yw cyfrif yn gysylltiedig â'r is-barth hwn"
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr "Nid yw'r pwynt terfyn hwn yn derbyn ceisiadau bot."
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr "Rhaid bod yn weinyddwr gweinydd"
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr "Mae'r terfynbwynt hwn yn gofyn am ddilysiad sylfaenol HTTP."
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr "Pennawd awdurdodi annilys ar gyfer awdur sylfaenol"
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr "Pennawd awdurdodiad coll ar gyfer awdur sylfaenol"
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr "Dim ond bachyngwe y gall bots bachyngwe eu cyrchu"
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr ""
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
@@ -4985,53 +4419,52 @@ msgstr ""
 "Mae eich cyfrif {username} wedi'i ddadactifadu. Cysylltwch â gweinyddwr eich "
 "sefydliad i'w ailysgogi."
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr "Mae'r cyfrinair yn rhy wan."
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr "Mae angen i subdomain fod â hyd 3 neu fwy."
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr "Ni all subdomain ddechrau na gorffen gyda &#39;-&#39;."
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr "Dim ond llythrennau bach, rhifau ac '-'au y gall is-barth eu cael."
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr "Defnyddiwch eich cyfeiriad e-bost go iawn."
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr ""
 "Nid yw&#39;r sefydliad rydych chi&#39;n ceisio ymuno ag ef gan ddefnyddio "
 "{email} yn bodoli."
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr "Gofynnwch am wahoddwr am {email} gan weinyddwr y sefydliad."
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
@@ -5040,11 +4473,11 @@ msgstr ""
 "Nid yw eich cyfeiriad e-bost, {email}, yn un o'r parthau y caniateir iddynt "
 "gofrestru ar gyfer cyfrifon yn y sefydliad hwn."
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr "Ni chaniateir cyfeiriadau e-bost sy'n cynnwys + yn y sefydliad hwn."
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
@@ -5054,41 +4487,40 @@ msgstr ""
 "Zulip yn cael eu defnyddio. Cysylltwch â'r person a'ch gwahoddodd a gofyn "
 "iddynt gynyddu nifer y trwyddedau, yna ceisiwch eto."
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 #, fuzzy
 #| msgid "Embedded bots are not enabled."
 msgid "Challenges are not enabled."
 msgstr "Nid yw bots wedi'u hymgorffori yn cael eu galluogi."
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "Cyfrinair newydd"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr "Cadarnhad cyfrinair newydd"
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "You're making too many attempts to sign in. Try again in "
 "{retry_after_string} or contact your organization administrator for help."
 msgstr ""
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
@@ -5096,90 +4528,88 @@ msgstr ""
 "Mae'ch cyfrinair wedi'i analluogi oherwydd ei fod yn rhy wan. Ailosodwch "
 "eich cyfrinair i greu un newydd."
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr "Tocyn"
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr "Rhowch 10 e-bost ar y mwyaf."
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr "Ni allem ddod o hyd i'r sefydliad Zulip hwnnw."
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr ""
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr "Pwnc ar goll"
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr ""
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr ""
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr "Rhaid i'r neges fod â derbynwyr"
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr "Math o neges annilys"
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr "Ymlyniad annilys"
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr "Digwyddodd gwall wrth ddileu'r atodiad. Rho gynnig Arni eto'n hwyrach."
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr "Rhaid bod gan y neges dderbynwyr!"
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Content can't be empty"
 msgid "Channel folder name can't be empty."
 msgstr "Ni all y cynnwys fod yn wag"
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Invalid data export ID"
 msgid "Invalid channel folder ID"
 msgstr "ID allforio data annilys"
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 #, fuzzy
 #| msgid "Confirm your email address"
 msgid "Configure owner account email address."
 msgstr "Cadarnhewch eich cyfeiriad e-bost"
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5188,72 +4618,72 @@ msgid ""
 "organization]({convert_demo}).\n"
 msgstr ""
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a date"
 msgid "{var_name} is not Base64 encoded"
 msgstr "nid yw {var_name} yn ddyddiad"
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 #, fuzzy
 #| msgid "Invalid emoji code."
 msgid "Invalid `device_id`"
 msgstr "Cod emoji annilys."
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr ""
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr "Ni all parth fod yn wag."
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr "Rhaid bod gan barth o leiaf un dot (.)"
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr "Mae parth yn rhy hir"
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr "Ni all parth ddechrau na gorffen gyda dot (.)"
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr "Yn olynol '.' ni chaniateir."
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr "Ni all is-barthau ddechrau na gorffen gyda '-'."
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr "Dim ond gall parth eu cael llythyrau, rhifau, '.' a '-'au."
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr "Rhaid i timestamp beidio â bod yn negyddol."
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr "Rhaid i'r pwnc beidio â chynnwys null bytes"
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr "Mae defnyddiwr wedi analluogi ddrafftiau cydamseru."
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr "Nid yw drafft yn bodoli"
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5261,181 +4691,180 @@ msgid ""
 "{error_message}"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr "Agorwch Zulip i weld y cynnwys difetha"
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr ""
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr "Cyfeiriad annilys."
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr "Y tu allan i'ch parth."
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr "Ni chaniateir cyfeiriadau e-bost sy'n cynnwys +."
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr "Wedi'i gadw ar gyfer bots system."
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr "mae gan {email} gyfrif eisoes"
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr "Eisoes ganddo gyfrif."
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr "Mae'r cyfrif wedi'i ddadactifadu."
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr ""
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr "Emoji personol annilys."
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr "Enw emoji personol annilys."
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr "Mae'r emoji personol hwn wedi'i ddadactifadu."
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr "Cod emoji annilys."
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr "Enw emoji annilys."
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr "Math emoji annilys."
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr "Rhaid bod yn weinyddwr sefydliad neu'n awdur emoji"
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr ""
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
 msgstr ""
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr "Mae enw Emoji ar goll"
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr "Methu dyrannu ciw digwyddiad"
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr "Heb fewngofnodi: Angen dilysu API neu sesiwn defnyddiwr"
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr ""
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr "perchennog y sefydliad"
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr "defnyddiwr"
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr "Methu dadactifadu'r unig {entity}."
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr "Mae Markdown annilys yn cynnwys datganiad: {include_statement}"
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr "JSON camffurfiedig"
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr "Rhaid bod yn weinyddwr sefydliad"
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr "Rhaid bod yn berchennog sefydliad"
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Must be an organization owner"
 msgid "Must be a bot user"
 msgstr "Rhaid bod yn berchennog sefydliad"
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr "Mae eich enw defnyddiwr neu gyfrinair yn anghywir"
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr "Mae'r sefydliad hwn wedi'i ddadactifadu"
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
@@ -5443,451 +4872,450 @@ msgstr ""
 "Mae'r cofrestriad gwasanaeth hysbysu gwthio symudol ar gyfer eich gweinydd "
 "wedi'i ddadactifadu"
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr "Mae dilysu cyfrinair yn analluogi yn y sefydliad hwn"
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr "Mae'ch cyfrinair wedi'i anablu ac mae angen ei ailosod"
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr "Allwedd API annilys"
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr "Allwedd API camffurfiedig"
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
 "webhook; ignoring"
 msgstr ""
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 "Methu dosrannu cais: A wnaeth {webhook_name} gynhyrchu'r digwyddiad hwn?"
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr "Isbarth annilys"
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr ""
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr ""
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr "Mynediad wedi ei wrthod"
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} most recent messages in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr "Mae adwaith eisoes yn bodoli."
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr "Nid yw adwaith yn bodoli."
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
 msgstr ""
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr ""
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr ""
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr ""
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr ""
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr ""
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Already has an account."
 msgid "Atlassian account ID"
 msgstr "Eisoes ganddo gyfrif."
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Behance username"
 msgstr "Enw, neu enw defnyddiwr, ddrwg"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 msgid "Bitbucket username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Codeberg username"
 msgstr "Enw, neu enw defnyddiwr, ddrwg"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Dribbble username"
 msgstr "E-bost neu enw defnyddiwr"
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Facebook username"
 msgstr "Enw, neu enw defnyddiwr, ddrwg"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "GitLab username"
 msgstr "E-bost neu enw defnyddiwr"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Instagram username"
 msgstr "Enw, neu enw defnyddiwr, ddrwg"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 msgid "Mastodon profile"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Medium username"
 msgstr "Enw, neu enw defnyddiwr, ddrwg"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Pinterest username"
 msgstr "Enw, neu enw defnyddiwr, ddrwg"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Reddit username"
 msgstr "E-bost neu enw defnyddiwr"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 msgid "Snapchat username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Threads username"
 msgstr "Enw, neu enw defnyddiwr, ddrwg"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "TikTok username"
 msgstr "E-bost neu enw defnyddiwr"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Twitch username"
 msgstr "E-bost neu enw defnyddiwr"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "Enw defnyddiwr"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr "Math o gyfrif allanol annilys"
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr "Fframweithiau integreiddio"
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 #, fuzzy
 #| msgid "Billing"
 msgid "Video calling"
 msgstr "Bilio"
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr "Integreiddio parhaus"
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr "Cefnogaeth i gwsmeriaid"
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr "Defnyddio"
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr "Adloniant"
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr "Cyfathrebu"
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr "Ariannol"
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr ""
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr "Marchnata"
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr "Amrywiol"
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr ""
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr "Rheoli prosiect"
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr "Cynhyrchedd"
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr "Rheoli fersiwn"
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr "Rhaid i'r neges beidio â bod yn wag"
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr "Rhaid i'r neges beidio â chynnwys bytes nwl"
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{fullname} moderation"
 msgstr "Soniodd {full_name} amdanoch chi:"
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr "Gweithredwr cul annilys: {desc}"
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr ""
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr ""
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr "Dadl 'angor' ar goll."
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 #, fuzzy
 #| msgid "Missing 'anchor' argument."
 msgid "Missing 'anchor_date' argument."
 msgstr "Dadl 'angor' ar goll."
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr "Angor annilys"
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr ""
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 #, fuzzy
 #| msgid "Confirmation link does not exist"
 msgid "Navigation view does not exist."
 msgstr "Nid yw dolen cadarnhad yn bodoli"
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5895,7 +5323,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5903,7 +5331,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5911,7 +5339,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5919,7 +5347,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5929,14 +5357,14 @@ msgid ""
 "a permanent organization]({convert_demo_organization_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
 "them in your [Inbox](/#inbox).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5944,7 +5372,7 @@ msgid ""
 "({navigation_tour_video_url}) for a quick app overview.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5959,14 +5387,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -5974,7 +5402,7 @@ msgid ""
 "and edit your [profile information](/help/edit-your-profile).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -5985,7 +5413,7 @@ msgid ""
 "experience in your [Preferences](#settings/preferences).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5996,7 +5424,7 @@ msgid ""
 "[Browse and subscribe to channels]({settings_link}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -6013,7 +5441,7 @@ msgid ""
 "discussed.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -6022,7 +5450,7 @@ msgid ""
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -6034,7 +5462,7 @@ msgid ""
 "times, and more.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6044,7 +5472,7 @@ msgid ""
 "or browse the [help center](/help/) to learn more!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6052,7 +5480,7 @@ msgid ""
 "get help, try one of the following messages: {bot_commands}\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6064,13 +5492,13 @@ msgid ""
 "({move_content_another_channel_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6084,12 +5512,11 @@ msgid ""
 "and above.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr ""
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -6097,14 +5524,14 @@ msgid ""
 "no matter how many other conversations are going on.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
 "conversations with unread messages.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -6112,7 +5539,7 @@ msgid ""
 "the `+` button next to its name.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -6120,13 +5547,13 @@ msgid ""
 "can we chat about…?”\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6134,7 +5561,7 @@ msgid ""
 "({format_message_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6154,127 +5581,127 @@ msgid ""
 "```\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
 "teammates.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
 "conversation.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr ""
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr ""
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr ""
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr "JSON annilys mewn ymateb"
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr "Fformat ymateb annilys"
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr "Tocyn hyd gwag neu annilys"
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr "Tocyn APNS annilys"
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr ""
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr "Nid yw Token yn bodoli"
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr "Soniodd {full_name} @ {user_group_name}:"
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr "Soniodd {full_name} amdanoch chi:"
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr "Soniodd {full_name} am bawb:"
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "Neges newydd"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 #, fuzzy
 #| msgid "Invalid API key"
 msgid "Invalid `push_key`"
 msgstr "Allwedd API annilys"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
@@ -6283,1120 +5710,1099 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr "Nid yw'r defnyddiwr wedi'i awdurdodi ar gyfer yr ymholiad hwn"
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr "Nid yw '{email}' bellach yn defnyddio Zulip."
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr ""
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr "mae {var_name} yn rhy hir (terfyn: {max_length} nod)"
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder does not exist"
 msgstr "Nid yw Token yn bodoli"
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr ""
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr "Methu penderfynu rhwng dadleuon '{var_name1}' a '{var_name2}'"
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr "Dadl ar goll '{var_name}'"
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr "Gwerth gwael ar gyfer '{var_name}': {bad_value}"
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr ""
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr ""
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr ""
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr ""
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 #, fuzzy
 #| msgid "You don't have permission to delete this message"
 msgid "You do not have permission to create new topics in this channel."
 msgstr "Nid oes gennych ganiatâd i ddileu'r neges hon"
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr ""
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr ""
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr ""
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr ""
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr ""
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr "Methu dadgodio delwedd; wnaethoch chi uwchlwytho ffeil delwedd?"
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr "Mae maint y ddelwedd yn fwy na'r terfyn."
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr "Nid yw {var_name} yn boolean"
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} does not have a length"
 msgid "{var_name} does not have the expected format"
 msgstr "Nid oes gan {var_name} hyd"
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr "nid yw {var_name} yn ddyddiad"
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr "nid yw {var_name} yn ddict"
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr "Annilys {var_name}"
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr "Nid yw {var_name} yn float"
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr "Mae {var_name} yn rhy fach"
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr "nid yw {var_name} yn gyfanrif"
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr "Mae {var_name} yn rhy fawr"
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr "nid yw {var_name} yn rhestr"
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr "mae {var_name} yn rhy hir (terfyn: {max_length} nod)"
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr "nid yw {var_name} yn llinyn"
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr "mae {var_name} yn rhy hir (terfyn: {max_length} nod)"
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr "mae {var_name} yn rhy hir (terfyn: {max_length} nod)"
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr "Llwyth tâl anffurf"
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr "Nid yw {var_name} yn god lliw hecs dilys"
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr "Annilys {setting_name}"
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr "Byddai'r llwyth yn fwy na chwota uwchlwytho eich sefydliad."
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr ""
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr ""
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr "Grŵp defnyddwyr annilys"
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid user group"
 msgid "Invalid user group ID: {user_group_id}"
 msgstr "Grŵp defnyddwyr annilys"
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr ""
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr ""
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr ""
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr "Ni phasiodd y cleient unrhyw werthoedd newydd."
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 "Rhaid i'r cleient basio emoji_name os yw'n pasio naill ai emoji_code neu "
 "reaction_type."
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr "Enw yn rhy hir!"
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 #, fuzzy
 #| msgid "Message must not be empty"
 msgid "Name must not be empty!"
 msgstr "Rhaid i'r neges beidio â bod yn wag"
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr "Cymeriadau annilys mewn enw!"
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr "Fformat annilys!"
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr ""
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr ""
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr "Enw, neu enw defnyddiwr, ddrwg"
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr ""
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr ""
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr ""
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr "Data cyfluniad annilys!"
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr "Math bot annilys"
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr "Math rhyngwyneb annilys"
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr ""
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr "Dim bot o'r fath"
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr "Dim defnyddiwr o'r fath"
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr "Mae'r defnyddiwr wedi'i ddadactifadu"
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr "Ni all {item} fod yn wag."
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr "mae gan {var_name} hyd anghywir {length}; dylai fod yn {target_length}"
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a string"
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr "nid yw {var_name} yn llinyn"
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr "Dylai fod gan {container} eitemau {length} yn union"
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr "mae allwedd {key_name} ar goll o {var_name}"
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr ""
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr "Nid yw {var_name} yn allow_type"
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr "{variable}! = {expected_value} ({value} yn anghywir)"
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr "nid yw {var_name} yn URL"
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr ""
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr "Ni all '{item}' fod yn wag."
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr ""
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr "Nid yw '{value}' yn ddewis dilys ar gyfer '{field_name}'."
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr "nid yw {var_name} yn llinyn nac yn rhestr gyfanrif"
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr "nid yw {var_name} yn llinyn nac yn gyfanrif"
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr "Nid oes gan {var_name} hyd"
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr "{var_name} ar goll"
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr "Ar goll pennawd digwyddiad HTTP '{header}'"
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr "Dylai fod slaes blaenllaw yn y zcommand."
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr ""
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr "Gwall CSRF: {reason}"
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr "Cyfrif allanol"
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr ""
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr "Neb"
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr ""
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "Aelodau"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr ""
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Invalid characters in emoji name"
 msgid "Invalid auto-conversion field: empty field name."
 msgstr "Cymeriadau annilys mewn enw emoji"
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr ""
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr "Gwall mynegiant rheolaidd anhysbys"
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 msgid "Example input does not match the linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in alternative URL template is not present in linkifier "
 "pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in linkifier pattern is not present in alternative URL "
 "template."
 msgstr ""
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr "Emoji Unicode"
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "Emoji personol"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr "Emoji ychwanegol Zulip"
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr "Cymeriadau annilys mewn enw emoji"
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr "Cymeriadau annilys mewn iaith pygments"
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr ""
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr ""
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr ""
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr ""
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr ""
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr "Ar gael ar Zulip Safonol. Uwchraddio i gael mynediad."
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr ""
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr ""
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr ""
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr "Gwe cyhoeddus"
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "Cyhoeddus"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr "Hanes preifat, a rennir"
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr "Hanes preifat, gwarchodedig"
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr "Gweinyddwyr, cymedrolwyr ac aelodau a gwesteion"
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr "Gweinyddwyr, cymedrolwyr ac aelodau"
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr "Gweinyddwyr a chymedrolwyr"
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr "Gweinyddwyr yn unig"
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr ""
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr "Perchennog y sefydliad"
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr "Gweinyddwr sefydliad"
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr "Cymedrolwr"
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "Aelod"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "Gwadd"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr "Cyfeiriad IP anhysbys"
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr "system weithredu anhysbys"
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr "Porwr anhysbys"
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr "Eitem 'queue_id' ar goll"
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr "Eitem 'last_event_id' ar goll"
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr "Mae digwyddiad mwy newydd na {event_id} eisoes wedi'i docio!"
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr "Nid oedd digwyddiad {event_id} yn y ciw hwn"
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr ""
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 #, fuzzy
 #| msgid "Failed to create Zoom call"
 msgid "Failed to generate challenge"
 msgstr "Wedi methu creu galwad Zoom"
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr ""
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr "Ni phasiwyd unrhyw docyn gwe JSON ar gais"
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr "Tocyn gwe JSON drwg"
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr ""
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr "Angen isbarth"
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr "Mae'r cyfrinair yn anghywir."
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr "Pennawd Defnyddiwr-Asiant ar goll o gais"
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr "Ni all label fod yn wag."
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr "Rhaid i gae gael o leiaf un dewis."
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 #, fuzzy
 #| msgid "Presence is not supported for bot users."
 msgid "Field type not supported for use for user matching."
 msgstr "Ni chefnogir presenoldeb ar gyfer defnyddwyr bot."
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr "Math cae annilys."
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr "Mae maes gyda'r label hwnnw eisoes yn bodoli."
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr "Ni ellir diweddaru maes arfer diofyn."
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr "Pwynt gorffen ddim ar gael wrth gynhyrchu."
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr "DevAuthBackend heb ei alluogi."
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr ""
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr ""
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr ""
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr ""
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr ""
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr ""
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr "Dim gwahoddiad o'r fath"
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 #, fuzzy
 #| msgid "Confirmation link expired or deactivated"
 msgid "Invitation already used or deactivated."
 msgstr "Mae'r ddolen gadarnhau wedi dod i ben neu wedi'i dadactifadu"
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr ""
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr ""
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr "Rhaid i chi nodi o leiaf un cyfeiriad e-bost."
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
@@ -7404,104 +6810,102 @@ msgstr ""
 "Mae rhai o'r cyfeiriadau hynny eisoes yn defnyddio Zulip, felly ni wnaethom "
 "anfon gwahoddiad atynt. Fe wnaethon ni anfon gwahoddiadau at bawb arall!"
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr "Mae hanes golygu neges wedi'i anablu yn y sefydliad hwn"
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr "Nid oes gennych ganiatâd i ddileu'r neges hon"
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr "Mae'r terfyn amser ar gyfer dileur neges hon wedi mynd heibio"
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr "Neges wedi'i dileu eisoes"
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr ""
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr ""
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr ""
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr ""
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Zephyr mirroring is not allowed in this organization"
 msgid "Message reporting is not enabled in this organization."
 msgstr "Ni chaniateir adlewyrchu Zephyr yn y sefydliad hwn"
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr "Anfonwr ar goll"
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr "Ni chaniateir adlewyrchu gydag IDau defnyddiwr sy'n eu derbyn"
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr "Neges annilys wedi'i adlewyrchu"
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr ""
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr ""
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr ""
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr "Ni all fudo'ch hun"
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr "Defnyddiwr eisoes wedi'i dawelu"
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr "Nid yw'r defnyddiwr yn dawel"
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 #, fuzzy
 #| msgid "Reaction already exists."
 msgid "Navigation view already exists."
 msgstr "Mae adwaith eisoes yn bodoli."
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7509,58 +6913,58 @@ msgid ""
 "later. Is this a good time?\n"
 msgstr ""
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr "Ni chefnogir presenoldeb ar gyfer defnyddwyr bot."
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr "Dim data presenoldeb ar gyfer {user_id_or_email}"
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 #, fuzzy
 #| msgid "You don't have permission to delete this message"
 msgid "You do not have permission to manage plans and billing."
 msgstr "Nid oes gennych ganiatâd i ddileu'r neges hon"
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr ""
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr ""
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
@@ -7568,511 +6972,509 @@ msgstr ""
 "Rhaid io leiaf un o'r dadleuon canlynol fod yn bresennol: emoji_name, "
 "emoji_code"
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr ""
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr ""
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr "Rhaid galluogi o leiaf un dull dilysu."
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr ""
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr ""
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr "Rhaid bod yn sefydliad demo."
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr ""
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr "Mae'r parth {domain} eisoes yn rhan o'ch sefydliad."
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr "Ni ddarganfuwyd cofnod ar gyfer parth {domain}."
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr "Rhaid i chi uwchlwytho un ffeil yn union."
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr ""
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 #, fuzzy
 #| msgid "Disposable email addresses are not allowed in this organization"
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr "Ni chaniateir cyfeiriadau e-bost tafladwy yn y sefydliad hwn"
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr "Tu hwnt i'r terfyn cyfradd."
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr "ID allforio data annilys"
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr "Allforio wedi'i ddileu eisoes"
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr ""
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr ""
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr "Rhaid i chi uwchlwytho un eicon yn union."
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr "Ni chafwyd hyd i gysylltydd."
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr "Rhaid i chi uwchlwytho un logo yn union."
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid characters in pygments language"
 msgid "Invalid character in language: {character}"
 msgstr "Cymeriadau annilys mewn iaith pygments"
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not an allowed_type"
 msgid "Language '{language}' is not allowed."
 msgstr "Nid yw {var_name} yn allow_type"
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr "Maes chwarae annilys"
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr ""
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "Direct messages"
 msgid "Importing messages…"
 msgstr "Negeseuon uniongyrchol"
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 msgid "Your name"
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr ""
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr ""
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr ""
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr "Rhaid i chi basio \"new_description\" neu \"new_group_name\"."
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr ""
 "Gwerth annilys ar gyfer \"op\". Nodwch un o \"ychwanegu\" neu \"tynnu\"."
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr "Paramedrau annilys"
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr ""
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr ""
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr "Dim byd i wneud. Nodwch o leiaf un o 'ychwanegu' neu 'dileu'."
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr ""
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr ""
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr ""
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr ""
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
 "**"
 msgstr ""
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr ""
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr ""
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr ""
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr "Json annilys ar gyfer submessage"
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr ""
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr ""
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr "Rhestr wag 'to'"
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr ""
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr "<p>Nid oes gennych awdurdod i weld y ffeil hon.</p>"
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr "Tocyn annilys"
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr "Enw ffeil annilys"
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr "Rhaid i chi nodi ffeil i'w huwchlwytho"
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr "Dim ond un ffeil y gallwch ei lanlwytho ar y tro"
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr "Ni chyflenwyd unrhyw ddata newydd"
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 msgstr ""
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr "Mae defnyddiwr {user_id} eisoes yn aelod o'r grŵp hwn"
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr ""
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
 "subgroups."
 msgstr ""
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr "Mae newidiadau Afatar yn anabl yn y sefydliad hwn."
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr "Mae newidiadau cyfeiriad e-bost yn anabl yn y sefydliad hwn."
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr "Default_language annilys"
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr ""
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr ""
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr "Rheolir eich cyfrinair Zulip yn LDAP"
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr "Cyfrinair anghywir!"
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, fuzzy, python-brace-format
 #| msgid "You can try again in %(retry_after)s seconds."
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr "Gallwch roi cynnig arall arni mewn %(retry_after)s eiliad."
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr "Mae cyfrinair newydd yn rhy wan!"
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr "Rhaid i chi uwchlwytho un avatar yn union."
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr "Nid yw'r pwnc yn cael ei dawelu"
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr "Ni all ddadactifadu unig berchennog y sefydliad"
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 msgid "User is not allowed to delete other user's messages."
 msgstr ""
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 "Ni ellir tynnu caniatâd y perchennog oddi wrth unig berchennog y sefydliad."
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr ""
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr ""
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
@@ -8084,25 +7486,25 @@ msgstr ""
 "Methu creu bots nes bod FAKE_EMAIL_DOMAIN wedi'i ffurfweddu'n gywir. \n"
 "Cysylltwch â'ch gweinyddwr gweinydd."
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 #, fuzzy
 #| msgid "Email address"
 msgid "Email address already in use"
 msgstr "Cyfeiriad ebost"
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr "Wedi methu newid perchennog, dim defnyddiwr o'r fath"
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr "Wedi methu newid perchennog, mae'r defnyddiwr wedi'i ddadactifadu"
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr "Wedi methu newid perchennog, ni all bots fod yn berchen ar bots eraill"
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
@@ -8110,291 +7512,291 @@ msgstr ""
 "Methu creu bots nes bod FAKE_EMAIL_DOMAIN wedi'i ffurfweddu'n gywir. \n"
 "Cysylltwch â'ch gweinyddwr gweinydd."
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr "Nid yw bots wedi'u hymgorffori yn cael eu galluogi."
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr "Enw bot gwreiddio annilys."
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr ""
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr "Ni chaniateir e-bost '{email}' yn y sefydliad hwn"
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr "Ni chaniateir cyfeiriadau e-bost tafladwy yn y sefydliad hwn"
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom access token"
 msgid "Invalid {provider_name} access token"
 msgstr "Tocyn mynediad Zoom annilys"
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} call"
 msgstr "Wedi methu creu galwad Zoom"
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Zoom credentials have not been configured"
 msgid "{provider_name} credentials have not been configured"
 msgstr "Nid yw tystlythyrau chwyddo wedi'u ffurfweddu"
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom credentials"
 msgid "Invalid {provider_name} credentials"
 msgstr "Cymwysterau Zoom annilys"
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error connecting to the BigBlueButton server."
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr "Gwall wrth gysylltu â gweinydd BigBlueButton."
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error authenticating to the BigBlueButton server."
 msgid "Error authenticating to the {provider_name} server"
 msgstr "Gwall yn dilysu i'r gweinydd BigBlueButton."
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "BigBlueButton server returned an unexpected error."
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr "Dychwelodd gweinydd BigBlueButton wall annisgwyl."
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom session identifier"
 msgid "Invalid {provider_name} session identifier"
 msgstr "Dynodwr sesiwn Zoom annilys"
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr ""
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} public room."
 msgstr "Wedi methu creu galwad Zoom"
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr "Llofnod annilys."
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{full_name}'s Zulip room"
 msgstr "Soniodd {full_name} amdanoch chi:"
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr "Llwyth tâl annilys"
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr "Cais anhysbys ar webhook"
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr "Ni all y pwnc fod yn wag"
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr "Ni all y cynnwys fod yn wag"
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr ""
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr "Mewnbwn JSON wedi'i gamffurfio"
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr ""
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr "Gwall: paramedr sianelau_map_to_topics heblaw 0 neu 1"
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr ""
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
 "({export_settings_link})."
 msgstr ""
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr ""
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr ""
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr ""
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr ""
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr "Subdomain annilys ar gyfer hysbysiadau gwthio bouncer"
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr "Rhaid dilysu gydag allwedd API gweinydd Zulip dilys"
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr "UUID annilys"
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr "Math tocyn annilys"
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr ""
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr ""
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr ""
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr ""
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
 "try again later or reach out to {support_email} for assistance."
 msgstr ""
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr ""
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr ""
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr ""
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr "user_id neu user_uuid ar goll"
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
 "server: {reason}"
 msgstr ""
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr ""
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr ""
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr ""
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr "Mae'r data allan o drefn."
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr ""
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr ""
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr "Mae angen i chi ailosod eich cyfrinair."
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr "Paramedr id_token ar goll"
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 #, fuzzy
 #| msgid "Missing id_token parameter"
 msgid "Missing idp param"
 msgstr "Paramedr id_token ar goll"
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr "OTP annilys"
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr "Methu defnyddio mobile_flow_otp a desktop_flow_otp gyda'i gilydd."
 

--- a/locale/da/LC_MESSAGES/django.po
+++ b/locale/da/LC_MESSAGES/django.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 18:59+0000\n"
 "Last-Translator: Achton Smidt Winther <achton@reload.dk>\n"
 "Language-Team: Danish <https://hosted.weblate.org/projects/zulip/django/da/"
@@ -22,51 +22,51 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "Ikke tilladt for gæstebrugere"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "Ugyldig organisation"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr "Offentlige kanaler"
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr "Private kanaler"
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr "Private beskeder"
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr "Private gruppe beskeder"
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr "Manglende kanal for diagram: {chart_name}"
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr "Ukendt navn på diagram: {chart_name}"
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr "Starttidspunkt ligger efter sluttidspunkt. Start: {start}, slut: {end}"
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr ""
 "Ingen analysedata tilgængelig. Kontakt venligst din server-administrator."
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -79,7 +79,7 @@ msgstr ""
 "inaktive brugere]({deactivate_user_help_page_link}) for at lukke nye brugere "
 "ind."
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -90,7 +90,7 @@ msgstr ""
 "licenser]({billing_page_link}) eller [deaktivere inaktive brugere]"
 "({deactivate_user_help_page_link}) for at lukke nye brugere ind."
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -101,7 +101,7 @@ msgstr ""
 "licenser]({billing_page_link}) eller [deaktivere inaktive brugere]"
 "({deactivate_user_help_page_link}) for at lukke nye brugere ind."
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -112,7 +112,7 @@ msgstr ""
 "licenser]({billing_page_link}) eller [deaktivere inaktive brugere]"
 "({deactivate_user_help_page_link}) for at lukke nye brugere ind."
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -125,14 +125,14 @@ msgstr ""
 "af licenser for den aktuelle og kommende faktueringsperiode]"
 "({billing_page_link}) er større end det aktuelle antal brugere."
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr ""
 "Din organisation har ikke nok Zulip-licenser. Invitationerne blev ikke sendt."
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
@@ -140,16 +140,15 @@ msgstr ""
 "Din organisation har ikke nok Zulip-licenser til at ændre en gæstebrugers "
 "rolle."
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr "Registrering er deaktiveret"
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr "Ugyldig ekstern server."
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
@@ -158,7 +157,7 @@ msgstr ""
 "Du skal købe licenser til alle aktive brugere i din organisation (mindst "
 "{min_licenses})."
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
@@ -167,61 +166,61 @@ msgstr ""
 "Regninger med mere end {max_licenses} licenser kan ikke processeres på denne "
 "side. Kontakt {email} for at fuldføre opgraderingen."
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr "Ingen betalingsmetode angivet."
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr "{brand} slutter om {last4}"
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr "Ukendt betalingsmetode. Kontakt venligst {email}."
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr "Noget gik galt. Kontakt venligst {email}."
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "Noget gik galt. Genindlæs venligst siden."
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr "Noget gik galt. Vent venligst et par sekunder og prøv igen."
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 "Tilføj venligst et kreditkort før du påbegynder din gratis prøveperiode."
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr "Tilføj venligst kreditkort for at planlægge opgradering."
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
 msgstr ""
 "Kunne ikke forny plan. Din plan er udløbet og er blevet erstattet af en ny."
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr "Kunne ikke forny abonnement. Dit abonnement blev afsluttet."
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 "Kan ikke opdatere licenser i den aktuelle faktureringsperiode for gratis "
 "prøveperiode."
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
@@ -229,7 +228,7 @@ msgstr ""
 "Kan ikke opdatere licenser manuelt. Dit abonnement er på automatisk "
 "licensstyring."
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
@@ -237,12 +236,12 @@ msgstr ""
 "Dit abonnement har allerede {licenses} licenser i den aktuelle "
 "faktureringsperiode."
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr ""
 "Du kan ikke reducere antallet af licenser i den aktuelle faktureringsperiode."
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
@@ -250,7 +249,7 @@ msgstr ""
 "Kan ikke ændre licenser for næste faktureringsperiode for et abonnement der "
 "nedgraderes."
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
@@ -259,7 +258,7 @@ msgstr ""
 "Dit abonnement er planlagt til fornyelse med {licenses_at_next_renewal} "
 "licenser."
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
@@ -268,27 +267,27 @@ msgstr ""
 "Du har allerede købt {licenses_at_next_renewal} licenser for den kommende "
 "faktureringsperiode."
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr "Intet at ændre."
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr "Du er ikke kunde for denne organisation!"
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr "Session ikke fundet"
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr "Betalingshensigt ikke fundet"
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr "Videregiv stripe_session_id eller stripe_invoice_id"
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -303,20 +302,19 @@ msgstr ""
 "Hvis I vil {begin_link}angive Zulip som sponsor på jeres "
 "hjemmeside{end_link}, sætter vi stor pris på det!"
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr "Parameter 'confirmed' er påkrævet"
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr "Access token for fakturering er udløbet."
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr "Ugyldig access token for fakturering."
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
@@ -325,38 +323,37 @@ msgstr ""
 "Kunne ikke afstemme faktureringsdata mellem server og realm. Kontakt "
 "venligst {support_email}"
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr "Brugerkonto eksisterer endnu ikke."
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr "Du skal acceptere servicevilkårene for at fortsætte."
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr "Dette zulip_org_id er ikke registreret i Zulips faktureringssystem."
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr "Ugyldig zulip_org_key for dette zulip_org_id."
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr "Din serverregistrering er blevet deaktiveret."
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "Fejl"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr "Siden blev ikke fundet (404)"
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
@@ -365,11 +362,11 @@ msgstr ""
 "Hvis dette er en uventet fejl, kan du <a href=\"mailto:"
 "%(support_email)s\">kontakte supporten</a>."
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr "Adgang forbudt (403)"
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
@@ -377,11 +374,11 @@ msgstr ""
 "Forespørgslen kunne ikke fuldføres, da din browser ikke sendte de rette "
 "oplysninger påkrævet for at give dig adgang. For at løse denne fejl:"
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr "Sørg for, at din browser tillader cookies for denne hjemmeside."
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
@@ -389,16 +386,15 @@ msgstr ""
 "Tjek om der er browserindstillinger eller udvidelser, der blokerer Referer-"
 "headers, og deaktiver dem for dette websted."
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr "Metode ikke tilladt (405)"
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr "Intern serverfejl"
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
@@ -406,7 +402,7 @@ msgstr ""
 "Der opstod en fejl. Beklager! Vi er opmærksomme på problemet og arbejder på "
 "at løse det. Zulip indlæses automatisk, når det fungerer igen."
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -417,7 +413,7 @@ msgstr ""
 "information, og <a href=\"mailto:%(support_email)s\">kontakt Zulip-support</"
 "a>, hvis du har spørgsmål."
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
@@ -425,7 +421,7 @@ msgstr ""
 "Der opstod en fejl. Beklager! Zulip indlæses automatisk, når det fungerer "
 "igen."
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
@@ -434,7 +430,7 @@ msgstr ""
 "<a href=\"mailto:%(support_email)s\">Kontakt denne servers administratorer</"
 "a> for at få support."
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
@@ -443,269 +439,250 @@ msgstr ""
 "Hvis du administrerer denne server, kan du med fordel læse <a "
 "href=\"%(troubleshooting_url)s\">Zulip-serverens fejlfindingsvejledning</a>."
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr ""
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr ""
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr ""
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr "Antal brugere"
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr ""
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr "Antal gæster"
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr ""
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr ""
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr ""
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "Aktive brugere"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr ""
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr ""
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr ""
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "Brugere"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr ""
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "Mig"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "Alle"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "Sidste uge"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "Sidste måned"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "Sidste år"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "Altid"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr "Beskeder over tid"
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "Daglig"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "Ugentlig"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr "Akkumulerede"
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "Personer"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "Bots"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr ""
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr ""
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr "Sidste opdatering"
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr "Mailadresse ændret"
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr "Mailadresse ændret!"
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
 "%(old_email_html_tag)s to %(new_email_html_tag)s"
 msgstr ""
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr "Bekræft din mailadresse"
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr "Hov. Vi kunne ikke finde dit godkendelseslink i systemet."
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr ""
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr "Hov. Dit godkendelseslink er udløbet eller er blevet deaktiveret."
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
 msgstr ""
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr "Fakturering"
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr "Luk vindue"
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr "Glem det"
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr "Nedgrader"
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "Annuller"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr "Bekræft"
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr "Annuller nedgradering"
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr "Faktureringsstatus"
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr "Abonnementsstyring ikke tilgængelig"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -716,19 +693,19 @@ msgid ""
 "server."
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -736,792 +713,301 @@ msgid ""
 "%(support_email)s'>contact support</a> with any questions."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr "Prisgrænse nået"
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr "Prisgrænse nået."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, python-format
 msgid "You can try again in %(retry_after_string)s."
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr "Opgrader"
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr "Send faktura og start gratis prøveperiode"
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr "Send faktura"
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr ""
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr "Filtrer efter katagori"
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "Alt"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr "Katagorier"
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr "10.000 beskeder"
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr "Ubegrænset"
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr "Filer op til 10 MB"
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr "Filer op til 1 GB"
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr "Understøttet"
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr "Selvforvaltet"
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr "For organisationer med op til 10 brugere"
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr "Mindst 25 brugere"
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr "Ikke tilgængelig"
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr "Zulips udviklerfællesskab"
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr ""
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr "Deltag som bruger"
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr "Deltag som bidragsyder"
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "Opret organisation"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr "Modtag demo"
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr "Host Zulip selv"
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr "Ansøg om sponsorering"
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr "Priser for uddannelse"
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr "Se priser"
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr "Zulip for professionelle"
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Zulip for business"
 msgid "Zulip for open source"
 msgstr "Zulip for professionelle"
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Messages sent over time"
 msgid "Message with code"
 msgstr "Beskeder over tid"
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr "Kontakt support"
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr "Fra"
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr "Organisation"
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr "Emne"
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr "Besked"
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr "Indsend"
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr "Tak for at tage kontakt til os"
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr "Tak for at tage kontakt til os!"
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr "Vi vil snart tage kontakt til dig."
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
 msgstr ""
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 msgid "Get started"
 msgstr ""
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
 "continue."
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr "Accepter handelsbetingelser"
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr "Velkommen til Zulip"
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "Email"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr "Abonner på Zulips sjældne nyhedsbrev (få emails om året)."
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr "Fortsæt"
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1529,78 +1015,77 @@ msgid ""
 "from Zulip."
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
 msgstr ""
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr ""
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr "Ingen samtaler matcher dine filtre."
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr ""
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr ""
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr "Videoopkald afsluttet"
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr ""
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr ""
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
 msgstr ""
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1608,212 +1093,205 @@ msgid ""
 "href=\"%(doc_url)s\">documentation</a>."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, python-format
 msgid "No account found for %(email)s."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Create a new organization"
 msgid "Try Zulip in a demo organization"
 msgstr "Opret ny organisation"
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Zulip"
 msgid "Try Zulip"
 msgstr "Zulip"
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "Opret ny organisation"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr "Din email"
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr "Organisationstype"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid "Import chat history?"
 msgstr "Importer chathistorik?"
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr "Organisationsnavn"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "organisationens URL"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "OR"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "Registrer"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "Registrer dig hos Zulip"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "Log ind"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr "Hvem kan se din e-mail adresse"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1821,101 +1299,100 @@ msgid ""
 "noreferrer\">after you join</a>."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr "Administratorer i denne Zulip-organisation kan se denne mailadresse."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "Skift"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "Navn"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "Password"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr ""
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
@@ -1924,22 +1401,22 @@ msgstr ""
 "Jeg accepterer <a href=\"%(root_domain_url)s/policies/terms\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">handelsbetingelserne</a>."
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr ""
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr ""
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -1947,45 +1424,45 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 msgid ""
 "This organization has been deactivated, and all organization data has been "
 "deleted."
 msgstr ""
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
 "inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
 "administrators</a> to inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 msgid "This organization has been deactivated."
 msgstr ""
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
 "%(support_email)s\">contact Zulip support</a> to reactivate it."
 msgstr ""
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -1993,167 +1470,166 @@ msgid ""
 "reactivate it."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr "Afslut"
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr "Forkert token."
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr "Token godkendt. Logger dig ind…"
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 "Kopier denne token og gå tilbage til din Zulip app for at færdiggøre dit "
 "login:"
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "Kopier"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr "Anonym bruger"
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr "Ejere"
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "Administratorer"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr "Moderatorer"
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr "Gæstebrugere"
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "Normale brugere"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "Luk"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "Opdater"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr "Zulip"
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
 "<b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr "Velkommen til Zulip!"
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
 "href=\"%(apps_page_link)s\">mobile and desktop</a> apps:"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr "Organisations URL: %(organization_url)s"
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr "Dit brugernavn: %(ldap_username)s"
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr "Gå til organisation"
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
 "href=\"%(getting_user_started_link)s\">getting started guide</a>!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2161,83 +1637,83 @@ msgid ""
 "Zulip</a>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
 "to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
 "desktop apps (%(apps_page_link)s):"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
 "(%(getting_user_started_link)s)!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
 "(%(getting_organization_started_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr "Hej,"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2245,32 +1721,32 @@ msgid ""
 "password for this account, please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "%(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 msgid "Verify your email address for your Zulip demo organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "<%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2278,113 +1754,113 @@ msgid ""
 "please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
 "— we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
 "deactivated, and you will no longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr "Nye kanaler"
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2392,22 +1868,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because your organization <a "
@@ -2415,8 +1891,8 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to <a "
@@ -2424,39 +1900,39 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr ""
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because your organization hides "
@@ -2464,81 +1940,74 @@ msgid ""
 "details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to hide "
 "message content in email notifications. See %(help_url)s for more details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr "Log ind på Zulip for at følge med: %(organization_url)s."
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr ""
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
 "organizations:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
 "organizations hosted by %(external_host)s:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
 "href=\"%(help_reset_password_link)s\">reset your password</a>."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
 "%(external_host)s."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2546,97 +2015,94 @@ msgid ""
 "to find your account."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
 "try another way to find your account (%(help_logging_in_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
 "communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr ""
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
 "-- the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr "Hej igen,"
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
 "Zulip &mdash; the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
 "to ask %(referrer_name)s for another one."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2644,72 +2110,70 @@ msgid ""
 "productivity."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at <a href=\"mailto:%(email)s\">%(email)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
 "%(email)s\">Contact us</a> — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
 "#%(channel_name)s > %(topic_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2717,68 +2181,68 @@ msgid ""
 "preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails (<a href=\"%(url)s\">help</a>)."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr "[afsluttet] #%(channel_name)s > %(topic_name)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr "Nye beskeder"
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2786,22 +2250,22 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2809,52 +2273,52 @@ msgid ""
 "immediately at <%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr "Organisation: %(organization_link)s"
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2862,31 +2326,31 @@ msgid ""
 "contact us immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr "Tak,"
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr "Organisation: %(organization_url)s"
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2894,7 +2358,7 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -2902,25 +2366,25 @@ msgid ""
 "Zulip</a> to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
 "with you and share their unique perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -2928,7 +2392,7 @@ msgid ""
 "experience how a new chat app will help your team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -2936,148 +2400,148 @@ msgid ""
 "action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
 "team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
 "organizations like yours!"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3085,11 +2549,11 @@ msgid ""
 "about…?”"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3098,23 +2562,23 @@ msgid ""
 "href=\"%(move_channels_link)s\">move a topic to a different channel</a>."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3123,23 +2587,23 @@ msgid ""
 "(%(move_channels_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
 "%(email)s on %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3147,46 +2611,46 @@ msgid ""
 "href=\"%(help_link)s\">reactivate your account</a>."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
 "You can contact an organization administrator to reactivate your account."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3194,543 +2658,539 @@ msgid ""
 "have been voided."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
 "to %(upgrade_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip demo organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip demo organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Create a new organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "Opret ny organisation"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for <b>%(remote_server_hostname)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 msgid "Click the button below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for %(remote_server_hostname)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
 "management for <b>%(remote_realm_host)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
 "management for %(remote_realm_host)s."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the <a href=\"%(plans_link)s\">Zulip Community plan</a>."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
 "website</a>, we would really appreciate it!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
 msgstr ""
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
 "accounts for another email address</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr "Email adresse"
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "Find konti"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr "Produkt"
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr ""
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr ""
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Zulip"
 msgid "Zulip Cloud"
 msgstr "Zulip"
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr ""
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr ""
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "Integrationer"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr "Desktop og mobil -apps"
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr ""
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr ""
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr "Business"
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr ""
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr ""
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr ""
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr ""
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr ""
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr ""
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr ""
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr ""
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr ""
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr ""
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr ""
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr ""
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr ""
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr ""
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr ""
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr ""
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr ""
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr ""
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr ""
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "Historik"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr ""
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr ""
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr ""
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr "Støt Zulip"
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr ""
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr ""
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 msgid "Bluesky"
 msgstr ""
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr ""
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr ""
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr ""
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 msgid ""
 "And hundreds more through <a href=\"/integrations/zapier\">Zapier</a> and <a "
 "href=\"/integrations/ifttt\">IFTTT</a>."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3738,7 +3198,7 @@ msgid ""
 "emails with your email domain."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3746,7 +3206,7 @@ msgid ""
 "disposable email addresses."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3754,24 +3214,24 @@ msgid ""
 "emails that contain \"+\"."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3779,7 +3239,7 @@ msgid ""
 "%(support_email)s\">contact Zulip support</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3787,89 +3247,89 @@ msgid ""
 "%(support_email)s\">contact this Zulip server's administrators</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
 "management for your Zulip server."
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr ""
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr ""
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr ""
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "Brugernavn"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr "Glemt dit password?"
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr ""
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr ""
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> because all Zulip Cloud licenses are in use."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -3878,44 +3338,42 @@ msgid ""
 "or misconfiguration."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 #, fuzzy
 #| msgid "Organization name"
 msgid "Demo organizations disabled"
 msgstr "Organisationsnavn"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -3923,22 +3381,21 @@ msgid ""
 "organization for more information."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -3946,46 +3403,44 @@ msgid ""
 "Zulip support</a> for assistance in resolving this issue."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
 "a> like Firefox, Chrome, and Edge."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Invalid organization"
 msgid "Finalize organization import"
 msgstr "Ugyldig organisation"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 msgid "Organization import completed!"
 msgstr "Organisationsimport fuldendt!"
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -3993,54 +3448,53 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 msgid "Select your account"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create a new organization"
 msgid "Create new account"
 msgstr "Opret ny organisation"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr ""
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr "Næste"
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4048,83 +3502,83 @@ msgid ""
 "have one yet."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 #, fuzzy
 #| msgid "Self-host Zulip"
 msgid "Self-hosting Zulip?"
 msgstr "Host Zulip selv"
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">log in to manage plans and billing.</a>"
 msgstr ""
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr ""
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
 msgstr ""
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr ""
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr ""
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr ""
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr ""
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr ""
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4132,7 +3586,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4141,57 +3595,57 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr ""
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4199,7 +3653,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4207,40 +3661,40 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4248,210 +3702,207 @@ msgid ""
 "away!"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
 "href=\"%(realm_url)s/#settings/notifications\">notification settings</a>."
 msgstr ""
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr ""
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr ""
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr ""
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr ""
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr ""
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr ""
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr ""
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 msgid "Cannot reactivate a deleted user"
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr ""
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr ""
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr ""
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr ""
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
 msgstr ""
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
 msgstr ""
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr ""
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr ""
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr ""
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr ""
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr ""
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr ""
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr ""
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr ""
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr ""
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr ""
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr "{user} har markeret dette emne som løst."
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr "{user} har markeret dette emne som uløst."
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr "Dette emne blev flyttet til {new_location} af {user}."
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr "En besked var flyttet fra dette emne til {new_location} af {user}."
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
@@ -4460,19 +3911,19 @@ msgstr ""
 "{changed_messages_count} beskeder var flyttet fra dette emne til "
 "{new_location} af {user}."
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr "Dette emne er flyttet hertil fra {old_location} af {user}."
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 msgstr ""
 "[En besked]({message_link}) blev flyttet hertil fra {old_location} af {user}."
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
@@ -4481,72 +3932,69 @@ msgstr ""
 "{changed_messages_count} beskeder var flyttet her til fra {old_location} af "
 "{user}."
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to resolve topics in this channel."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr ""
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr ""
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr ""
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr ""
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr ""
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
 "but there is no channel with that ID."
 msgstr ""
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4554,36 +4002,36 @@ msgid ""
 "it."
 msgstr ""
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
 "The channel exists but does not have any subscribers."
 msgstr ""
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr ""
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr ""
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr ""
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4591,107 +4039,105 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
 "authentication method."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr ""
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 msgid "Reminder could not be sent."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
 "the following error:"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr ""
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr ""
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr ""
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr ""
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr ""
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
 "**{old_policy}** to **{new_policy}**."
 msgstr ""
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -4700,51 +4146,49 @@ msgid ""
 "* **New**: {new_setting_description}\n"
 msgstr ""
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr "{user_name} omdøbte kanal {old_channel_name} til {new_channel_name}."
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr "Ingen beskrivelse."
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr "{user} ændrede beskrivelsen for denne kanal."
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr "Gammel beskrivelse"
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr "Ny beskrivelse"
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr "For evigt"
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr ""
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 msgstr ""
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr ""
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -4755,283 +4199,269 @@ msgid ""
 "{summary_line}"
 msgstr ""
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr ""
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr ""
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr ""
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr "Utilstrækkelige tilladelser"
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr ""
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr ""
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr ""
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr ""
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr ""
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr ""
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr ""
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
 "organization administrator to reactivate it."
 msgstr ""
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr ""
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr ""
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr ""
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr ""
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr ""
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr ""
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr ""
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
 "to register for accounts in this organization."
 msgstr ""
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr ""
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 msgid "Challenges are not enabled."
 msgstr ""
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr ""
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr ""
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "You're making too many attempts to sign in. Try again in "
 "{retry_after_string} or contact your organization administrator for help."
 msgstr ""
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
 msgstr ""
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr ""
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr ""
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr ""
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr ""
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr "Manglende emne"
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr ""
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr "Manglende kanal"
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr ""
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr ""
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr ""
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr ""
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr "Beskeder skal have modtagere!"
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name can't be empty."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 msgid "Invalid channel folder ID"
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 msgid "Configure owner account email address."
 msgstr "Konfigurer ejer-kontoens emailadresse."
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5040,69 +4470,69 @@ msgid ""
 "organization]({convert_demo}).\n"
 msgstr ""
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, python-brace-format
 msgid "{var_name} is not Base64 encoded"
 msgstr ""
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 msgid "Invalid `device_id`"
 msgstr ""
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr ""
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr ""
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr ""
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr ""
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr ""
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr ""
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr ""
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr ""
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr ""
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr ""
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5110,614 +4540,612 @@ msgid ""
 "{error_message}"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr ""
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr ""
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr ""
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr ""
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr ""
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr ""
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr ""
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr ""
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr ""
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr ""
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr ""
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr ""
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr ""
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
 msgstr ""
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr ""
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr ""
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr ""
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr ""
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr "bruger"
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr ""
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr ""
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr ""
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Number of users"
 msgid "Must be a bot user"
 msgstr "Antal brugere"
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr ""
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr ""
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr ""
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
 "webhook; ignoring"
 msgstr ""
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr ""
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr ""
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr ""
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr ""
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} most recent messages in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr ""
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr ""
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
 msgstr ""
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr ""
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr ""
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr ""
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr ""
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr ""
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Find accounts"
 msgid "Atlassian account ID"
 msgstr "Find konti"
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Cancel upgrade"
 msgid "Behance username"
 msgstr "Annuller nedgradering"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 msgid "Bitbucket username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 msgid "Codeberg username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 msgid "Dribbble username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 msgid "Facebook username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "GitLab username"
 msgstr "Brugernavn"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 msgid "Instagram username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 msgid "Mastodon profile"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "Medium username"
 msgstr "Brugernavn"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 msgid "Pinterest username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "Reddit username"
 msgstr "Brugernavn"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 msgid "Snapchat username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 msgid "Threads username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "TikTok username"
 msgstr "Brugernavn"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "Twitch username"
 msgstr "Brugernavn"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "Brugernavn"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr ""
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr ""
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 #, fuzzy
 #| msgid "Video call ended"
 msgid "Video calling"
 msgstr "Videoopkald afsluttet"
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr ""
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr ""
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr ""
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr ""
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr ""
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr ""
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr ""
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr ""
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr ""
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr ""
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr ""
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr ""
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr ""
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr ""
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid "{fullname}'s moderation requests"
 msgid "{fullname} moderation"
 msgstr "{fullname}s anmodninger om moderation"
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr ""
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr ""
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor_date' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr ""
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 msgid "Navigation view does not exist."
 msgstr ""
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5725,7 +5153,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5733,7 +5161,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5741,7 +5169,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5749,7 +5177,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5759,14 +5187,14 @@ msgid ""
 "a permanent organization]({convert_demo_organization_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
 "them in your [Inbox](/#inbox).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5774,7 +5202,7 @@ msgid ""
 "({navigation_tour_video_url}) for a quick app overview.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5789,14 +5217,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -5804,7 +5232,7 @@ msgid ""
 "and edit your [profile information](/help/edit-your-profile).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -5815,7 +5243,7 @@ msgid ""
 "experience in your [Preferences](#settings/preferences).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5826,7 +5254,7 @@ msgid ""
 "[Browse and subscribe to channels]({settings_link}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -5843,7 +5271,7 @@ msgid ""
 "discussed.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -5852,7 +5280,7 @@ msgid ""
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -5864,7 +5292,7 @@ msgid ""
 "times, and more.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5874,7 +5302,7 @@ msgid ""
 "or browse the [help center](/help/) to learn more!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5882,7 +5310,7 @@ msgid ""
 "get help, try one of the following messages: {bot_commands}\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5894,13 +5322,13 @@ msgid ""
 "({move_content_another_channel_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5914,12 +5342,11 @@ msgid ""
 "and above.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr ""
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -5927,14 +5354,14 @@ msgid ""
 "no matter how many other conversations are going on.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
 "conversations with unread messages.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -5942,7 +5369,7 @@ msgid ""
 "the `+` button next to its name.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -5950,13 +5377,13 @@ msgid ""
 "can we chat about…?”\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5964,7 +5391,7 @@ msgid ""
 "({format_message_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5984,1328 +5411,1305 @@ msgid ""
 "```\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
 "teammates.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
 "conversation.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr ""
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr ""
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr ""
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr ""
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr "{full_name} nævnte @{user_group_name}:"
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr "{full_name} nævnte dig:"
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr "{full_name} nævnte alle:"
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "Ny besked"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr "Test notifikation"
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 #, fuzzy
 #| msgid "Invalid token"
 msgid "Invalid `push_key`"
 msgstr "Ugyldig token"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr ""
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr ""
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr ""
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 msgid "Reminder does not exist"
 msgstr ""
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr ""
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr ""
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr ""
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr ""
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr ""
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr ""
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr ""
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr ""
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 msgid "You do not have permission to create new topics in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr ""
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr ""
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr ""
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr ""
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr ""
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr ""
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} does not have the expected format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr "Ugyldigt {setting_name}"
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr ""
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr ""
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr ""
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {user_group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr ""
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr ""
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr ""
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr ""
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr ""
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 msgid "Name must not be empty!"
 msgstr ""
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr ""
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr ""
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr ""
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr ""
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr ""
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr ""
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr ""
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr ""
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr ""
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr ""
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr ""
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr ""
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr ""
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr ""
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr ""
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr ""
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr ""
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr ""
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr ""
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr ""
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr ""
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr ""
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr ""
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr ""
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr ""
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr ""
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr ""
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr ""
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr ""
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr ""
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr ""
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr ""
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr "Pronomener"
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr "Ingen"
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr ""
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "Medlemmer"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr ""
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: empty field name."
 msgstr ""
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr ""
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr ""
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 msgid "Example input does not match the linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in alternative URL template is not present in linkifier "
 "pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in linkifier pattern is not present in alternative URL "
 "template."
 msgstr ""
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr ""
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr ""
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr ""
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr ""
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr ""
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr ""
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr "systembeskeder for kanal"
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr ""
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr ""
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr ""
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr ""
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr "Web-offentligt"
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "Offentlig"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr "Privat, fuld adgang til historik"
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr "Privat, beskyttet historik"
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr "Admin, ejere, medlemmer og gæster"
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr "Admin, ejere og medlemmer"
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr "Admin og ejere"
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr "Kun admin"
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr ""
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr ""
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr ""
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr "Moderator"
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "Medlem"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "Gæst"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr ""
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr ""
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr ""
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr ""
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 msgid "Failed to generate challenge"
 msgstr ""
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr ""
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr ""
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr ""
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr ""
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr ""
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr ""
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for use for user matching."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr ""
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr ""
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr ""
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr ""
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr ""
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr ""
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr ""
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr ""
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 #, fuzzy
 #| msgid "Registration is deactivated"
 msgid "Invitation already used or deactivated."
 msgstr "Registrering er deaktiveret"
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr ""
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr ""
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr ""
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
 msgstr ""
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr ""
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr ""
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr ""
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr ""
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr ""
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr ""
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr ""
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr ""
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Topics are required in this organization."
 msgid "Message reporting is not enabled in this organization."
 msgstr "Emne skal udfyldes."
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr ""
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr ""
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr ""
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr ""
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr ""
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr ""
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr ""
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr ""
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr ""
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 msgid "Navigation view already exists."
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7313,561 +6717,559 @@ msgid ""
 "later. Is this a good time?\n"
 msgstr ""
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr ""
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr ""
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 msgid "You do not have permission to manage plans and billing."
 msgstr ""
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr ""
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr ""
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr ""
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr ""
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr ""
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr ""
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr ""
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr ""
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr ""
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr ""
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr ""
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 #, fuzzy
 #| msgid "Topics are required in this organization."
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr "Emne skal udfyldes."
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr ""
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr ""
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr ""
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr ""
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr ""
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr ""
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr ""
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Invalid character in language: {character}"
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Language '{language}' is not allowed."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr ""
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr ""
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 msgid "Importing messages…"
 msgstr "Importerer beskeder…"
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "Your email"
 msgid "Your name"
 msgstr "Din email"
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr ""
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr ""
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr ""
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr ""
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr ""
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr "Invalide parametre"
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr ""
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr ""
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr ""
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr "{user_full_name} tilføjede dig til kanalen {channel_name}."
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr ""
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr ""
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr "Nye kanaler"
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
 "**"
 msgstr ""
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr ""
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr ""
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr ""
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr ""
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr ""
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr ""
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr ""
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr ""
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr "Ugyldig token"
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr "Ugyldigt filnavn"
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr "Du skal vælge en fil at uploade"
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr "Du kan kun uploade én fil ad gangen"
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr ""
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 msgstr ""
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr "{user_full_name} tilføjede dig til gruppen {group_name}."
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr ""
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr ""
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
 "subgroups."
 msgstr ""
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr ""
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr ""
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr ""
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr ""
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr ""
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr ""
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr ""
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr ""
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr ""
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr ""
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 msgid "User is not allowed to delete other user's messages."
 msgstr ""
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr ""
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr ""
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "No analytics data available. Please contact your server administrator."
@@ -7877,307 +7279,307 @@ msgid ""
 msgstr ""
 "Ingen analysedata tilgængelig. Kontakt venligst din server-administrator."
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 #, fuzzy
 #| msgid "Email address"
 msgid "Email address already in use"
 msgstr "Email adresse"
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr ""
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr ""
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr ""
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 msgstr ""
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr ""
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr ""
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr ""
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr ""
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr ""
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid billing access token."
 msgid "Invalid {provider_name} access token"
 msgstr "Ugyldig access token for fakturering."
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} call"
 msgstr ""
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} credentials have not been configured"
 msgstr ""
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} credentials"
 msgstr ""
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr ""
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error authenticating to the {provider_name} server"
 msgstr ""
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr ""
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} session identifier"
 msgstr ""
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr ""
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} public room."
 msgstr ""
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr ""
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{full_name}'s Zulip room"
 msgstr "{full_name} nævnte dig:"
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr ""
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr ""
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr ""
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr ""
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr ""
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr ""
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr ""
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr ""
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr ""
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
 "({export_settings_link})."
 msgstr ""
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr ""
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr ""
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr ""
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr ""
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr ""
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr ""
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr ""
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr ""
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr ""
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr ""
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr ""
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr ""
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
 "try again later or reach out to {support_email} for assistance."
 msgstr ""
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr ""
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr ""
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr ""
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr ""
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
 "server: {reason}"
 msgstr ""
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr ""
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr ""
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr ""
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr ""
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr ""
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr ""
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr ""
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr ""
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 #, fuzzy
 #| msgid "Missing topic"
 msgid "Missing idp param"
 msgstr "Manglende emne"
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr ""
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr ""
 

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -45,7 +45,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 19:18+0000\n"
 "Last-Translator: Jo Jo <volke.jojo@gmail.com>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/zulip/django/de/"
@@ -57,51 +57,51 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "Nicht erlaubt für Gastnutzer"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "Ungültige Organisation"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr "Öffentliche Kanäle"
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr "Private Kanäle"
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr "Direktnachrichten"
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr "Gruppennachrichten"
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr "Kanal für Diagramm: {chart_name} fehlt"
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr "Unbekannter Diagrammname: {chart_name}"
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr "Die Startzeit ist später als die Endzeit. Start: {start}, Ende: {end}"
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr ""
 "Keine Analysedaten verfügbar. Bitte kontaktiere den Server-Administrator."
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -114,7 +114,7 @@ msgstr ""
 "({billing_page_link}) oder [deaktiviere inaktive Nutzer]"
 "({deactivate_user_help_page_link}), damit neue Nutzer beitreten können."
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -126,7 +126,7 @@ msgstr ""
 "Nutzer deaktivieren]({deactivate_user_help_page_link}), damit mehr als nur "
 "noch ein Nutzer beitreten kann."
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -138,7 +138,7 @@ msgstr ""
 "Nutzer:innen deaktivieren]({deactivate_user_help_page_link}), damit mehr als "
 "nur noch zwei Nutzer:innen beitreten können."
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -150,7 +150,7 @@ msgstr ""
 "Nutzer:innen deaktivieren]({deactivate_user_help_page_link}), damit mehr als "
 "nur noch drei Nutzer:innen beitreten können."
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -164,7 +164,7 @@ msgstr ""
 "nächsten Abrechnungszeitraum]({billing_page_link}) größer ist als die "
 "aktuelle Anzahl an Nutzer:innen."
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
@@ -172,7 +172,7 @@ msgstr ""
 "Deine Organisation hat nicht genug Zulip-Lizenzen. Einladungen wurden nicht "
 "gesendet."
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
@@ -180,16 +180,15 @@ msgstr ""
 "Deine Organisation hat nicht genug Zulip-Lizenzen zur Änderung der Rolle von "
 "Gast-Nutzer:innen."
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr "Registrierungen sind deaktiviert"
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr "Ungültiger Remote-Server."
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
@@ -198,7 +197,7 @@ msgstr ""
 "Du musst Lizenzen für alle aktiven Nutzer in deiner Organisation erwerben "
 "(mindestens {min_licenses})."
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
@@ -208,45 +207,45 @@ msgstr ""
 "Seite aus verarbeitet werden. Um das Upgrade zu vollenden, kontaktiere bitte "
 "{email}."
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr "Keine Zahlungsmethode hinterlegt."
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr "{brand} endet in {last4}"
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr "Unbekannte Zahlungsmethode. Bitte kontaktiere {email}."
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr "Etwas hat nicht geklappt. Bitte {email} kontaktieren."
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "Etwas ist schief gelaufen. Bitte lade die Seite erneut."
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr ""
 "Etwas ist schief gelaufen. Bitte warte ein paar Sekunden und versuche es "
 "erneut."
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 "Bitte füge vor Beginn deiner kostenlosen Testphase eine Kreditkarte hinzu."
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr "Bitte füge eine Kreditkarte hinzu, um ein Upgrade zu planen."
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
@@ -254,18 +253,18 @@ msgstr ""
 "Konnte den Tarif nicht erneuern. Das Angebot ist abgelaufen und wurde durch "
 "ein neues ersetzt."
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr "Konnte den Tarif nicht erneuern. Das Angebot wurde beendet."
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 "Kann Lizenzen im aktuellen Abrechnungszeitraum für das kostenlose "
 "Testabonnement nicht aktualisieren."
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
@@ -273,20 +272,20 @@ msgstr ""
 "Konnte die Lizenzen nicht manuell erneuern. Dein Tarif sieht ein "
 "automatisches Lizenzmanagement vor."
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr ""
 "Dein Tarif hat bereits {licenses} Lizenzen im aktuellen Abrechnungszeitraum."
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr ""
 "Du kannst die Anzahl der Lizenzen im aktuellen Abrechnungszeitraum nicht "
 "reduzieren."
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
@@ -294,7 +293,7 @@ msgstr ""
 "Für einen Tarif, der herabgestuft wird, können Lizenzen für den nächsten "
 "Abrechnungszyklus nicht geändert werden."
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
@@ -303,7 +302,7 @@ msgstr ""
 "Dein Tarif sieht bereits vor, mit {licenses_at_next_renewal} verlängert zu "
 "werden."
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
@@ -312,27 +311,27 @@ msgstr ""
 "Du hast bereits {licenses_at_next_renewal} Lizenzen für den nächsten "
 "Abrechnungszeitraum erworben."
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr "Es gibt nichts zu ändern."
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr "Du bist kein Kunde dieser Organisation!"
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr "Session nicht gefunden"
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr "Keine Zahlabsicht gefunden"
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr "Übergib stripe_session_id oder stripe_payment_intent_id"
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -347,20 +346,19 @@ msgstr ""
 "Wenn ihr {begin_link}Zulip als Sponsor auf eurer Website auflisten "
 "könntet{end_link}, wären wir euch sehr dankbar!"
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr "Parameter 'confirmed' ist erforderlich"
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr "Zugriffstoken für die Abrechnung ist abgelaufen."
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr "Zugriffstoken für die Abrechnung ist ungültig."
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
@@ -369,39 +367,38 @@ msgstr ""
 "Abrechnungsdaten konnten nicht zwischen Server und Realm abgestimmt werden. "
 "Bitte kontaktiere {support_email}"
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr "Nutzeraccount existiert noch nicht."
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr "Du musst den Nutzungsbedingungen zustimmen, um fortzufahren."
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 "Diese zulip_org_id ist nicht im Abrechnungssystem von Zulip registriert."
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr "Ungültiger zulip_org_key für diese zulip_org_id."
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr "Deine Server-Registrierung wurde deaktiviert."
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "Fehler"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr "Seite nicht gefunden (404)"
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
@@ -410,11 +407,11 @@ msgstr ""
 "Wenn dieser Fehler unerwartet ist, kannst du <a href=\"mailto:"
 "%(support_email)s\">den Support kontaktieren</a>."
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr "Zugriff verboten (403)"
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
@@ -423,11 +420,11 @@ msgstr ""
 "Anmeldedaten gesendet hat, die zur Authentifizierung deines Zugriffs "
 "erforderlich sind. Um dieses Problem zu beheben:"
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr "Stelle sicher, das dein Browser Cookies für diese Website zulässt."
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
@@ -435,16 +432,15 @@ msgstr ""
 "Prüfe, ob du Privatsphäre-Einstellungen oder Erweiterungen hast, die Referer-"
 "Header blocken, und deaktiviere sie für diese Seite."
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr "Methode nicht erlaubt (405)"
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr "Interner Serverfehler"
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
@@ -453,7 +449,7 @@ msgstr ""
 "arbeiten an einer Lösung. Zulip wird automatisch neu laden, sobald es wieder "
 "funktioniert."
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -464,7 +460,7 @@ msgstr ""
 "weiteren Informationen und <a href=\"mailto:%(support_email)s\">kontaktiere "
 "den Zulip-Support</a>, falls es Fragen gibt."
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
@@ -472,7 +468,7 @@ msgstr ""
 "Es ist etwas schiefgelaufen. Tut uns leid! Zulip lädt automatisch, sobald es "
 "wieder funktioniert."
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
@@ -481,7 +477,7 @@ msgstr ""
 "In der Zwischenzeit kannst du für Unterstützung <a href=\"mailto:"
 "%(support_email)s\">den Administrator dieses Servers kontaktieren</a>."
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
@@ -491,138 +487,136 @@ msgstr ""
 "href=\"%(troubleshooting_url)s\">Anleitung zur Fehlerbehebung von Zulip-"
 "Servern</a> ansehen."
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr "Statistik für %(target_name)s | Zulip"
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 "Analysedaten sind 24 Stunden nach Erstellung der Organisation vollständig "
 "verfügbar."
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr "Zulip Analytics für %(target_name)s"
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr "Überblick über die Organisation"
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr "Anzahl an Nutzern"
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr "In den letzten 15 Tagen aktive Nutzer"
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr "Anzahl an Gästen"
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr "Gesamtzahl an Nachrichten"
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr "Anzahl an Nachrichten in den letzten 30 Tagen"
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr "Genutzter Dateispeicher"
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "Aktive Nutzer"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr "Täglich aktive Nutzer"
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr "15-tägig aktive Nutzer"
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr "Gesamtzahl der aktiven Nutzer"
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "Nutzer"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr "Gesendete Nachrichten pro Ziel"
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "Ich"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "Jeder"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "Letzte Woche"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "Letzter Monat"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "Letztes Jahr"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "Insgesamt"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr "Versendete Nachrichten"
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "Täglich"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "Wöchentlich"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr "Insgesamt"
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "Menschen"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "Bots"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr "Gelesene Nachrichten"
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr "Gesendete Nachrichten je Plattform"
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr "Letztes Update"
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
@@ -630,15 +624,15 @@ msgstr ""
 "Statistiken werden einmal täglich komplett aktualisiert. Die Ansicht "
 "“Versendete Nachrichten” wird einmal stündlich aktualisiert."
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr "E-Mail-Adresse geändert"
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr "E-Mail-Adresse geändert!"
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
@@ -647,21 +641,21 @@ msgstr ""
 "Hiermit wird bestätigt, dass die E-Mail-Adresse deines Zulip-Accounts "
 "geändert wurde von %(old_email_html_tag)s zu %(new_email_html_tag)s"
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr "Bestätige deine E-Mail-Adresse"
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr "Der Bestätigungslink existiert nicht"
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr "Na sowas. Wir konnten deinen Bestätigungslink nicht im System finden."
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
@@ -670,29 +664,29 @@ msgstr ""
 "Wie dem auch sei, schicke uns eine Nachricht an %(support_email_html_tag)s "
 "und wir schaffen dem schnellstmöglich Abhilfe."
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr "Der Bestätigungslink ist abgelaufen oder wurde deaktiviert"
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr "Na sowas. Der Bestätigungslink ist abgelaufen oder wurde deaktiviert."
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr ""
 "Bitte setze dich mit dem Administrator deiner Organisation in Verbindung, um "
 "einen neuen Link zu erhalten."
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr "Der Bestätigungslink ist ungültig"
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr "Na sowas. Der Bestätigungslink hat ein falsches Format."
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
@@ -701,72 +695,55 @@ msgstr ""
 "Solltest du wieder auf dieser Seite landen, liegt es vermutlich an uns. Tut "
 "uns leid."
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr "Abrechnung"
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr "Fenster schließen"
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr "Abbrechen"
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr "Herabstufen"
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr "Bestätigen"
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr "Upgrade abbrechen"
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr "Rechnungsstatus"
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr "Serverregistrierung deaktivieren?"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr "Tarif-Management ist nicht verfügbar"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -783,7 +760,7 @@ msgstr ""
 "to-billing-management\">Anleitung zum Einloggen in die Tarifverwaltung</a> "
 "an, um den Tarif deines Zulip-Servers zu verwalten."
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
@@ -792,7 +769,7 @@ msgstr ""
 "anderen Fragen, <a href=\"mailto:{{ support_email }}\">kontaktiere den "
 "Support</a>."
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
@@ -800,7 +777,7 @@ msgstr ""
 "Für diesen Server ist keine Tarifverwaltung verfügbar, da mindestens eine "
 "auf diesem Server gehostete Organisation bereits einen aktiven Tarif hat."
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -812,17 +789,17 @@ msgstr ""
 "href='mailto:%(support_email)s'>den Support kontaktieren</a> und etwaige "
 "Fragen klären."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr "Tarifgrenze überschritten"
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr "Tarifgrenze überschritten."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
@@ -830,720 +807,230 @@ msgstr ""
 "Dein Server hat das Limit, wie oft diese Aktion ausgeführt werden kann, "
 "überschritten."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, fuzzy, python-format
 #| msgid "You can try again in %(retry_after)s seconds."
 msgid "You can try again in %(retry_after_string)s."
 msgstr "Du kannst es in %(retry_after)s Sekunden erneut versuchen."
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr "Aktualisieren"
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr "Rechnung senden und kostenlose Testversion starten"
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr "Rechnung senden"
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr "Community-Verzeichnis öffnen"
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr "Nach Kategorie filtern"
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "Alles"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr "Kategorien"
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr "10.000 Nachrichten"
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr "Unbegrenzt"
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr "Dateien bis zu 10 MB"
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr "Dateien bis zu 1 GB"
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr "Unterstützt"
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr "selbst gemanaged"
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr "Für Organisationen mit bis zu 10 Nutzern"
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr "25 Benutzer mindestens"
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr "Nicht verfügbar"
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr "Die Community der Zulip-Entwickler"
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr "Als Nutzer beitreten"
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr "Als Selbst-Hoster beitreten"
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr "Als Contributor beitreten"
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "Organisation erstellen"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr "Eine Demo erhalten"
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr "Zulip selbst hosten"
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr "Förderung anfragen"
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr "Preise für Ausbildung"
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr "Preise ansehen"
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr "Zulip für Business"
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Zulip guide for open-source projects"
 msgid "Zulip for open source"
 msgstr "Zulip-Leitfaden für Open-Source-Projekte"
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "start a conversation"
 msgid "Screenshot of Zulip conversation"
 msgstr "Eine Unterhaltung beginnen"
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Messages sent over time"
 msgid "Message with code"
 msgstr "Versendete Nachrichten"
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr "Link"
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr "Support kontaktieren"
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr "Von"
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr "Organisation"
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr "Betreff"
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr "Nachricht"
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr "Abschicken"
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr "Vielen Dank für die Kontaktaufnahme"
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr "Vielen Dank für die Kontaktaufnahme!"
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr "Wir melden uns bald bei dir."
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
@@ -1551,13 +1038,13 @@ msgstr ""
 "Antworten auf häufig gestellte Fragen findest du im <a href=\"/help/\">Zulip "
 "Hilfecenter</a>."
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 #, fuzzy
 #| msgid "Getting started"
 msgid "Get started"
 msgstr "Loslegen"
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
@@ -1567,51 +1054,50 @@ msgstr ""
 "<a href=\"https://zulip.com/policies/terms\">Zulip Nutzungsbedingungen</a>, "
 "um fortzufahren."
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr "Alternativ kannst du ein Ersatzhandy nutzen:"
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr "Falls alle Stricke reißen, kannst du ein Sicherheitstoken verwenden:"
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr "Sicherheitstoken benutzen"
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr "Nutzungsbedingungen akzeptieren"
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr "Willkomen bei Zulip"
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "E-Mail"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr ""
 "Abonniere den selten erscheinenden Zulip-Newsletter (einige wenige E-Mails "
 "pro Jahr)."
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr "Fortfahren"
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr "Bestätige deine E-Mail-Adresse"
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1622,7 +1108,7 @@ msgstr ""
 "class=\"user_email semi-bold\">%(email)s</span>) auf eine Bestätigungs-E-"
 "Mail von Zulip."
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
@@ -1631,31 +1117,31 @@ msgstr ""
 "siehst, können wir sie <a href=\"#\" id=\"resend_email_link\">erneut senden</"
 "a>."
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr "Öffentliche Ansicht von {org_name} | Zulip team chat"
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 "Durchsuche die öffentlich zugänglichen Kanäle in {org_name} ohne Anmeldung."
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
@@ -1663,39 +1149,38 @@ msgstr ""
 "Wenn diese Meldung nicht verschwindet, versuche die Seite <a class=\"reload-"
 "lnk\">neu zu laden</a>."
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 "Fehler beim Laden von Zulip. Versuche die Seite <a class=\"reload-lnk\">neu "
 "zu laden</a>."
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr "Keine Unterhaltungen entsprechen deinen Filtern."
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr "Diese Ansicht lädt noch Nachrichten."
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr "Weitere laden"
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr "Videoanruf beendet"
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr "Du kannst dieses Fenster nun schließen."
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr "Konfigurationsfehler"
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
@@ -1704,7 +1189,7 @@ msgstr ""
 "erstellt zu haben. Bitte verwende EmailAuthBackend zum Erstellen deiner "
 "Organisation und versuche es dann erneut."
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1715,72 +1200,70 @@ msgstr ""
 "konfiguriert Für Anweisungen zur Einrichtung von Push-Benachrichtigungen, "
 "sieh in der <a href=\"%(doc_url)s\">Dokumentation</a> nach.."
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr "Konto nicht gefunden"
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr "Zulip-Account nicht gefunden."
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, python-format
 msgid "No account found for %(email)s."
 msgstr "Kein Account gefunden für %(email)s."
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr "Mit einem anderen Account anmelden"
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr "Mit der Registrierung fortfahren"
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Must be a demo organization."
 msgid "Try Zulip in a demo organization"
 msgstr "Muss eine Demo-Organisation sein."
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Try Zulip now"
 msgid "Try Zulip"
 msgstr "Probiere Zulip jetzt aus"
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "Eine neue Organisation erstellen"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr "Neue Organisation erstellen"
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr "E-Mail-Adressen eingeben"
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr "Deine E-Mail"
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
@@ -1790,11 +1273,11 @@ msgstr ""
 "import-from-mattermost\">Mattermost</a>, oder <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a> importieren."
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr "Wie hast du zuerst von Zulip erfahren?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
@@ -1802,42 +1285,41 @@ msgstr ""
 "Dieser Wert wird nur verwendet, wenn du einen Tarif wählst. In dem Fall wird "
 "er an das Zulip-Team gesendet."
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr "Wähle eine Option"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr "Bitte beschreiben"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr "Wo hast du die Anzeige gesehen?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr "Welche Organisation?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr "Welche?"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr "Einen wählen"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr "Organisationstyp"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr "Organisationssprache"
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
@@ -1847,73 +1329,69 @@ msgstr ""
 "oder <a href=\"/help/import-from-rocketchat\">Rocket.Chat</a> importieren "
 "kannst."
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid "Import chat history?"
 msgstr "Chatverlauf importieren?"
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr "Name der Organisation"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "URL der Organisation"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr "Benutze %(external_host)s"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "ODER"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "Registrieren"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "Bei Zulip registrieren"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr ""
 "Du musst eingeladen werden, um dieser Organisation beitreten zu können."
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr "Registrieren mit %(identity_provider)s"
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr "Du hast bereits ein Konto?"
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "Anmelden"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr "Konfiguriere die Privatsphäre der E-Mail-Adresse"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
@@ -1921,7 +1399,7 @@ msgstr ""
 "Mit Zulip kannst du steuern, welche Rollen in der Organisation deine E-Mail-"
 "Adresse sehen können."
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
@@ -1929,11 +1407,11 @@ msgstr ""
 "Möchtest du die Privatsphäre-Einstellung für deine E-Mail von der "
 "Standardkonfiguration für diese Organisation ändern?"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr "Wer kann deine E-Mail-Adresse anzeigen"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1944,14 +1422,14 @@ msgstr ""
 "configure-email-visibility\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">nach deinem Beitritt</a> ändern."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 "Administratoren dieser Zulip-Organisation können diese E-Mail-Adresse sehen."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
@@ -1959,92 +1437,91 @@ msgstr ""
 "Administratoren und Moderatoren dieser Zulip-Organisation können diese E-"
 "Mail-Adresse sehen."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr "Niemand in dieser Zulip-Organisation kann diese E-Mail-Adresse sehen."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 "Andere Nutzer in dieser Zulip-Organisation können diese E-Mail-Adresse sehen."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "Ändern"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr "Registrierung"
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr "Erstelle deine Organisation"
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr "Erstelle deinen Account"
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr "<p>Gebe deine Kontodaten ein, um die Registrierung abzuschließen.</p>"
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr "Deine Organisation"
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr "Dein Account"
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr "Keine Einstellungen importieren"
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr "Einstellungen von einem anderen Zulip-Account importieren"
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr "Dein vollständiger Name"
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "Name"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr "So wird dein Account in Zulip angezeigt."
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "Passwort"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr "Gib dein LDAP/Active Directory Passwort ein."
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 "Dies wird für mobile Anwendungen und andere Programme, die ein Passwort "
 "benötigen, verwendet."
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr "Passwortstärke"
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr "Woran bist du interessiert?"
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
@@ -2053,15 +1530,15 @@ msgstr ""
 "Ich stimme den <a href=\"%(root_domain_url)s/policies/terms\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">Nutzungsbedingungen</a> zu."
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr "Deaktivierte Organisation"
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr "Organisation verschoben"
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
@@ -2070,7 +1547,7 @@ msgstr ""
 "Diese Organisation ist nach <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a> umgezogen."
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -2081,7 +1558,7 @@ msgstr ""
 "span> Sekunden automatisch zur <a href=\"%(auto_redirect_to)s\" "
 "id=\"deactivated-org-auto-redirect\">neuen URL</a> umleiten."
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 msgid ""
 "This organization has been deactivated, and all organization data has been "
 "deleted."
@@ -2089,7 +1566,7 @@ msgstr ""
 "Diese Organisation wurde deaktiviert und alle Daten der Organisation wurden "
 "gelöscht."
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
@@ -2099,7 +1576,7 @@ msgstr ""
 "kontaktieren</a>, um die Wiederverwendung dieser URL für eine neue "
 "Organisation anzufragen."
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
@@ -2108,11 +1585,11 @@ msgstr ""
 "In der Zwischenzeit kannst du für Unterstützung <a href=\"mailto:"
 "%(support_email)s\">den Administrator dieses Servers kontaktieren</a>."
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 msgid "This organization has been deactivated."
 msgstr "Diese Organisation wurde deaktiviert."
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -2122,7 +1599,7 @@ msgstr ""
 "%(support_email)s\">den Zulip-Support kontaktieren</a>, um sie zu "
 "reaktivieren."
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
@@ -2132,7 +1609,7 @@ msgstr ""
 "weshalb sie deaktiviert worden ist, wende dich bitte direkt an den "
 "Administrator der Organisation."
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -2143,15 +1620,15 @@ msgstr ""
 "%(support_email)s\">die Administrator:innen dieses Zulip-Servers "
 "kontaktieren</a>, um sie zu reaktivieren."
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr "Schließe das Login über die Desktop-App ab"
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr "Desktop-Login abschließen"
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
@@ -2159,93 +1636,92 @@ msgstr ""
 "Nutze deinen Webbrowser, um den Login-Prozess abzuschließen, danach kehre "
 "hierher zurück, um dein Login-Token einzufügen."
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr "Füge dein Token hier ein"
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr "Abschließen"
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr "Falsches Token."
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr "Token akzeptiert. Du wirst eingeloggt…"
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr "In der Desktop-App einloggen"
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 "Kopiere dieses Login-Token und kehre zu deiner Zulip-App zurück, um das "
 "Einloggen abzuschließen:"
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "Kopieren"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr "Danach kannst du dieses Fenster schließen."
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr "Oder fahre in deinem Browser fort."
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr "Anonymer Nutzer"
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr "Besitzer"
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "Administratoren"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr "Moderatoren"
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr "Gastnutzer"
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "Normale Nutzer"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr "E-Mails an ein E-Mail-Konto weiterleiten"
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "Schließen"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "Aktualisieren"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr "Zulip"
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr "Zusammenfassung"
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
@@ -2254,17 +1730,17 @@ msgstr ""
 "Gratulation, du hast eine neue Zulip-Organisation erstellt: "
 "<b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr "Willkommen bei Zulip!"
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr "Du bist der Zulip-Organisation <b>%(realm_name)s</b> beigetreten."
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
@@ -2273,36 +1749,36 @@ msgstr ""
 "Du benötigst die folgenden Angaben zum Anmelden in den <a "
 "href=\"%(apps_page_link)s\">Mobil- und Desktop-</a>Apps:"
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr "URL der Organisation: %(organization_url)s"
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr "Dein Nutzername: %(ldap_username)s"
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr "Benutze deinen LDAP-Account zum Einloggen"
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr "E-Mail-Adresse deines Kontos: %(email)s"
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr "Zur Organisation gehen"
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
@@ -2311,7 +1787,7 @@ msgstr ""
 "Wenn du neu bist, sieh dir unsere <a "
 "href=\"%(getting_user_started_link)s\">Anleitung für den Einstieg</a> an!"
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2322,7 +1798,7 @@ msgstr ""
 "href=\"%(getting_organization_started_link)s\">deine Organisation zu Zulip "
 "umziehst</a>."
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
@@ -2331,29 +1807,29 @@ msgstr ""
 "Fragen? <a href=\"mailto:%(support_email)s\">Kontaktiere uns</a> — wir "
 "helfen dir gerne weiter!"
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr "%(realm_name)s auf Zulip: Details zu deiner neuen Organisation"
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr "%(realm_name)s auf Zulip: Details zu deinem neuen Account"
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr ""
 "Gratulation, du hast eine neue Zulip-Organisation erstellt: %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr "Du bist der Zulip-Organisation %(realm_name)s beigetreten."
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
@@ -2362,7 +1838,7 @@ msgstr ""
 "Du benötigst die folgenden Angaben zum Anmelden in den Mobil- und Desktop-"
 "Apps (%(apps_page_link)s):"
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
@@ -2371,7 +1847,7 @@ msgstr ""
 "Wenn du neu bei Zulip bist, schau dir doch einmal unsere Anleitung für den "
 "Einstieg (%(getting_user_started_link)s) an!"
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
@@ -2380,19 +1856,19 @@ msgstr ""
 "Wir haben auch eine Anleitung, wie du deine Organisation zu Zulip umziehst "
 "(%(getting_organization_started_link)s)."
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 "Fragen? Kontaktiere uns unter %(support_email)s — wir helfen dir gerne "
 "weiter!"
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2401,17 +1877,17 @@ msgstr ""
 "Bei Fragen wende dich bitte an die Administratoren dieses Zulip-Servers "
 "unter %(support_email)s."
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr "Hallo,"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2423,12 +1899,12 @@ msgstr ""
 "Änderung zu bestätigen und ein Passwort für dieses Konto festzulegen, klicke "
 "bitte unten:"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr "Bestätigen und Passwort festlegen"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2437,14 +1913,14 @@ msgstr ""
 "Solltest du diese Änderung nicht veranlasst haben, setze dich bitte gleich "
 "über %(support_email)s mit uns in Verbindung."
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 #, fuzzy
 #| msgid "Verify your new email address for your demo Zulip organization"
 msgid "Verify your email address for your Zulip demo organization"
 msgstr "Bestätige deine neue E-Mail-Adresse für deine Demo-Zulip-Organisation"
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2453,8 +1929,8 @@ msgstr ""
 "Falls du diese Änderung nicht vorgenommen hast, kontaktiere uns bitte sofort "
 "unter <%(support_email)s>."
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2465,33 +1941,33 @@ msgstr ""
 "auf %(realm_url)s von %(old_email)s zu %(new_email)s zu ändern. Falls du "
 "diese Änderung bestätigen möchtest, klicke bitte hier unten:"
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr "Änderung der E-Mail-Adresse bestätigen"
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr "Bestätige deine neue E-Mail-Adresse für %(organization_host)s"
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr "Du hast eine neue Zulip-Organisation angefordert:"
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr "Organisationstyp: %(organization_type)s"
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr "Du hast dich vor kurzem bei Zulip angemeldet. Super!"
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
@@ -2500,33 +1976,33 @@ msgstr ""
 "Account zu registrieren. Wenn du möchtest, kannst du die Informationen oben "
 "jederzeit aktualisieren."
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr "Klicke den Button unten, um die Registrierung abschließen."
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr "Registrierung abschließen"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr "Erstelle deine Zulip-Organisation"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr "Aktiviere deinen Zulip-Account"
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr "Klicke den Button unten, um die Registrierung abschließen."
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
@@ -2535,20 +2011,20 @@ msgstr ""
 "Hast du Fragen oder Feedback? Kontaktiere uns unter %(support_email)s — wir "
 "helfen dir gerne weiter!"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr "E-Mail-Einstellungen verwalten"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr "Marketing-E-Mails abbestellen"
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
@@ -2557,17 +2033,17 @@ msgstr ""
 "Dein Zulip-Account auf <a href=\"%(realm_url)s\">%(realm_url)s</a> wurde "
 "deaktiviert und du kannst dich nicht mehr anmelden."
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr "Die Administratoren haben dazu folgenden Kommentar abgegeben:"
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr "Benachrichtigung über Deaktivierung des Accounts auf %(realm_name)s"
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
@@ -2576,11 +2052,11 @@ msgstr ""
 "Dein Zulip-Account auf %(realm_url)s wurde deaktiviert und du kannst dich "
 "nicht mehr anmelden."
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr "Neue Kanäle"
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2591,7 +2067,7 @@ msgstr ""
 "%(new_streams_count)s neue Kanäle in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
@@ -2600,7 +2076,7 @@ msgstr ""
 "Du hast %(new_messages_count)s neue Nachrichten in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
@@ -2609,8 +2085,8 @@ msgstr ""
 "Es gibt %(new_streams_count)s neue Kanäle in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because your organization <a "
@@ -2622,8 +2098,8 @@ msgstr ""
 "href=\"%(help_url)s\">Nachrichteninhalte in E-Mail-Benachrichtigungen "
 "ausblendet.</a> ."
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to <a "
@@ -2635,23 +2111,23 @@ msgstr ""
 "href=\"%(help_url)s\">Nachrichteninhalte in E-Mail-Benachrichtigungen "
 "auszublenden</a> ."
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr ""
 "<a href=\"%(realm_url)s\">Anmelden</a> bei Zulip um auf dem Laufenden zu "
 "bleiben."
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr "Abmelden von E-Mails mit Zusammenfassungen"
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr "Zulip-Zusammenfassung für %(realm_name)s"
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2660,18 +2136,18 @@ msgstr ""
 "Du hast %(new_messages_count)s neue Nachrichten und es gibt "
 "%(new_streams_count)s neue Kanäle in %(realm_name)s."
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr "Du hast %(new_messages_count)s neue Nachrichten in %(realm_name)s."
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr "Es gibt %(new_streams_count)s neue Kanäle in %(realm_name)s."
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because your organization hides "
@@ -2682,8 +2158,8 @@ msgstr ""
 "Nachrichteninhalte in E-Mail-Benachrichtigungen ausblendet. Siehe "
 "%(hide_content_url)s für mehr Details."
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to hide "
@@ -2693,34 +2169,32 @@ msgstr ""
 "Nachrichteninhalte in E-Mail-Benachrichtigungen darzustellen, abgewählt "
 "hast. Siehe %(help_url)s für weitere Details."
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr ""
 "Melde dich bei Zulip an, um auf dem Laufenden zu bleiben: "
 "%(organization_url)s."
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr "E-Mail-Einstellungen verwalten:"
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr "Abmelden von E-Mails mit Zusammenfassungen:"
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr "Schwimmender Fisch"
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr "Danke für deine Anfrage!"
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
@@ -2729,8 +2203,7 @@ msgstr ""
 "Deine E-Mail-Adresse %(email)s hat Accounts in den folgenden Zulip Cloud-"
 "Organisationen:"
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
@@ -2739,7 +2212,7 @@ msgstr ""
 "Deine E-Mail-Adresse %(email)s hat bei den folgenden, von %(external_host)s "
 "gehosteten Zulip-Organisationen Accounts:"
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
@@ -2748,20 +2221,16 @@ msgstr ""
 "Wenn du Probleme bei der Anmeldung hast, kannst du <a "
 "href=\"%(help_reset_password_link)s\">dein Passwort zurücksetzen</a>."
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 "Du hast eine Liste von Zulip-Accounts für diese E-Mail-Adresse angefordert."
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr "Leider wurden keine Zulip Cloud-Accounts gefunden."
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
@@ -2770,7 +2239,7 @@ msgstr ""
 "Leider wurden keine Accounts in Zulip-Organisationen gefunden, die bei "
 "%(external_host)s gehostet sind."
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2781,30 +2250,27 @@ msgstr ""
 "\"%(find_accounts_link)s\" >nach Accounts suchen</a> oder versuchen, deinen "
 "Account <a href =\"%(help_logging_in_link)s\">auf andere Weise</a> zu finden."
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 "Falls dir diese Anfrage nicht bekannt vorkommt, kannst du diese E-Mail "
 "ignorieren."
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr "Deine Zulip-Accounts"
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr "Keine Zulip-Accounts gefunden"
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 "Wenn du Probleme bei der Anmeldung hast, kannst du dein Passwort "
 "zurücksetzen."
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
@@ -2814,12 +2280,12 @@ msgstr ""
 "(%(find_accounts_link)s) oder versuchen, deinen Account auf andere Weise zu "
 "finden (%(help_logging_in_link)s)."
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr "Hallo,"
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
@@ -2828,19 +2294,19 @@ msgstr ""
 "%(referrer_name)s möchte, dass du Zulip beitrittst &mdash; dem Team-"
 "Kommunikationstool, das für Produktivität entworfen wurde."
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr "Um loszulegen, klicke bitte hier."
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 "%(referrer_full_name)s hat dich eingeladen, %(referrer_realm_name)s "
 "beizutreten"
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
@@ -2849,17 +2315,17 @@ msgstr ""
 "%(referrer_full_name)s (%(referrer_email)s) hat dich zu Zulip eingeladen "
 "&mdash; dem Team-Kommunikationstool, das für Produktivität entworfen wurde."
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr "Um loszulegen, klicke bitte auf den nachfolgenden Link."
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr "Hallo nochmal,"
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
@@ -2869,13 +2335,13 @@ msgstr ""
 "Zulip eingeladen hat &mdash; dem Team-Kommunikationstool, das für "
 "Produktivität entworfen wurde."
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr "Das ist die letzte Erinnerung, die du für die Einladung erhältst."
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
@@ -2884,12 +2350,12 @@ msgstr ""
 "Diese Einladung verfällt in zwei Tagen. Wenn die Einladung verfallen ist, "
 "musst du von %(referrer_name)s eine neue anfordern."
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr "Erinnerung: Tritt %(referrer_name)s auf %(referrer_realm_name)s bei"
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2900,7 +2366,7 @@ msgstr ""
 "(%(referrer_email)s) dich zu Zulip eingeladen hat — dem Team-"
 "Kommunikationstool, das für Produktivität entworfen wurde."
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2909,7 +2375,7 @@ msgstr ""
 "Bei Fragen wende dich bitte an die Administratoren dieses Zulip-Servers "
 "unter <a href=\"mailto:%(email)s\">%(email)s</a>."
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
@@ -2918,13 +2384,13 @@ msgstr ""
 "Hast du Fragen oder Feedback? <a href=\"mailto:%(email)s\">Kontaktiere uns</"
 "a> — wir helfen dir gerne weiter!"
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr "Du erhältst diese Nachricht, weil du persönlich erwähnt wurdest."
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
@@ -2932,10 +2398,8 @@ msgstr ""
 "Du erhältst diese Nachricht, weil @%(mentioned_user_group_name)s erwähnt "
 "wurde."
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
@@ -2944,8 +2408,8 @@ msgstr ""
 "Du erhältst diese Nachricht, weil alle Themen-Teilnehmer in "
 "#%(channel_name)s > %(topic_name)s erwähnt wurden."
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
@@ -2953,16 +2417,16 @@ msgstr ""
 "Du erhältst diese Nachricht, weil du für Themen, denen du folgst, "
 "Benachrichtigungen für Platzhalter-Erwähnungen aktiviert hast."
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 "Du erhältst diese Nachricht, weil alle in #%(channel_name)s erwähnt wurden."
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
@@ -2970,8 +2434,8 @@ msgstr ""
 "Du erhältst diese Nachricht, weil du für Themen, denen du folgst, E-Mail-"
 "Benachrichtigungen aktiviert hast."
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
@@ -2980,7 +2444,7 @@ msgstr ""
 "Du erhältst diese Nachricht, weil du für #%(channel_name)s E-Mail-"
 "Benachrichtigungen aktiviert hast."
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2991,7 +2455,7 @@ msgstr ""
 "%(realm_name)s - Zulip</a> an oder <a href=\"%(notif_url)s\">bearbeite die E-"
 "Mail-Einstellungen</a>."
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
@@ -3000,7 +2464,7 @@ msgstr ""
 "<a href=\"%(narrow_url)s\">In %(realm_name)s-Zulip ansehen oder antworten</"
 "a> oder <a href=\"%(notif_url)s\">E-Mail-Einstellungen bearbeiten</a>."
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
@@ -3009,7 +2473,7 @@ msgstr ""
 "<a href=\"%(narrow_url)s\">In %(realm_name)s - Zulip antworten</a> oder <a "
 "href=\"%(notif_url)s\">die E-Mail-Einstellungen bearbeiten</a>."
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
@@ -3019,43 +2483,43 @@ msgstr ""
 "eingerichtet, eingehende E-Mails zu akzeptieren (<a href=\"%(url)s\">Hilfe</"
 "a>)."
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr "Gruppen-DMs mit %(direct_message_group_display_name)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr "DMs mit %(sender_str)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr "[gelöst] #%(channel_name)s > %(topic_name)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr "Neue Nachrichten"
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 "Antworte direkt auf diese E-Mail oder sieh sie dir in %(realm_name)s - Zulip "
 "an:"
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr "In %(realm_name)s-Zulip ansehen oder antworten:"
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr "In %(realm_name)s - Zulip antworten:"
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
@@ -3063,7 +2527,7 @@ msgstr ""
 "Antworte nicht auf diese E-Mail. Dieser Zulip-Server ist nicht dafür "
 "eingerichtet, eingehende E-Mails zu akzeptieren. Hilfe:"
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -3074,22 +2538,22 @@ msgstr ""
 "%(new_email)s geändert. Falls du diese Änderung nicht vorgenommen hast, "
 "kontaktiere uns bitte sofort unter %(support_email)s."
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr "Viele Grüße,"
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr "das Zulip Team"
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr "Zulip-E-Mail-Adresse geändert für %(realm_name)s"
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -3100,7 +2564,7 @@ msgstr ""
 "%(new_email)s geändert. Falls du diese Änderung nicht vorgenommen hast, "
 "kontaktiere uns bitte sofort unter %(support_email)s."
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
@@ -3108,48 +2572,48 @@ msgstr ""
 "Organisation: %(organization_url)s Zeit: %(login_time)s E-Mail: "
 "%(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr ""
 "Uns ist aufgefallen, dass der folgende Zulip-Account sich vor Kurzem "
 "eingeloggt hat."
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr "Organisation: %(organization_link)s"
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr "E-Mail: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr "Zeitstempel: %(login_time)s"
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr "Gerät: %(device_browser)s unter %(device_os)s."
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr "IP-Adresse: %(device_ip)s"
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr "Falls du das selbst warst, musst du nichts weiter tun."
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3160,31 +2624,31 @@ msgstr ""
 "möglicherweise gehackt wurde, <a href=\"%(reset_link)s\">setze bitte dein "
 "Passwort zurück</a> oder melde dich umgehend unter %(support_email)s bei uns."
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr "Vielen Dank,"
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr "Zulip-Sicherheitsdienst"
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr "Keine Anmeldebenachrichtigungen mehr erhalten"
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr "Neuer Login von %(device_browser)s unter %(device_os)s"
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr "Organisation: %(organization_url)s"
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3195,7 +2659,7 @@ msgstr ""
 "möglicherweise gehackt wurde, setze bitte dein Passwort über %(reset_link)s "
 "zurück oder melde dich umgehend unter %(support_email)s bei uns."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -3207,7 +2671,7 @@ msgstr ""
 "href=\"%(get_organization_started)s\">Anleitung zum Umzug zu Zulip</a> "
 "nutzen, um loszulegen."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
@@ -3215,7 +2679,7 @@ msgstr ""
 "Ansonsten sind hier einige Tipps, die wir oft von Kunden hören, um "
 "<i>verschiedene</i> Team-Chat-Produkte zu bewerten:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
@@ -3224,12 +2688,12 @@ msgstr ""
 "<a href=\"%(invite_users)s\"><b>Lade deine Teammitglieder ein</b></a>, die "
 "App mit dir zu erkunden und ihre individuellen Perspektiven zu teilen."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr "Nutze die App selbst, um über deine Eindrücke zu sprechen."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -3241,7 +2705,7 @@ msgstr ""
 "du wirklich erleben, wie eine neue Chat-App die Kommunikation in deinem Team "
 "unterstützen kann."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -3252,21 +2716,21 @@ msgstr ""
 "Kommunikation zu ermöglichen</a>, und wir hoffen, dass diese Tipps deinem "
 "Team helfen, die App in Aktion zu erleben."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr "Von Willkommens-E-Mails für %(realm_name)s abmelden"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr "Die passende Chat-App für dein Team auswählen"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
@@ -3275,7 +2739,7 @@ msgstr ""
 "nutzen, herzlich willkommen! Du kannst unsere Anleitung zum Umzug zu Zulip "
 "nutzen, um loszulegen."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
@@ -3283,7 +2747,7 @@ msgstr ""
 "Ansonsten sind hier einige Tipps, die wir oft von Kunden hören, um "
 "verschiedene Team-Chat-Produkte zu bewerten:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
@@ -3291,7 +2755,7 @@ msgstr ""
 "Lade deine Teammitglieder ein, die App mit dir zu erkunden und ihre "
 "individuellen Perspektiven zu teilen."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
@@ -3301,7 +2765,7 @@ msgstr ""
 "Tools zu benutzen. Nur so kannst du wirklich erleben, wie eine neue Chat-App "
 "die Kommunikation in deinem Team unterstützen kann."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
@@ -3309,8 +2773,8 @@ msgstr ""
 "Zulip wurde entwickelt, um effiziente Kommunikation zu ermöglichen, und wir "
 "hoffen, dass diese Tipps deinem Team helfen, die App in Aktion zu erleben."
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
@@ -3321,71 +2785,71 @@ msgstr ""
 "dir diese Anleitung zu den wichtigsten Zulip-Funktionen für Organisationen "
 "wie deine an!"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr "Zulip-Leitfaden für Unternehmen ansehen"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr "Zulip-Leitfaden für Open-Source-Projekte ansehen"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr "Zulip-Leitfaden für Bildung ansehen"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr "Zulip-Leitfaden für Forschung ansehen"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr "Zulip-Leitfaden für Veranstaltungen und Konferenzen ansehen"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr "Zulip-Leitfaden für gemeinnützige Organisationen ansehen"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr "Zulip-Leitfaden für Gemeinschaften ansehen"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr "Zulip-Leitfaden für Unternehmen"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr "Zulip-Leitfaden für Open-Source-Projekte"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr "Zulip-Leitfaden für Bildung"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr "Zulip-Leitfaden für Forschung"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr "Zulip-Leitfaden für Veranstaltungen und Konferenzen"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr "Zulip-Leitfaden für gemeinnützige Organisationen"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr "Zulip-Leitfaden für Gemeinschaften"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
@@ -3393,7 +2857,7 @@ msgstr ""
 "Hier findest du einige Tipps, wie du deine Zulip-Unterhaltungen nach Themen "
 "ordnen kannst."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
@@ -3401,8 +2865,8 @@ msgstr ""
 "In Zulip bestimmen <b>Kanäle</b>, wer eine Nachricht erhält. <b>Themen</b> "
 "verraten dir, worum es in der Nachricht geht."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
@@ -3411,12 +2875,12 @@ msgstr ""
 "lesen. Du siehst jede Nachricht im Kontext, unabhängig davon, wie viele "
 "verschiedene Diskussionen gerade stattfinden."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr "Kanäle und Themen in der Zulip-App"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3429,11 +2893,11 @@ msgstr ""
 "den folgenden Satz vervollständigen kann: „Hey, können wir uns über … "
 "unterhalten?“"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr "Beispiele für kurze Themen"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3448,17 +2912,17 @@ msgstr ""
 "href=\"%(move_channels_link)s\">Themen in andere Kanäle verschoben</a> "
 "werden."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr "Gehe zu Zulip"
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr "Organisiere deine Unterhaltungen mit Themen"
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
@@ -3466,7 +2930,7 @@ msgstr ""
 "In Zulip bestimmen Kanäle, wer eine Nachricht erhält. Themen verraten dir, "
 "worum es in der Nachricht geht."
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3479,8 +2943,8 @@ msgstr ""
 "(%(move_messages_link)s), Themen umbenannt (%(rename_topics_link)s) oder "
 "sogar Themen in andere Kanäle verschoben (%(move_channels_link)s) werden."
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
@@ -3489,15 +2953,15 @@ msgstr ""
 "Jemand (möglicherweise du selbst) hat ein neues Passwort für dein Zulip-"
 "Konto %(email)s bei %(realm_url)s angefordert."
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr "Klicke den Button unten, um dein Passwort zurückzusetzen."
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr "Passwort zurücksetzen"
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3508,18 +2972,18 @@ msgstr ""
 "deaktiviert. Du kannst einen Organisations-Administrator kontaktieren, um <a "
 "href=\"%(help_link)s\">deinen Account zu reaktivieren</a>."
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr "Du hast keinen Account in dieser Zulip-Organisation."
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr "Du hast aktive Accounts in folgender/n Organistation(en)."
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
@@ -3527,24 +2991,24 @@ msgstr ""
 "Du kannst versuchen, dich bei der/den oben stehenden Organisation(en) "
 "anzumelden oder dein Passwort zu ändern."
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 "Falls dir diese Aktivität nicht bekannt vorkommt, kannst du diese E-Mail "
 "ignorieren."
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr "Passwortänderung angefordert für %(realm_name)s"
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr "Klicke den Button unten, um dein Passwort zu ändern."
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
@@ -3554,7 +3018,7 @@ msgstr ""
 "deaktiviert. Du kannst einen Organisations-Administrator kontaktieren, um "
 "deinen Account zu reaktivieren."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3565,7 +3029,7 @@ msgstr ""
 "Zulip Cloud-Tarif herabgestuft, da es noch offene Rechnungen gibt. Die "
 "unbezahlten Rechnungen wurden storniert."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
@@ -3574,7 +3038,7 @@ msgstr ""
 "Um im Zulip Cloud Standard-Tarif fortzufahren, upgrade bitte wieder über "
 "%(upgrade_url)s."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
@@ -3583,8 +3047,8 @@ msgstr ""
 "Wenn du denkst, dass das ein Fehler ist oder wenn du weitere Details "
 "benötigst, bitte kontaktiere uns über %(support_email)s."
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "You have deactivated your Zulip organization, %(realm_name)s, on "
@@ -3596,8 +3060,8 @@ msgstr ""
 "Du hast deine Zulip-Organisation %(realm_name)s am %(localized_date)s "
 "deaktiviert."
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "Your Zulip organization, %(realm_name)s, was deactivated by "
@@ -3609,8 +3073,8 @@ msgstr ""
 "Deine Zulip-Organisation %(realm_name)s wurde am %(localized_date)s von "
 "%(deactivating_owner)sdeaktiviert."
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "Your Zulip organization, %(realm_name)s, was deactivated on "
@@ -3622,8 +3086,8 @@ msgstr ""
 "Deine Zulip-Organisation %(realm_name)s wurde am %(localized_date)s "
 "deaktiviert."
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
@@ -3632,8 +3096,8 @@ msgstr ""
 "Du hast deine Zulip-Organisation %(realm_name)s am %(localized_date)s "
 "deaktiviert."
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
@@ -3642,8 +3106,8 @@ msgstr ""
 "Deine Zulip-Organisation %(realm_name)s wurde am %(localized_date)s von "
 "%(deactivating_owner)sdeaktiviert."
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
@@ -3652,15 +3116,15 @@ msgstr ""
 "Deine Zulip-Organisation %(realm_name)s wurde am %(localized_date)s "
 "deaktiviert."
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 "Alle Daten, die zu dieser Organisation gehörten, wurden endgültig gelöscht."
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
@@ -3669,8 +3133,8 @@ msgstr ""
 "Alle Daten, die zu dieser Organisation gehören, werden am %(deletion_date)s "
 "endgültig gelöscht."
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
@@ -3678,19 +3142,19 @@ msgstr ""
 "Bitte antworte so schnell wie möglich auf diese Mail, falls du Fragen oder "
 "Bedenken hast."
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr "Deine Zulip-Organisation %(realm_name)s wurde deaktiviert"
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr "Liebe ehemalige Administratoren von %(realm_name)s,"
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "One of your administrators requested reactivation of the previously "
@@ -3702,8 +3166,8 @@ msgstr ""
 "Einer deiner Administratoren hat eine Reaktivierung der zuvor deaktivierten "
 "Zulip-Organisation auf %(realm_url)s beantragt."
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
@@ -3712,16 +3176,16 @@ msgstr ""
 "Einer deiner Administratoren hat eine Reaktivierung der zuvor deaktivierten "
 "Zulip-Organisation auf %(realm_url)s beantragt."
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr "Klicke den Button unten, um deine Organisation zu reaktivieren."
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr "Organisation reaktivieren"
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
@@ -3729,21 +3193,21 @@ msgstr ""
 "Falls die Anfrage ungewollt ist, musst du nichts machen – der Link wird nach "
 "24 Stunden ungültig."
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Reactivate your Zulip organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "Reaktiviere deine Zulip-Organisation"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr "Reaktiviere deine Zulip-Organisation"
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr "Klicke den Button unten, um deine Organisation zu reaktivieren."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3752,18 +3216,18 @@ msgstr ""
 "Entweder du oder jemand in deinem Auftrag hat einen Anmeldelink angefordert, "
 "um den Zulip-Tarif für <b>%(remote_server_hostname)s</b> zu verwalten."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 msgid "Click the button below to log in."
 msgstr "Klicke auf den Button unten, um dich anzumelden."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr "Dieser Link läuft in %(validity_in_hours)s Stunden ab."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
@@ -3772,11 +3236,11 @@ msgstr ""
 "Fragen? <a href=\"%(billing_help_link)s\">Erfahre mehr</a> oder kontaktiere "
 "%(billing_contact_email)s."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr "Bei der Zulip-Tarifverwaltung anmelden"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3785,12 +3249,12 @@ msgstr ""
 "Entweder du oder jemand in deinem Auftrag hat einen Anmeldelink angefordert, "
 "um den Zulip-Tarif für %(remote_server_hostname)s zu verwalten."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr "Klicke auf den Link unten, um dich anzumelden."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
@@ -3799,7 +3263,7 @@ msgstr ""
 "Fragen? Erfahre mehr unter %(billing_help_link)s oder kontaktiere "
 "%(billing_contact_email)s."
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
@@ -3808,16 +3272,16 @@ msgstr ""
 "Klicke auf den Link unten, um deine E-Mail zu bestätigen und dich bei der "
 "Zulip-Tarifverwaltung für <b>%(remote_realm_host)s</b> anzumelden."
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr "Bestätigen und anmelden"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr "E-Mail für die Zulip-Tarifverwaltung bestätigen"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
@@ -3826,7 +3290,7 @@ msgstr ""
 "Klicke auf den Link unten, um deine E-Mail zu bestätigen und dich bei der "
 "Zulip-Tarifverwaltung für %(remote_realm_host)s anzumelden."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
@@ -3836,7 +3300,7 @@ msgstr ""
 "wurde auf den <a href=\"%(plans_link)s\">Zulip Community-Tarif</a> "
 "upgegradet."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
@@ -3845,12 +3309,12 @@ msgstr ""
 "Wenn du <a href=\"%(link_to_zulip)s\">Zulip als Sponsor auf deiner Website "
 "auflisten könntest</a>, würden wir uns sehr freuen!"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr "Community-Tarif-Sponsoring für %(billing_entity)s genehmigt!"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
@@ -3858,7 +3322,7 @@ msgstr ""
 "Dein Antrag auf ein Zulip-Sponsoring wurde genehmigt! Deine Organisation "
 "wurde auf den Zulip Community-Tarif upgegradet."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
@@ -3866,22 +3330,22 @@ msgstr ""
 "Wenn du Zulip als Sponsor deiner Webseite aufführen könntest, wüssten wir "
 "das sehr zu schätzen!"
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr "Finde deine Konten"
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr "Finde deine Zulip-Accounts"
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 "E-Mails gesendet! Die auf der vorherigen Seite eingegebenen Adressen sind "
 "unten aufgeführt:"
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
@@ -3890,7 +3354,7 @@ msgstr ""
 "Falls du keine E-Mail erhältst, kannst du <a "
 "href=\"%(current_url)s\">Accounts für andere E-Mail-Adressen finden</a>."
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
@@ -3898,7 +3362,7 @@ msgstr ""
 "Gib deine E-Mail-Adresse ein, um eine E-Mail mit den URLs für alle Zulip "
 "Cloud-Organisationen zu erhalten, in denen du aktive Accounts hast."
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
@@ -3906,7 +3370,7 @@ msgstr ""
 "Gib deine E-Mail-Adresse ein, um eine E-Mail mit den URLs für alle Zulip-"
 "Organisationen zu erhalten, in denen du aktive Accounts hast."
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
@@ -3914,216 +3378,216 @@ msgstr ""
 "Wenn du auch dein Passwort vergessen hast, kannst du <a href=\"/help/change-"
 "your-password\">es zurücksetzen</a>."
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr "E-Mail-Adresse"
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "Accounts finden"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr "Produkt"
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr "Warum Zulip"
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr "Features"
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr "Pläne & Preise"
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Zulip Cloud status"
 msgid "Zulip Cloud"
 msgstr "Zulip Cloud-Status"
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr "Selbst hosten"
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr "Sicherheit"
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "Integrationen"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr "Desktop- & Mobil-Apps"
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr "Neue Organisation"
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr "Lösungen"
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr "Business"
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr "Bildung"
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr "Forschung"
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr "Veranstaltungen & Konferenzen"
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr "Open-Source-Projekte"
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr "Gemeinschaften"
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr "Erfahrungen von Kunden"
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr "Offene Communities"
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr "Ressourcen"
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr "Loslegen"
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr "Hilfecenter"
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr "Community-Chat"
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr "Partner"
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr "Zulip Cloud-Status"
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr "Umzug zu Zulip"
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr "Einen Zulip-Server installieren"
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr "Einen Zulip-Server upgraden"
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr "Mitwirken"
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr "Leitfaden zur Mitwirkung"
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr "Entwickler-Community"
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr "Übersetzung"
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr "GitHub"
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr "Über uns"
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr "Team"
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "Verlauf"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr "Werte"
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr "Jobs"
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr "Blog"
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr "Zulip unterstützen"
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr "Mastodon"
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Values"
 msgid "Bluesky"
 msgstr "Werte"
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr "Unterstützt von <a href=\"https://zulip.com\">Zulip</a>"
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr "Nutzungsbedingungen"
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr "Datenschutzrichtlinie"
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr "Webseiten-Urheberschaft"
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr "Mehr als %(integrations_count_display)s native Integrationen."
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 #, fuzzy
 #| msgid ""
 #| "And hundreds more through <a href=\"/integrations/doc/zapier\">Zapier</a> "
@@ -4135,52 +3599,48 @@ msgstr ""
 "Und hunderte weitere mit <a href=\"/integrations/doc/zapier\">Zapier</a>, "
 "und <a href=\"/integrations/doc/ifttt\">IFTTT</a>."
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr "Integration suchen"
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr "Eigene Integrationen"
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr "Eingehende Webhooks"
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr "Interaktive Bots"
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr "REST API"
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr "Ungültige E-Mail-Adresse"
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr "E-Mail nicht erlaubt"
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr ""
 "Die E-Mail-Adresse, mit der du versuchst dich anzumelden, ist ungültig."
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4191,7 +3651,7 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>, erlaubt keine Anmeldungen über E-"
 "Mail-Adressen mit deiner E-Mail-Domäne."
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4202,7 +3662,7 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>, erlaubt keine Anmeldungen über "
 "Wegwerf-E-Mail-Adressen."
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4213,24 +3673,24 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>, erlaubt keine Anmeldungen über E-"
 "Mail-Adressen, die ein \"+\" enthalten."
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr "Bitte melde dich mit einer gültigen E-Mail-Adresse an."
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr "Bitte melde dich mit einer zulässigen E-Mail-Adresse an."
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr "Keine Organisation gefunden"
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr "Es gibt keine Zulip-Organisation bei <b>%(current_url)s</b>."
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -4241,7 +3701,7 @@ msgstr ""
 "\">erhalte eine Liste deiner Zulip Cloud-Accounts</a> oder <a href=\"mailto:"
 "%(support_email)s\">kontaktiere den Zulip-Support</a>."
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -4253,7 +3713,7 @@ msgstr ""
 "href=\"mailto:%(support_email)s\">kontaktiere die Administratoren dieses "
 "Servers</a>."
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
@@ -4262,61 +3722,61 @@ msgstr ""
 "<a href=\"%(current_url)s/serverlogin/\">Klicke hier</a>, um die "
 "Tarifverwaltung für deinen Zulip-Server aufzurufen."
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr "Ungültige oder abgelaufene Login-Sitzung"
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr "Ungültige oder abgelaufene Login-Sitzung."
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr "Bei Zulip anmelden"
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 "Du hast dich bereits mit dieser E-Mail-Adresse registriert. Bitte melde dich "
 "weiter unten an."
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr "E-Mail-Adresse oder Nutzername"
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "Nutzername"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr "Passwort vergessen?"
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr "Anmelden mit %(identity_provider)s"
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr "Ansicht ohne Account"
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 "Du hast noch keinen Account? Du musst eingeladen werden, um dieser "
 "Organisation beitreten zu können."
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr "Keine Lizenzen verfügbar"
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr "Die Organisation kann derzeit keine neuen Mitglieder aufnehmen"
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
@@ -4325,7 +3785,7 @@ msgstr ""
 "Neue Mitglieder können <a href=\"%(realm_url)s\">%(realm_name)s</a> nicht "
 "beitreten, da alle Zulip Cloud-Lizenzen verwendet werden."
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
@@ -4333,19 +3793,19 @@ msgstr ""
 "Bitte wende dich an die Person, die dich eingeladen hat, und bitten sie, die "
 "Anzahl der Lizenzen zu erhöhen. Versuche es dann erneut."
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr "Zum Hauptinhalt springen"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr "Fehler der Authentifizierungs-Subdomain"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr "Authentifizierungs-Subdomain"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -4360,18 +3820,17 @@ msgstr ""
 "sein, als du versucht hast, dich einzuloggen, ist es wahrscheinlich ein "
 "Serverfehler oder eine falsche Serverkonfiguration."
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 #, fuzzy
 #| msgid "No organization found"
 msgid "Demo organizations disabled"
 msgstr "Keine Organisation gefunden"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr "Update erforderlich"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
@@ -4379,7 +3838,7 @@ msgstr ""
 "Du nutzt eine alte Version der Zulip Desktop- App, die nicht mehr "
 "unterstützt wird."
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
@@ -4387,23 +3846,22 @@ msgstr ""
 "Das automatische Update in dieser alten Version der Zulip Desktop-App "
 "funktioniert nicht mehr."
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr "Lade die neuste Version herunter."
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 "Du hast das Limit überschritten, wie oft ein Nutzer diese Aktion durchführen "
 "kann."
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr "Es wird ein Link zum Erstellen der Organisation benötigt"
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -4416,12 +3874,11 @@ msgstr ""
 "organizations.html\">Dokumentation</a> über das Erstellen einer neuen "
 "Organisation an, um mehr zu erfahren."
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr "Der Link zum Erstellen der Organisation ist abgelaufen oder ungültig"
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
@@ -4430,11 +3887,11 @@ msgstr ""
 "Bitte <a href=\"/new/\">besorge dir einen neuen Link</a> und versuche es "
 "erneut."
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr "Unerwartete Zulip-Serverregistrierung"
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -4445,17 +3902,16 @@ msgstr ""
 "zugeordnet. Bitte <a href=\"mailto:%(support_email)s\">kontaktiere den Zulip-"
 "Support</a>, um Hilfe bei der Lösung dieses Problems zu erhalten."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr "Nicht unterstützter Browser"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr "%(browser_name)s wird von Zulip nicht unterstützt."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
@@ -4464,7 +3920,7 @@ msgstr ""
 "Zulip unterstützt <a href=\"%(supported_browsers_page_link)s\">moderne "
 "Browser</a> wie Firefox, Chrome und Edge."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
@@ -4472,21 +3928,20 @@ msgstr ""
 "Du kannst auch die <a href=\"%(apps_page_link)s\">Zulip Desktop-App</a> "
 "verwenden."
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr "Account ist deaktiviert"
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 msgid "Finalize organization import"
 msgstr "Organisationsimport abschließen"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 msgid "Organization import completed!"
 msgstr "Organisationsimport abgeschlossen!"
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -4497,57 +3952,56 @@ msgstr ""
 "Zulip verifiziert hast (<strong>%(verified_email)s</strong>). Wähle ein "
 "Konto, das mit deiner E-Mail-Adresse verknüpft werden soll."
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 msgid "Select your account"
 msgstr "Wähle deinen Account"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Create new account"
 msgstr "Erstelle deinen Account"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr "Organisation erfolgreich reaktiviert"
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr "Deine Organisation wurde erfolgreich reaktiviert."
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr ""
 "Der Link zur Reaktivierung der Organisation ist abgelaufen oder ungültig"
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr ""
 "Der Link zur Reaktivierung der Organisationen ist abgelaufen oder nicht "
 "länger gültig."
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr "Melde dich bei deiner Organisation an"
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr "deine-organisation"
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr "Du kennst die URL deiner Organisation nicht?"
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr "Finde deine Organisation."
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr "Nächste"
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4558,11 +4012,11 @@ msgstr ""
 "href=\"%(org_creation_link)s\">Erstelle eine neue Organisation</a>, wenn du "
 "noch keine hast."
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 msgid "Self-hosting Zulip?"
 msgstr "Hostest du Zulip selbst?"
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4572,11 +4026,11 @@ msgstr ""
 "href=\"%(self_hosted_login_help)s\">einloggen, um Preispläne und "
 "Rechnungswesen zu bearbeiten.</a>"
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr "Setze dein Passwort zurück"
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
@@ -4584,64 +4038,64 @@ msgstr ""
 "Passwort vergessen? Kein Problem, wir senden einen Link zum Zurücksetzen des "
 "Passworts an die Adresse, mit der du hier registriert bist."
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr "Reset-Link senden"
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr "Neues Passwort festlegen"
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "Passwort bestätigen"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr ""
 "Entschuldige, der von dir angegebene Link ist ungültig oder wurde schon "
 "verwendet."
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr "Neues Passwort erfolgreich festgelegt"
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr "Du hast ein neues Passwort festgelegt!"
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr ""
 "Bitte mit deinem neuen Passwort <a href=\"%(login_url)s\">anmelden</a>."
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr "E-Mail für das Zurücksetzen des Passworts gesendet"
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr "Zurücksetzungslink für Passwort gesendet!"
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr ""
 "Schau in einigen Augenblicken in deine E-Mails, um den Vorgang abzuschließen."
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr "Import von Slack"
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr "Importfortschritt"
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr "Prüfe Importstatus…"
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4649,7 +4103,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4662,15 +4116,15 @@ msgstr ""
 "rel=\"noopener noreferrer\" target=\"_blank\">diesen Anweisungen</a> um ein "
 "<strong>Bot User OAuth Token</strong> zu erhalten."
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr "Slack-Bot Benutzer OAuth token"
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr "Lade deine Slack-Exportdatei hoch"
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
@@ -4680,41 +4134,41 @@ msgstr ""
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">diesen Anweisungen</a> "
 "um den Export deiner Slack-Nachrichtenhistorie zu erhalten."
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 #, fuzzy
 #| msgid "Start import"
 msgid "Start upload"
 msgstr "Import starten"
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr "Hochgeladene Exportdatei"
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 #, fuzzy
 #| msgid ""
 #| "Nobody in this Zulip organization will be able to see this email address."
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr "Niemand in dieser Zulip-Organisation kann diese E-Mail-Adresse sehen."
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr "Import starten"
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
@@ -4722,7 +4176,7 @@ msgstr ""
 "Oder <span id=\"cancel-slack-import\" tabindex=\"0\">eine Organisation "
 "erstellen</span>, ohne Daten zu importieren."
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4730,7 +4184,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4738,21 +4192,21 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr "Wähle ein Konto für die Authentifizierung"
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr "<h1 class=\"get-started\">Account auswählen</h1>"
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 "Dein GitHub Account ist mit nicht verifizierten E-Mail-Adressen verbunden."
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
@@ -4760,15 +4214,15 @@ msgstr ""
 "Um eine davon zu nutzen, um dich bei Zulip einzuloggen, muss du sie erst <a "
 "href=\"https://github.com/settings/emails\">bei GitHub bestätigen.</a>"
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr "Fehler beim Abmelden der E-Mail-Adresse"
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr "Abmeldung für diese E-Mail-Adresse ist unbekannt"
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
@@ -4776,7 +4230,7 @@ msgstr ""
 "Hallo! Anscheinend hast du versucht, sich von etwas abzumelden, aber wir "
 "erkennen die URL nicht."
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4787,12 +4241,11 @@ msgstr ""
 "erneut, oder <a href=\"mailto:%(support_email)s\">sende uns eine E-Mail</a> "
 "und wir finden eine Lösung!"
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr "E-Mail-Einstellungen wurden aktualisiert"
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
@@ -4801,7 +4254,7 @@ msgstr ""
 "Du hast dich erfolgreich von Zulip %(subscription_type)s E-Mails für <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a> abgemeldet."
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
@@ -4811,51 +4264,50 @@ msgstr ""
 "<a href=\"%(realm_url)s/#settings/"
 "notifications\">Benachrichtigungseinstellungen</a> prüfen."
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr "Ungültige Anordungs-Zuweisung."
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr "Fragen und Diskussion über die Nutzung von Zulip."
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr "Experimentiere hier mit Zulip. :test_tube:"
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr "Für team-weite Unterhaltungen"
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr "Anmeldungen"
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr "{user} ist dieser Organisation beigetreten."
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr "{user} hat deine Einladung zum Beitritt zu Zulip angenommen!"
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 "Ein Platzhalterkonto kann nicht aktiviert werden; fordere den Nutzer "
 "stattdessen auf, sich zu registrieren."
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 #, fuzzy
 #| msgid "Cannot deactivate user group in use."
 msgid "Cannot reactivate a deleted user"
 msgstr "Kann Nutzergruppe in Benutzung nicht deaktivieren."
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
@@ -4863,35 +4315,34 @@ msgstr ""
 "Du darfst dieses Feld nicht ändern. Kontaktiere einen Administrator, um es "
 "zu aktualisieren."
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr "Die Feld-ID {id} konnte nicht gefunden werden."
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr "Ungültiger Standardkanal-Gruppenname '{group_name}'"
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr "Standardkanal-Gruppenname zu lang (Limit: {max_length} Zeichen)"
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr "Standardkanal-Gruppenname '{group_name}' enthält NULL-Zeichen (0x00)."
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr "Ungültige Standardkanal-Gruppe {group_name}"
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
@@ -4899,12 +4350,12 @@ msgstr ""
 "'{channel_name}' ist ein Standardkanal und kann nicht zu '{group_name}' "
 "hinzugefügt werden"
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr "Standard-Kanalgruppe '{group_name}' existiert bereits"
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
@@ -4913,7 +4364,7 @@ msgstr ""
 "Der Kanal '{channel_name}' existiert bereits in der Standard-Kanalgruppe "
 "'{group_name}'"
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
@@ -4922,12 +4373,12 @@ msgstr ""
 "Der Kanal '{channel_name}' existiert nicht in der Standard-Streamgruppe "
 "'{group_name}'"
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr "Diese Standardkanal-Gruppe heißt bereits '{group_name}'"
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
@@ -4936,7 +4387,7 @@ msgstr ""
 "pro Tag versenden kannst. Da du dieses Limit bereits erreicht hast, wurden "
 "keine Einladungen versandt."
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
@@ -4945,80 +4396,80 @@ msgstr ""
 "verschicken zu können. Frage eine Administrator der Organisation oder einen "
 "erfahreneren Nutzer."
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 "Einige E-Mail-Adressen konnten nicht validiert werden, deshalb wurden noch "
 "keine Einladungen gesendet."
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr "Kann niemanden mehr einladen."
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr "Nichts zu ändern"
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr "Direktnachrichten können nicht in Kanäle verschoben werden."
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr "Direktnachrichten können keine Themen haben."
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr "Ungültiger propagate_mode ohne Bearbeitung des Themas"
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr "Der allgemeine Chat kann nicht als gelöst markiert werden"
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 "Kann den Inhalt von Nachrichten nicht ändern, während der Kanal geändert wird"
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr "Widgets können nicht bearbeitet werden."
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr "Das Editieren von Nachrichten ist in deiner Organisation deaktiviert"
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr "Du bist nicht berechtigt, diese Nachricht zu bearbeiten"
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr "Das Editierlimit für diese Nachricht ist ausgelaufen"
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr "{user} hat dieses Thema als gelöst markiert."
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr "{user} hat dieses Thema als ungelöst markiert."
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr "Dieses Thema wurde von {user} nach {new_location} verschoben."
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr ""
 "Eine Nachricht wurde von {user} aus diesem Thema nach {new_location} "
 "verschoben."
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
@@ -5027,12 +4478,12 @@ msgstr ""
 "{changed_messages_count} Nachrichten wurden von {user} aus diesem Thema nach "
 "{new_location} verschoben."
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr "Dieses Thema wurde von {user} aus {old_location} hierher verschoben."
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
@@ -5040,7 +4491,7 @@ msgstr ""
 "[Eine Nachricht]({message_link}) wurde von {user} aus {old_location} hierher "
 "verschoben."
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
@@ -5049,69 +4500,66 @@ msgstr ""
 "{changed_messages_count} Nachrichten wurden von {user} aus {old_location} "
 "hierher verschoben."
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to resolve topics in this channel."
 msgstr ""
 "Du hast keine Berechtigung, Themen in diesem Kanal als gelöst zu markieren."
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr ""
 "Das Zeitlimit zum Bearbeiten des Themas dieser Nachricht ist abgelaufen."
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr "Du bist nicht berechtigt, diese Nachricht zu verschieben"
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr "Die Frist für das Ändern des Kanals dieser Nachricht ist abgelaufen"
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr "Ungültiges Flag: '{flag}'"
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr "Flag nicht editierbar: '{flag}'"
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr "Ungültige Nachrichten-Flag-Operation: '{operation}'"
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr "Ungültige Nachricht(en)"
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr "Kann Nachricht nicht rendern"
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr "Erwarte genau einen Kanal"
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr "Ungültiger Datentyp für Kanal"
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr "Ungültiger Datentyp für Empfänger"
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 "Empfängerlisten können E-Mail-Adressen oder Nutzer-IDs enthalten, aber nicht "
 "beides."
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
@@ -5120,7 +4568,7 @@ msgstr ""
 "Dein Bot {bot_identity} hat versucht, eine Nachricht an den Kanal mit der ID "
 "{channel_id} zu senden, aber es gibt keinen Kanal mit dieser ID."
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -5131,7 +4579,7 @@ msgstr ""
 "{channel_name} zu senden, aber dieser Kanal existiert nicht. Klicke [hier]"
 "({new_channel_link}), um ihn zu erstellen."
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
@@ -5140,30 +4588,30 @@ msgstr ""
 "Dein Bot {bot_identity} hat versucht, eine Nachricht an den Kanal "
 "{channel_name} zu senden. Der Kanal existiert, hat aber keine Abonnenten."
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr "Du bist nicht berechtigt, auf einige der Empfänger zuzugreifen."
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr "Widgets: Der API-Programmierer hat ungültiges JSON gesendet"
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr "Widgets: {error_msg}"
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, fuzzy, python-brace-format
 #| msgid "{user_name} created the following channels: {new_channels}."
 msgid "{user} has made the following changes to your account."
 msgstr "{user_name} hat die folgenden Kanäle angelegt: {new_channels}."
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5171,26 +4619,24 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr "Es existiert bereits ein eigenes Emoji mit diesem Namen."
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr "Ungültiges Bildformat"
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr "Die geordnete Liste darf keine doppelten Linkifier enthalten"
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 "Die geordnete Liste muss alle vorhandenen Linkifier genau einmal aufführen"
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
@@ -5199,42 +4645,42 @@ msgstr ""
 "Du musst zu dem Tarif {required_upgrade_plan_name} wechseln, um diese "
 "Authentifizierungsmethode zu verwenden."
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 "Ungültige Authentifizierungsmethode: {name}. Gültige Methoden sind: {methods}"
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 "Die Authentifizierungsmethode {name} ist in deinem aktuellen Tarif nicht "
 "verfügbar."
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr "Der Kanal für Moderationsanfragen muss privat sein."
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr "Gespeicherter Ausschnitt existiert nicht."
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr "Die geplante Nachricht wurde bereits gesendet"
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 #, fuzzy
 #| msgid "Reminder does not exist"
 msgid "Reminder could not be sent."
 msgstr "Erinnerung existiert nicht"
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr "Die Nachricht konnte zum geplanten Zeitpunkt nicht gesendet werden."
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
@@ -5243,38 +4689,38 @@ msgstr ""
 "Die für {delivery_datetime} geplante Nachricht wurde aufgrund des folgenden "
 "Fehlers nicht gesendet:"
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr "[Geplante Nachrichten anzeigen](#scheduled)"
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr "Kanal ist bereits deaktiviert"
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr "Kanal #**{channel_name}** wurde archiviert."
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr "Kanal ist derzeit nicht deaktiviert"
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr "Kanal mit dem Namen {channel_name} existiert bereits"
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr "Kanal ist Privat und hat keine Abonnenten"
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr "Kanal #**{channel_name}** wurde nicht archiviert."
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
@@ -5283,7 +4729,7 @@ msgstr ""
 "{user} hat die [Zugriffsrechte]({help_link}) für diesen Kanal von "
 "**{old_policy}** zu **{new_policy}** geändert."
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -5296,41 +4742,39 @@ msgstr ""
 "* **Alt**: {old_setting_description}\n"
 "* **Neu**: {new_setting_description}\n"
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 "{user_name} hat den Kanal {old_channel_name} in {new_channel_name} umbenannt."
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr "Keine Beschreibung."
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr "{user} hat die Beschreibung für diesen Kanal geändert."
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr "Alte Beschreibung"
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr "Neue Beschreibung"
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr "Für immer"
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr "{number_of_days} Tage"
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
@@ -5339,11 +4783,11 @@ msgstr ""
 "Nachrichten in diesem Kanal werden jetzt {number_of_days} Tage nach dem "
 "Versand gelöscht."
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr "Nachrichten in diesem Kanal werden jetzt für immer aufbewahrt."
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -5360,26 +4804,26 @@ msgstr ""
 "\n"
 "{summary_line}"
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr "Automatisch"
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr "*{empty_topic_display_name}* Thema erlaubt"
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr "Kein *{empty_topic_display_name}* Thema"
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr "Nur *{empty_topic_display_name}* Thema erlaubt"
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
@@ -5388,73 +4832,63 @@ msgstr ""
 "{user_name} änderte die \"Posten im *Allgemeiner Chat* Thema erlauben?\"-"
 "Einstellung von {old_topics_policy} zu {new_topics_policy}."
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr "Du kannst keine Unternachricht an diese Nachricht anhängen."
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr "Ungültige Nutzer-ID {user_id}"
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr "Nutzergruppe '{group_name}' existiert bereits."
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr "Unzureichende Berechtigungen"
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr "Diese API ist nicht zugänglich für \"Incoming Webhook\"-Bots."
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr "Der Account gehört nicht zu dieser Subdomain"
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr "Dieser Endpunkt akzeptiert keine Bot-Anfragen."
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr "Muss ein Server-Administrator sein"
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr "Dieser Endpunkt benötigt HTTP Basic Authentication."
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr "Ungültiger Authorization Header für Basic Auth"
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr "Fehlender Authentifikations-Header für Basic Auth"
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr "Webhook-Bots können nur auf Webhooks zugreifen"
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr "E-Mail-Adresse oder Passwort falsch."
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
@@ -5463,56 +4897,55 @@ msgstr ""
 "Dein Account {username} wurde deaktiviert. Bitte setze dich mit dem "
 "Administrator deiner Organisation in Verbindung, um ihn zu reaktivieren."
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr "Das Passwort ist zu schwach."
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr "Subdomain muss mindestens 3 Zeichen lang sein."
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr "Die Subdomain darf nicht mit einem '-' beginnen oder enden."
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr "Die Subdomain darf nur Kleinbuchstaben, Zahlen und '-' enthalten."
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr "Subdomain wird bereits verwendet. Bitte wähle eine andere."
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr "Subdomain bereits reserviert. Bitte wähle eine andere."
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr "Bitte benutze deine echte E-Mail-Adresse."
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr ""
 "Die Organisation, der du mit der E-Mail-Adresse {email} beitreten willst, "
 "existiert nicht."
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr ""
 "Bitte frage den Organisations-Administrator nach einer Einladung für {email}."
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 "Kann der Organisation nicht beitreten: Passwort-Authentifizierung ist nicht "
 "aktiviert."
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
@@ -5521,12 +4954,12 @@ msgstr ""
 "Deine E-Mail-Adresse {email} gehört zu keiner der für die Registrierung bei "
 "dieser Organisation erlaubten Domains."
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr ""
 "E-Mail-Adressen, die + enthalten, sind in dieser Organisation nicht erlaubt."
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
@@ -5537,32 +4970,31 @@ msgstr ""
 "eingeladen hat, und bitte sie, die Anzahl der Lizenzen zu erhöhen, und "
 "versuche es dann erneut."
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr "Verifiziert, das du ein menschlicher Nutzer bist!"
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr "Verifiziere, das du kein Bot bist…"
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 msgid "Challenges are not enabled."
 msgstr "Herausforderungen sind nicht aktiviert."
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr "Verifikation fehlgeschlagen, bitte versuche es erneut."
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "Neues Passwort"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr "Neues Passwort Bestätigung"
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "You're making too many attempts to sign in. Try again in {seconds} "
@@ -5575,7 +5007,7 @@ msgstr ""
 "erneut oder wende dich an deinen Organisations-Administrator, um Hilfe zu "
 "erhalten."
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
@@ -5583,86 +5015,84 @@ msgstr ""
 "Dein Passwort wurde deaktiviert, weil es zu schwach ist. Setze dein Passwort "
 "zurück, um ein neues zu erstellen."
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr "Token"
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr "Tipp: Du kannst mehrere E-Mail-Adressen mit Kommas getrennt eingeben."
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr "Bitte gib höchstens 10 E-Mail-Adressen ein."
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr "Wir konnten diese Zulip-Organisation nicht finden."
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr "Ungültige E-Mail '{email}'"
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr "Fehlendes Thema"
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr "Kann nicht an mehrere Kanäle senden"
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr "Fehlender Kanal"
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr "Nachricht muss Empfänger haben"
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr "Ungültiger Nachrichtentyp"
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr "Ungültiger Anhang"
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr ""
 "Beim Löschen des Anhangs ist ein Fehler aufgetreten. Bitte versuche es "
 "später erneut."
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr "Nachricht muss Empfänger haben!"
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name can't be empty."
 msgstr "Kanalordnername kann nicht leer sein."
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr "Ungültiges Zeichen in Kanalordnername an Position {position}."
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr "Kanalordnername wird bereits verwendet."
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 msgid "Invalid channel folder ID"
 msgstr "Ungültige Kanalordner-ID"
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 msgid "Configure owner account email address."
 msgstr "Besitzer-Account E-Mail-Adresse konfigurieren."
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "\n"
@@ -5684,72 +5114,72 @@ msgstr ""
 "[in eine permanente Organisation]({convert_demo_organization_help_url}) "
 "konvertiert.\n"
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a date"
 msgid "{var_name} is not Base64 encoded"
 msgstr "{var_name} ist kein Datum"
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 #, fuzzy
 #| msgid "Invalid emoji code."
 msgid "Invalid `device_id`"
 msgstr "Ungültiger Emoji-Code."
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr "{service_name} Zusammenfassung"
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr "Die Domain darf nicht leer sein."
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr "Die Domain muss mindestens einen Punkt (.) enthalten"
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr "Zu lange Domain"
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr "Die Domain darf nicht mit einem Punkt (.) beginnen oder enden"
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr "Aufeinanderfolgende '.' sind nich erlaubt."
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr "Subdomains dürfen nicht mit einem '-' beginnen oder enden."
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr "Domains dürfen nur Buchstaben, Zahlen, '.' und '-' enthalten."
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr "Zeitstempel darf nicht negativ sein."
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr "Thema darf keine Null-Bytes enthalten"
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr "Muss genau 1 Kanal-ID für Kanal-Nachrichten angeben"
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr "Nutzer hat die Synchronisierung der Entwürfe deaktiviert."
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr "Entwurf existiert nicht"
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5760,88 +5190,88 @@ msgstr ""
 "Antwortbenachrichtigung:\n"
 "{error_message}"
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr "E-Mail ohne Betreff"
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr "Öffne Zulip, um den Inhalt des Spoilers zu sehen"
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr "{service_name} Benachrichtigungen"
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr "Ungültige Adresse."
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr "Außerhalb deiner Domain."
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr "E-Mail-Adressen, die + enthalten, sind nicht erlaubt."
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr "Für System-Bots reserviert."
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr "Ein Account für {email} existiert bereits"
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr "Hat schon ein Konto."
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr "Account wurde deaktiviert."
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr "Emoji '{emoji_name}' existiert nicht"
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr "Ungültiges eigenes Emoji."
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr "Ungültiger Name für ein eigenes Emoji."
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr "Dieses eigene Emoji wurde deaktiviert."
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr "Ungültiger Emoji-Code."
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr "Ungültiger Emoji-Name."
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr "Ungültiger Emoji-Typ."
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr "Muss ein Organisations-Administrator oder Emoji-Autor sein"
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr ""
 "Namen von Emojis müssen entweder mit einem Buchstaben oder mit einer Zahl "
 "enden."
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
@@ -5849,96 +5279,95 @@ msgstr ""
 "Namen von Emojis dürfen nur aus Kleinbuchstaben ohne Umlauten, Zahlen, "
 "Leerzeichen, Strichen und Unterstrichen bestehen."
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr "Emoji-Bezeichnung fehlt"
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr "Kann Ereigniskette nicht zuteilen"
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr "Nicht angemeldet: API-Authentifizierung oder Nutzer-Session benötigt"
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr "Ein Kanal mit dem Namen '{channel_name}' existiert bereits"
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr "Kanal '{stream}' existiert nicht"
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr "Kanal mit ID '{stream_id}' existiert nicht"
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr "Nicht unterstützte Parameterkombination: {parameters}"
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr "Organisations-Besitzer"
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr "Nutzer"
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr "Mindestens eine/r/s {entity} muss aktiviert bleiben."
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr "Ungültiges Markdown-Include-Statement: {include_statement}"
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr "Fehlerhaftes JSON"
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr "Muss ein:e Organisations-Administrator:in sein"
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr "Muss ein:e Organisations-Besitzer:in sein"
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Must be an organization owner"
 msgid "Must be a bot user"
 msgstr "Muss ein:e Organisations-Besitzer:in sein"
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr "Dein Nutzername oder Passwort ist falsch"
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr "Diese Organisation wurde deaktiviert"
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
@@ -5946,24 +5375,24 @@ msgstr ""
 "Die Registrierung für die mobilen Push-Benachrichtigungen wurde für deinen "
 "Server deaktiviert"
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr ""
 "In dieser Organisation ist die Authentifikation mit Passwort ausgeschaltet"
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr "Dein Passwort wurde deaktiviert und muss zurückgesetzt werden"
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr "Ungültiger API-Schlüssel"
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr "Inkorrekter API-Schlüssel"
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
@@ -5972,28 +5401,27 @@ msgstr ""
 "Das Ereignis '{event_type}' wird derzeit vom Webhook {webhook_name} nicht "
 "unterstützt; ignoriere"
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 "Konnte die Anfrage nicht parsen: Hat {webhook_name} dieses Ereignis "
 "generiert?"
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr "Nutzer:in nicht authentifiziert"
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr "Ungültige Subdomain"
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 "Du hast keine Berechtigung, Direktnachrichten-Unterhaltungen zu starten."
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
@@ -6002,12 +5430,12 @@ msgstr ""
 "Nachrichten an {empty_topic_display_name} senden ist in diesem Kanal nicht "
 "erlaubt."
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr "Nur das Thema {empty_topic_display_name} ist in diesem Kanal erlaubt."
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
@@ -6017,20 +5445,20 @@ msgstr ""
 "Kanal im Thema {empty_topic_display_name} sein. Erwäge andere Themen "
 "umzubenennen oder zu löschen."
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr "Direktnachrichten sind in dieser Organisation deaktiviert."
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr ""
 "Diese Unterhaltung enthält keine Nutzer:innen, welche sie autorisieren kann."
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr "Zugang verweigert"
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
@@ -6040,15 +5468,15 @@ msgstr ""
 "{total_messages_in_topic} neuesten Nachrichten in diesem Thema zu "
 "verschieben."
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr "Reaktion existiert bereits."
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr "Reaktion existiert nicht."
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
@@ -6057,278 +5485,278 @@ msgstr ""
 "zugeordnet. Bitte kontaktiere den Zulip-Support, um Hilfe bei der Lösung "
 "dieses Problems zu erhalten."
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr "Organisation nicht registriert"
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 "Du bist nicht berechtigt, Kanal-Platzhalter-Erwähnungen in diesem Kanal zu "
 "nutzen."
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 "Du bist nicht berechtigt, Themen-Platzhalter-Erwähnungen in diesem Stream zu "
 "nutzen."
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr "'{field_name}' Wert entspricht nicht dem erwarteten Wert."
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr "'{setting_name}' muss eine System-Benutzergruppe sein."
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr "Kann Nutzergruppe in Benutzung nicht deaktivieren."
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr "Du bist nicht berechtigt, diesen Kanal zu administrieren."
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr "Du bist nicht berechtigt, Standard-Kanäle zu ändern."
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr "E-Mail-Adresse wird bereits verwendet."
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr "Die geplante Sendezeit muss in der Zukunft liegen."
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr "Ungültiger bouncer_public_key"
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr "Anfrage abgelaufen"
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr "Ungültige encrypted_push_registration"
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 "Server ist nicht zur Verwendung des Push-Benachrichtungsdienstes "
 "konfiguriert."
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Already has an account."
 msgid "Atlassian account ID"
 msgstr "Hat schon ein Konto."
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Behance username"
 msgstr "Ungültiger Name oder Nutzername"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Bitbucket username"
 msgstr "GitHub-Benutzername"
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Codeberg username"
 msgstr "Twitter-Benutzername"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Dribbble username"
 msgstr "GitHub-Benutzername"
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Facebook username"
 msgstr "Ungültiger Name oder Nutzername"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr "GitHub-Benutzername"
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "GitLab username"
 msgstr "GitHub-Benutzername"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Instagram username"
 msgstr "Twitter-Benutzername"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Mastodon"
 msgid "Mastodon profile"
 msgstr "Mastodon"
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Medium username"
 msgstr "GitHub-Benutzername"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Pinterest username"
 msgstr "Twitter-Benutzername"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Reddit username"
 msgstr "GitHub-Benutzername"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Snapchat username"
 msgstr "GitHub-Benutzername"
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Threads username"
 msgstr "Twitter-Benutzername"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "TikTok username"
 msgstr "Twitter-Benutzername"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Twitch username"
 msgstr "Twitter-Benutzername"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "Nutzername"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr "Unzulässige externe Kontoart"
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr "Integrations-Frameworks"
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 msgid "Video calling"
 msgstr "Videoanruf"
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr "Kontinuierliche Integration"
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr "Kundenbetreuung"
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr "Softwarebereitstellung"
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr "Entertainment"
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr "Kommunikation"
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr "Finanzen"
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr "Personal"
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr "Marketing"
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr "Verschiedenes"
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr "Monitoring"
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr "Projektmanagement"
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr "Produktivität"
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr "Versionsverwaltung"
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr "Nachricht darf nicht leer sein"
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr "Nachricht darf keine Null-Bytes enthalten"
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 "Du bist nicht berechtigt, die Nutzergruppe '{user_group_name}' zu erwähnen."
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "{reporting_user_mention} reported a DM sent by {reported_user_mention} to "
@@ -6340,7 +5768,7 @@ msgstr ""
 "{reporting_user_mention} hat eine DM von {reported_user_mention} an "
 "{recipient_mentions} und {last_user_mention} gemeldet."
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "{reporting_user_mention} reported a DM sent by {reported_user_mention} to "
@@ -6352,7 +5780,7 @@ msgstr ""
 "{reporting_user_mention} hat eine DM von {reported_user_mention} an "
 "{recipient_mentions} und {last_user_mention} gemeldet."
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "{reporting_user_mention} reported a DM sent by {reported_user_mention} to "
@@ -6364,74 +5792,74 @@ msgstr ""
 "{reporting_user_mention} hat eine DM von {reported_user_mention} an "
 "{recipient_mentions} und {last_user_mention} gemeldet."
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid "{fullname}'s moderation requests"
 msgid "{fullname} moderation"
 msgstr "{fullname}'s Moderationsanfragen"
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr "Ungültiger Begrenzungs-Operator: {desc}"
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr "Ungültiger Begrenzungs-Operator: {desc}"
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr "Doppelter Operator 'with'."
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr "Ungültiger Operator 'with'"
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr "Fehlendes 'anchor'-Argument."
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 #, fuzzy
 #| msgid "Missing 'anchor' argument."
 msgid "Missing 'anchor_date' argument."
 msgstr "Fehlendes 'anchor'-Argument."
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr "Ungültiger Anker"
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr "Operator {operator} nicht unterstützt."
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr "Operand {operand} wird nicht unterstützt."
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 msgid "Navigation view does not exist."
 msgstr "Navigationsansicht existiert nicht."
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr "Eine Anmerkung von {admin_group_syntax}:"
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6442,7 +5870,7 @@ msgstr ""
 "Um mehr zu erfahren, sieh dir unseren [Leitfaden zur Nutzung von Zulip für "
 "eine Klasse]({getting_started_url}) an!\n"
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6453,7 +5881,7 @@ msgstr ""
 "Um mehr zu erfahren, sieh dir unseren [Leitfaden für den Start]"
 "({getting_started_url}) an!\n"
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6464,7 +5892,7 @@ msgstr ""
 "Wir haben auch eine Anleitung [für die Einrichtung von Zulip für eine Klasse]"
 "({organization_setup_url}).\n"
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6475,7 +5903,7 @@ msgstr ""
 "Wir haben auch eine Anleitung, wie du [deine Organisation zu Zulip umziehst]"
 "({organization_setup_url}).\n"
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "\n"
@@ -6498,7 +5926,7 @@ msgstr ""
 "[in eine permanente Organisation]({convert_demo_organization_help_url}) "
 "konvertiert.\n"
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
@@ -6509,7 +5937,7 @@ msgstr ""
 "erleichtern. Du findest sie\n"
 "in deinem [Eingang](/#inbox).\n"
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6521,7 +5949,7 @@ msgstr ""
 "({navigation_tour_video_url}) zurückkehren für einen schnellen Überblick "
 "über die App.\n"
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6546,7 +5974,7 @@ msgstr ""
 "{demo_organization_text}\n"
 "\n"
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
@@ -6556,7 +5984,7 @@ msgstr ""
 "Du kannst [mobile und Desktop-Apps](/apps) [herunterladen](/apps).\n"
 "Zulip funktioniert auch wunderbar im Browser.\n"
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -6568,7 +5996,7 @@ msgstr ""
 "help/change-your-profile-picture) hinzuzufügen\n"
 "und deine [Profilinformation](/help/edit-your-profile) zu bearbeiten.\n"
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -6587,7 +6015,7 @@ msgstr ""
 "Erlebnis\n"
 "in den [Einstellungen](#settings/preferences) vornehmen.\n"
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6604,7 +6032,7 @@ msgstr ""
 "\n"
 "[Suche und abonniere Kanäle]({settings_link}).\n"
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -6635,7 +6063,7 @@ msgstr ""
 "Sieh dir [neueste Unterhaltungen](#recent) an für eine Liste der Themen die\n"
 "diskutiert werden.\n"
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -6650,7 +6078,7 @@ msgstr ""
 "\n"
 "Drücke jederzeit `?` um ein [Merkblatt](#keyboard-shortcuts) anzusehen.\n"
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -6669,7 +6097,7 @@ msgstr ""
 "Sieh dir das [Merkblatt](#message-formatting) an, um über Spoiler, globale\n"
 "Zeiten und mehr zu lernen.\n"
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6685,7 +6113,7 @@ msgstr ""
 "an,\n"
 "oder durchsuche das [Hilfe-Center](/help/), um mehr zu erfahren!\n"
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6696,7 +6124,7 @@ msgstr ""
 "Du kannst mit mir so viel chatten wie du möchtest! Um\n"
 "Hilfe zu erhalten, probiere eine der folgenden Nachrichten:: {bot_commands}\n"
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6715,7 +6143,7 @@ msgstr ""
 "oder sogar ein Thema in einen [anderen Kanal zu verschieben]"
 "({move_content_another_channel_help_url}).\n"
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
@@ -6724,7 +6152,7 @@ msgstr ""
 ":point_right: Versuche diese Nachricht in ein anderes Thema und zurück zu "
 "verschieben.\n"
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6748,12 +6176,11 @@ msgstr ""
 "Seitenleiste\n"
 "und oben sehen kannst.\n"
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr "willkommen bei Zulip!"
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -6765,7 +6192,7 @@ msgstr ""
 "Nachricht im Kontext siehst,\n"
 "unabhängig davon, wie viele verschiedene Diskussionen gerade stattfinden.\n"
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
@@ -6775,7 +6202,7 @@ msgstr ""
 ":point_right: Für mehr Unterhaltungen mit ungelesenen Nachrichten,\n"
 "prüfe deinen [Eingang](/#inbox) wenn du bereit bist.\n"
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -6787,7 +6214,7 @@ msgstr ""
 "Seitenleiste und klicke auf\n"
 "den `+` Button seinem Namen.\n"
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -6799,7 +6226,7 @@ msgstr ""
 "zu vervollständigen: “Hey,\n"
 "können wir über … reden?”\n"
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
@@ -6807,7 +6234,7 @@ msgstr ""
 "\n"
 ":point_right: Versuche eine neue Unterhaltung in diesem Kanal zu starten.\n"
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6818,7 +6245,7 @@ msgstr ""
 ":point_right:  Verwende dieses Thema um [Zulips Nachrichtenfunktionen]"
 "({format_message_help_url}) auszuprobieren.\n"
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6854,7 +6281,7 @@ msgstr ""
 "\n"
 "```\n"
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
@@ -6864,7 +6291,7 @@ msgstr ""
 "Dieses **Grüße**-Thema ist ein toller Ort um “hi” :wave: zu deinen Team-"
 "Mitgliedern zu sagen.\n"
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
@@ -6874,105 +6301,105 @@ msgstr ""
 ":point_right: Klicke auf diese Nachricht um eine neue Nachricht in derselben "
 "Unterhaltung zu beginnen.\n"
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr "Nachrichten verschieben"
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr "Experimente"
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr "Eine Unterhaltung beginnen"
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr "Grüße"
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr "Ungültige JSON-Antwort"
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr "Ungültiges Format der Antwort"
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr "Token leer oder Länge ungültig"
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr "Ungültiges APNS Token"
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr "Ungültiger GCM-Option zum Bouncer: Priorität {priority!r}"
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr "Ungültige GCM-Option zum Bouncer: {options}"
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr "Token existiert nicht"
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr "{full_name} hat @{user_group_name} erwähnt:"
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr "{full_name} hat dich erwähnt:"
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr "{full_name} hat alle erwähnt:"
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "Neue Nachricht"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr "Testbenachrichtigung"
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr "Dies ist eine Testbenachrichtigung von {realm_name} ({realm_url})."
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr "Gerät nicht erkannt"
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr "Gerät vom Push-Bouncer nicht erkannt"
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr "Kein aktives registriertes Push-Gerät"
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 "Netzwerkfehler beim Verbindungsaufbau mit dem Zulip Push-Benachrichtigungs-"
 "Dienst."
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 "Server verwendet den Dienst für Push-Benachrichtungen nicht, versuche es "
 "später wieder."
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
@@ -6981,46 +6408,44 @@ msgstr ""
 "dem Server, bitte wende dich an den Server-Administrator oder versuche es "
 "später wieder."
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 #, fuzzy
 #| msgid "Invalid API key"
 msgid "Invalid `push_key`"
 msgstr "Ungültiger API-Schlüssel"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr "Ungültiger Datentyp für Kanal-ID"
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr "Nutzer:in für diese Anfrage nicht autorisiert"
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr "'{email}' verwendet Zulip nicht mehr."
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr ""
 "Du kannst keine Direktnachrichten außerhalb deiner Organisation senden."
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr "Maximale Länger der Notiz für die Erinnerung: ({max_length} Zeichen)"
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "You requested a reminder for the following direct message. Note:\n"
@@ -7033,13 +6458,13 @@ msgstr ""
 "Notiz:\n"
 " > {note}"
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 #, fuzzy
 #| msgid "You requested a reminder for the following direct message."
 msgid "You requested a reminder for the following message."
 msgstr "Du hast eine Erinnerung für die folgende Direktnachricht angefordert."
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
@@ -7049,11 +6474,11 @@ msgstr ""
 "Notiz:\n"
 " > {note}"
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr "Du hast eine Erinnerung für die folgende Direktnachricht angefordert."
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{user_silent_mention} [sent]({conversation_url}) a todo list."
 msgid ""
@@ -7061,14 +6486,14 @@ msgid ""
 "{topic_pretty_link}."
 msgstr "{user_silent_mention} [sendete]({conversation_url}) eine Todo-Liste."
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{user_silent_mention} [said]({conversation_url}):"
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr "{user_silent_mention} [sagte]({conversation_url}):"
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{user_silent_mention} [sent]({conversation_url}) a todo list."
 msgid ""
@@ -7076,7 +6501,7 @@ msgid ""
 "{list_of_recipient_mentions}."
 msgstr "{user_silent_mention} [sendete]({conversation_url}) eine Todo-Liste."
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{user_silent_mention} [said]({conversation_url}):"
 msgid ""
@@ -7084,566 +6509,550 @@ msgid ""
 "{list_of_recipient_mentions}:"
 msgstr "{user_silent_mention} [sagte]({conversation_url}):"
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{user_silent_mention} [sent]({conversation_url}) a todo list."
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr "{user_silent_mention} [sendete]({conversation_url}) eine Todo-Liste."
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{user_silent_mention} [sent]({conversation_url}) a todo list."
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr "{user_silent_mention} [sendete]({conversation_url}) eine Todo-Liste."
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 msgid "Reminder does not exist"
 msgstr "Erinnerung existiert nicht"
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr "Push-Benachrichtigungen-Bouncer-Fehler: {error}"
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr ""
 "Kann nicht zwischen den Parametern '{var_name1}' und '{var_name2}' "
 "entscheiden"
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr "Fehlendes Argument '{var_name}'"
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr "Ungültiger Wert für '{var_name}': {bad_value}"
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr "Die geplante Nachricht ist nicht vorhanden"
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr "{service_name} Accountsicherheit"
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr "Ein Standardkanal kann nicht privat sein."
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr "Im Netz öffentliche Kanäle sind nicht aktiviert."
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr "Du bist nicht berechtigt, in diesem Kanal zu posten."
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr "Nicht zum Senden in den Kanal '{channel_name}' autorisiert"
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 #, fuzzy
 #| msgid "You don't have permission to resolve topics in this channel."
 msgid "You do not have permission to create new topics in this channel."
 msgstr ""
 "Du hast keine Berechtigung, Themen in diesem Kanal als gelöst zu markieren."
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr "Ungültige Kanal-ID"
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr "Ungültiger Kanalname '{channel_name}'"
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr "Kanal(e) ({channel_names}) existieren nicht"
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr "Standard-Kanalgruppe mit der ID '{group_id}' existiert nicht."
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr "Kanalname kann nicht leer sein."
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr "Kanalname zu lang (Limit: {max_length} Zeichen)."
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr "Ungültiges Zeichen in Kanalname an Position {position}."
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr "Ungültiges Zeichen im Thema an Position {position}!"
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr "Daten zu Abonnent:innen dieses Kanals sind nicht verfügbar"
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr "Kann Abonnent:innen des privaten Kanals nicht laden"
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr "Konnte das Bild nicht dekodieren; hast du eine Bilddatei hochgeladen?"
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr "Bildgröße überschreitet das Limit."
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr "Bild beschädigt oder abgeschnitten"
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr "{var_name} ist kein Boolean"
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} does not have the expected format"
 msgstr "{var_name} hat nicht das erwartete Format"
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr "{var_name} ist kein Datum"
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr "{var_name} ist kein Dict"
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr "Ungültige {var_name}"
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr "Unerwartetes Argument \"{argument}\" bei {var_name}"
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr "{var_name} ist kein Float"
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr "{var_name} ist zu klein"
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr "{var_name} ist kein Integer"
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr "{var_name} ist kein gültiges JSON"
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr "{var_name} ist zu groß"
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr "{var_name} ist keine Liste"
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr "{var_name} ist zu lang (Limit: {max_length} Zeichen)"
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr "{var_name} ist zu kurz."
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr "{var_name} ist kein String"
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr "{var_name} hat ein ungültiges Format"
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr "{var_name} hat nicht die Länge {length}"
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr "{var_name} ist zu lang (Limit: {max_length} Zeichen)"
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr "{var_name} ist zu lang (Limit: {max_length} Zeichen)"
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr "{var_name} darf nicht leer sein"
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr "Ungültige {var_name}: {msg}"
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr "Feld {var_name} fehlt: {msg}"
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr "Fehlerhafter Payload"
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr "Nicht in der Liste der möglichen Werte"
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr "Keine URL"
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr "Keine bekannte Zeitzone"
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr "{var_name} ist kein gültiger Hex-Farbcode"
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr "Ungültige {setting_name}"
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr ""
 "Dieser Upload würde das Upload-Budget deiner Organisation überschreiten."
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr "Bildgröße überschreitet das Limit"
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr "Nutzergruppe ist deaktiviert."
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr "Ungültige Nutzergruppe"
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid user group ID: {group_id}"
 msgid "Invalid user group ID: {user_group_id}"
 msgstr "Ungültige Nutzergruppen-ID: {group_id}"
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr "Ungültiger Systemgruppenname."
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr "Ungültige Nutzergruppen-ID: {group_id}"
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 "Einstellung '{setting_name}' kann nicht auf Gruppe 'role:internet' gesetzt "
 "werden."
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 "Einstellung '{setting_name}' kann nicht auf Gruppe 'role:nobody' gesetzt "
 "werden."
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 "Einstellung '{setting_name}' kann nicht auf Gruppe 'role:everyone' gesetzt "
 "werden."
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 "Einstellung '{setting_name}' kann nicht auf Gruppe '{group_name}' gesetzt "
 "werden."
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr "Nutzergruppen-Name darf nicht leer sein!"
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr "Nutzergruppen-Name darf nicht länger als {max_length} Zeichen sein."
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr "Nutzergruppen-Name darf nicht mit '{prefix}' beginnen."
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr "Der Client hat keine neuen Werte übertragen."
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 "Der Client muss emoji_name mitsenden, wenn er entweder emoji_code oder "
 "reaction_type sendet."
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr "Name zu lang!"
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 msgid "Name must not be empty!"
 msgstr "Name darf nicht leer sein!"
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr "Ungültige Zeichen im Namen!"
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr "Ungültiges Format!"
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr "In dieser Organisation sind einzigartige Namen erforderlich."
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr "Name wird bereits verwendet."
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr "Ungültiger Name oder Nutzername"
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr "Ungültige Integration '{integration_name}'."
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr "Fehlende Konfigurationsparameter: {keys}"
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr "Ungültiger {key}-Wert {value} ({error})"
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr "Ungültige Konfigurationsdaten!"
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr "Ungültiger Bottyp"
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr "Ungültiger Interface-Typ"
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr "Ungültige Nutzer-ID: {user_id}"
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr "Bot nicht vorhanden"
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr "Nutzer:in nicht vorhanden"
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr "Nutzer:in ist deaktiviert"
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr "{item} darf nicht leer sein."
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr ""
 "{var_name} hat die ungültige Länge {length}; korrekt ist {target_length}"
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a string"
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr "{var_name} ist kein String"
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr "{container} sollte genau aus {length} Elementen bestehen"
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr "Der Key {key_name} fehlt in {var_name}"
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr "Unerwartete Argumente: {keys}"
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr "{var_name} ist kein allowed_type"
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr "{variable} != {expected_value} ({value} ist falsch)"
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr "{var_name} ist keine URL"
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr "Das URL-Muster muss '%(username)s' enthalten."
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr "'{item}' darf nicht leer sein."
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr "Das Feld darf keine doppelten Auswahloptionen haben."
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr "'{value}' ist keine gültige Option für '{field_name}'."
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr "{var_name} ist kein String oder Integer-Liste"
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr "{var_name} ist kein String oder Integer"
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr "{var_name} hat keine Länge"
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr "{var_name} fehlt"
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr "Unbekannte 'PresetUrlOption': {config}"
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr "Der HTTP-Eventheader '{header}' fehlt"
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr "Der Algorithmus '{algorithm}' wird nicht unterstützt."
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
@@ -7651,105 +7060,105 @@ msgstr ""
 "Das Secret des Webhooks fehlt. Bitte setze das webhook_secret beim "
 "Generieren der URL."
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr "Verifikation der Webhook-Signatur fehlgeschlagen."
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr "Das zcommand sollte einen vorangestellten Schrägstrich enthalten."
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr "Befehl nicht vorhanden: {command}"
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr "`zulip_update_announcements_stream` ist unerwartet deaktiviert."
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr "CSRF-Fehler: {reason}"
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr "Reverse-Proxy-Fehlkonfiguration: {proxy_reason}"
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr "Ungültige Nutzer-IDs: {invalid_ids}"
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr "Nutzer:in mit ID {user_id} ist deaktiviert"
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr "Nutzer:in mit ID {user_id} ist ein Bot"
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr "Datum"
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr "Externer Account"
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr "Pronomen"
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr "Niemand"
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr "vollwertige Mitglieder"
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "Mitglieder"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr "Alle im Internet"
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Invalid characters in emoji name"
 msgid "Invalid auto-conversion field: empty field name."
 msgstr "Der Emoji-Name enthält ungültige Zeichen"
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid ""
@@ -7757,51 +7166,51 @@ msgid ""
 msgstr ""
 "Gruppe %(name)r in der URL-Vorlage ist nicht im Linkifier-Muster enthalten."
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr "Ungültiger regulärer Ausdruck: {regex}"
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr "Fehler: Unbekannter regulärer Ausdruck"
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr "Ungültige URL-Vorlage."
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid "Example input does not match the linkifier pattern."
 msgstr ""
 "Gruppe %(name)r in der URL-Vorlage ist nicht im Linkifier-Muster enthalten."
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 "Gruppe %(name)r in der URL-Vorlage ist nicht im Linkifier-Muster enthalten."
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 "Gruppe %(name)r im Linkifier-Muster ist nicht in der URL-Vorlage enthalten."
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid ""
@@ -7810,7 +7219,7 @@ msgid ""
 msgstr ""
 "Gruppe %(name)r in der URL-Vorlage ist nicht im Linkifier-Muster enthalten."
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgid ""
@@ -7819,341 +7228,338 @@ msgid ""
 msgstr ""
 "Gruppe %(name)r im Linkifier-Muster ist nicht in der URL-Vorlage enthalten."
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr "Unicode Emoji"
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "Eigene Emoji"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr "Zulip Extra-Emoji"
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr "Der Emoji-Name enthält ungültige Zeichen"
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr "Die pygments Sprache enthält ungültige Zeichen"
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr "Erforderliche Variable \"code\" fehlt in der URL-Vorlage"
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr ""
 "\"code\" sollte die einzige Variable sein, die in der URL-Vorlage enthalten "
 "ist"
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr "Sandbox"
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr "allgemein"
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr "Kanalereignisse"
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr "Spam"
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr "Belästigung"
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr "Unangemessene Inhalte"
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr "Verstößt gegen Community-Normen"
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr "anderer Grund"
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr "Zulip-Updates"
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr "Auf Zulip Cloud Standard verfügbar. Upgraden, um darauf zuzugreifen."
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr "Auf Zulip Cloud Standard verfügbar. Upgrade, um darauf zuzugreifen."
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr "GIFs mit der Bewertung \"G\" zulassen (Level 2: allgemeines Publikum)"
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr "GIFs mit der Bewertung \"PG\" zulassen (Level 3: Kindersicherung)"
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 "GIFs mit der Bewertung \"PG-13\" zulassen (Level 4: Jugendschutz - unter 13 "
 "Jahren)"
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr ""
 "GIFs mit der Bewertung \"R\" zulassen (Level 5: nicht für Jugendliche "
 "geeignet)"
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr "öffentlich im Netz"
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "Öffentlich"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr "Privat, geteilter Verlauf"
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr "Privat, geschützter Verlauf"
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr "Administratoren, Moderatoren, Mitglieder und Gäste"
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr "Administratoren, Moderatoren und Mitglieder"
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr "Administratoren und Moderatoren"
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr "Nur Administratoren"
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr "Unbekannte:r Nutzer:in"
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr "Organisations-Besitzer:in"
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr "Organisations-Administrator:in"
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr "Moderator:in"
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "Mitglied"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "Gast"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr "Unbekannte IP-Adresse"
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr "ein unbekanntes Betriebssystem"
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr "Ein unbekannter Browser"
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr "Fehlendes Argument 'query_id'"
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr "Fehlendes Argument 'last_event_id'"
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr "Ein neueres Ereignis als {event_id} ist bereits entfernt worden!"
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr "Ereignis {event_id} war nicht in dieser Warteschlange enthalten"
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr "Ungültige Event-Queue-ID: {queue_id}"
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 msgid "Failed to generate challenge"
 msgstr "Generierung der Challenge fehlgeschlagen"
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr "JWT-Authentifizierung ist für diese Organisation nicht aktiviert"
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr "Kein JSON Web-Token in diesem Request vorhanden"
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr "Ungültiges JSON Web-Token"
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr "In den Claims des JSON Web-Tokens wurde keine E-Mail-Adresse angegeben"
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr "Subdomain benötigt"
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr "Das Passwort stimmt nicht."
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 "Du musst alle Kanäle aus diesem Ordner entfernen, um ihn zu archivieren."
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr "User-Agent Header fehlt im Request"
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr "Beschriftung darf nicht leer sein."
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr "Feld muss mindestens eine Auswahloption haben."
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr "Feldtyp kann in der Profilzusammenfassung nicht angezeigt werden."
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 #, fuzzy
 #| msgid "Field type not supported for display in profile summary."
 msgid "Field type not supported for use for user matching."
 msgstr "Feldtyp kann in der Profilzusammenfassung nicht angezeigt werden."
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr "Ungültiger Feldtyp."
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 "Nur 2 eigene Profilfelder können der Profilzusammenfassung angezeigt werden."
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr "Es gibt schon ein Feld mit dieser Beschriftung."
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr "Nutzerdefiniertes Standard-Feld kann nicht aktualisiert werden."
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr "Dieser Endpunkt ist im Betriebsmodus nicht verfügbar."
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr "DevAuthBackend ist nicht aktiviert."
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr "Ungültiger '{key}'-Parameter für anonyme Anfrage"
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr "Datenbank ist leer"
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr "Keine Abfrage von postgresql möglich"
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr "Kann keine Verbindung zu rabbitmq herstellen"
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr "Keine Abfrage von rabbitmq möglich"
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr "Keine Abfrage von redis möglich"
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr "Kein Schreiben in memcached möglich"
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr "Keine Abfrage von memcached möglich"
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr "Einladung nicht vorhanden"
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 #, fuzzy
 #| msgid "Invitation has already been revoked"
 msgid "Invitation already used or deactivated."
 msgstr "Die Einladung wurde bereits widerrufen"
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr "Die Einladung wurde bereits widerrufen"
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 "Ungültige Kanal-ID {channel_id}. Es wurden keine Einladungen versendet."
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr ""
 "Du bist nicht berechtigt, andere Nutzer:innen für Kanäle zu abonnieren."
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr "Du musst mindestens eine E-Mail-Adresse angeben."
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
@@ -8162,102 +7568,100 @@ msgstr ""
 "wurden an diese keine Einladungen gesendet. An alle übrigen wurden "
 "Einladungen gesendet!"
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr ""
 "Die Anzeige des Bearbeitungsverlaufs von Nachrichten ist in dieser "
 "Organisation deaktiviert"
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr "Du bist nicht berechtigt, diese Nachricht zu löschen"
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr "Das Zeitlimit für das Entfernen dieser Nachricht ist überschritten"
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr "Nachricht ist bereits gelöscht"
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr "Zu viele Nachrichten angefordert (Maximum {max_messages})."
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr "Der Anker kann nur am Ende des Bereichs ausgeschlossen werden"
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr "Thema '{topic}' nicht vorhanden"
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr "Eine Erklärung ist erforderlich."
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 msgid "Message reporting is not enabled in this organization."
 msgstr "Das Melden von Nachrichten ist in dieser Organisation nicht aktiviert."
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr "Fehlende:r Absender:in"
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr "Mirroring mit Empfänger-Nutzer-IDs nicht erlaubt"
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr "Ungültige gespiegelte Nachricht"
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr "KI-Funktionen sind auf diesem Server nicht aktiviert."
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr "Monatliches Limit von KI-Credits erreicht."
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr "Keine Nachrichten zur Zusammenfassung in Unterhaltung"
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr "Kann sich nicht selbst stummstellen"
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr "Nutzer:in ist bereits stummgeschaltet"
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr "Nutzer:in ist nicht stummgeschaltet"
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr "Eingebaute Ansichten können keine benutzerdefinierte Namen haben."
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr "Eigene Ansichten müssen einen gültigen Namen haben."
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 msgid "Navigation view already exists."
 msgstr "Navigationsansicht existiert bereits."
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr "Unbekannter onboarding_step: {onboarding_step}"
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -8269,58 +7673,58 @@ msgstr ""
 "({navigation_tour_video_url}) später ansehen zu wollen. Ist das eine gute "
 "Zeit?\n"
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr "Anwesenheitsinformationen werden bei Bots nicht unterstützt."
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr "Keine Anwesenheitsdaten für {user_id_or_email}"
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr "Ungültiger Status: {status}"
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 #, fuzzy
 #| msgid "You do not have permission to change default channels."
 msgid "You do not have permission to manage plans and billing."
 msgstr "Du bist nicht berechtigt, Standard-Kanäle zu ändern."
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr "Server verwendet den Dienst für Push-Benachrichtungen nicht"
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr "Vom Bouncer zurückgegebener Fehler: {result}"
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr "Verifizierungsgeheimnis nicht vorbereitet"
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
@@ -8328,50 +7732,50 @@ msgstr ""
 "Mindestens eines der folgenden Argumente muss gegeben sein: emoji_name, "
 "emoji_code"
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr "Empfangsbestätigungen sind in dieser Organisation deaktiviert."
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr "Ungültige Sprache '{language}'"
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr "Es muss mindestens eine Authentifizierungs-Möglichkeit aktiviert sein."
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr "Ungültiger video_chat_provider {video_chat_provider}"
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid giphy_rating {giphy_rating}"
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr "Ungültiges giphy_rating {giphy_rating}"
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr "Muss eine Demo-Organisation sein."
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
@@ -8379,7 +7783,7 @@ msgstr ""
 "Löschzeitpunkt für Daten darf höchstens {max_allowed_days} Tage in der "
 "Zukunft liegen."
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
@@ -8387,232 +7791,231 @@ msgstr ""
 "Löschzeitpunkt für Daten muss mindestens {min_allowed_days} Tage in der "
 "Zukunft liegen."
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr "Ungültige Domain: {error}"
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr "Die Domain {domain} gehört schon zu deiner Organisation."
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr "Keinen Eintrag für die Domain {domain} gefunden."
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr "Du musst genau eine Datei hochladen."
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr "Nur Administrator:innen können die Standard-Emoji überschreiben."
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr ""
 "Hochgeladene Datei ist größer als das erlaubte Maximum von {max_size} MiB"
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 #, fuzzy
 #| msgid "JWT authentication is not enabled for this organization"
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr "JWT-Authentifizierung ist für diese Organisation nicht aktiviert"
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr "Überschreitung des Grenzwertes."
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr "Ungültige Daten-Export-ID"
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr "Export ist bereits gelöscht"
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr "Export fehlgeschlagen, nichts zu löschen"
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr "Export läuft noch"
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr "Du musst genau ein Icon hochladen."
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr "Linkifier nicht gefunden."
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr "Du must genau ein Logo hochladen."
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid characters in pygments language"
 msgid "Invalid character in language: {character}"
 msgstr "Die pygments Sprache enthält ungültige Zeichen"
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid language '{language}'"
 msgid "Language '{language}' is not allowed."
 msgstr "Ungültige Sprache '{language}'"
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr "Ungültige Spielwiese"
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr "Import kann nicht abgebrochen werden, nachdem er gestartet wurde."
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr "Nicht authentifiziert"
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 msgid "Importing messages…"
 msgstr "Importiere Nachrichten…"
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr "Importiere Anhangsdaten…"
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr "Importiere konvertierte Slack-Daten…"
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr "Finalisiere Import…"
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr "Erledigt!"
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr "Keine Nutzer entsprechen der angegebenen E-Mail-Adresse."
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "Your full name"
 msgid "Your name"
 msgstr "Dein vollständiger Name"
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr ""
 "Beim Aktualisieren des Typs der geplanten Nachricht ist ein:e Empfänger:in "
 "erforderlich."
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 "Thema erforderlich, wenn der Typ der geplanten Nachricht auf Kanal "
 "aktualisiert wird."
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr "Ungültiges Anfrageformat"
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr "Ungültige DSN"
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr "Private Kanäle können nicht als Standard gesetzt werden."
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr "Du musst \"new_description\" oder \"new_group_name\" übergeben."
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr "Ungültiger Wert für \"op\". Gib \"add\" oder \"remove\" an."
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr "Ungültige Parameter"
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr "Zugriff auf Inhalt des Kanals ist erforderlich."
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr "Der Kanal hat schon diesen Namen."
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr "Es gibt nichts zu tun. Gib mindestens \"add\" oder \"delete\" an."
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr "{user_full_name} hat dich zum Kanal {channel_name} hinzugefügt."
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr "{user_full_name} hat dich zu den folgenden Kanälen hinzugefügt:"
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr "Kann auf Kanal ({channel_name}) nicht zugreifen."
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr "{user_name} hat die folgenden Kanäle angelegt: {new_channels}."
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr "{user_name} hat den neuen Kanal {new_channels} angelegt."
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr "neue Kanäle"
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 "**Öffentlich im Netz** Kanal erstellt von {user_name}. **Beschreibung:**"
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr "**Öffentlicher** Kanal erstellt von {user_name}. **Beschreibung:**"
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
@@ -8620,7 +8023,7 @@ msgstr ""
 "**Privat, gemeinsamer Verlauf** Kanal erstellt von {user_name}. "
 "**Beschreibung:**"
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
@@ -8629,26 +8032,26 @@ msgstr ""
 "**Privat, geschützter Verlauf** Kanal erstellt von {user_name}. "
 "**Beschreibung:**"
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr "{property} ist kein Boolean"
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr "Unbekannte Abonnementeigenschaft: {property}"
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr "Kanal-ID {channel_id} nicht abonniert"
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr "Ungültiges JSON für Subnachricht"
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
@@ -8657,7 +8060,7 @@ msgstr ""
 "Datei ist größer als die maximale Upload-Größe ({max_size} MiB), die von "
 "deiner Organisation erlaubt ist."
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
@@ -8666,7 +8069,7 @@ msgstr ""
 "Datei ist größer als die auf diesem Server konfigurierte maximale Upload-"
 "Größe ({max_size} MiB)."
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
@@ -8675,54 +8078,53 @@ msgstr ""
 "Hochgeladene Datei ist größer als das erlaubte Maximum von {max_file_size} "
 "MiB"
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 "Nutzer:in hat die Schreibbenachrichtigungen für Kanalnachrichten deaktiviert"
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr "Fehlendes Argument 'to'"
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr "Kein Eintrag für 'to'-Empfänger"
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr ""
 "Nutzer:in hat die Schreibbenachrichtigungen für Direktnachrichten deaktiviert"
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr "<p>Diese Datei existiert nicht oder wurde gelöscht.</p>"
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr "<p>Du bist nicht dazu autorisiert, auf diese Datei zuzugreifen.</p>"
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr "Ungültiger Token"
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr "Ungültiger Dateiname"
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr "Du musst mindestens eine Datei zum Hochladen auswählen"
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr "Du kannst nur eine Datei auf einmal hochladen"
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr "Keine neuen Daten übergeben"
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
@@ -8730,33 +8132,33 @@ msgstr ""
 "Nichts zu tun. Gibt mindestens \"add\", \"delete\", \"add_subgroups\" or "
 "\"delete_subgroups\" an."
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr "{user_full_name} hat dich zu der Gruppe {group_name} hinzugefügt."
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr "{user_full_name} hat dich aus der Gruppe {group_name} entfernt."
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr "Nutzer:in {user_id} ist bereits Mitglied dieser Gruppe"
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr "Es gibt kein Mitglied '{user_id}' in dieser Nutzergruppe"
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr ""
 "Die Nutzergruppe {group_id} ist bereits eine Untergruppe dieser Gruppe."
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
@@ -8765,108 +8167,108 @@ msgstr ""
 "Nutzergruppe {user_group_id} ist bereits eine Untergruppe einer der "
 "angegebenen Untergruppen."
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr "Die Nutzergruppe {group_id} ist keine Untergruppe dieser Gruppe."
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr "Änderungen am Avatar sind in dieser Organisation deaktiviert."
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr ""
 "Die Änderung von E-Mail-Adressen ist für diese Organisation deaktiviert."
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr "Ungültige default_language"
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr "Ungültiger Benachrichtigungs-Ton: '{notification_sound}'"
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr "Ungültiger E-Mail-Batching-Zeitraum: {seconds} Sekunden"
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr "Dein Zulip-Passwort wird von LDAP verwaltet"
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr "Falsches Passwort!"
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, fuzzy, python-brace-format
 #| msgid "You're making too many attempts! Try again in {seconds} seconds."
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr ""
 "Du brauchst zu viele Versuche! Probiere es in {seconds} Sekunden erneut."
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr "Neues Passwort ist zu schwach!"
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr "Du musst genau einen Avatar hochladen."
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr "Thema ist nicht stummgestellt"
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr ""
 "Der:die einzige Organisations-Besitzer:in kann nicht deaktiviert werden"
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Nobody in this Zulip organization will be able to see this email address."
 msgid "User is not allowed to delete other user's messages."
 msgstr "Niemand in dieser Zulip-Organisation kann diese E-Mail-Adresse sehen."
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr "Nutzer:in nicht berechtigt, E-Mail-Adressen von Nutzer:innen zu ändern"
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 "Die Eigentümerberechtigung kann dem:der einzigen Organisations-Besitzer:in "
 "nicht entzogen werden."
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr "Ungültige neue E-Mail-Adresse."
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr "Fehler bei neuer E-Mail-Adresse: {message}"
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
@@ -8879,27 +8281,27 @@ msgstr ""
 "sein.\n"
 "Bitte kontaktiere deine:n Server-Administrator:in."
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 #, fuzzy
 #| msgid "Email is already in use."
 msgid "Email address already in use"
 msgstr "E-Mail-Adresse wird bereits verwendet."
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr "Änderung des Besitzers fehlgeschlagen, Nutzer:in nicht vorhanden"
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr "Änderung des Besitzers fehlgeschlagen, Nutzer:in ist deaktiviert"
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr ""
 "Änderung des:der Besitzer:in fehlgeschlagen, Bots können keine anderen Bots "
 "besitzen"
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
@@ -8908,140 +8310,140 @@ msgstr ""
 "sein.\n"
 "Bitte kontaktiere deine:n Server-Administrator:in."
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr "Eingebettete Bots sind nicht aktiviert."
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr "Ungültiger Name für einen eingebetteten Bot."
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr "Nutzer:in nicht berechtigt, Nutzer:innen anzulegen"
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr "E-Mail-Adresse '{email}' ist in dieser Organisation nicht erlaubt"
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr "Wegwerf-E-Mail-Adressen sind in dieser Organisation nicht erlaubt"
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom access token"
 msgid "Invalid {provider_name} access token"
 msgstr "Ungültiger Zoom-Access-Token"
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} call"
 msgstr "Konnte keinen Anruf über Zoom erstellen"
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Zoom credentials have not been configured"
 msgid "{provider_name} credentials have not been configured"
 msgstr "Die Zoom-Zugangsdaten wurden noch nicht konfiguriert"
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom credentials"
 msgid "Invalid {provider_name} credentials"
 msgstr "Ungültige Zoom-Zugangsdaten"
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error connecting to the BigBlueButton server."
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr "Fehler bei der Verbindung zum BigBlueButton-Server."
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error authenticating to the BigBlueButton server."
 msgid "Error authenticating to the {provider_name} server"
 msgstr "Fehler bei der Authentifikation am BigBlueButton-Server."
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "BigBlueButton server returned an unexpected error."
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr "Der BigBlueButton-Server gab eine unerwartete Fehlermeldung zurück."
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom session identifier"
 msgid "Invalid {provider_name} session identifier"
 msgstr "Ungültiger Zoom-Session-Identifier"
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr "Unbekannte Zoom-Nutzer-E-Mail-Adresse"
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} public room."
 msgstr "Konnte keinen Anruf über Zoom erstellen"
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr "Ungültige Signatur."
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{full_name}'s Zulip room"
 msgstr "{full_name} hat dich erwähnt:"
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 "Projekte, welche diesen Anbieter für Versionsverwaltung nutzen, werden nicht "
 "unterstützt"
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr "Ungültige Payload"
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr "Unbekannte Webhook-Anfrage"
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr "Thema kann nicht leer sein"
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr "Inhalt kann nicht leer sein"
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr "Jotform Payload konnte nicht bearbeitet werden"
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr "Fehlerhafte JSON-Eingabe"
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr "Events-Key fehlt im Payload"
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr "Fehler: channels_map_to_topics hat einen anderen Wert als 0 oder 1"
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr "Unbekannte WordPress Webhook-Aktion: {hook}"
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
@@ -9050,76 +8452,76 @@ msgstr ""
 "Dein Datenexport ist abgeschlossen. [Exporte anzeigen und herunterladen]"
 "({export_settings_link})."
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr "Das Verifikationsgeheimnis ist abgelaufen"
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr "Das Verifikationsgeheimnis ist ungültig"
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr "Das Verifikationsgeheimnis hat ein falsches Format"
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr "Das Verifikationsgeheimnis ist für einen anderen Hostnamen"
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr "Ungültige Subdomain für Push-Notification-Bouncer"
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr "Muss mit gültigem Zulip-Server-API-Schlüssel validiert werden"
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr "Ungültige UUID"
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr "Ungültiger Token-Typ"
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 "{hostname} enthält ungültige Komponenten (z. B. Pfad, Query, Fragment)."
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr "{hostname} ist kein gültiger Hostname"
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr "{hostname} noch nicht registriert"
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr "Ungültige E-Mail-Adresse des Server-Administrators: {email_reason}"
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr "example.com ist keine gültige E-Mail-Domain."
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr "{domain} ist ungültig, weil keine MX-Records vorhanden sind"
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr "{domain} existiert nicht"
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
@@ -9129,29 +8531,29 @@ msgstr ""
 "erreicht. Bitte versuche es später erneut oder melde dich bei "
 "{support_email} für Unterstützung."
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr "Registrierung für diesen Hostnamen nicht gefunden"
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr "Der Host hat gemeldet, dass er kein Verifikationsgeheimnis hat."
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, fuzzy, python-brace-format
 #| msgid "Error response received from the host: {status_code}"
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr "Fehlerantwort vom Host erhalten: {status_code}"
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr "Fehlende ios_app_id"
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr "Fehlende user_id oder user_uuid"
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
@@ -9160,50 +8562,50 @@ msgstr ""
 "Dein Tarif erlaubt den Versand von Push-Benachrichtigungen nicht. Vom Server "
 "bereitgestellte Begründung: {reason}"
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr "Dein Tarif erlaubt nicht das Versenden von Push-Benachrichtigungen."
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr "Ungültige Eigenschaft {property}"
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr "Ungültiger Event-Typ."
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr "Die Daten sind nicht in Ordnung."
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr "Doppelte Registrierung erkannt."
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr "Fehlerhafte Audit-Log-Daten"
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr "Du musst dein Passwort zurücksetzen."
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr "Fehlende id_token Parameter"
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 #, fuzzy
 #| msgid "Missing id_token parameter"
 msgid "Missing idp param"
 msgstr "Fehlende id_token Parameter"
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr "Ungültiges OTP"
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr ""
 "Es geht nicht, gleichzeitig sowohl mobile_flow_otp als auch desktop_flow_otp "

--- a/locale/el/LC_MESSAGES/django.po
+++ b/locale/el/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 19:23+0000\n"
 "Last-Translator: Pavlos M <pavlos.mrls@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/zulip/django/el/>\n"
@@ -19,50 +19,50 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "Δεν επιτρέπεται για επισκέπτες"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "Μη έγκυρος οργανισμός"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr "Δημόσια κανάλια"
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr "Ιδιωτικά κανάλια"
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr "Προσωπικά μηνύματα"
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr "Προσωπικά μηνύματα ομάδων"
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr ""
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr ""
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -71,7 +71,7 @@ msgid ""
 "users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -79,7 +79,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than one user to join."
 msgstr ""
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -87,7 +87,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than two users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -95,7 +95,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than three users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -104,151 +104,150 @@ msgid ""
 "({billing_page_link}) is greater than the current number of users."
 msgstr ""
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr ""
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr "Η εγγραφή είναι απενεργοποιημένη"
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr "Μη έγκυρος απομακρυσμένος διακομιστής."
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
 "(minimum {min_licenses})."
 msgstr ""
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
 "page. To complete the upgrade, please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr ""
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr ""
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr "Άγνωστη μέθοδος πληρωμής. Παρακαλώ επικοινωνήστε με {email}."
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr "Κάτι πήγε λάθος. Παρακαλούμε επικοινωνήστε με {email}."
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "Κάτι πήγε λάθος. Παρακαλούμε επαναφορτώστε τη σελίδα."
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr ""
 "Κάτι πήγε λάθος. Παρακαλούμε περιμένετε μερικά δευτερόλεπτα και δοκιμάστε "
 "ξανά."
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 "Παρακαλούμε προσθέστε μια πιστωτική κάρτα πριν εκκινήσετε τη δωρεάν δοκιμή."
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr ""
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr ""
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
 msgstr ""
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
 msgstr ""
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
 "licenses."
 msgstr ""
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
 "billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr ""
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr ""
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr ""
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -258,100 +257,97 @@ msgid ""
 "we would really appreciate it!"
 msgstr ""
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
 "{support_email}"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr "Πρέπει να αποδεχτείτε τους Όρους Παροχής Υπηρεσιών για να προχωρήσετε."
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr ""
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "Λάθος"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr "Η σελίδα δεν βρέθηκε (404)"
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
 "%(support_email)s\">contact support</a>."
 msgstr ""
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr ""
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
 msgstr ""
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr ""
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
 msgstr ""
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr ""
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr ""
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
 msgstr ""
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -359,289 +355,270 @@ msgid ""
 "a> with any questions."
 msgstr ""
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
 "a> for support."
 msgstr ""
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
 "href=\"%(troubleshooting_url)s\">Zulip server troubleshooting guide</a>."
 msgstr ""
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr ""
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr ""
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr ""
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr "Αριθμός χρηστών"
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr "Ενεργοί χρήστες τις τελευταίες 15 μέρες"
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr "Αριθμός επισκεπτών"
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr "Συνολικός αριθμός μηνυμάτων"
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr "Αριθμός μηνυμάτων τις τελευταίες 30 μέρες"
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr "Αποθηκευτικός χώρος που χρησιμοποιείται"
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "Ενεργοί χρήστες"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr ""
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr ""
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr "Συνολικοί χρήστες"
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "Χρήστες"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr ""
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "Εγώ"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "Όλοι"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "Τελευταία εβδομάδα"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "Τελευταίος μήνας"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "Τελευταίο έτος"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "Οποτεδήποτε"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr ""
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr ""
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr ""
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr ""
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr ""
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr ""
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr ""
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr ""
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr ""
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
 "%(old_email_html_tag)s to %(new_email_html_tag)s"
 msgstr ""
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr ""
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
 msgstr ""
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "Ακύρωση"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr "Επιβεβαίωση"
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr ""
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr ""
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -652,19 +629,19 @@ msgid ""
 "server."
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -672,790 +649,299 @@ msgid ""
 "%(support_email)s'>contact support</a> with any questions."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, python-format
 msgid "You can try again in %(retry_after_string)s."
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr ""
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr ""
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr ""
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "Όλα"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr ""
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr ""
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr ""
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr ""
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr ""
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr ""
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr ""
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr ""
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr ""
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr ""
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 msgid "Zulip for open source"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "start a conversation"
 msgid "Screenshot of Zulip conversation"
 msgstr "ξεκινήστε μια συζήτηση"
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 msgid "Message with code"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr "Σύνδεσμος"
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr "Από"
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr "Οργανισμός"
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr "Θέμα"
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr "Μήνυμα"
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr "Υποβολή"
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
 msgstr ""
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 msgid "Get started"
 msgstr ""
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
 "continue."
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "Διεύθυνση email"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr "Συνέχεια"
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr "Επιβεβαιώστε τη διεύθυνση email σας"
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1466,7 +952,7 @@ msgstr ""
 "class=\"user_email semi-bold\">%(email)s</span>) για ένα email επιβεβαίωσης "
 "από το Zulip."
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
@@ -1475,72 +961,71 @@ msgstr ""
 "Ανεπιθύμητα, μπορούμε να το <a href=\"#\" "
 "id=\"resend_email_link\">ξαναστείλουμε</a>."
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr ""
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr ""
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr ""
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr "Φορτώστε περισσότερα"
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr ""
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr "Μπορείτε τώρα να κλείσετε αυτό το παράθυρο."
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr ""
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
 msgstr ""
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1548,212 +1033,205 @@ msgid ""
 "href=\"%(doc_url)s\">documentation</a>."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr "Ο λογαριασμός δεν βρέθηκε"
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr "Ο λογαριασμός Zulip δεν βρέθηκε."
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, python-format
 msgid "No account found for %(email)s."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr "Συνδεθείτε με άλλο λογαριασμό"
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr "Προχωρήστε στην εγγραφή"
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Create a new Zulip organization"
 msgid "Try Zulip in a demo organization"
 msgstr "Δημιουργία νέου οργανισμού Zulip"
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Zulip"
 msgid "Try Zulip"
 msgstr "Zulip"
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "Δημιουργία νέου οργανισμού"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr "Δημιουργία νέου οργανισμού Zulip"
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr "Πληκτρολογήστε τη διεύθυνση email σας"
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr "Το email σας"
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid "Import chat history?"
 msgstr "Εισαγωγή ιστορικού συνομιλιών;"
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "URL Οργανισμού"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "Ή"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "Εγγραφείτε"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "Εγγραφείτε στο Zulip"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr "Εγγραφείτε με %(identity_provider)s"
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr "Έχετε ήδη λογαριασμό;"
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "Συνδεθείτε"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1761,123 +1239,122 @@ msgid ""
 "noreferrer\">after you join</a>."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "Αλλαγή"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr "Εγγραφή"
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr "Δημιουργήστε τον οργανισμό σας"
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr "Δημιουργήστε τον λογαριασμός σας"
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr "Το πλήρες όνομά σας"
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "Όνομα"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "Κωδικός πρόσβασης"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr ""
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">Terms of Service</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr "Απενεργοποιημένος οργανισμός"
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr ""
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -1885,45 +1362,45 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 msgid ""
 "This organization has been deactivated, and all organization data has been "
 "deleted."
 msgstr ""
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
 "inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
 "administrators</a> to inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 msgid "This organization has been deactivated."
 msgstr "Αυτός ο οργανισμός έχει απενεργοποιηθεί."
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
 "%(support_email)s\">contact Zulip support</a> to reactivate it."
 msgstr ""
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -1931,165 +1408,164 @@ msgid ""
 "reactivate it."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr "Ολοκλήρωση"
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "Αντιγραφή"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr "Ανώνυμος χρήστης"
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr "Ιδιοκτήτες"
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "Διαχειριστές"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr "Συντονιστές"
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr "Επισκέπτες"
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "Κανονικοί χρήστες"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "Κλείσιμο"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "Ανανέωση"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr "Zulip"
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
 "<b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr "Καλώς ήρθατε στο Zulip!"
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
 "href=\"%(apps_page_link)s\">mobile and desktop</a> apps:"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
 "href=\"%(getting_user_started_link)s\">getting started guide</a>!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2097,83 +1573,83 @@ msgid ""
 "Zulip</a>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
 "to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
 "desktop apps (%(apps_page_link)s):"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
 "(%(getting_user_started_link)s)!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
 "(%(getting_organization_started_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr "Γεια,"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2181,32 +1657,32 @@ msgid ""
 "password for this account, please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "%(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 msgid "Verify your email address for your Zulip demo organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "<%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2214,113 +1690,113 @@ msgid ""
 "please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr "Ολοκλήρωση εγγραφής"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
 "— we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
 "deactivated, and you will no longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr "Νέα κανάλια"
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2328,22 +1804,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because your organization <a "
@@ -2351,8 +1827,8 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to <a "
@@ -2360,39 +1836,39 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr ""
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because your organization hides "
@@ -2400,81 +1876,74 @@ msgid ""
 "details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to hide "
 "message content in email notifications. See %(help_url)s for more details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr "Εισέλθετε στο Zulip για να ενημερωθείτε: %(organization_url)s."
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr ""
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
 "organizations:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
 "organizations hosted by %(external_host)s:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
 "href=\"%(help_reset_password_link)s\">reset your password</a>."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
 "%(external_host)s."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2482,97 +1951,94 @@ msgid ""
 "to find your account."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
 "try another way to find your account (%(help_logging_in_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
 "communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr ""
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
 "-- the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr "Για να ξεκινήσετε, πατήστε τον παρακάτω σύνδεσμο."
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
 "Zulip &mdash; the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
 "to ask %(referrer_name)s for another one."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2580,72 +2046,70 @@ msgid ""
 "productivity."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at <a href=\"mailto:%(email)s\">%(email)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
 "%(email)s\">Contact us</a> — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
 "#%(channel_name)s > %(topic_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2653,68 +2117,68 @@ msgid ""
 "preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails (<a href=\"%(url)s\">help</a>)."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr "Νέα μηνύματα"
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2722,22 +2186,22 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2745,52 +2209,52 @@ msgid ""
 "immediately at <%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr "Οργανισμός: %(organization_link)s"
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr "Διεύθυνση email: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr "Ώρα: %(login_time)s"
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr "Συσκευή: %(device_browser)s σε %(device_os)s."
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr "Διεύθυνση IP: %(device_ip)s"
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2798,31 +2262,31 @@ msgid ""
 "contact us immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr "Ευχαριστούμε,"
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr "Οργανισμός: %(organization_url)s"
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2830,7 +2294,7 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -2838,25 +2302,25 @@ msgid ""
 "Zulip</a> to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
 "with you and share their unique perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -2864,7 +2328,7 @@ msgid ""
 "experience how a new chat app will help your team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -2872,148 +2336,148 @@ msgid ""
 "action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
 "team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
 "organizations like yours!"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3021,11 +2485,11 @@ msgid ""
 "about…?”"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3034,23 +2498,23 @@ msgid ""
 "href=\"%(move_channels_link)s\">move a topic to a different channel</a>."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr "Πηγαίντε στο Zulip"
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3059,23 +2523,23 @@ msgid ""
 "(%(move_channels_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
 "%(email)s on %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr "Επανακαθορισμός κωδικού πρόσβασης"
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3083,46 +2547,46 @@ msgid ""
 "href=\"%(help_link)s\">reactivate your account</a>."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr "Δεν έχετε λογαριασμός σε αυτόν τον οργανισμό Zulip."
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
 "You can contact an organization administrator to reactivate your account."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3130,545 +2594,541 @@ msgid ""
 "have been voided."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
 "to %(upgrade_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip demo organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip demo organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Deactivated organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "Απενεργοποιημένος οργανισμός"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for <b>%(remote_server_hostname)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, fuzzy
 #| msgid "Click the link below to log in."
 msgid "Click the button below to log in."
 msgstr "Πατήστε τον παρακάτω σύνδεσμο για να συνδεθείτε."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for %(remote_server_hostname)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr "Πατήστε τον παρακάτω σύνδεσμο για να συνδεθείτε."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
 "management for <b>%(remote_realm_host)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr "Επιβεβαιώστε και συνδεθείτε"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
 "management for %(remote_realm_host)s."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the <a href=\"%(plans_link)s\">Zulip Community plan</a>."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
 "website</a>, we would really appreciate it!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
 msgstr ""
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr "Βρείτε τους λογαριασμούς σας"
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr "Βρείτε τους λογαριασμούς σας στο Zulip"
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
 "accounts for another email address</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr "Διεύθυνση email"
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "Εύρεση λογαριασμών"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr ""
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr ""
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr ""
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Zulip"
 msgid "Zulip Cloud"
 msgstr "Zulip"
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr ""
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr ""
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr ""
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr ""
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr ""
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr ""
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr ""
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr "Εκπαίδευση"
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr ""
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr ""
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr ""
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr "Κοινότητες"
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr ""
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr ""
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr ""
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr ""
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr ""
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr ""
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr ""
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr ""
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr ""
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr ""
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr ""
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr ""
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr "Σχετικά με εμάς"
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr ""
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "Ιστορικό"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr ""
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr ""
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr ""
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr ""
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr ""
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 msgid "Bluesky"
 msgstr ""
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr ""
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr "Όροι Παροχής Υπηρεσιών"
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr ""
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 msgid ""
 "And hundreds more through <a href=\"/integrations/zapier\">Zapier</a> and <a "
 "href=\"/integrations/ifttt\">IFTTT</a>."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3676,7 +3136,7 @@ msgid ""
 "emails with your email domain."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3684,7 +3144,7 @@ msgid ""
 "disposable email addresses."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3692,24 +3152,24 @@ msgid ""
 "emails that contain \"+\"."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3717,7 +3177,7 @@ msgid ""
 "%(support_email)s\">contact Zulip support</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3725,89 +3185,89 @@ msgid ""
 "%(support_email)s\">contact this Zulip server's administrators</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
 "management for your Zulip server."
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr ""
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr "Συνδεθείτε στο Zulip"
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr "Διεύθυνση email ή όνομα χρήστη"
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "Όνομα χρήστη"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr "Ξεχάσατε τον κωδικό πρόσβασης;"
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr "Συνδεθείτε με %(identity_provider)s"
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr ""
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> because all Zulip Cloud licenses are in use."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -3816,44 +3276,42 @@ msgid ""
 "or misconfiguration."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 #, fuzzy
 #| msgid "This organization has been deactivated."
 msgid "Demo organizations disabled"
 msgstr "Αυτός ο οργανισμός έχει απενεργοποιηθεί."
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -3861,22 +3319,21 @@ msgid ""
 "organization for more information."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -3884,48 +3341,46 @@ msgid ""
 "Zulip support</a> for assistance in resolving this issue."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
 "a> like Firefox, Chrome, and Edge."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Invalid organization"
 msgid "Finalize organization import"
 msgstr "Μη έγκυρος οργανισμός"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Organization owner"
 msgid "Organization import completed!"
 msgstr "Ιδιοκτήτης/τρια του οργανισμού"
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -3933,56 +3388,55 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Select your account"
 msgstr "Δημιουργήστε τον λογαριασμός σας"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Create new account"
 msgstr "Δημιουργήστε τον λογαριασμός σας"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr ""
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr "Επόμενο"
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -3990,81 +3444,81 @@ msgid ""
 "have one yet."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 msgid "Self-hosting Zulip?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">log in to manage plans and billing.</a>"
 msgstr ""
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr ""
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
 msgstr ""
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "Επιβεβαιώστε τον κωδικό πρόσβασης"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr ""
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr ""
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr ""
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr ""
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr ""
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4072,7 +3526,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4081,57 +3535,57 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr ""
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4139,7 +3593,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4147,40 +3601,40 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4188,300 +3642,294 @@ msgid ""
 "away!"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
 "href=\"%(realm_url)s/#settings/notifications\">notification settings</a>."
 msgstr ""
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr ""
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr ""
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr ""
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr ""
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr ""
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr ""
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr ""
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 msgid "Cannot reactivate a deleted user"
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr ""
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr ""
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr ""
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr ""
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
 msgstr ""
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
 msgstr ""
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr ""
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr ""
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr ""
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr ""
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr ""
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr ""
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr ""
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr ""
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr ""
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr ""
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
 "{new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
 "{user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to resolve topics in this channel."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr ""
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr ""
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr ""
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr ""
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr ""
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
 "but there is no channel with that ID."
 msgstr ""
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4489,36 +3937,36 @@ msgid ""
 "it."
 msgstr ""
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
 "The channel exists but does not have any subscribers."
 msgstr ""
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr ""
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr ""
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr ""
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4526,107 +3974,105 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
 "authentication method."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr ""
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 msgid "Reminder could not be sent."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
 "the following error:"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr ""
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr ""
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr ""
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr ""
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr ""
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
 "**{old_policy}** to **{new_policy}**."
 msgstr ""
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -4635,51 +4081,49 @@ msgid ""
 "* **New**: {new_setting_description}\n"
 msgstr ""
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr ""
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr ""
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr ""
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr ""
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr "Για πάντα"
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr ""
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 msgstr ""
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr ""
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -4690,285 +4134,271 @@ msgid ""
 "{summary_line}"
 msgstr ""
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr ""
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr ""
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr ""
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr ""
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr ""
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr ""
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr ""
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr ""
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr ""
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr ""
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr ""
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
 "organization administrator to reactivate it."
 msgstr ""
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr ""
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr ""
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr ""
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr ""
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr ""
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr ""
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr ""
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
 "to register for accounts in this organization."
 msgstr ""
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr ""
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 msgid "Challenges are not enabled."
 msgstr ""
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "Νέος κωδικός πρόσβασης"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr "Επιβεβαίωση νέου κωδικού πρόσβασης"
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "You're making too many attempts to sign in. Try again in "
 "{retry_after_string} or contact your organization administrator for help."
 msgstr ""
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
 msgstr ""
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr ""
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr ""
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr ""
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr ""
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr ""
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr ""
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr ""
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr ""
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr ""
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr ""
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr ""
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name can't be empty."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 msgid "Invalid channel folder ID"
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 #, fuzzy
 #| msgid "Confirm your email address"
 msgid "Configure owner account email address."
 msgstr "Επιβεβαιώστε τη διεύθυνση email σας"
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4977,69 +4407,69 @@ msgid ""
 "organization]({convert_demo}).\n"
 msgstr ""
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, python-brace-format
 msgid "{var_name} is not Base64 encoded"
 msgstr ""
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 msgid "Invalid `device_id`"
 msgstr ""
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr ""
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr ""
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr ""
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr ""
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr ""
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr ""
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr ""
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr ""
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr ""
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr ""
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5047,623 +4477,621 @@ msgid ""
 "{error_message}"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr ""
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr ""
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr ""
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr ""
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr ""
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr ""
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr ""
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr ""
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr ""
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr ""
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr ""
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr ""
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr ""
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
 msgstr ""
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr ""
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr ""
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr ""
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr ""
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr ""
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr ""
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr ""
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr ""
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Number of users"
 msgid "Must be a bot user"
 msgstr "Αριθμός χρηστών"
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr ""
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr ""
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr ""
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
 "webhook; ignoring"
 msgstr ""
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr ""
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr ""
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr ""
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr "Η πρόσβαση δεν επιτρέπεται"
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} most recent messages in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr ""
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr ""
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
 msgstr ""
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr ""
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr ""
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr ""
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr ""
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr ""
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Find accounts"
 msgid "Atlassian account ID"
 msgstr "Εύρεση λογαριασμών"
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Behance username"
 msgstr "Διεύθυνση email ή όνομα χρήστη"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 msgid "Bitbucket username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Codeberg username"
 msgstr "Διεύθυνση email ή όνομα χρήστη"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Dribbble username"
 msgstr "Διεύθυνση email ή όνομα χρήστη"
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Facebook username"
 msgstr "Διεύθυνση email ή όνομα χρήστη"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "GitLab username"
 msgstr "Διεύθυνση email ή όνομα χρήστη"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Instagram username"
 msgstr "Διεύθυνση email ή όνομα χρήστη"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 msgid "Mastodon profile"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Medium username"
 msgstr "Διεύθυνση email ή όνομα χρήστη"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Pinterest username"
 msgstr "Διεύθυνση email ή όνομα χρήστη"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Reddit username"
 msgstr "Διεύθυνση email ή όνομα χρήστη"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 msgid "Snapchat username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Threads username"
 msgstr "Διεύθυνση email ή όνομα χρήστη"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "TikTok username"
 msgstr "Διεύθυνση email ή όνομα χρήστη"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Twitch username"
 msgstr "Διεύθυνση email ή όνομα χρήστη"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "Όνομα χρήστη"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr ""
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr ""
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 msgid "Video calling"
 msgstr ""
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr ""
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr ""
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr ""
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr ""
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr ""
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr ""
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr ""
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr ""
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr ""
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr ""
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr ""
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr ""
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr ""
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr ""
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "{fullname} moderation"
 msgstr ""
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr ""
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr ""
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor_date' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr ""
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 msgid "Navigation view does not exist."
 msgstr ""
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5671,7 +5099,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5679,7 +5107,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5687,7 +5115,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5695,7 +5123,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5705,14 +5133,14 @@ msgid ""
 "a permanent organization]({convert_demo_organization_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
 "them in your [Inbox](/#inbox).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5720,7 +5148,7 @@ msgid ""
 "({navigation_tour_video_url}) for a quick app overview.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5735,14 +5163,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -5750,7 +5178,7 @@ msgid ""
 "and edit your [profile information](/help/edit-your-profile).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -5761,7 +5189,7 @@ msgid ""
 "experience in your [Preferences](#settings/preferences).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5772,7 +5200,7 @@ msgid ""
 "[Browse and subscribe to channels]({settings_link}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -5789,7 +5217,7 @@ msgid ""
 "discussed.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -5798,7 +5226,7 @@ msgid ""
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -5810,7 +5238,7 @@ msgid ""
 "times, and more.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5820,7 +5248,7 @@ msgid ""
 "or browse the [help center](/help/) to learn more!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5828,7 +5256,7 @@ msgid ""
 "get help, try one of the following messages: {bot_commands}\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5840,13 +5268,13 @@ msgid ""
 "({move_content_another_channel_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5860,12 +5288,11 @@ msgid ""
 "and above.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr "καλώς ήρθατε στο Zulip!"
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -5873,14 +5300,14 @@ msgid ""
 "no matter how many other conversations are going on.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
 "conversations with unread messages.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -5888,7 +5315,7 @@ msgid ""
 "the `+` button next to its name.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -5896,13 +5323,13 @@ msgid ""
 "can we chat about…?”\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5910,7 +5337,7 @@ msgid ""
 "({format_message_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5930,1324 +5357,1301 @@ msgid ""
 "```\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
 "teammates.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
 "conversation.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr ""
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr ""
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr "ξεκινήστε μια συζήτηση"
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr ""
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "Νέο μήνυμα"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 msgid "Invalid `push_key`"
 msgstr ""
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr ""
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr ""
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr ""
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 msgid "Reminder does not exist"
 msgstr ""
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr ""
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr ""
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr ""
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr ""
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr ""
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr ""
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr ""
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr ""
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 msgid "You do not have permission to create new topics in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr ""
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr ""
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr ""
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr ""
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr ""
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr ""
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} does not have the expected format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr ""
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr ""
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr ""
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {user_group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr ""
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr ""
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr ""
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr ""
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr ""
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 msgid "Name must not be empty!"
 msgstr ""
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr ""
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr ""
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr ""
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr ""
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr ""
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr ""
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr ""
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr ""
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr ""
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr ""
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr ""
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr ""
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr ""
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr ""
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr ""
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr ""
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr ""
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr ""
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr ""
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr ""
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr ""
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr ""
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr ""
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr ""
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr ""
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr ""
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr ""
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr ""
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr ""
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr ""
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr ""
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr ""
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr "Ημερομηνία"
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr "Αντωνυμίες"
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr "Κανείς"
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr ""
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr ""
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr ""
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: empty field name."
 msgstr ""
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr ""
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr ""
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 msgid "Example input does not match the linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in alternative URL template is not present in linkifier "
 "pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in linkifier pattern is not present in alternative URL "
 "template."
 msgstr ""
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr ""
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr ""
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr ""
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr ""
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr ""
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr ""
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr ""
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr ""
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr ""
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr ""
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr ""
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr ""
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "Δημόσιο"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr "Ιδιωτικό, διαμοιρασμένο ιστορικό"
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr "Ιδιωτικό, προστατευμένο ιστορικό"
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr "Διαχειριστές, επόπτες, μέλη και επισκέπτες"
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr "Διαχειριστές, επόπτες και μέλη"
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr "Διαχειριστές και επόπτες"
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr "Μόνο διαχειριστές"
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr "Άγνωστος χρήστης"
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr "Ιδιοκτήτης/τρια του οργανισμού"
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr "Διαχειριστής/στρια του οργανισμού"
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr "Συντονιστής/στρια"
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "Μέλος"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "Επισκέπτης/τρια"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr ""
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr ""
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr ""
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr ""
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 msgid "Failed to generate challenge"
 msgstr ""
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr ""
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr ""
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr ""
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr ""
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr ""
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr ""
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for use for user matching."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr ""
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr ""
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr ""
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr ""
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr ""
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr ""
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr ""
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr ""
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 #, fuzzy
 #| msgid "Registration is deactivated"
 msgid "Invitation already used or deactivated."
 msgstr "Η εγγραφή είναι απενεργοποιημένη"
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr ""
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr ""
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr ""
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
 msgstr ""
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr ""
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr ""
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr ""
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr ""
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr ""
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr ""
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr ""
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr ""
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 msgid "Message reporting is not enabled in this organization."
 msgstr ""
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr ""
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr ""
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr ""
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr ""
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr ""
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr ""
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr ""
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr ""
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr ""
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 msgid "Navigation view already exists."
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7255,861 +6659,859 @@ msgid ""
 "later. Is this a good time?\n"
 msgstr ""
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr ""
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr ""
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 msgid "You do not have permission to manage plans and billing."
 msgstr ""
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr ""
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr ""
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr ""
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr ""
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr ""
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr ""
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr ""
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr ""
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr ""
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr ""
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr ""
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr ""
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr ""
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr ""
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr ""
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr ""
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr ""
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr ""
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr ""
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Invalid character in language: {character}"
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Language '{language}' is not allowed."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr ""
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr ""
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 msgid "Importing messages…"
 msgstr "Εισαγωγή μηνυμάτων…"
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "Your full name"
 msgid "Your name"
 msgstr "Το πλήρες όνομά σας"
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr ""
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr ""
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr ""
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr ""
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr ""
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr "Λάθος παράμετροι"
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr ""
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr ""
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr ""
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr ""
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr ""
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr ""
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr ""
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
 "**"
 msgstr ""
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr ""
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr ""
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr ""
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr ""
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr ""
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr ""
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr ""
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr ""
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr ""
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr ""
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr ""
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr ""
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr ""
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 msgstr ""
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr ""
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr ""
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
 "subgroups."
 msgstr ""
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr ""
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr ""
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr ""
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr ""
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr "Λανθασμένος κωδικός πρόσβασης!"
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr ""
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr ""
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr ""
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr ""
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr ""
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 msgid "User is not allowed to delete other user's messages."
 msgstr ""
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr ""
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr ""
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 msgid ""
 "Can't change bot email until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 msgstr ""
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 #, fuzzy
 #| msgid "Email address"
 msgid "Email address already in use"
 msgstr "Διεύθυνση email"
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr ""
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr ""
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr ""
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 msgstr ""
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr ""
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr ""
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr ""
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr ""
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr ""
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} access token"
 msgstr ""
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} call"
 msgstr ""
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} credentials have not been configured"
 msgstr ""
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} credentials"
 msgstr ""
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr ""
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error authenticating to the {provider_name} server"
 msgstr ""
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr ""
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} session identifier"
 msgstr ""
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr ""
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} public room."
 msgstr ""
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr ""
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{full_name}'s Zulip room"
 msgstr ""
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr ""
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr ""
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr ""
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr ""
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr ""
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr ""
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr ""
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr ""
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr ""
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
 "({export_settings_link})."
 msgstr ""
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr ""
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr ""
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr ""
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr ""
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr ""
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr ""
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr ""
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr ""
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr ""
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr ""
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr ""
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr ""
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
 "try again later or reach out to {support_email} for assistance."
 msgstr ""
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr ""
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr ""
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr ""
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr ""
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
 "server: {reason}"
 msgstr ""
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr ""
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr ""
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr ""
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr ""
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr ""
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr ""
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr "Χρειάζεται να επανακαθορίσετε τον κωδικό πρόσβασής σας."
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr ""
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 msgid "Missing idp param"
 msgstr ""
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr ""
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr ""
 

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-04-27 01:48+0000\n"
 "Last-Translator: MicXDev <msh2009@outlook.com>\n"
 "Language-Team: English (United Kingdom) <https://hosted.weblate.org/projects/"
@@ -23,50 +23,50 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.17.1-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "Not allowed for guest users"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "Invalid organisation"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr "Public channels"
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr "Private channels"
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr "Direct messages"
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr "Group direct messages"
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr "Missing channel for chart: {chart_name}"
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr "Unknown chart name: {chart_name}"
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr "Start time is later than end time. Start: {start}, End: {end}"
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr "No analytics data available. Please contact your server administrator."
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -79,7 +79,7 @@ msgstr ""
 "[deactivate inactive users]({deactivate_user_help_page_link}) to allow new "
 "users to join."
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -90,7 +90,7 @@ msgstr ""
 "the number of licenses]({billing_page_link}) or [deactivate inactive users]"
 "({deactivate_user_help_page_link}) to allow more than one user to join."
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -101,7 +101,7 @@ msgstr ""
 "the number of licenses]({billing_page_link}) or [deactivate inactive users]"
 "({deactivate_user_help_page_link}) to allow more than two users to join."
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -112,7 +112,7 @@ msgstr ""
 "the number of licenses]({billing_page_link}) or [deactivate inactive users]"
 "({deactivate_user_help_page_link}) to allow more than three users to join."
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -125,7 +125,7 @@ msgstr ""
 "[number of licenses for the current and next billing period]"
 "({billing_page_link}) is greater than the current number of users."
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
@@ -133,7 +133,7 @@ msgstr ""
 "Your organisation does not have enough Zulip licenses. Invitations were not "
 "sent."
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
@@ -141,16 +141,15 @@ msgstr ""
 "Your organisation does not have enough Zulip licenses to change a guest "
 "user's role."
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr "Registration is deactivated"
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr "Invalid remote server."
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
@@ -159,7 +158,7 @@ msgstr ""
 "You must purchase licenses for all active users in your organisation "
 "(minimum {min_licenses})."
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
@@ -168,42 +167,42 @@ msgstr ""
 "Invoices with more than {max_licenses} licences can't be processed from this "
 "page. To complete the upgrade, please contact {email}."
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr "No payment method on file."
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr "{brand} ending in {last4}"
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr "Unknown payment method. Please contact {email}."
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr "Something went wrong. Please contact {email}."
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "Something went wrong. Please reload the page."
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr "Something went wrong. Please wait a few seconds and try again."
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr "Please add a credit card before starting your free trial."
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr "Please add a credit card to schedule upgrade."
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
@@ -211,17 +210,17 @@ msgstr ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr "Unable to update the plan. The plan has ended."
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 "Cannot update licenses in the current billing period for free trial plan."
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
@@ -229,18 +228,18 @@ msgstr ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr ""
 "Your plan is already on {licenses} licenses in the current billing period."
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr "You cannot decrease the licenses in the current billing period."
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
@@ -248,7 +247,7 @@ msgstr ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
@@ -257,7 +256,7 @@ msgstr ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
 "licenses."
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
@@ -266,27 +265,27 @@ msgstr ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
 "billing period."
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr "Nothing to change."
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr "No customer for this organisation!"
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr "Session not found"
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr "Payment intent not found"
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr "Pass stripe_session_id or stripe_invoice_id"
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -301,20 +300,19 @@ msgstr ""
 "If you could {begin_link}list Zulip as a sponsor on your website{end_link}, "
 "we would really appreciate it!"
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr "Parameter 'confirmed' is required"
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr "Billing access token expired."
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr "Invalid billing access token."
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
@@ -323,39 +321,38 @@ msgstr ""
 "Couldn't reconcile billing data between server and realm. Please contact "
 "{support_email}"
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr "User account doesn't exist yet."
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr "You must accept the Terms of Service to proceed."
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr "Invalid zulip_org_key for this zulip_org_id."
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr "Your server registration has been deactivated."
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "Error"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr "Page not found (404)"
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
@@ -364,11 +361,11 @@ msgstr ""
 "If this error is unexpected, you can <a href=\"mailto:"
 "%(support_email)s\">contact support</a>."
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr "Access forbidden (403)"
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
@@ -376,11 +373,11 @@ msgstr ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr "Make sure that your browser allows cookies for this site."
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
@@ -388,22 +385,21 @@ msgstr ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr "Method not allowed (405)"
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr "Internal server error"
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
 msgstr ""
 
-#: templates/500.html:27
+#: templates/500.html
 #, fuzzy, python-format
 #| msgid ""
 #| "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -418,13 +414,13 @@ msgstr ""
 "\">get a list of your Zulip Cloud accounts</a>, or <a href=\"mailto:"
 "%(support_email)s\">contact Zulip support</a>."
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -442,7 +438,7 @@ msgstr ""
 "                this server's administrators</a> for support.\n"
 "                "
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
@@ -451,136 +447,134 @@ msgstr ""
 "If you administer this server, you may want to check out the <a "
 "href=\"%(troubleshooting_url)s\">Zulip server troubleshooting guide</a>."
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr "Analytics for %(target_name)s | Zulip"
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr "Analytics are fully available 24 hours after organisation creation."
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr "Zulip analytics for %(target_name)s"
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr "Organisation summary"
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr "Number of users"
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr "Users active during the last 15 days"
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr "Number of guests"
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr "Total number of messages"
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr "Number of messages in the last 30 days"
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr "File storage in use"
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "Active users"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr "Daily actives"
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr "15 day actives"
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr "Total users"
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "Users"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr "Messages sent by recipient type"
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "Me"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "Everyone"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "Last week"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "Last month"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "Last year"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "All time"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr "Messages sent over time"
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "Daily"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "Weekly"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr "Cumulative"
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "Humans"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "Bots"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr "Messages read over time"
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr "Messages sent by client"
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr "Last update"
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
@@ -588,15 +582,15 @@ msgstr ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr "Email changed"
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr "Email changed!"
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
@@ -605,21 +599,21 @@ msgstr ""
 "This confirms that the email address for your Zulip account has changed from "
 "%(old_email_html_tag)s to %(new_email_html_tag)s"
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr "Confirming your email address"
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr "Confirmation link does not exist"
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr "Whoops. We couldn't find your confirmation link in the system."
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
@@ -628,27 +622,27 @@ msgstr ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr "Confirmation link expired or deactivated"
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr "Whoops. The confirmation link has expired or been deactivated."
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr "Please contact your organisation administrator for a new link."
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr "Confirmation link malformed"
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr "Whoops. The confirmation link is malformed."
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
@@ -656,72 +650,55 @@ msgstr ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr "Billing"
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr "Close modal"
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr "Never mind"
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr "Downgrade"
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "Cancel"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr "Confirm"
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr "Cancel upgrade"
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr "Billing status"
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr "Deactivate server registration?"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr "Plan management not available"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -738,7 +715,7 @@ msgstr ""
 "management\">log in instructions</a> to administer the plan for your Zulip "
 "server."
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
@@ -746,7 +723,7 @@ msgstr ""
 "To move the plan from the server to this organisation, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
@@ -754,7 +731,7 @@ msgstr ""
 "Plan management for this server is not available because at least one "
 "organisation hosted on this server already has an active plan."
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -765,17 +742,17 @@ msgstr ""
 "in</a> to plan management for your organisation instead, or <a href='mailto:"
 "%(support_email)s'>contact support</a> with any questions."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr "Rate limit exceeded"
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr "Rate limit exceeded."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
@@ -783,720 +760,230 @@ msgstr ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, fuzzy, python-format
 #| msgid "You can try again in %(retry_after)s seconds."
 msgid "You can try again in %(retry_after_string)s."
 msgstr "You can try again in %(retry_after)s seconds."
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr "Upgrade"
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr "Send invoice and start free trial"
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr "Send invoice"
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr "Open communities directory"
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr "Filter by category"
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "All"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr "Categories"
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr "10,000 messages"
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr "Unlimited"
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr "Files up to 10 MB"
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr "Files up to 1 GB"
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr "Supported"
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr "Self-managed"
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr "For organisations with up to 10 users"
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr "25 users minimum"
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr "Not available"
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr "The Zulip development community"
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr "Join as a user"
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr "Join as a self-hoster"
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr "Join as a contributor"
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "Create organisation"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr "Get a demo"
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr "Self-host Zulip"
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr "Request sponsorship"
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr "Education pricing"
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr "View pricing"
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr "Zulip for business"
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Zulip guide for open-source projects"
 msgid "Zulip for open source"
 msgstr "Zulip guide for open-source projects"
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "start a conversation"
 msgid "Screenshot of Zulip conversation"
 msgstr "start a conversation"
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Messages sent over time"
 msgid "Message with code"
 msgstr "Messages sent over time"
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr "Link"
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr "Contact support"
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr "From"
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr "Organisation"
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr "Subject"
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr "Message"
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr "Submit"
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr "Thanks for contacting us"
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr "Thanks for contacting us!"
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr "We will be in touch with you soon."
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
@@ -1504,13 +991,13 @@ msgstr ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 #, fuzzy
 #| msgid "Getting started"
 msgid "Get started"
 msgstr "Getting started"
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
@@ -1520,49 +1007,48 @@ msgstr ""
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
 "continue."
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr "Or, alternatively, use one of your backup phones:"
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr "As a last resort, you can use a backup token:"
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr "Use backup token"
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr "Accept the Terms of Service"
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr "Welcome to Zulip"
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "Email"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr "Continue"
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr "Confirm your email address"
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1573,7 +1059,7 @@ msgstr ""
 "class=\"user_email semi-bold\">%(email)s</span>) for a confirmation email "
 "from Zulip."
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
@@ -1581,31 +1067,31 @@ msgstr ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr "Public view of {org_name} | Zulip team chat"
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
@@ -1613,38 +1099,37 @@ msgstr ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr "No conversations match your filters."
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr "This view is still loading messages."
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr "Load more"
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr "Video call ended"
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr "You may now close this window."
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr "Configuration error"
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
@@ -1652,7 +1137,7 @@ msgstr ""
 "You are trying to log in using LDAP without creating an organisation first. "
 "Please use EmailAuthBackend to create your organisation and then try again."
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1663,73 +1148,71 @@ msgstr ""
 "how to configure push notifications, please see the <a "
 "href=\"%(doc_url)s\">documentation</a>."
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr "Account not found"
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr "Zulip account not found."
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, fuzzy, python-format
 #| msgid "Your account email: %(email)s"
 msgid "No account found for %(email)s."
 msgstr "Your account email: %(email)s"
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr "Log in with another account"
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr "Continue to registration"
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Must be a demo organization."
 msgid "Try Zulip in a demo organization"
 msgstr "Must be a demo organisation."
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Try Zulip now"
 msgid "Try Zulip"
 msgstr "Try Zulip now"
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "Create a new organisation"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr "Create a new Zulip organisation"
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr "Enter your email address"
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr "Your email"
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
@@ -1739,11 +1222,11 @@ msgstr ""
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr "How did you first hear about Zulip?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
@@ -1751,42 +1234,41 @@ msgstr ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr "Select an option"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr "Please describe"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr "Where did you see the ad?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr "Which organisation?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr "Which one?"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr "Select one"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr "Organisation type"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr "Organisation language"
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 #, fuzzy
 #| msgid ""
 #| "\n"
@@ -1809,74 +1291,70 @@ msgstr ""
 "a>.\n"
 "                "
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 #, fuzzy
 #| msgid "Private, shared history"
 msgid "Import chat history?"
 msgstr "Private, shared history"
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr "Organisation name"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "Organisation URL"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr "Use %(external_host)s"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "OR"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "Sign up"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "Sign up for Zulip"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr "You need an invitation to join this organisation."
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr "Sign up with %(identity_provider)s"
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr "Already have an account?"
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "Log in"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr "Configure email address privacy"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
@@ -1884,7 +1362,7 @@ msgstr ""
 "Zulip lets you control which roles in the organisation can view your email "
 "address."
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
@@ -1892,11 +1370,11 @@ msgstr ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organisation?"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr "Who can access your email address"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1907,7 +1385,7 @@ msgstr ""
 "configure-email-visibility\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">after you join</a>."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
@@ -1915,7 +1393,7 @@ msgstr ""
 "Administrators of this Zulip organisation will be able to see this email "
 "address."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
@@ -1923,13 +1401,13 @@ msgstr ""
 "Administrators and moderators of this Zulip organisation will be able to see "
 "this email address."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 "Nobody in this Zulip organisation will be able to see this email address."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
@@ -1937,79 +1415,78 @@ msgstr ""
 "Other users in this Zulip organisation will be able to see this email "
 "address."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "Change"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr "Registration"
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr "Create your organisation"
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr "Create your account"
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr "<p>Enter your account details to complete registration.</p>"
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr "Your organisation"
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr "Your account"
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr "Don&rsquo;t import settings"
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr "Import settings from existing Zulip account"
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr "Your full name"
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "Name"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr "This is how your account is displayed in Zulip."
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "Password"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr "Enter your LDAP/Active Directory password."
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 "This is used for mobile applications and other tools that require a password."
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr "Password strength"
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr "What are you interested in?"
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
@@ -2018,15 +1495,15 @@ msgstr ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">Terms of Service</a>."
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr "Deactivated organisation"
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr "Organisation moved"
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
@@ -2035,7 +1512,7 @@ msgstr ""
 "This organisation has moved to <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -2043,7 +1520,7 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid ""
@@ -2051,7 +1528,7 @@ msgid ""
 "deleted."
 msgstr "This organisation has been deactivated"
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2067,7 +1544,7 @@ msgstr ""
 "%(support_email)s\">contact Zulip support</a>.\n"
 "                "
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2085,13 +1562,13 @@ msgstr ""
 "                this server's administrators</a> for support.\n"
 "                "
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid "This organization has been deactivated."
 msgstr "This organisation has been deactivated"
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -2100,14 +1577,14 @@ msgstr ""
 "If you are an owner of this organisation, you can <a href=\"mailto:"
 "%(support_email)s\">contact Zulip support</a> to reactivate it."
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -2118,15 +1595,15 @@ msgstr ""
 "%(support_email)s\">contact this Zulip server's administrators</a> to "
 "reactivate it."
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr "Finish desktop app login"
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr "Finish desktop login"
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
@@ -2134,92 +1611,91 @@ msgstr ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr "Paste token here"
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr "Finish"
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr "Incorrect token."
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr "Token accepted.  Logging you in…"
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr "Log in to desktop app"
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "Copy"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr "You may then close this window."
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr "Or, continue in your browser."
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr "Anonymous user"
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr "Owners"
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "Administrators"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr "Moderators"
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr "Guest users"
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "Normal users"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr "Forward emails to an email account"
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "Close"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "Update"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr "Zulip"
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr "Digest"
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
@@ -2228,17 +1704,17 @@ msgstr ""
 "Congratulations, you have created a new Zulip organisation: "
 "<b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr "Welcome to Zulip!"
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr "You've joined the Zulip organisation <b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
@@ -2247,36 +1723,36 @@ msgstr ""
 "You will use the following info to log into the Zulip web, <a "
 "href=\"%(apps_page_link)s\">mobile and desktop</a> apps:"
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr "Organisation URL: %(organization_url)s"
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr "Your username: %(ldap_username)s"
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr "Use your LDAP account to log in"
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr "Your account email: %(email)s"
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr "Go to organisation"
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
@@ -2285,7 +1761,7 @@ msgstr ""
 "If you are new to Zulip, check out our <a "
 "href=\"%(getting_user_started_link)s\">getting started guide</a>!"
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2296,7 +1772,7 @@ msgstr ""
 "href=\"%(getting_organization_started_link)s\">moving your organisation to "
 "Zulip</a>."
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
@@ -2305,29 +1781,29 @@ msgstr ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
 "to help!"
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr "%(realm_name)s on Zulip: Your new organisation details"
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr "%(realm_name)s on Zulip: Your new account details"
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr ""
 "Congratulations, you have created a new Zulip organisation: %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr "You've joined the Zulip organisation %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
@@ -2336,7 +1812,7 @@ msgstr ""
 "You will use the following info to log into the Zulip web, mobile and "
 "desktop apps (%(apps_page_link)s):"
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
@@ -2345,7 +1821,7 @@ msgstr ""
 "If you are new to Zulip, check out our getting started guide "
 "(%(getting_user_started_link)s)!"
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
@@ -2354,17 +1830,17 @@ msgstr ""
 "We also have a guide for moving your organisation to Zulip "
 "(%(getting_organization_started_link)s)."
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr "Questions? Contact us at %(support_email)s — we'd love to help!"
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2373,17 +1849,17 @@ msgstr ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at %(support_email)s."
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr "Hi,"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2394,12 +1870,12 @@ msgstr ""
 "demo organisation account on %(realm_url)s. To confirm this update and set a "
 "password for this account, please click below:"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr "Confirm and set password"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2408,14 +1884,14 @@ msgstr ""
 "If you did not request this change, please contact us immediately at "
 "%(support_email)s."
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 #, fuzzy
 #| msgid "Verify your new email address for your demo Zulip organization"
 msgid "Verify your email address for your Zulip demo organization"
 msgstr "Verify your new email address for your demo Zulip organisation"
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2424,8 +1900,8 @@ msgstr ""
 "If you did not request this change, please contact us immediately at "
 "<%(support_email)s>."
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2436,33 +1912,33 @@ msgstr ""
 "%(realm_url)s from %(old_email)s to %(new_email)s. To confirm this change, "
 "please click below:"
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr "Confirm email change"
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr "Verify your new email address for %(organization_host)s"
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr "You have requested a new Zulip organisation:"
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr "Organisation type: %(organization_type)s"
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr "You recently signed up for Zulip. Awesome!"
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
@@ -2470,33 +1946,33 @@ msgstr ""
 "Click the button below to create the organisation and register your account. "
 "You'll be able to update the information above if you like."
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr "Click the button below to complete registration."
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr "Complete registration"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr "Create your Zulip organisation"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr "Activate your Zulip account"
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr "Click the link below to complete registration."
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
@@ -2505,20 +1981,20 @@ msgstr ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
 "— we'd love to help!"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr "Manage email preferences"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr "Unsubscribe from marketing emails"
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
@@ -2527,17 +2003,17 @@ msgstr ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
 "deactivated, and you will no longer be able to log in."
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr "The administrators provided the following comment:"
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr "Notification of account deactivation on %(realm_name)s"
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
@@ -2546,11 +2022,11 @@ msgstr ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr "New channels"
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2558,22 +2034,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because your organization has "
@@ -2589,8 +2065,8 @@ msgstr ""
 "disabled <a class=\"content_disabled_help_link\" "
 "href=\"%(help_url)s\">message content appearing in email notifications</a>."
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because you have disabled <a "
@@ -2605,40 +2081,40 @@ msgstr ""
 "class=\"content_disabled_help_link\" href=\"%(alert_notif_url)s\">message "
 "content appearing in email notifications</a>."
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, fuzzy, python-format
 #| msgid "Click here to log in to Zulip and catch up."
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr "Click here to log in to Zulip and catch up."
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr "Unsubscribe from digest emails"
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr "Zulip digest for %(realm_name)s"
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2655,8 +2131,8 @@ msgstr ""
 "disabled message content appearing in email notifications.\n"
 "See %(hide_content_url)s for more details.\n"
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2672,33 +2148,31 @@ msgstr ""
 "message content appearing in email notifications.\n"
 "See %(alert_notif_url)s for more details.\n"
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, fuzzy, python-format
 #| msgid "Click here to log in to Zulip and catch up: %(organization_url)s."
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr "Click here to log in to Zulip and catch up: %(organization_url)s."
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr "Manage email preferences:"
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr "Unsubscribe from digest emails:"
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr "Swimming fish"
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr "Thanks for your request!"
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
@@ -2707,8 +2181,7 @@ msgstr ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
 "organisations:"
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
@@ -2717,7 +2190,7 @@ msgstr ""
 "Your email address %(email)s has accounts with the following Zulip "
 "organisations hosted by %(external_host)s:"
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
@@ -2726,19 +2199,15 @@ msgstr ""
 "If you have trouble logging in, you can <a "
 "href=\"%(help_reset_password_link)s\">reset your password</a>."
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr "You have requested a list of Zulip accounts for this email address."
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr "Unfortunately, no Zulip Cloud accounts were found."
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
@@ -2747,7 +2216,7 @@ msgstr ""
 "Unfortunately, no accounts were found in Zulip organisations hosted by "
 "%(external_host)s."
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2758,27 +2227,24 @@ msgstr ""
 "another email, or <a href =\"%(help_logging_in_link)s\">try another way</a> "
 "to find your account."
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 "If you do not recognise this request, you can safely ignore this email."
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr "Your Zulip accounts"
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr "No Zulip accounts found"
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr "If you have trouble logging in, you can reset your password."
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
@@ -2787,12 +2253,12 @@ msgstr ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
 "try another way to find your account (%(help_logging_in_link)s)."
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr "Hi there,"
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
@@ -2801,17 +2267,17 @@ msgstr ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
 "communication tool designed for productivity."
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr "To get started, click the button below."
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
@@ -2820,17 +2286,17 @@ msgstr ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
 "-- the team communication tool designed for productivity."
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr "To get started, click the link below."
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr "Hi again,"
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
@@ -2839,13 +2305,13 @@ msgstr ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
 "Zulip &mdash; the team communication tool designed for productivity."
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr "This is the last reminder you'll receive for this invitation."
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
@@ -2854,12 +2320,12 @@ msgstr ""
 "This invitation expires in two days. If the invitation expires, you'll need "
 "to ask %(referrer_name)s for another one."
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2870,7 +2336,7 @@ msgstr ""
 "wants you to join them on Zulip -- the team communication tool designed for "
 "productivity."
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2879,7 +2345,7 @@ msgstr ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at <a href=\"mailto:%(email)s\">%(email)s</a>."
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
@@ -2888,23 +2354,21 @@ msgstr ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
 "%(email)s\">Contact us</a> — we'd love to help!"
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr "You are receiving this because you were personally mentioned."
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
@@ -2913,8 +2377,8 @@ msgstr ""
 "You are receiving this because all topic participants were mentioned in "
 "#%(channel_name)s > %(topic_name)s."
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
@@ -2922,16 +2386,16 @@ msgstr ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
@@ -2939,8 +2403,8 @@ msgstr ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
@@ -2949,7 +2413,7 @@ msgstr ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2960,7 +2424,7 @@ msgstr ""
 "%(realm_name)s Zulip</a>, or <a href=\"%(notif_url)s\">manage email "
 "preferences</a>."
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
@@ -2969,7 +2433,7 @@ msgstr ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
@@ -2978,7 +2442,7 @@ msgstr ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
@@ -2987,41 +2451,41 @@ msgstr ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails (<a href=\"%(url)s\">help</a>)."
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr "Group DMs with %(direct_message_group_display_name)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr "DMs with %(sender_str)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr "[resolved] #%(channel_name)s > %(topic_name)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr "New messages"
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr "View or reply in %(realm_name)s Zulip:"
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr "Reply in %(realm_name)s Zulip:"
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
@@ -3029,7 +2493,7 @@ msgstr ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -3040,22 +2504,22 @@ msgstr ""
 "%(new_email)s. If you did not request this change, please contact us "
 "immediately at %(support_email)s."
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr "Best,"
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr "Team Zulip"
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr "Zulip email changed for %(realm_name)s"
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -3066,53 +2530,53 @@ msgstr ""
 "%(new_email)s. If you did not request this change, please contact us "
 "immediately at <%(support_email)s>."
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 msgstr ""
 "Organisation: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr "We noticed a recent login for the following Zulip account."
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr "Organisation: %(organization_link)s"
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr "Email: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr "Time: %(login_time)s"
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr "Device: %(device_browser)s on %(device_os)s."
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr "IP address: %(device_ip)s"
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr "If this was you, great! There's nothing else you need to do."
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3123,31 +2587,31 @@ msgstr ""
 "compromised, please <a href=\"%(reset_link)s\">reset your password</a> or "
 "contact us immediately at %(support_email)s."
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr "Thanks,"
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr "Zulip Security"
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr "Unsubscribe from login notifications"
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr "New login from %(device_browser)s on %(device_os)s"
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr "Organisation: %(organization_url)s"
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3158,7 +2622,7 @@ msgstr ""
 "compromised, please reset your password at %(reset_link)s or contact us "
 "immediately at %(support_email)s."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -3169,7 +2633,7 @@ msgstr ""
 "can use our <a href=\"%(get_organization_started)s\">guide for moving to "
 "Zulip</a> to get started."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
@@ -3177,7 +2641,7 @@ msgstr ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
@@ -3186,12 +2650,12 @@ msgstr ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
 "with you and share their unique perspectives."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr "Use the app itself to chat about your impressions."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -3202,7 +2666,7 @@ msgstr ""
 "team, without using any other chat tools. This is the only way to truly "
 "experience how a new chat app will help your team communicate."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -3213,21 +2677,21 @@ msgstr ""
 "communication</a>, and we hope these tips help your team experience it in "
 "action."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr "Unsubscribe from welcome emails for %(realm_name)s"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr "Choosing the chat app for your team"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
@@ -3235,7 +2699,7 @@ msgstr ""
 "If you've already decided to use Zulip for your organisation, welcome! You "
 "can use our guide for moving to Zulip to get started."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
@@ -3243,7 +2707,7 @@ msgstr ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
@@ -3251,7 +2715,7 @@ msgstr ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
@@ -3261,7 +2725,7 @@ msgstr ""
 "This is the only way to truly experience how a new chat app will help your "
 "team communicate."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
@@ -3269,8 +2733,8 @@ msgstr ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
@@ -3280,71 +2744,71 @@ msgstr ""
 "can work best for your needs. Check out this guide to key Zulip features for "
 "organisations like yours!"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr "View Zulip guide for businesses"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr "View Zulip guide for open-source projects"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr "View Zulip guide for education"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr "View Zulip guide for research"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr "View Zulip guide for events and conferences"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr "View Zulip guide for non-profits"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr "View Zulip guide for communities"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr "Zulip guide for businesses"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr "Zulip guide for open-source projects"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr "Zulip guide for education"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr "Zulip guide for research"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr "Zulip guide for events and conferences"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr "Zulip guide for non-profits"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr "Zulip guide for communities"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
@@ -3352,7 +2816,7 @@ msgstr ""
 "Here are some tips for keeping your Zulip conversations organised with "
 "topics."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
@@ -3360,8 +2824,8 @@ msgstr ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
@@ -3369,12 +2833,12 @@ msgstr ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr "Channels and topics in the Zulip app"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3386,11 +2850,11 @@ msgstr ""
 "For a good topic name, think about finishing the sentence: “Hey, can we chat "
 "about…?”"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr "Examples of short topics"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3403,17 +2867,17 @@ msgstr ""
 "a>, <a href=\"%(rename_topics_link)s\">rename topics</a>, or even <a "
 "href=\"%(move_channels_link)s\">move a topic to a different channel</a>."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr "Go to Zulip"
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr "Keep your conversations organised with topics"
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
@@ -3421,7 +2885,7 @@ msgstr ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3434,8 +2898,8 @@ msgstr ""
 "topics (%(rename_topics_link)s), or even move a topic to a different channel "
 "(%(move_channels_link)s)."
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
@@ -3444,15 +2908,15 @@ msgstr ""
 "Somebody (possibly you) requested a new password for the Zulip account "
 "%(email)s on %(realm_url)s."
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr "Click the button below to reset your password."
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr "Reset password"
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3463,18 +2927,18 @@ msgstr ""
 "deactivated. You can contact an organisation administrator to <a "
 "href=\"%(help_link)s\">reactivate your account</a>."
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr "You do not have an account in that Zulip organisation."
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr "You do have active accounts in the following organisation(s)."
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
@@ -3482,23 +2946,23 @@ msgstr ""
 "You can try logging in or resetting your password in the organisation(s) "
 "above."
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 "If you do not recognise this activity, you can safely ignore this email."
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr "Password reset request for %(realm_name)s"
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr "Click the link below to reset your password."
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
@@ -3507,7 +2971,7 @@ msgstr ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
 "You can contact an organisation administrator to reactivate your account."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3518,7 +2982,7 @@ msgstr ""
 "the Zulip Cloud Free plan because of unpaid invoices. The unpaid invoices "
 "have been voided."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
@@ -3527,7 +2991,7 @@ msgstr ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
 "to %(upgrade_url)s."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
@@ -3536,8 +3000,8 @@ msgstr ""
 "If you think this was a mistake or need more details, please reach out to us "
 "at %(support_email)s."
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "You have deactivated your Zulip organization, %(realm_name)s, on "
@@ -3549,8 +3013,8 @@ msgstr ""
 "You have deactivated your Zulip organisation, %(realm_name)s, on "
 "%(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "Your Zulip organization, %(realm_name)s, was deactivated by "
@@ -3562,8 +3026,8 @@ msgstr ""
 "Your Zulip organisation, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "Your Zulip organization, %(realm_name)s, was deactivated on "
@@ -3575,8 +3039,8 @@ msgstr ""
 "Your Zulip organisation, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
@@ -3585,8 +3049,8 @@ msgstr ""
 "You have deactivated your Zulip organisation, %(realm_name)s, on "
 "%(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
@@ -3595,8 +3059,8 @@ msgstr ""
 "Your Zulip organisation, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
@@ -3605,15 +3069,15 @@ msgstr ""
 "Your Zulip organisation, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 "All data associated with this organisation has been permanently deleted."
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
@@ -3622,8 +3086,8 @@ msgstr ""
 "All data associated with this organisation will be permanently deleted on "
 "%(deletion_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
@@ -3631,19 +3095,19 @@ msgstr ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr "Your Zulip organisation %(realm_name)s has been deactivated"
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr "Dear former administrators of %(realm_name)s,"
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "One of your administrators requested reactivation of the previously "
@@ -3655,8 +3119,8 @@ msgstr ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organisation hosted at %(realm_url)s."
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
@@ -3665,16 +3129,16 @@ msgstr ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organisation hosted at %(realm_url)s."
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr "Click the button below to reactivate your organisation."
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr "Reactivate organisation"
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
@@ -3682,21 +3146,21 @@ msgstr ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Reactivate your Zulip organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "Reactivate your Zulip organisation"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr "Reactivate your Zulip organisation"
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr "Click the link below to reactivate your organisation."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3705,20 +3169,20 @@ msgstr ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for <b>%(remote_server_hostname)s</b>."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, fuzzy
 #| msgid "Click the link below to log in."
 msgid "Click the button below to log in."
 msgstr "Click the link below to log in."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr "This link will expire in %(validity_in_hours)s hours."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
@@ -3727,11 +3191,11 @@ msgstr ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
 "%(billing_contact_email)s."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr "Log in to Zulip plan management"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3740,12 +3204,12 @@ msgstr ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for %(remote_server_hostname)s."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr "Click the link below to log in."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
@@ -3754,7 +3218,7 @@ msgstr ""
 "Questions? Learn more at %(billing_help_link)s or contact "
 "%(billing_contact_email)s."
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
@@ -3763,16 +3227,16 @@ msgstr ""
 "Click the button below to confirm your email and log in to Zulip plan "
 "management for <b>%(remote_realm_host)s</b>."
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr "Confirm and log in"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr "Confirm email for Zulip plan management"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
@@ -3781,7 +3245,7 @@ msgstr ""
 "Click the link below to confirm your email and log in to Zulip plan "
 "management for %(remote_realm_host)s."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
@@ -3790,7 +3254,7 @@ msgstr ""
 "Your request for Zulip sponsorship has been approved! Your organisation has "
 "been upgraded to the <a href=\"%(plans_link)s\">Zulip Community plan</a>."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
@@ -3799,12 +3263,12 @@ msgstr ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
 "website</a>, we would really appreciate it!"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr "Community plan sponsorship approved for %(billing_entity)s!"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
@@ -3812,7 +3276,7 @@ msgstr ""
 "Your request for Zulip sponsorship has been approved! Your organisation has "
 "been upgraded to the Zulip Community plan."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
@@ -3820,21 +3284,21 @@ msgstr ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr "Find your accounts"
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr "Find your Zulip accounts"
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
@@ -3843,7 +3307,7 @@ msgstr ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
 "accounts for another email address</a>."
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
@@ -3851,7 +3315,7 @@ msgstr ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organisations in which you have active accounts."
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
@@ -3859,7 +3323,7 @@ msgstr ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organisations on this server in which you have active accounts."
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
@@ -3867,216 +3331,216 @@ msgstr ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr "Email address"
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "Find accounts"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr "Product"
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr "Why Zulip"
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr "Features"
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr "Plans & pricing"
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Zulip Cloud status"
 msgid "Zulip Cloud"
 msgstr "Zulip Cloud status"
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr "Self-hosting"
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr "Security"
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "Integrations"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr "Desktop & mobile apps"
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr "New organisation"
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr "Solutions"
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr "Business"
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr "Education"
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr "Research"
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr "Events & conferences"
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr "Open source projects"
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr "Communities"
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr "Customer stories"
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr "Open communities"
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr "Resources"
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr "Getting started"
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr "Help centre"
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr "Community chat"
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr "Zulip Cloud status"
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr "Moving to Zulip"
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr "Installing a Zulip server"
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr "Upgrading a Zulip server"
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr "Contributing"
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr "Contributing guide"
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr "Development community"
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr "Translation"
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr "GitHub"
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr "About us"
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr "Team"
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "History"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr "Values"
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr "Jobs"
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr "Blog"
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr "Support Zulip"
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr "Mastodon"
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Values"
 msgid "Bluesky"
 msgstr "Values"
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr "Terms of Service"
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr "Privacy policy"
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr "Website attributions"
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr "Over %(integrations_count_display)s native integrations."
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 #, fuzzy
 #| msgid ""
 #| "And hundreds more through <a href=\"/integrations/doc/zapier\">Zapier</a> "
@@ -4088,51 +3552,47 @@ msgstr ""
 "And hundreds more through <a href=\"/integrations/doc/zapier\">Zapier</a> "
 "and <a href=\"/integrations/doc/ifttt\">IFTTT</a>."
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr "Search integrations"
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr "Custom integrations"
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr "Incoming webhooks"
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr "Interactive bots"
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr "REST API"
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr "Invalid email"
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr "Email not allowed"
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr "The email address you are trying to sign up with is not valid."
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4143,7 +3603,7 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>, does not allow signups using "
 "emails with your email domain."
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4154,7 +3614,7 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>, does not allow signups using "
 "disposable email addresses."
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4165,24 +3625,24 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>, does not allow signups using "
 "emails that contain \"+\"."
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr "Please sign up using a valid email address."
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr "Please sign up using an allowed email address."
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr "No organisation found"
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr "There is no Zulip organisation at <b>%(current_url)s</b>."
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -4193,7 +3653,7 @@ msgstr ""
 "\">get a list of your Zulip Cloud accounts</a>, or <a href=\"mailto:"
 "%(support_email)s\">contact Zulip support</a>."
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -4204,7 +3664,7 @@ msgstr ""
 "\">get a list of your accounts</a> on this server, or <a href=\"mailto:"
 "%(support_email)s\">contact this Zulip server's administrators</a>."
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
@@ -4213,59 +3673,59 @@ msgstr ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
 "management for your Zulip server."
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr "Invalid or expired login session"
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr "Invalid or expired login session."
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr "Log in to Zulip"
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 "You've already registered with this email address. Please log in below."
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr "Email or username"
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "Username"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr "Forgot your password?"
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr "Log in with %(identity_provider)s"
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr "View without an account"
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 "Don't have an account yet? You need to be invited to join this organisation."
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr "No licenses available"
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr "Organisation cannot accept new members right now"
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
@@ -4274,7 +3734,7 @@ msgstr ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> because all Zulip Cloud licenses are in use."
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
@@ -4282,19 +3742,19 @@ msgstr ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr "Skip to main content"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr "Authentication subdomain error"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr "Authentication subdomain"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -4308,18 +3768,17 @@ msgstr ""
 "you got stuck here while trying to log in, this is most likely a server bug "
 "or misconfiguration."
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 #, fuzzy
 #| msgid "No organization found"
 msgid "Demo organizations disabled"
 msgstr "No organisation found"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr "Update required"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
@@ -4327,7 +3786,7 @@ msgstr ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
@@ -4335,22 +3794,21 @@ msgstr ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr "Download the latest release."
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 "You have exceeded the limit for how often a user can perform this action."
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr "Organisation creation link required"
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -4362,12 +3820,11 @@ msgstr ""
 "production/multiple-organizations.html\">documentation</a> on creating a new "
 "organisation for more information."
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr "Organisation creation link expired or invalid"
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
@@ -4375,11 +3832,11 @@ msgstr ""
 "Unfortunately, this is not a valid link for creating an organisation. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr "Unexpected Zulip server registration"
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -4390,17 +3847,16 @@ msgstr ""
 "server installation. Please <a href=\"mailto:%(support_email)s\">contact "
 "Zulip support</a> for assistance in resolving this issue."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr "Unsupported browser"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr "%(browser_name)s is not supported by Zulip."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
@@ -4409,30 +3865,29 @@ msgstr ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
 "a> like Firefox, Chrome, and Edge."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr "Account is deactivated"
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 msgid "Finalize organization import"
 msgstr "Finalise organization import"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Organization moved"
 msgid "Organization import completed!"
 msgstr "Organisation moved"
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -4440,56 +3895,55 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Select your account"
 msgstr "Create your account"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Create new account"
 msgstr "Create your account"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr "Organisation successfully reactivated"
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr "Your organisation has been successfully reactivated."
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr "Organisation reactivation link expired or invalid"
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr "The organisation reactivation link has expired or is not valid."
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr "Log in to your organisation"
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr "your-organisation"
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr "Don't know your organisation URL?"
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr "Find your organisation."
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr "Next"
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4500,13 +3954,13 @@ msgstr ""
 "href=\"%(org_creation_link)s\">Create a new organisation</a> if you don't "
 "have one yet."
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 #, fuzzy
 #| msgid "Self-host Zulip"
 msgid "Self-hosting Zulip?"
 msgstr "Self-host Zulip"
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, fuzzy, python-format
 #| msgid ""
 #| "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4520,11 +3974,11 @@ msgstr ""
 "href=\"%(org_creation_link)s\">Create a new organisation</a> if you don't "
 "have one yet."
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr "Reset your password"
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
@@ -4532,62 +3986,62 @@ msgstr ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr "Send reset link"
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr "Set a new password"
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "Confirm password"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr "Sorry, the link you provided is invalid or has already been used."
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr "New password successfully set"
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr "You've set a new password!"
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr "Password reset email sent"
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr "Password reset sent!"
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr "Check your email in a few minutes to finish the process."
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 #, fuzzy
 #| msgid "Export still in progress"
 msgid "Import progress"
 msgstr "Export still in progress"
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4595,7 +4049,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4604,30 +4058,30 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 #, fuzzy
 #| msgid ""
 #| "Nobody in this Zulip organization will be able to see this email address."
@@ -4635,30 +4089,30 @@ msgid "Who will be allowed to see other users' email addresses?"
 msgstr ""
 "Nobody in this Zulip organisation will be able to see this email address."
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4666,7 +4120,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4674,21 +4128,21 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr "Select account for authentication"
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr "<h1 class=\"get-started\">Select account</h1>"
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 "Your GitHub account also has unverified email addresses associated with it."
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
@@ -4696,15 +4150,15 @@ msgstr ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr "Error unsubscribing email"
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr "Unknown email unsubscribe request"
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
@@ -4712,7 +4166,7 @@ msgstr ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognise the URL."
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4723,12 +4177,11 @@ msgstr ""
 "href=\"mailto:%(support_email)s\">email us</a> and we'll get this squared "
 "away!"
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr "Email settings updated"
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
@@ -4737,7 +4190,7 @@ msgstr ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
@@ -4746,50 +4199,49 @@ msgstr ""
 "You can undo this change or review your preferences in your <a "
 "href=\"%(realm_url)s/#settings/notifications\">notification settings</a>."
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr "Invalid order mapping."
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr "Questions and discussion about using Zulip."
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr "Experiment with Zulip here. :test_tube:"
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr "For team-wide conversations"
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr "signups"
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr "{user} joined this organisation."
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr "{user} accepted your invitation to join Zulip!"
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 #, fuzzy
 #| msgid "Cannot deactivate user group in use."
 msgid "Cannot reactivate a deleted user"
 msgstr "Cannot deactivate user group in use."
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
@@ -4797,48 +4249,47 @@ msgstr ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr "Field id {id} not found."
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr "Invalid default channel group name '{group_name}'"
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr "Default channel group name too long (limit: {max_length} characters)"
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr "Invalid default channel group {group_name}"
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr "Default channel group '{group_name}' already exists"
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
@@ -4847,7 +4298,7 @@ msgstr ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
@@ -4856,12 +4307,12 @@ msgstr ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr "This default channel group is already named '{group_name}'"
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
@@ -4869,7 +4320,7 @@ msgstr ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
@@ -4877,75 +4328,75 @@ msgstr ""
 "Your account is too new to send invites for this organisation. Ask an "
 "organisation admin, or a more experienced user."
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr "Some emails did not validate, so we didn't send any invitations."
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr "We weren't able to invite anyone."
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr "Nothing to change"
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr "Direct messages cannot be moved to channels."
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr "Direct messages cannot have topics."
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr "Invalid propagate_mode without topic edit"
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr "General chat cannot be marked as resolved"
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr "Cannot change message content while changing channel"
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr "Widgets cannot be edited."
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr "Your organisation has turned off message editing"
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr "You don't have permission to edit this message"
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr "The time limit for editing this message has passed"
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr "{user} has marked this topic as resolved."
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr "{user} has marked this topic as unresolved."
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr "This topic was moved to {new_location} by {user}."
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr "A message was moved from this topic to {new_location} by {user}."
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
@@ -4954,19 +4405,19 @@ msgstr ""
 "{changed_messages_count} messages were moved from this topic to "
 "{new_location} by {user}."
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr "This topic was moved here from {old_location} by {user}."
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 msgstr ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
@@ -4975,67 +4426,64 @@ msgstr ""
 "{changed_messages_count} messages were moved here from {old_location} by "
 "{user}."
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 #, fuzzy
 #| msgid "You do not have permission to post in this channel."
 msgid "You don't have permission to resolve topics in this channel."
 msgstr "You do not have permission to post in this channel."
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr "The time limit for editing this message's topic has passed."
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr "You don't have permission to move this message"
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr "The time limit for editing this message's channel has passed"
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr "Invalid flag: '{flag}'"
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr "Flag not editable: '{flag}'"
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr "Invalid message flag operation: '{operation}'"
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr "Invalid message(s)"
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr "Unable to render message"
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr "Expected exactly one channel"
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr "Invalid data type for channel"
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr "Invalid data type for recipients"
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr "Recipient lists may contain emails or user IDs, but not both."
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
@@ -5044,7 +4492,7 @@ msgstr ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
 "but there is no channel with that ID."
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -5055,7 +4503,7 @@ msgstr ""
 "but that channel does not exist. Click [here]({new_channel_link}) to create "
 "it."
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
@@ -5064,30 +4512,30 @@ msgstr ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
 "The channel exists but does not have any subscribers."
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr "You do not have permission to access some of the recipients."
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr "Widgets: API programmer sent invalid JSON content"
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr "Widgets: {error_msg}"
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, fuzzy, python-brace-format
 #| msgid "{user_name} created the following channels: {new_channels}."
 msgid "{user} has made the following changes to your account."
 msgstr "{user_name} created the following channels: {new_channels}."
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5095,25 +4543,23 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr "A custom emoji with this name already exists."
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr "Invalid image format"
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr "The ordered list must not contain duplicated linkifiers"
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr "The ordered list must enumerate all existing linkifiers exactly once"
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
@@ -5122,39 +4568,39 @@ msgstr ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
 "authentication method."
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr "Invalid authentication method: {name}. Valid methods are: {methods}"
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr "Authentication method {name} is not available on your current plan."
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr "Moderation request channel must be private."
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr "Saved snippet does not exist."
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr "Scheduled message was already sent"
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder could not be sent."
 msgstr "Token does not exist"
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr "Message could not be sent at the scheduled time."
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
@@ -5163,40 +4609,40 @@ msgstr ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
 "the following error:"
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr "[View scheduled messages](#scheduled)"
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr "Channel is already deactivated"
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, fuzzy, python-brace-format
 #| msgid "Channel {channel_name} has been archived."
 msgid "Channel #**{channel_name}** has been archived."
 msgstr "Channel {channel_name} has been archived."
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr "Channel is not currently deactivated"
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr "Channel named {channel_name} already exists"
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr "Channel is private and have no subscribers"
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, fuzzy, python-brace-format
 #| msgid "Channel {channel_name} has been archived."
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr "Channel {channel_name} has been archived."
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
@@ -5205,7 +4651,7 @@ msgstr ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
 "**{old_policy}** to **{new_policy}**."
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -5218,40 +4664,38 @@ msgstr ""
 "* **Old**: {old_setting_description}\n"
 "* **New**: {new_setting_description}\n"
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr "No description."
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr "{user} changed the description for this channel."
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr "Old description"
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr "New description"
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr "Forever"
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr "{number_of_days} days"
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
@@ -5260,11 +4704,11 @@ msgstr ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr "Messages in this channel will now be retained forever."
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -5281,99 +4725,89 @@ msgstr ""
 "\n"
 "{summary_line}"
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr "You cannot attach a submessage to this message."
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr "Invalid user ID {user_id}"
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr "User group '{group_name}' already exists."
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr "Insufficient permission"
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr "This API is not available to incoming webhook bots."
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr "Account is not associated with this subdomain"
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr "This endpoint does not accept bot requests."
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr "Must be an server administrator"
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr "This endpoint requires HTTP basic authentication."
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr "Invalid authorisation header for basic auth"
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr "Missing authorisation header for basic auth"
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr "Webhook bots can only access webhooks"
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr "Incorrect email or password."
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
@@ -5382,52 +4816,51 @@ msgstr ""
 "Your account {username} has been deactivated. Please contact your "
 "organisation administrator to reactivate it."
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr "The password is too weak."
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr "Subdomain needs to have length 3 or greater."
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr "Subdomain cannot start or end with a '-'."
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr "Subdomain can only have lowercase letters, numbers, and '-'s."
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr "Subdomain is already in use. Please choose a different one."
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr "Subdomain reserved. Please choose a different one."
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr "Please use your real email address."
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr "The organisation you are trying to join using {email} does not exist."
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr ""
 "Please request an invite for {email} from the organisation administrator."
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
@@ -5436,11 +4869,11 @@ msgstr ""
 "Your email address, {email}, is not in one of the domains that are allowed "
 "to register for accounts in this organisation."
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr "Email addresses containing + are not allowed in this organisation."
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
@@ -5450,34 +4883,33 @@ msgstr ""
 "use. Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 #, fuzzy
 #| msgid "Embedded bots are not enabled."
 msgid "Challenges are not enabled."
 msgstr "Embedded bots are not enabled."
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "New password"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr "New password confirmation"
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "You're making too many attempts to sign in. Try again in {seconds} "
@@ -5489,7 +4921,7 @@ msgstr ""
 "You're making too many attempts to sign in. Try again in {seconds} seconds "
 "or contact your organisation administrator for help."
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
@@ -5497,94 +4929,92 @@ msgstr ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr "Token"
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr "Tip: You can enter multiple email addresses with commas between them."
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr "Please enter at most 10 emails."
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr "We couldn't find that Zulip organisation."
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr "Invalid email '{email}'"
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr "Missing topic"
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr "Cannot send to multiple channels"
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr "Missing channel"
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr "Message must have recipients"
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr "Invalid message type"
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr "Invalid attachment"
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr ""
 "An error occurred while deleting the attachment. Please try again later."
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr "Message must have recipients!"
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Channel name can't be empty."
 msgid "Channel folder name can't be empty."
 msgstr "Channel name can't be empty."
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid character in channel name, at position {position}."
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr "Invalid character in channel name, at position {position}."
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Channel name is already in use."
 msgid "Channel folder name already in use"
 msgstr "Channel name is already in use."
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Invalid channel ID"
 msgid "Invalid channel folder ID"
 msgstr "Invalid channel ID"
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 #, fuzzy
 #| msgid "Confirm your email address"
 msgid "Configure owner account email address."
 msgstr "Confirm your email address"
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "\n"
@@ -5601,72 +5031,72 @@ msgstr ""
 "Note that this is a [demo organization]({demo_organization_help_url}) and\n"
 "will be **automatically deleted** in 30 days.\n"
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a date"
 msgid "{var_name} is not Base64 encoded"
 msgstr "{var_name} is not a date"
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 #, fuzzy
 #| msgid "Invalid emoji code."
 msgid "Invalid `device_id`"
 msgstr "Invalid emoji code."
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr "{service_name} digest"
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr "Domain can't be empty."
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr "Domain must have at least one dot (.)"
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr "Domain is too long"
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr "Domain cannot start or end with a dot (.)"
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr "Consecutive '.' are not allowed."
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr "Subdomains cannot start or end with a '-'."
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr "Domain can only have letters, numbers, '.' and '-'s."
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr "Timestamp must not be negative."
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr "Topic must not contain null bytes"
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr "Must specify exactly 1 channel ID for channel messages"
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr "User has disabled synchronizing drafts."
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr "Draft does not exist"
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5677,86 +5107,86 @@ msgstr ""
 "email reply:\n"
 "{error_message}"
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr "Email with no subject"
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr "Open Zulip to see the spoiler content"
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr "{service_name} notifications"
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr "Invalid address."
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr "Outside your domain."
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr "Email addresses containing + are not allowed."
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr "Reserved for system bots."
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr "{email} already has an account"
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr "Already has an account."
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr "Account has been deactivated."
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr "Emoji '{emoji_name}' does not exist"
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr "Invalid custom emoji."
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr "Invalid custom emoji name."
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr "This custom emoji has been deactivated."
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr "Invalid emoji code."
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr "Invalid emoji name."
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr "Invalid emoji type."
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr "Must be an organisation administrator or emoji author"
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr "Emoji names must end with either a letter or digit."
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
@@ -5764,97 +5194,96 @@ msgstr ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr "Emoji name is missing"
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr "Could not allocate event queue"
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr "Not logged in: API authentication or user session required"
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, fuzzy, python-brace-format
 #| msgid "Channel named {channel_name} already exists"
 msgid "Channel '{channel_name}' already exists"
 msgstr "Channel named {channel_name} already exists"
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr "Channel '{stream}' does not exist"
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr "Channel with ID '{stream_id}' does not exist"
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr "Unsupported parameter combination: {parameters}"
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr "organisation owner"
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr "user"
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr "Cannot deactivate the only {entity}."
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr "Invalid Markdown include statement: {include_statement}"
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr "Malformed JSON"
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr "Must be an organisation administrator"
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr "Must be an organisation owner"
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Must be an organization owner"
 msgid "Must be a bot user"
 msgstr "Must be an organisation owner"
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr "Your username or password is incorrect"
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr "This organisation has been deactivated"
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
@@ -5862,23 +5291,23 @@ msgstr ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr "Password authentication is disabled in this organisation"
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr "Your password has been disabled and needs to be reset"
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr "Invalid API key"
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr "Malformed API key"
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
@@ -5887,56 +5316,55 @@ msgstr ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
 "webhook; ignoring"
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr "Unable to parse request: Did {webhook_name} generate this event?"
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr "User not authenticated"
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr "Invalid subdomain"
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr "You do not have permission to initiate direct message conversations."
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr "Direct messages are disabled in this organisation."
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr "This conversation does not include any users who can authorise it."
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr "Access denied"
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
@@ -5945,15 +5373,15 @@ msgstr ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} most recent messages in this topic."
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr "Reaction already exists."
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr "Reaction doesn't exist."
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
@@ -5961,368 +5389,368 @@ msgstr ""
 "Your organisation is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr "Organisation not registered"
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 "You do not have permission to use channel wildcard mentions in this channel."
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 "You do not have permission to use topic wildcard mentions in this topic."
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, fuzzy, python-brace-format
 #| msgid "'old' value does not match the expected value."
 msgid "'{field_name}' value does not match the expected value."
 msgstr "'old' value does not match the expected value."
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr "'{setting_name}' must be a system user group."
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr "Cannot deactivate user group in use."
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr "You do not have permission to administer this channel."
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr "You do not have permission to change default channels."
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr "Email is already in use."
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr "Scheduled delivery time must be in the future."
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Server doesn't use the push notification service"
 msgid "Server is not configured to use push notification service."
 msgstr "Server doesn't use the push notification service"
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Already has an account."
 msgid "Atlassian account ID"
 msgstr "Already has an account."
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Behance username"
 msgstr "Bad name or username"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Bitbucket username"
 msgstr "GitHub username"
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Codeberg username"
 msgstr "Twitter username"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Dribbble username"
 msgstr "GitHub username"
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Facebook username"
 msgstr "Bad name or username"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr "GitHub username"
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "GitLab username"
 msgstr "GitHub username"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Instagram username"
 msgstr "Twitter username"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Mastodon"
 msgid "Mastodon profile"
 msgstr "Mastodon"
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Medium username"
 msgstr "GitHub username"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Pinterest username"
 msgstr "Twitter username"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Reddit username"
 msgstr "GitHub username"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Snapchat username"
 msgstr "GitHub username"
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Threads username"
 msgstr "Twitter username"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "TikTok username"
 msgstr "Twitter username"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Twitch username"
 msgstr "Twitter username"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "Username"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr "Invalid external account type"
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr "Integration frameworks"
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 #, fuzzy
 #| msgid "Video call ended"
 msgid "Video calling"
 msgstr "Video call ended"
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr "Continuous integration"
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr "Customer support"
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr "Deployment"
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr "Entertainment"
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr "Communication"
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr "Financial"
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr "Human resources"
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr "Marketing"
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr "Miscellaneous"
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr "Monitoring"
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr "Project management"
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr "Productivity"
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr "Version control"
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr "Message must not be empty"
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr "Message must not contain null bytes"
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr "You are not allowed to mention user group '{user_group_name}'."
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{fullname} moderation"
 msgstr "{full_name} mentioned you:"
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr "Invalid narrow operator: {desc}"
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr "Invalid narrow operator combination: {desc}"
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr "Duplicate 'with' operators."
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr "Invalid 'with' operator"
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr "Missing 'anchor' argument."
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 #, fuzzy
 #| msgid "Missing 'anchor' argument."
 msgid "Missing 'anchor_date' argument."
 msgstr "Missing 'anchor' argument."
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr "Invalid anchor"
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr "Operator {operator} not supported."
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr "Operand {operand} not supported."
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 #, fuzzy
 #| msgid "Confirmation link does not exist"
 msgid "Navigation view does not exist."
 msgstr "Confirmation link does not exist"
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6333,7 +5761,7 @@ msgstr ""
 "To learn more, check out our [using Zulip for a class guide]"
 "({getting_started_url})!\n"
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6344,7 +5772,7 @@ msgstr ""
 "To learn more, check out our [getting started guide]"
 "({getting_started_url})!\n"
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6355,7 +5783,7 @@ msgstr ""
 "We also have a guide for [setting up Zulip for a class]"
 "({organization_setup_url}).\n"
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6366,7 +5794,7 @@ msgstr ""
 "We also have a guide for [moving your organisation to Zulip]"
 "({organization_setup_url}).\n"
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "\n"
@@ -6384,7 +5812,7 @@ msgstr ""
 "Note that this is a [demo organization]({demo_organization_help_url}) and\n"
 "will be **automatically deleted** in 30 days.\n"
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
@@ -6394,7 +5822,7 @@ msgstr ""
 "I've kicked off some conversations to help you get started. You can find\n"
 "them in your [Inbox](/#inbox).\n"
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6405,7 +5833,7 @@ msgstr ""
 "You can always come back to the [Welcome to Zulip video]"
 "({navigation_tour_video_url}) for a quick app overview.\n"
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6430,7 +5858,7 @@ msgstr ""
 "{demo_organization_text}\n"
 "\n"
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
@@ -6440,7 +5868,7 @@ msgstr ""
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -6452,7 +5880,7 @@ msgstr ""
 "change-your-profile-picture)\n"
 "and edit your [profile information](/help/edit-your-profile).\n"
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -6470,7 +5898,7 @@ msgstr ""
 "Zulip\n"
 "experience in your [Preferences](#settings/preferences).\n"
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6487,7 +5915,7 @@ msgstr ""
 "\n"
 "[Browse and subscribe to channels]({settings_link}).\n"
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -6517,7 +5945,7 @@ msgstr ""
 "being\n"
 "discussed.\n"
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -6531,7 +5959,7 @@ msgstr ""
 "\n"
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -6551,7 +5979,7 @@ msgstr ""
 "global\n"
 "times, and more.\n"
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "\n"
@@ -6572,7 +6000,7 @@ msgstr ""
 "Check out our [Getting started guide](/help/getting-started-with-zulip),\n"
 "or browse the [Help center](/help/) to learn more!\n"
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6583,7 +6011,7 @@ msgstr ""
 "You can chat with me as much as you like! To\n"
 "get help, try one of the following messages: {bot_commands}\n"
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6602,7 +6030,7 @@ msgstr ""
 "or even move a topic [to a different channel]"
 "({move_content_another_channel_help_url}).\n"
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
@@ -6610,7 +6038,7 @@ msgstr ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6633,12 +6061,11 @@ msgstr ""
 "sidebar\n"
 "and above.\n"
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr "welcome to Zulip!"
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -6650,7 +6077,7 @@ msgstr ""
 "context,\n"
 "no matter how many other conversations are going on.\n"
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
@@ -6660,7 +6087,7 @@ msgstr ""
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
 "conversations with unread messages.\n"
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -6672,7 +6099,7 @@ msgstr ""
 "click\n"
 "the `+` button next to its name.\n"
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -6684,7 +6111,7 @@ msgstr ""
 "“Hey,\n"
 "can we chat about…?”\n"
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
@@ -6692,7 +6119,7 @@ msgstr ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6703,7 +6130,7 @@ msgstr ""
 ":point_right:  Use this topic to try out [Zulip's messaging features]"
 "({format_message_help_url}).\n"
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6738,7 +6165,7 @@ msgstr ""
 "\n"
 "```\n"
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
@@ -6748,7 +6175,7 @@ msgstr ""
 "This **greetings** topic is a great place to say “hi” :wave: to your "
 "teammates.\n"
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
@@ -6758,900 +6185,882 @@ msgstr ""
 ":point_right: Click on this message to start a new message in the same "
 "conversation.\n"
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr "moving messages"
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr "experiments"
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr "start a conversation"
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr "greetings"
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr "Invalid JSON in response"
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr "Invalid response format"
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr "Empty or invalid length token"
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr "Invalid APNS token"
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr "Invalid GCM option to bouncer: priority {priority!r}"
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr "Invalid GCM options to bouncer: {options}"
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr "Token does not exist"
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr "{full_name} mentioned @{user_group_name}:"
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr "{full_name} mentioned you:"
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr "{full_name} mentioned everyone:"
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "New message"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr "Test notification"
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr "This is a test notification from {realm_name} ({realm_url})."
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr "Device not recognised"
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr "Device not recognised by the push bouncer"
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 #, fuzzy
 #| msgid "Server doesn't use the push notification service"
 msgid "Network error while connecting to Zulip push notification service."
 msgstr "Server doesn't use the push notification service"
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 #, fuzzy
 #| msgid "Server doesn't use the push notification service"
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr "Server doesn't use the push notification service"
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 #, fuzzy
 #| msgid "Invalid API key"
 msgid "Invalid `push_key`"
 msgstr "Invalid API key"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr "Invalid data type for channel ID"
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr "User not authorised for this query"
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr "'{email}' is no longer using Zulip."
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr "You can't send direct messages outside of your organisation."
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "Channel name too long (limit: {max_length} characters)."
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr "Channel name too long (limit: {max_length} characters)."
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder does not exist"
 msgstr "Token does not exist"
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr "Push notifications bouncer error: {error}"
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr "Missing '{var_name}' argument"
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr "Bad value for '{var_name}': {bad_value}"
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr "Scheduled message does not exist"
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr "{service_name} account security"
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr "A default channel cannot be private."
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr "Web-public channels are not enabled."
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr "You do not have permission to post in this channel."
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr "Not authorised to send to channel '{channel_name}'"
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 #, fuzzy
 #| msgid "You do not have permission to post in this channel."
 msgid "You do not have permission to create new topics in this channel."
 msgstr "You do not have permission to post in this channel."
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr "Invalid channel ID"
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr "Invalid channel name '{channel_name}'"
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr "Channel(s) ({channel_names}) do not exist"
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr "Default channel group with id '{group_id}' does not exist."
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr "Channel name can't be empty."
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr "Channel name too long (limit: {max_length} characters)."
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr "Invalid character in channel name, at position {position}."
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr "Invalid character in topic, at position {position}!"
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr "Subscriber data is not available for this channel"
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr "Unable to retrieve subscribers for private channel"
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr "Could not decode image; did you upload an image file?"
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr "Image size exceeds limit."
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr "Image is corrupted or truncated"
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr "{var_name} is not a boolean"
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} does not have a length"
 msgid "{var_name} does not have the expected format"
 msgstr "{var_name} does not have a length"
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr "{var_name} is not a date"
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr "{var_name} is not a dict"
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr "Invalid {var_name}"
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr "Argument \"{argument}\" at {var_name} is unexpected"
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr "{var_name} is not a float"
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr "{var_name} is too small"
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr "{var_name} is not an integer"
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr "{var_name} is not valid JSON"
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr "{var_name} is too large"
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr "{var_name} is not a list"
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr "{var_name} is too long (limit: {max_length} characters)"
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr "{var_name} is too short."
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr "{var_name} is not a string"
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr "{var_name} has invalid format"
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr "{var_name} is not length {length}"
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr "{var_name} is too long (limit: {max_length} characters)"
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr "{var_name} is too long (limit: {max_length} characters)"
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr "{var_name} cannot be blank"
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr "Invalid {var_name}: {msg}"
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr "{var_name} field is missing: {msg}"
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr "Malformed payload"
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr "Not in the list of possible values"
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr "Not a URL"
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr "Not a recognised time zone"
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr "{var_name} is not a valid hex colour code"
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr "Invalid {setting_name}"
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr "Upload would exceed your organisation's upload quota."
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr "Image size exceeds limit"
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr "User group is deactivated."
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr "Invalid user group"
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid user group ID: {group_id}"
 msgid "Invalid user group ID: {user_group_id}"
 msgstr "Invalid user group ID: {group_id}"
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr "Invalid system group name."
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr "Invalid user group ID: {group_id}"
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr "'{setting_name}' setting cannot be set to 'role:internet' group."
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr "'{setting_name}' setting cannot be set to 'role:nobody' group."
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr "'{setting_name}' setting cannot be set to 'role:everyone' group."
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr "'{setting_name}' setting cannot be set to '{group_name}' group."
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr "User group name can't be empty!"
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr "User group name cannot exceed {max_length} characters."
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr "User group name cannot start with '{prefix}'."
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr "Client did not pass any new values."
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr "Name too long!"
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 #, fuzzy
 #| msgid "Message must not be empty"
 msgid "Name must not be empty!"
 msgstr "Message must not be empty"
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr "Invalid characters in name!"
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr "Invalid format!"
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr "Unique names required in this organisation."
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr "Name is already in use."
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr "Bad name or username"
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr "Invalid integration '{integration_name}'."
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr "Missing configuration parameters: {keys}"
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr "Invalid {key} value {value} ({error})"
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr "Invalid configuration data!"
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr "Invalid bot type"
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr "Invalid interface type"
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr "Invalid user ID: {user_id}"
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr "No such bot"
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr "No such user"
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr "User is deactivated"
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr "{item} cannot be blank."
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr "{var_name} has incorrect length {length}; should be {target_length}"
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a string"
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr "{var_name} is not a string"
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr "{container} should have exactly {length} items"
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr "{key_name} key is missing from {var_name}"
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr "Unexpected arguments: {keys}"
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr "{var_name} is not an allowed_type"
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr "{variable} != {expected_value} ({value} is wrong)"
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr "{var_name} is not a URL"
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr "URL pattern must contain '%(username)s'."
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr "'{item}' cannot be blank."
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr "Field must not have duplicate choices."
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr "'{value}' is not a valid choice for '{field_name}'."
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr "{var_name} is not a string or an integer list"
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr "{var_name} is not a string or integer"
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr "{var_name} does not have a length"
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr "{var_name} is missing"
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr "Missing the HTTP event header '{header}'"
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, fuzzy, python-brace-format
 #| msgid "Operator {operator} not supported."
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr "Operator {operator} not supported."
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr "There should be a leading slash in the zcommand."
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr "No such command: {command}"
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr "`zulip_update_announcements_stream` is unexpectedly deactivated."
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr "CSRF error: {reason}"
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr "Reverse proxy misconfiguration: {proxy_reason}"
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr "Invalid user IDs: {invalid_ids}"
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr "User with ID {user_id} is deactivated"
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr "User with ID {user_id} is a bot"
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr "Date"
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr "External account"
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr "Pronouns"
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr "Nobody"
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr "Full members"
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "Members"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr "Everyone on the internet"
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Invalid characters in emoji name"
 msgid "Invalid auto-conversion field: empty field name."
 msgstr "Invalid characters in emoji name"
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr "Group %(name)r in URL template is not present in linkifier pattern."
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr "Bad regular expression: {regex}"
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr "Unknown regular expression error"
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr "Invalid URL template."
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid "Example input does not match the linkifier pattern."
 msgstr "Group %(name)r in URL template is not present in linkifier pattern."
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr "Group %(name)r in URL template is not present in linkifier pattern."
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr "Group %(name)r in linkifier pattern is not present in URL template."
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid ""
@@ -7659,7 +7068,7 @@ msgid ""
 "pattern."
 msgstr "Group %(name)r in URL template is not present in linkifier pattern."
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgid ""
@@ -7667,333 +7076,330 @@ msgid ""
 "template."
 msgstr "Group %(name)r in linkifier pattern is not present in URL template."
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr "Unicode emoji"
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "Custom emoji"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr "Zulip extra emoji"
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr "Invalid characters in emoji name"
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr "Invalid characters in pygments language"
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr "Missing the required variable \"code\" in the URL template"
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr "\"code\" should be the only variable present in the URL template"
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr "sandbox"
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr "general"
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr "channel events"
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr "Zulip updates"
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr "Available on Zulip Cloud Standard. Upgrade to access."
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr "Available on Zulip Cloud Plus. Upgrade to access."
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr "Allow GIFs rated G (General audience)"
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr "Allow GIFs rated PG (Parental guidance)"
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr "Allow GIFs rated R (Restricted)"
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr "Web-public"
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "Public"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr "Private, shared history"
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr "Private, protected history"
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr "Admins, moderators, members and guests"
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr "Admins, moderators and members"
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr "Admins and moderators"
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr "Admins only"
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr "Unknown user"
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr "Organisation owner"
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr "Organisation administrator"
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr "Moderator"
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "Member"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "Guest"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr "Unknown IP address"
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr "an unknown operating system"
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr "An unknown browser"
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr "Missing 'queue_id' argument"
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr "Missing 'last_event_id' argument"
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr "An event newer than {event_id} has already been pruned!"
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr "Event {event_id} was not in this queue"
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr "Bad event queue ID: {queue_id}"
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 #, fuzzy
 #| msgid "Failed to create Zoom call"
 msgid "Failed to generate challenge"
 msgstr "Failed to create Zoom call"
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr "JWT authentication is not enabled for this organisation"
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr "No JSON web token passed in request"
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr "Bad JSON web token"
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr "No email specified in JSON web token claims"
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr "Subdomain required"
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr "Password is incorrect."
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr "User-Agent header missing from request"
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr "Label cannot be blank."
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr "Field must have at least one choice."
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr "Field type not supported for display in profile summary."
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 #, fuzzy
 #| msgid "Field type not supported for display in profile summary."
 msgid "Field type not supported for use for user matching."
 msgstr "Field type not supported for display in profile summary."
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr "Invalid field type."
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr "Only 2 custom profile fields can be displayed in the profile summary."
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr "A field with that label already exists."
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr "Default custom field cannot be updated."
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr "Endpoint not available in production."
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr "DevAuthBackend not enabled."
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr "Invalid '{key}' parameter for anonymous request"
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr "Database is empty"
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr "Cannot query postgresql"
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr "Cannot connect to rabbitmq"
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr "Cannot query rabbitmq"
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr "Cannot query redis"
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr "Cannot write to memcached"
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr "Cannot query memcached"
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr "No such invitation"
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 #, fuzzy
 #| msgid "Invitation has already been revoked"
 msgid "Invitation already used or deactivated."
 msgstr "Invitation has already been revoked"
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr "Invitation has already been revoked"
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr "Invalid channel ID {channel_id}. No invites were sent."
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr "You do not have permission to subscribe other users to channels."
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr "You must specify at least one email address."
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
@@ -8001,108 +7407,106 @@ msgstr ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr "Message edit history is disabled in this organisation"
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr "You don't have permission to delete this message"
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr "The time limit for deleting this message has passed"
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr "Message already deleted"
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr "Too many messages requested (maximum {max_messages})."
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr "The anchor can only be excluded at an end of the range"
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr "No such topic '{topic}'"
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Channel content access is required."
 msgid "An explanation is required."
 msgstr "Channel content access is required."
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Zephyr mirroring is not allowed in this organization"
 msgid "Message reporting is not enabled in this organization."
 msgstr "Zephyr mirroring is not allowed in this organisation"
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr "Missing sender"
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr "Mirroring not allowed with recipient user IDs"
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr "Invalid mirrored message"
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr "AI features are not enabled on this server."
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr "Reached monthly limit for AI credits."
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr "No messages in conversation to summarise"
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr "Cannot mute self"
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr "User already muted"
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr "User is not muted"
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 #, fuzzy
 #| msgid "{hostname} is not a valid hostname"
 msgid "Custom views must have a valid name."
 msgstr "{hostname} is not a valid hostname"
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 #, fuzzy
 #| msgid "Reaction already exists."
 msgid "Navigation view already exists."
 msgstr "Reaction already exists."
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr "Unknown onboarding_step: {onboarding_step}"
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -8113,58 +7517,58 @@ msgstr ""
 "You asked to watch the [Welcome to Zulip video]({navigation_tour_video_url}) "
 "later. Is this a good time?\n"
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr "Presence is not supported for bot users."
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr "No presence data for {user_id_or_email}"
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr "Invalid status: {status}"
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 #, fuzzy
 #| msgid "You do not have permission to change default channels."
 msgid "You do not have permission to manage plans and billing."
 msgstr "You do not have permission to change default channels."
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr "Server doesn't use the push notification service"
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr "Error returned by the bouncer: {result}"
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr "Verification secret not prepared"
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
@@ -8172,297 +7576,296 @@ msgstr ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr "Read receipts are disabled in this organisation."
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr "Invalid language '{language}'"
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr "At least one authentication method must be enabled."
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr "Invalid video_chat_provider {video_chat_provider}"
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid giphy_rating {giphy_rating}"
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr "Invalid giphy_rating {giphy_rating}"
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr "Must be a demo organisation."
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr "Invalid domain: {error}"
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr "The domain {domain} is already a part of your organisation."
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr "No entry found for domain {domain}."
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr "You must upload exactly one file."
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr "Only administrators can override default emoji."
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr "Uploaded file is larger than the allowed limit of {max_size} MiB"
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 #, fuzzy
 #| msgid "JWT authentication is not enabled for this organization"
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr "JWT authentication is not enabled for this organisation"
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr "Exceeded rate limit."
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr "Invalid data export ID"
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr "Export already deleted"
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr "Export failed, nothing to delete"
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr "Export still in progress"
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr "You must upload exactly one icon."
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr "Linkifier not found."
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr "You must upload exactly one logo."
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid characters in pygments language"
 msgid "Invalid character in language: {character}"
 msgstr "Invalid characters in pygments language"
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid language '{language}'"
 msgid "Language '{language}' is not allowed."
 msgstr "Invalid language '{language}'"
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr "Invalid playground"
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "User not authenticated"
 msgid "Unauthenticated"
 msgstr "User not authenticated"
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "moving messages"
 msgid "Importing messages…"
 msgstr "moving messages"
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "Your full name"
 msgid "Your name"
 msgstr "Your full name"
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr "Recipient required when updating type of scheduled message."
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr "Topic required when updating scheduled message type to channel."
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr "Invalid request format"
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr "Invalid DSN"
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr "Private channels cannot be made default."
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr "You must pass \"new_description\" or \"new_group_name\"."
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr "Invalid parameters"
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr "Channel content access is required."
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr "Channel already has that name."
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, fuzzy, python-brace-format
 #| msgid "{user_full_name} subscribed you to the channel {channel_name}."
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr "{user_full_name} subscribed you to the channel {channel_name}."
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr "{user_full_name} subscribed you to the following channels:"
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr "Unable to access channel ({channel_name})."
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr "{user_name} created the following channels: {new_channels}."
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr "{user_name} created a new channel {new_channels}."
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr "new channels"
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, fuzzy, python-brace-format
 #| msgid "**{policy}** channel created by {user_name}. **Description:**"
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr "**{policy}** channel created by {user_name}. **Description:**"
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, fuzzy, python-brace-format
 #| msgid "**{policy}** channel created by {user_name}. **Description:**"
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr "**{policy}** channel created by {user_name}. **Description:**"
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, fuzzy, python-brace-format
 #| msgid "**{policy}** channel created by {user_name}. **Description:**"
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr "**{policy}** channel created by {user_name}. **Description:**"
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, fuzzy, python-brace-format
 #| msgid "**{policy}** channel created by {user_name}. **Description:**"
 msgid ""
@@ -8470,26 +7873,26 @@ msgid ""
 "**"
 msgstr "**{policy}** channel created by {user_name}. **Description:**"
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr "{property} is not a boolean"
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr "Unknown subscription property: {property}"
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr "Not subscribed to channel ID {channel_id}"
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr "Invalid json for submessage"
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
@@ -8498,7 +7901,7 @@ msgstr ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organisation's plan."
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
@@ -8507,7 +7910,7 @@ msgstr ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
@@ -8516,52 +7919,51 @@ msgstr ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr "User has disabled typing notifications for channel messages"
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr "Missing 'to' argument"
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr "Empty 'to' list"
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr "User has disabled typing notifications for direct messages"
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr "<p>This file does not exist or has been deleted.</p>"
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr "<p>You are not authorised to view this file.</p>"
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr "Invalid token"
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr "Invalid filename"
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr "You must specify a file to upload"
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr "You may only upload one file at a time"
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr "No new data supplied"
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
@@ -8569,32 +7971,32 @@ msgstr ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr "{user_full_name} added you to the group {group_name}."
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr "{user_full_name} removed you from the group {group_name}."
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr "User {user_id} is already a member of this group"
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr "There is no member '{user_id}' in this user group"
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr "User group {group_id} is already a subgroup of this group."
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
@@ -8603,78 +8005,78 @@ msgstr ""
 "User group {user_group_id} is already a subgroup of one of the passed "
 "subgroups."
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr "User group {group_id} is not a subgroup of this group."
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr "Avatar changes are disabled in this organisation."
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr "Email address changes are disabled in this organisation."
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr "Invalid default_language"
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr "Invalid notification sound '{notification_sound}'"
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr "Invalid email batching period: {seconds} seconds"
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr "Your Zulip password is managed in LDAP"
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr "Wrong password!"
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, fuzzy, python-brace-format
 #| msgid "You're making too many attempts! Try again in {seconds} seconds."
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr "You're making too many attempts! Try again in {seconds} seconds."
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr "New password is too weak!"
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr "You must upload exactly one avatar."
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr "Topic is not muted"
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr "Cannot deactivate the only organisation owner"
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Nobody in this Zulip organization will be able to see this email address."
@@ -8682,26 +8084,26 @@ msgid "User is not allowed to delete other user's messages."
 msgstr ""
 "Nobody in this Zulip organisation will be able to see this email address."
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr "User not authorised to change user emails"
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 "The owner permission cannot be removed from the only organisation owner."
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr "Invalid new email address."
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr "New email value error: {message}"
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
@@ -8713,25 +8115,25 @@ msgstr ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 #, fuzzy
 #| msgid "Email is already in use."
 msgid "Email address already in use"
 msgstr "Email is already in use."
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr "Failed to change owner, no such user"
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr "Failed to change owner, user is deactivated"
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr "Failed to change owner, bots can't own other bots"
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
@@ -8739,138 +8141,138 @@ msgstr ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr "Embedded bots are not enabled."
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr "Invalid embedded bot name."
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr "User not authorised to create users"
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr "Email '{email}' not allowed in this organisation"
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr "Disposable email addresses are not allowed in this organisation"
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom access token"
 msgid "Invalid {provider_name} access token"
 msgstr "Invalid Zoom access token"
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} call"
 msgstr "Failed to create Zoom call"
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Zoom credentials have not been configured"
 msgid "{provider_name} credentials have not been configured"
 msgstr "Zoom credentials have not been configured"
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom credentials"
 msgid "Invalid {provider_name} credentials"
 msgstr "Invalid Zoom credentials"
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error connecting to the BigBlueButton server."
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr "Error connecting to the BigBlueButton server."
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error authenticating to the BigBlueButton server."
 msgid "Error authenticating to the {provider_name} server"
 msgstr "Error authenticating to the BigBlueButton server."
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "BigBlueButton server returned an unexpected error."
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr "BigBlueButton server returned an unexpected error."
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom session identifier"
 msgid "Invalid {provider_name} session identifier"
 msgstr "Invalid Zoom session identifier"
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr "Unknown Zoom user email"
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} public room."
 msgstr "Failed to create Zoom call"
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr "Invalid signature."
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{full_name}'s Zulip room"
 msgstr "{full_name} mentioned you:"
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr "Projects using this version control system provider aren't supported"
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr "Invalid payload"
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr "Unknown webhook request"
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr "Topic can't be empty"
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr "Content can't be empty"
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr "Unable to handle Jotform payload"
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr "Malformed JSON input"
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr "Events key is missing from payload"
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr "Error: channels_map_to_topics parameter other than 0 or 1"
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr "Unknown WordPress webhook action: {hook}"
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
@@ -8879,75 +8281,75 @@ msgstr ""
 "Your data export is complete. [View and download exports]"
 "({export_settings_link})."
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr "The verification secret has expired"
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr "The verification secret is invalid"
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr "The verification secret is malformed"
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr "The verification secret is for a different hostname"
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr "Invalid subdomain for push notifications bouncer"
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr "Must validate with valid Zulip server API key"
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr "Invalid UUID"
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr "Invalid token type"
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr "{hostname} contains invalid components (e.g., path, query, fragment)."
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr "{hostname} is not a valid hostname"
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr "{hostname} not yet registered"
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr "{domain} is invalid because it does not have any MX records"
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr "{domain} does not exist"
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
@@ -8956,29 +8358,29 @@ msgstr ""
 "The global limits on recent usage of this endpoint have been reached. Please "
 "try again later or reach out to {support_email} for assistance."
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr "Registration not found for this hostname"
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr "The host reported it has no verification secret."
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, fuzzy, python-brace-format
 #| msgid "Error response received from the host: {status_code}"
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr "Error response received from the host: {status_code}"
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr "Missing ios_app_id"
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr "Missing user_id or user_uuid"
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
@@ -8987,50 +8389,50 @@ msgstr ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
 "server: {reason}"
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr "Your plan doesn't allow sending push notifications."
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr "Invalid property {property}"
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr "Invalid event type."
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr "Data is out of order."
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr "Duplicate registration detected."
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr "Malformed audit log data"
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr "You need to reset your password."
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr "Missing id_token parameter"
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 #, fuzzy
 #| msgid "Missing id_token parameter"
 msgid "Missing idp param"
 msgstr "Missing id_token parameter"
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr "Invalid OTP"
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr "Can't use both mobile_flow_otp and desktop_flow_otp together."
 

--- a/locale/eo/LC_MESSAGES/django.po
+++ b/locale/eo/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 19:39+0000\n"
 "Last-Translator: Alex Vandiver <alexmv@zulip.com>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/zulip/django/"
@@ -19,50 +19,50 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr ""
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr ""
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr ""
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr ""
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr ""
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr ""
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -71,7 +71,7 @@ msgid ""
 "users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -79,7 +79,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than one user to join."
 msgstr ""
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -87,7 +87,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than two users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -95,7 +95,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than three users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -104,148 +104,147 @@ msgid ""
 "({billing_page_link}) is greater than the current number of users."
 msgstr ""
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr ""
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr ""
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
 "(minimum {min_licenses})."
 msgstr ""
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
 "page. To complete the upgrade, please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr ""
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr ""
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr ""
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr ""
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr ""
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr ""
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
 msgstr ""
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
 msgstr ""
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
 "licenses."
 msgstr ""
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
 "billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr ""
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr ""
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr ""
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -255,100 +254,97 @@ msgid ""
 "we would really appreciate it!"
 msgstr ""
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
 "{support_email}"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr ""
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr ""
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr ""
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
 "%(support_email)s\">contact support</a>."
 msgstr ""
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr ""
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
 msgstr ""
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr ""
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
 msgstr ""
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr ""
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr ""
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
 msgstr ""
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -356,289 +352,270 @@ msgid ""
 "a> with any questions."
 msgstr ""
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
 "a> for support."
 msgstr ""
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
 "href=\"%(troubleshooting_url)s\">Zulip server troubleshooting guide</a>."
 msgstr ""
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr ""
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr ""
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr ""
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr ""
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr ""
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr ""
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr ""
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr ""
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr ""
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr ""
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr ""
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr ""
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr ""
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr ""
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr ""
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr ""
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr ""
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr ""
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr ""
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr ""
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr ""
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr ""
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr ""
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr ""
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr ""
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr ""
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr ""
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr ""
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr ""
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr ""
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
 "%(old_email_html_tag)s to %(new_email_html_tag)s"
 msgstr ""
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr ""
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
 msgstr ""
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr ""
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr ""
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -649,19 +626,19 @@ msgid ""
 "server."
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -669,788 +646,297 @@ msgid ""
 "%(support_email)s'>contact support</a> with any questions."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, python-format
 msgid "You can try again in %(retry_after_string)s."
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr ""
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr ""
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr ""
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr ""
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr ""
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr ""
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr ""
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr ""
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr ""
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr ""
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr ""
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr ""
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr ""
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr ""
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 msgid "Zulip for open source"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 msgid "Message with code"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
 msgstr ""
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 msgid "Get started"
 msgstr ""
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
 "continue."
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1458,78 +944,77 @@ msgid ""
 "from Zulip."
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
 msgstr ""
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr ""
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr ""
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr ""
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr ""
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr ""
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr ""
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr ""
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
 msgstr ""
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1537,208 +1022,201 @@ msgid ""
 "href=\"%(doc_url)s\">documentation</a>."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, python-format
 msgid "No account found for %(email)s."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 msgid "Try Zulip in a demo organization"
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 msgid "Try Zulip"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid "Import chat history?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1746,123 +1224,122 @@ msgid ""
 "noreferrer\">after you join</a>."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr ""
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">Terms of Service</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr ""
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr ""
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -1870,45 +1347,45 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 msgid ""
 "This organization has been deactivated, and all organization data has been "
 "deleted."
 msgstr ""
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
 "inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
 "administrators</a> to inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 msgid "This organization has been deactivated."
 msgstr ""
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
 "%(support_email)s\">contact Zulip support</a> to reactivate it."
 msgstr ""
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -1916,165 +1393,164 @@ msgid ""
 "reactivate it."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr ""
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr ""
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
 "<b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
 "href=\"%(apps_page_link)s\">mobile and desktop</a> apps:"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
 "href=\"%(getting_user_started_link)s\">getting started guide</a>!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2082,83 +1558,83 @@ msgid ""
 "Zulip</a>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
 "to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
 "desktop apps (%(apps_page_link)s):"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
 "(%(getting_user_started_link)s)!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
 "(%(getting_organization_started_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2166,32 +1642,32 @@ msgid ""
 "password for this account, please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "%(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 msgid "Verify your email address for your Zulip demo organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "<%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2199,113 +1675,113 @@ msgid ""
 "please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
 "— we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
 "deactivated, and you will no longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr ""
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2313,22 +1789,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because your organization <a "
@@ -2336,8 +1812,8 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to <a "
@@ -2345,39 +1821,39 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr ""
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because your organization hides "
@@ -2385,81 +1861,74 @@ msgid ""
 "details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to hide "
 "message content in email notifications. See %(help_url)s for more details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr ""
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
 "organizations:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
 "organizations hosted by %(external_host)s:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
 "href=\"%(help_reset_password_link)s\">reset your password</a>."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
 "%(external_host)s."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2467,97 +1936,94 @@ msgid ""
 "to find your account."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
 "try another way to find your account (%(help_logging_in_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
 "communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr ""
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
 "-- the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
 "Zulip &mdash; the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
 "to ask %(referrer_name)s for another one."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2565,72 +2031,70 @@ msgid ""
 "productivity."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at <a href=\"mailto:%(email)s\">%(email)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
 "%(email)s\">Contact us</a> — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
 "#%(channel_name)s > %(topic_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2638,68 +2102,68 @@ msgid ""
 "preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails (<a href=\"%(url)s\">help</a>)."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2707,22 +2171,22 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2730,52 +2194,52 @@ msgid ""
 "immediately at <%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2783,31 +2247,31 @@ msgid ""
 "contact us immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2815,7 +2279,7 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -2823,25 +2287,25 @@ msgid ""
 "Zulip</a> to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
 "with you and share their unique perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -2849,7 +2313,7 @@ msgid ""
 "experience how a new chat app will help your team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -2857,148 +2321,148 @@ msgid ""
 "action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
 "team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
 "organizations like yours!"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3006,11 +2470,11 @@ msgid ""
 "about…?”"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3019,23 +2483,23 @@ msgid ""
 "href=\"%(move_channels_link)s\">move a topic to a different channel</a>."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3044,23 +2508,23 @@ msgid ""
 "(%(move_channels_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
 "%(email)s on %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3068,46 +2532,46 @@ msgid ""
 "href=\"%(help_link)s\">reactivate your account</a>."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
 "You can contact an organization administrator to reactivate your account."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3115,539 +2579,535 @@ msgid ""
 "have been voided."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
 "to %(upgrade_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip demo organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip demo organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip demo organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for <b>%(remote_server_hostname)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 msgid "Click the button below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for %(remote_server_hostname)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
 "management for <b>%(remote_realm_host)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
 "management for %(remote_realm_host)s."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the <a href=\"%(plans_link)s\">Zulip Community plan</a>."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
 "website</a>, we would really appreciate it!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
 msgstr ""
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
 "accounts for another email address</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr ""
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr ""
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr ""
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr ""
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr ""
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 msgid "Zulip Cloud"
 msgstr ""
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr ""
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr ""
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr ""
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr ""
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr ""
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr ""
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr ""
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr ""
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr ""
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr ""
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr ""
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr ""
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr ""
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr ""
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr ""
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr ""
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr ""
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr ""
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr ""
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr ""
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr ""
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr ""
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr ""
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr ""
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr ""
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr ""
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr ""
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr ""
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr ""
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr ""
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr ""
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr ""
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 msgid "Bluesky"
 msgstr ""
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr ""
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr ""
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr ""
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 msgid ""
 "And hundreds more through <a href=\"/integrations/zapier\">Zapier</a> and <a "
 "href=\"/integrations/ifttt\">IFTTT</a>."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3655,7 +3115,7 @@ msgid ""
 "emails with your email domain."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3663,7 +3123,7 @@ msgid ""
 "disposable email addresses."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3671,24 +3131,24 @@ msgid ""
 "emails that contain \"+\"."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3696,7 +3156,7 @@ msgid ""
 "%(support_email)s\">contact Zulip support</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3704,89 +3164,89 @@ msgid ""
 "%(support_email)s\">contact this Zulip server's administrators</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
 "management for your Zulip server."
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr ""
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr ""
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr ""
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr ""
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr ""
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr ""
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr ""
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> because all Zulip Cloud licenses are in use."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -3795,42 +3255,40 @@ msgid ""
 "or misconfiguration."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 msgid "Demo organizations disabled"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -3838,22 +3296,21 @@ msgid ""
 "organization for more information."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -3861,44 +3318,42 @@ msgid ""
 "Zulip support</a> for assistance in resolving this issue."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
 "a> like Firefox, Chrome, and Edge."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 msgid "Finalize organization import"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 msgid "Organization import completed!"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -3906,52 +3361,51 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 msgid "Select your account"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 msgid "Create new account"
 msgstr ""
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr ""
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -3959,81 +3413,81 @@ msgid ""
 "have one yet."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 msgid "Self-hosting Zulip?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">log in to manage plans and billing.</a>"
 msgstr ""
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr ""
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
 msgstr ""
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr ""
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr ""
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr ""
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr ""
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr ""
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4041,7 +3495,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4050,57 +3504,57 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr ""
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4108,7 +3562,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4116,40 +3570,40 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4157,300 +3611,294 @@ msgid ""
 "away!"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
 "href=\"%(realm_url)s/#settings/notifications\">notification settings</a>."
 msgstr ""
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr ""
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr ""
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr ""
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr ""
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr ""
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr ""
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr ""
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 msgid "Cannot reactivate a deleted user"
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr ""
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr ""
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr ""
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr ""
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
 msgstr ""
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
 msgstr ""
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr ""
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr ""
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr ""
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr ""
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr ""
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr ""
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr ""
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr ""
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr ""
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr ""
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
 "{new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
 "{user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to resolve topics in this channel."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr ""
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr ""
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr ""
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr ""
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr ""
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
 "but there is no channel with that ID."
 msgstr ""
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4458,36 +3906,36 @@ msgid ""
 "it."
 msgstr ""
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
 "The channel exists but does not have any subscribers."
 msgstr ""
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr ""
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr ""
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr ""
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4495,107 +3943,105 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
 "authentication method."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr ""
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 msgid "Reminder could not be sent."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
 "the following error:"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr ""
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr ""
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr ""
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr ""
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr ""
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
 "**{old_policy}** to **{new_policy}**."
 msgstr ""
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -4604,51 +4050,49 @@ msgid ""
 "* **New**: {new_setting_description}\n"
 msgstr ""
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr ""
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr ""
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr ""
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr ""
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr ""
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr ""
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 msgstr ""
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr ""
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -4659,283 +4103,269 @@ msgid ""
 "{summary_line}"
 msgstr ""
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr ""
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr ""
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr ""
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr ""
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr ""
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr ""
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr ""
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr ""
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr ""
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr ""
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr ""
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
 "organization administrator to reactivate it."
 msgstr ""
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr ""
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr ""
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr ""
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr ""
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr ""
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr ""
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr ""
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
 "to register for accounts in this organization."
 msgstr ""
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr ""
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 msgid "Challenges are not enabled."
 msgstr ""
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr ""
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr ""
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "You're making too many attempts to sign in. Try again in "
 "{retry_after_string} or contact your organization administrator for help."
 msgstr ""
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
 msgstr ""
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr ""
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr ""
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr ""
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr ""
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr ""
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr ""
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr ""
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr ""
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr ""
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr ""
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr ""
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name can't be empty."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 msgid "Invalid channel folder ID"
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 msgid "Configure owner account email address."
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4944,69 +4374,69 @@ msgid ""
 "organization]({convert_demo}).\n"
 msgstr ""
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, python-brace-format
 msgid "{var_name} is not Base64 encoded"
 msgstr ""
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 msgid "Invalid `device_id`"
 msgstr ""
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr ""
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr ""
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr ""
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr ""
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr ""
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr ""
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr ""
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr ""
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr ""
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr ""
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5014,593 +4444,591 @@ msgid ""
 "{error_message}"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr ""
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr ""
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr ""
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr ""
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr ""
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr ""
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr ""
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr ""
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr ""
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr ""
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr ""
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr ""
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr ""
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
 msgstr ""
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr ""
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr ""
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr ""
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr ""
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr ""
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr ""
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr ""
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr ""
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 msgid "Must be a bot user"
 msgstr ""
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr ""
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr ""
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr ""
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
 "webhook; ignoring"
 msgstr ""
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr ""
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr ""
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr ""
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr ""
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} most recent messages in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr ""
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr ""
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
 msgstr ""
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr ""
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr ""
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr ""
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr ""
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr ""
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 msgid "Atlassian account ID"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 msgid "Behance username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 msgid "Bitbucket username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 msgid "Codeberg username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 msgid "Dribbble username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 msgid "Facebook username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 msgid "GitLab username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 msgid "Instagram username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 msgid "Mastodon profile"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 msgid "Medium username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 msgid "Pinterest username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 msgid "Reddit username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 msgid "Snapchat username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 msgid "Threads username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 msgid "TikTok username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 msgid "Twitch username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 msgid "X username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr ""
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr ""
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 msgid "Video calling"
 msgstr ""
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr ""
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr ""
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr ""
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr ""
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr ""
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr ""
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr ""
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr ""
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr ""
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr ""
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr ""
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr ""
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr ""
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr ""
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "{fullname} moderation"
 msgstr ""
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr ""
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr ""
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor_date' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr ""
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 msgid "Navigation view does not exist."
 msgstr ""
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5608,7 +5036,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5616,7 +5044,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5624,7 +5052,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5632,7 +5060,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5642,14 +5070,14 @@ msgid ""
 "a permanent organization]({convert_demo_organization_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
 "them in your [Inbox](/#inbox).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5657,7 +5085,7 @@ msgid ""
 "({navigation_tour_video_url}) for a quick app overview.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5672,14 +5100,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -5687,7 +5115,7 @@ msgid ""
 "and edit your [profile information](/help/edit-your-profile).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -5698,7 +5126,7 @@ msgid ""
 "experience in your [Preferences](#settings/preferences).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5709,7 +5137,7 @@ msgid ""
 "[Browse and subscribe to channels]({settings_link}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -5726,7 +5154,7 @@ msgid ""
 "discussed.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -5735,7 +5163,7 @@ msgid ""
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -5747,7 +5175,7 @@ msgid ""
 "times, and more.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5757,7 +5185,7 @@ msgid ""
 "or browse the [help center](/help/) to learn more!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5765,7 +5193,7 @@ msgid ""
 "get help, try one of the following messages: {bot_commands}\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5777,13 +5205,13 @@ msgid ""
 "({move_content_another_channel_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5797,12 +5225,11 @@ msgid ""
 "and above.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr ""
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -5810,14 +5237,14 @@ msgid ""
 "no matter how many other conversations are going on.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
 "conversations with unread messages.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -5825,7 +5252,7 @@ msgid ""
 "the `+` button next to its name.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -5833,13 +5260,13 @@ msgid ""
 "can we chat about…?”\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5847,7 +5274,7 @@ msgid ""
 "({format_message_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5867,1322 +5294,1299 @@ msgid ""
 "```\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
 "teammates.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
 "conversation.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr ""
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr ""
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr ""
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr ""
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 msgid "Invalid `push_key`"
 msgstr ""
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr ""
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr ""
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr ""
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 msgid "Reminder does not exist"
 msgstr ""
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr ""
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr ""
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr ""
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr ""
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr ""
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr ""
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr ""
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr ""
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 msgid "You do not have permission to create new topics in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr ""
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr ""
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr ""
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr ""
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr ""
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr ""
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} does not have the expected format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr ""
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr ""
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr ""
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {user_group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr ""
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr ""
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr ""
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr ""
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr ""
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 msgid "Name must not be empty!"
 msgstr ""
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr ""
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr ""
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr ""
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr ""
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr ""
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr ""
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr ""
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr ""
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr ""
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr ""
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr ""
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr ""
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr ""
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr ""
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr ""
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr ""
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr ""
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr ""
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr ""
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr ""
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr ""
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr ""
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr ""
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr ""
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr ""
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr ""
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr ""
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr ""
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr ""
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr ""
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr ""
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr ""
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr ""
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr ""
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr ""
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr ""
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr ""
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: empty field name."
 msgstr ""
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr ""
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr ""
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 msgid "Example input does not match the linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in alternative URL template is not present in linkifier "
 "pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in linkifier pattern is not present in alternative URL "
 "template."
 msgstr ""
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr ""
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr ""
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr ""
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr ""
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr ""
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr ""
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr ""
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr ""
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr ""
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr ""
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr ""
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr ""
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr ""
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr ""
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr ""
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr ""
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr ""
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr ""
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr ""
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr ""
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr ""
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr ""
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr ""
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr ""
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr ""
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr ""
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr ""
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr ""
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr ""
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 msgid "Failed to generate challenge"
 msgstr ""
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr ""
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr ""
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr ""
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr ""
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr ""
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr ""
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for use for user matching."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr ""
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr ""
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr ""
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr ""
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr ""
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr ""
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr ""
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr ""
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 msgid "Invitation already used or deactivated."
 msgstr ""
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr ""
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr ""
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr ""
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
 msgstr ""
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr ""
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr ""
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr ""
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr ""
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr ""
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr ""
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr ""
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr ""
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 msgid "Message reporting is not enabled in this organization."
 msgstr ""
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr ""
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr ""
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr ""
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr ""
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr ""
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr ""
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr ""
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr ""
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr ""
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 msgid "Navigation view already exists."
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7190,856 +6594,854 @@ msgid ""
 "later. Is this a good time?\n"
 msgstr ""
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr ""
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr ""
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 msgid "You do not have permission to manage plans and billing."
 msgstr ""
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr ""
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr ""
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr ""
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr ""
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr ""
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr ""
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr ""
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr ""
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr ""
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr ""
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr ""
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr ""
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr ""
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr ""
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr ""
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr ""
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr ""
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr ""
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr ""
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Invalid character in language: {character}"
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Language '{language}' is not allowed."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr ""
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr ""
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 msgid "Importing messages…"
 msgstr ""
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 msgid "Your name"
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr ""
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr ""
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr ""
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr ""
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr ""
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr ""
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr ""
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr ""
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr ""
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr ""
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr ""
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr ""
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr ""
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
 "**"
 msgstr ""
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr ""
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr ""
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr ""
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr ""
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr ""
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr ""
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr ""
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr ""
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr ""
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr ""
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr ""
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr ""
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr ""
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 msgstr ""
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr ""
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr ""
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
 "subgroups."
 msgstr ""
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr ""
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr ""
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr ""
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr ""
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr ""
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr ""
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr ""
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr ""
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr ""
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr ""
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 msgid "User is not allowed to delete other user's messages."
 msgstr ""
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr ""
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr ""
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 msgid ""
 "Can't change bot email until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 msgstr ""
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 msgid "Email address already in use"
 msgstr ""
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr ""
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr ""
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr ""
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 msgstr ""
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr ""
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr ""
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr ""
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr ""
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr ""
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} access token"
 msgstr ""
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} call"
 msgstr ""
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} credentials have not been configured"
 msgstr ""
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} credentials"
 msgstr ""
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr ""
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error authenticating to the {provider_name} server"
 msgstr ""
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr ""
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} session identifier"
 msgstr ""
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr ""
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} public room."
 msgstr ""
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr ""
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{full_name}'s Zulip room"
 msgstr ""
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr ""
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr ""
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr ""
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr ""
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr ""
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr ""
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr ""
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr ""
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr ""
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
 "({export_settings_link})."
 msgstr ""
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr ""
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr ""
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr ""
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr ""
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr ""
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr ""
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr ""
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr ""
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr ""
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr ""
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr ""
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr ""
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
 "try again later or reach out to {support_email} for assistance."
 msgstr ""
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr ""
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr ""
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr ""
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr ""
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
 "server: {reason}"
 msgstr ""
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr ""
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr ""
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr ""
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr ""
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr ""
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr ""
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr ""
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr ""
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 msgid "Missing idp param"
 msgstr ""
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr ""
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr ""

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -28,7 +28,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-04-26 05:26+0000\n"
 "Last-Translator: Daniel Capilla <dcapillae@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/zulip/django/es/"
@@ -41,54 +41,54 @@ msgstr ""
 "0) ? 1 : 2);\n"
 "X-Generator: Weblate 5.17.1-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "No está permitido para usuarios invitados"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "Organización inválida"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr "Canales públicos"
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr "Canales privados"
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr "Mensajes directos"
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr "Mensajes directos grupales"
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr "Canal ausente para el gráfico: {chart_name}"
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr "Nombre de gráfico desconocido: {chart_name}"
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr ""
 "La hora de inicio es más tarde que la hora de fin. Inicio: {start}, Fin: "
 "{end}"
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr ""
 "No hay datos de analíticas disponible. Por favor, contacta con el "
 "administrador de tu servidor."
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -101,7 +101,7 @@ msgstr ""
 "({billing_page_link}) o [desactiva usuarios]"
 "({deactivate_user_help_page_link}) para permitir agregar nuevos usuarios."
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -113,7 +113,7 @@ msgstr ""
 "inactivos]({deactivate_user_help_page_link}) para permitir que pueda unirse "
 "más de un usuario a tu organización."
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -125,7 +125,7 @@ msgstr ""
 "inactivos]({deactivate_user_help_page_link}) para permitir que puedan unirse "
 "más de dos usuarios a tu organización."
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -137,7 +137,7 @@ msgstr ""
 "inactivos]({deactivate_user_help_page_link}) para permitir que puedan unirse "
 "más de tres usuarios a tu organización."
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -151,7 +151,7 @@ msgstr ""
 "facturación actual y el próximo]({billing_page_link}) es mayor que el número "
 "actual de usuarios."
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
@@ -159,7 +159,7 @@ msgstr ""
 "Su organización no tiene suficiente licencias Zulip. Las invitaciones no han "
 "sido enviadas."
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
@@ -167,16 +167,15 @@ msgstr ""
 "Su organización no tiene suficiente licencias Zulip para cambiar el rol de "
 "un usuario invitado."
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr "El registro está desactivado"
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr "Servidor remoto no válido."
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
@@ -185,7 +184,7 @@ msgstr ""
 "Debes comprar licencias para todos los usuarios activos en tu organización "
 "(mínimo {min_licenses})."
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
@@ -195,45 +194,45 @@ msgstr ""
 "través de esta página. Para completar esta compra, por favor contactar con "
 "{email}."
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr "No hay método de pago registrado."
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr "{brand} terminada en {last4}"
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr "Método de pago desconocido. Ponte en contacto con {email}."
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr "Algo ha fallado. Contacta en {email}."
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "Algo salió mal. Por favor, recarga la página."
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr "Algo salió mal. Por favor, espera unos segundos e inténtalo de nuevo."
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 "Por favor, añada una tarjeta de crédito antes de comenzar su periodo de "
 "prueba."
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr ""
 "Por favor, añada una tarjeta de crédito para programar la actualización."
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
@@ -241,18 +240,18 @@ msgstr ""
 "No se puede actualizar el plan. El plan venció y se reemplazó con un nuevo "
 "plan."
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr "No es posible actualizar el plan. El plan ha finalizado."
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 "No se pueden actualizar las licencias en el período de facturación actual "
 "para el plan de prueba gratuita."
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
@@ -260,7 +259,7 @@ msgstr ""
 "No es posible actualizar las licencias manualmente. Tu plan gestiona las "
 "licencias automáticamente."
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
@@ -268,11 +267,11 @@ msgstr ""
 "Tu plan ya dispone de {licenses} licencias en el periodo de facturación "
 "actual."
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr "No puedes disminuir las licencias en el periodo de facturación actual."
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
@@ -280,7 +279,7 @@ msgstr ""
 "No se pueden cambiar las licencias para el próximo ciclo de facturación para "
 "un plan que se está pasando a un nivel inferior."
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
@@ -289,7 +288,7 @@ msgstr ""
 "Tu plan ya está planeado para renovarse con {licenses_at_next_renewal} "
 "licencias."
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
@@ -298,27 +297,27 @@ msgstr ""
 "Ya ha comprado {licenses_at_next_renewal} licencias para el próximo periodo "
 "de facturación."
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr "Nada que cambiar."
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr "¡No hay clientes para esta organización!"
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr "Sesión no encontrada"
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr "Intento de pago no encontrado"
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr "Introduce el stripe_session_id o el stripe_invoice_id"
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -334,20 +333,19 @@ msgstr ""
 "¡Agradeceríamos mucho si pudieras {begin_link} añadir a Zulip como un "
 "patrocinador de tu página web{end_link}!"
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr "El parámetro 'confirmado' es necesario"
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr "El token de acceso a facturación expiró."
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr "El token de acceso a facturación es incorrecto."
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
@@ -356,40 +354,39 @@ msgstr ""
 "No se han podido reconciliar los datos entre el servidor y el dominio. Por "
 "favor, contacte con {support_email}"
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr "La cuenta de usuario aún no existe.."
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr "Debes aceptar los Términos del Servicio para continuar."
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 "Este zulip_org_id no está registrado en el sistema de gestión de facturación "
 "de Zulip."
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr "zulip_org_key no es válida para este zulip_org_id."
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr "El registro de tu servidor ha sido desactivado."
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "Error"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr "Página no encontrada (404)"
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
@@ -398,11 +395,11 @@ msgstr ""
 "Si este error es inesperado, puedes <a href=\"mailto:"
 "%(support_email)s\">ponerte en contacto con el servicio de asistencia</a>."
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr "Acceso prohibido (403)"
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
@@ -411,11 +408,11 @@ msgstr ""
 "credenciales requeridas para autenticar su acceso. Para resolver este "
 "problema:"
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr "Asegúrese de que su navegador permite cookies para este sitio."
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
@@ -423,16 +420,15 @@ msgstr ""
 "Comprueba si hay algún ajuste de privacidad del navegador o alguna extensión "
 "que bloquee los encabezados Referer y desactívalos para este sitio web."
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr "Método no permitido (405)"
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr "Error interno del servidor"
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
@@ -441,7 +437,7 @@ msgstr ""
 "estamos trabajando para solucionarlo. Zulip se cargará automáticamente "
 "cuando vuelva a funcionar."
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -453,7 +449,7 @@ msgstr ""
 "contacto con el servicio de asistencia de Zulip</a> si tienes alguna "
 "pregunta."
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
@@ -461,7 +457,7 @@ msgstr ""
 "Ha habido un error. ¡Lo sentimos! Zulip se cargará automáticamente en cuanto "
 "vuelva a funcionar."
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
@@ -470,7 +466,7 @@ msgstr ""
 "<a href=\"mailto:%(support_email)s\">Ponte en contacto con los "
 "administradores de este servidor</a> para obtener asistencia."
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
@@ -480,138 +476,136 @@ msgstr ""
 "href=\"%(troubleshooting_url)s\">la guía de solución de problemas para "
 "servidores Zulip</a>."
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr "Estadísticas para %(target_name)s | Zulip"
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 "Las estadísticas están disponibles 24 horas después de crear una "
 "organización."
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr "Analíticas de Zulip para %(target_name)s"
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr "Resumen de la organización"
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr "Número de usuarios"
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr "Usuarios activos en los últimos 15 días"
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr "Número de invitados"
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr "Número total de mensajes"
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr "Número de mensajes en los últimos 30 días"
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr "Almacenamiento de archivos usado"
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "Usuarios activos"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr "Activos cada día"
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr "Activos en 15 días"
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr "Usuarios totales"
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "Usuarios"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr "Mensajes enviados por tipo de recipiente"
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "Yo"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "Todos"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "Última semana"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "Último mes"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "Último año"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "Todos los tiempos"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr "Mensajes enviados a lo largo del tiempo"
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "Diaria"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "Semanal"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr "Acumulativa"
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "Humanos"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "Bots"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr "Mensajes leídos a lo largo del tiempo"
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr "Mensajes enviados por cliente"
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr "Última actualización"
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
@@ -620,15 +614,15 @@ msgstr ""
 "gráfica de \"mensajes enviados a lo largo del tiempo\" se actualiza cada "
 "hora."
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr "Email actualizado"
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr "¡Correo electrónico cambiado!"
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
@@ -637,21 +631,21 @@ msgstr ""
 "Esto confirma que la dirección de correo de tu cuenta Zulip ha cambiado de "
 "%(old_email_html_tag)s a %(new_email_html_tag)s"
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr "Confirmando tu dirección de email"
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr "El enlace de confirmación no existe"
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr "Ups. No hemos encontrado tu enlace de confirmación en el sistema."
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
@@ -660,27 +654,27 @@ msgstr ""
 "En cualquier caso, envíanos un correo a %(support_email_html_tag)s y lo "
 "solucionaremos en breve."
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr "El enlace de confirmación ha expirado o ha sido desactivado"
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr "Ups. El enlace de confirmación ha caducado o ha sido desactivado."
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr "Por favor, pídele un nuevo enlace al administrador de tu organización."
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr "El enlace de confirmación mal formado"
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr "¡Vaya! El enlace de confirmación está mal formado."
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
@@ -689,72 +683,55 @@ msgstr ""
 "sigues encontrándote con esta página, probablemente sea culpa nuestra. Lo "
 "sentimos."
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr "Facturación"
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr "Cerrar diálogo"
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr "Olvídalo"
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr "Rebajar"
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr "Confirmar"
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr "Cancelar actualización"
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr "Estado de facturación"
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr "¿Desactivar el registro del servidor?"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr "Gestión de plan no disponible"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -771,7 +748,7 @@ msgstr ""
 "help/self-hosted-billing#log-in-to-billing-management\">instrucciones de "
 "inicio de sesión</a> para administrar el plan de tu servidor Zulip."
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
@@ -780,7 +757,7 @@ msgstr ""
 "otra pregunta, <a href=\"mailto:{{ support_email }}\">ponte en contacto con "
 "el servicio de asistencia</a>."
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
@@ -788,7 +765,7 @@ msgstr ""
 "La gestión de planes para este servidor no está disponible porque al menos "
 "una de las organizaciones alojadas en este servidor ya tiene un plan activo."
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -800,730 +777,240 @@ msgstr ""
 "href='mailto:%(support_email)s'>ponte en contacto con el servicio de "
 "asistencia</a> si tienes alguna pregunta."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr "Límite de votación excedido"
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr "Límite de votación excedido."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 "Tu servidor ha superado el límite de veces que se puede realizar esta acción."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, python-format
 msgid "You can try again in %(retry_after_string)s."
 msgstr "Puedes volver a intentarlo en %(retry_after_string)s segundos."
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr "Actualizar"
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr "Enviar la factura y empieza la prueba gratuita"
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr "Enviar factura"
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr "Directorio de comunidades abiertas"
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr "Filtrar por categoría"
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "Todo"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr "Categorías"
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr "10,000 mensajes"
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr "ilimitado"
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr "Archivos de hasta 10 MB"
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr "Archivos de hasta 1 GB"
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr "Soportado"
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr "Autogestionado"
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr "Para organización de hasta 10 usuarios"
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr "Mínimo de 25 usuarios"
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr "No disponible"
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr "Comunidad de desarrollo de Zulip"
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr "Unirse como usuario"
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr "Unirse como autohospedador"
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr "Unirse como contribuidor"
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "Crear organización"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr "Solicita una demostración"
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr "Zulip autohospedado"
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr "Solicitar patrocinio"
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr "Tarifa para educación"
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr "Mostrar precios"
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr "Zulip para empresas"
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 msgid "Zulip for open source"
 msgstr "Zulip para código abierto"
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr "Perro con gafas y un ordenador portátil"
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation"
 msgstr "Captura de pantalla de una conversación en Zulip"
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr "Captura de pantalla de una conversación en Zulip con el bot Sentry"
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr "Captura de pantalla de la bandeja de entrada de Zulip"
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr "Portátil abierto con un libro dentro"
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr "Dos manos montando un rompecabezas"
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 msgid "Message with code"
 msgstr "Mensaje con código"
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr "Rayo"
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr "Enlace"
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr "Rueda de timón"
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr "Contacta con el servicio de asistencia"
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr "Desde"
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr "Organización"
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr "Asunto"
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr "Mensaje"
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr "Enviar"
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr "Gracias por contactarnos"
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr "¡Gracias por contactarnos!"
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr "Nos pondremos en contacto contigo pronto."
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
@@ -1531,11 +1018,11 @@ msgstr ""
 "Puedes ver respuestas a las preguntas más comunes en el <a href=\"/help/"
 "\">Centro de Ayuda de Zulip</a>."
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 msgid "Get started"
 msgstr "Empieza"
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
@@ -1545,51 +1032,50 @@ msgstr ""
 "<a href=\"https://zulip.com/policies/terms\">Condiciones del servicio de "
 "Zulip</a> para continuar."
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr "O, alternativamente, usa uno de tus teléfonos de respaldo:"
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr "Como último recurso, puedes usar un token de respaldo:"
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr "Usar token de respaldo"
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr "Acepta los Términos de Servicio"
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr "Te damos la bienvenida a Zulip"
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "Correo"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr ""
 "Suscríbeme al boletín informativo de Zulip, que no envía muchos correos "
 "(solo unos pocos al año)."
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr "Continuar"
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr "Confirma tu dirección de email"
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1600,7 +1086,7 @@ msgstr ""
 "class=\"user_email semi-bold\">%(email)s</span>) y busca un correo de "
 "confirmación de Zulip."
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
@@ -1609,12 +1095,12 @@ msgstr ""
 "de Correo no deseado, podemos <a href=\"#\" "
 "id=\"resend_email_link\">enviártelo de nuevo</a>."
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr "Vista pública de {org_name} | Chat del equipo de Zulip"
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
@@ -1622,14 +1108,14 @@ msgstr ""
 "Explora los canales de acceso público de {org_name} sin necesidad de iniciar "
 "sesión."
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 "Como estás utilizando un navegador que no es compatible o que es muy "
 "antiguo, es posible que Zulip no se cargue."
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
@@ -1640,7 +1126,7 @@ msgstr ""
 "apps/\" target=\"_blank\" rel=\"noopener noreferrer\">Descarga la última "
 "versión.</a>"
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
@@ -1648,38 +1134,37 @@ msgstr ""
 "Si este mensaje no desaparece, intenta <a class=\"reload-lnk\">recargar</a> "
 "la página."
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 "Error cargando Zulip. Intenta <a class=\"reload-lnk\">recargar</a> la página."
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr "Ninguna conversación coincide con estos filtros."
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr "Se siguen cargando los mensajes de esta vista."
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr "Cargar más"
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr "Videollamada finalizada"
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr "Ya puedes cerrar esta pestaña."
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr "Error de configuración"
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
@@ -1688,7 +1173,7 @@ msgstr ""
 "organización. Por favor, usa EmailAuthBackend para crear tu organización y "
 "luego inténtalo de nuevo."
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1699,33 +1184,32 @@ msgstr ""
 "instrucciones sobre cómo configurarlas, por favor vea la <a "
 "href=\"%(doc_url)s\">documentación</a>."
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr "Cuenta no encontrada"
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr "Cuenta de Zulip no encontrada."
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, python-format
 msgid "No account found for %(email)s."
 msgstr "No se ha encontrado ninguna cuenta para %(email)s."
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr "Iniciar sesión con otra cuenta"
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr "Proceder al registro"
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 msgid "Try Zulip in a demo organization"
 msgstr "Prueba Zulip en una organización de demostración"
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
@@ -1735,19 +1219,19 @@ msgstr ""
 "class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/new/"
 "\">crea una organización permanente</a>."
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 msgid "Try Zulip"
 msgstr "Prueba Zulip"
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "Crear una nueva organización"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr "Crear una nueva organización de Zulip"
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
@@ -1757,16 +1241,15 @@ msgstr ""
 "new/demo/\">crea una organización de demostración</a> — ¡no se necesita "
 "correo electrónico!"
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr "Introduce tu dirección de correo electrónico"
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr "Tu email"
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
@@ -1776,11 +1259,11 @@ msgstr ""
 "href=\"/help/import-from-mattermost\">Mattermost</a> o <a href=\"/help/"
 "import-from-rocketchat\">Rocket.Chat</a>."
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr "¿Cómo conociste Zulip?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
@@ -1788,42 +1271,41 @@ msgstr ""
 "Este dato solo se utiliza si te suscribes a un plan; en ese caso, se enviará "
 "al equipo de Zulip."
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr "Selecciona una opción"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr "Por favor, describe"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr "¿Dónde viste el anuncio?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr "¿Qué organización?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr "¿Cuál?"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr "Selecciona una"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr "Tipo de organización"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr "Idioma de la organización"
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
@@ -1833,72 +1315,68 @@ msgstr ""
 "mattermost\">Mattermost</a> o <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid "Import chat history?"
 msgstr "¿Importar el historial de chat?"
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr "Nombre de la organización"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "URL de la organización"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr "Usar %(external_host)s"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "O"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "Registrarse"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "Iniciar sesión en Zulip"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr "Necesitas una invitación para unirte a esta organización."
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr "Registrarse con %(identity_provider)s"
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr "¿Ya tienes una cuenta?"
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "Entrar"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr "Configurar la privacidad de las direcciones de correo"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
@@ -1906,7 +1384,7 @@ msgstr ""
 "Zulip te permite controlar qué roles en la organización pueden ver tu correo "
 "electrónico."
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
@@ -1914,11 +1392,11 @@ msgstr ""
 "¿Deseas cambiar los ajustes de privacidad para tu correo electrónico con "
 "respecto a los ajustes predeterminados de esta organización?"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr "Quiénes pueden acceder a tu dirección de correo"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1929,7 +1407,7 @@ msgstr ""
 "configure-email-visibility\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">después de unirte</a>."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
@@ -1937,7 +1415,7 @@ msgstr ""
 "Los administradores de esta organización de Zulip podrán ver esta dirección "
 "de correo electrónico."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
@@ -1945,14 +1423,14 @@ msgstr ""
 "Los administradores y moderadores de esta organización de Zulip podrán ver "
 "esta dirección de correo electrónico."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 "Nadie de esta organización de Zulip podrá ver esta dirección de correo "
 "electrónico."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
@@ -1960,80 +1438,79 @@ msgstr ""
 "Los demás usuarios de esta organización de Zulip podrán ver esta dirección "
 "de correo electrónico."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "Cambiar"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr "Inscripción"
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr "Crea tu organización"
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr "Crea tu cuenta"
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr "<p>Introduce los datos de tu cuenta para completar el registro.</p>"
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr "Tu organización"
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr "Tu cuenta"
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr "No importar ajustes"
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr "Importar ajustes desde una cuenta Zulip existente"
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr "Tu nombre completo"
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "Nombre"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr "Así es como se muestra tu cuenta en Zulip."
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "Contraseña"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr "Introduce la contraseña del servidor LDAP/Active Directory."
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 "Es usado en aplicaciones móviles y otras herramientas que necesitas una "
 "contraseña."
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr "Fortaleza de la contraseña"
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr "¿Qué te interesa?"
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
@@ -2042,15 +1519,15 @@ msgstr ""
 "Acepta los <a href=\"%(root_domain_url)s/policies/terms\" target=\"_blank\" "
 "rel=\"noopener noreferrer\">Términos de Servicio</a>."
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr "Organización desactivada"
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr "La organización se ha trasladado"
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
@@ -2059,7 +1536,7 @@ msgstr ""
 "Esta organización se ha trasladado a <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -2071,14 +1548,14 @@ msgstr ""
 "URL</a> en <span id=\"deactivated-org-auto-redirect-countdown\">5</span> "
 "segundos."
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 msgid ""
 "This organization has been deactivated, and all organization data has been "
 "deleted."
 msgstr ""
 "Esta organización ha sido desactivada y se han eliminado todos sus datos."
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
@@ -2088,7 +1565,7 @@ msgstr ""
 "servicio de asistencia de Zulip</a> para preguntar si es posible reutilizar "
 "esta URL para una nueva organización."
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
@@ -2098,11 +1575,11 @@ msgstr ""
 "administradores de este servidor de Zulip</a> para preguntar sobre la "
 "posibilidad de reutilizar esta URL para una nueva organización."
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 msgid "This organization has been deactivated."
 msgstr "Esta organización ha sido desactivada."
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -2112,7 +1589,7 @@ msgstr ""
 "%(support_email)s\">ponerte en contacto con el servicio de asistencia de "
 "Zulip</a> para reactivarla."
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
@@ -2121,7 +1598,7 @@ msgstr ""
 "Si eres miembro de la organización y deseas saber por qué se ha desactivado, "
 "ponte en contacto directamente con los administradores de la organización."
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -2132,15 +1609,15 @@ msgstr ""
 "%(support_email)s\">ponerte en contacto con los administradores de este "
 "servidor de Zulip</a> para reactivarla."
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr "Finalizar inicio de sesión en la aplicación de escritorio"
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr "Finalizar inicio de sesión de escritorio"
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
@@ -2148,93 +1625,92 @@ msgstr ""
 "Usa tu navegador web para completar la inscripción. Después vuelve aquí para "
 "pegar tu token de inicio de sesión."
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr "Pegar token aquí"
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr "Finalizar"
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr "Token incorrecto."
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr "Token correcto. Iniciando sesión…"
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr "Iniciar sesión en la aplicación de escritorio"
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 "Copia este token de inicio de sesión y vuelve a tu aplicación de Zulip para "
 "terminar el inicio de sesión:"
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "Copiar"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr "Podrás entonces cerrar esta pestaña."
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr "O, continuar en tu navegador."
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr "Usuario anónimo"
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr "Propietarios"
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "Administradores"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr "Moderadores"
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr "Usuarios invitados"
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "Usuarios normales"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr "Reenviar los correos a una dirección de correo"
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "Cerrar"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "Actualizar"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr "Zulip"
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr "Resumen"
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
@@ -2243,18 +1719,18 @@ msgstr ""
 "Enhorabuena, acaba de crear una nueva organización de Zulip: "
 "<b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr "¡Bienvenido a Zulip!"
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr ""
 "Acabas de iniciar sesión en la organización de Zulip <b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
@@ -2263,36 +1739,36 @@ msgstr ""
 "Usarás la siguiente información para iniciar sesión en las aplicaciones web, "
 "<a href=\"%(apps_page_link)s\">móviles y de escritorio</a> de Zulip:"
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr "URL Organización: %(organization_url)s"
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr "Tu nombre de usuario:%(ldap_username)s"
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr "Usa tu cuenta LDAP para iniciar sesión"
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr "Tu cuenta de email:%(email)s"
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr "Ir a tu organización"
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
@@ -2301,7 +1777,7 @@ msgstr ""
 "Si eres nuevo en Zulip, ¡echa un vistazo a nuestra <a "
 "href=\"%(getting_user_started_link)s\">guía de introducción</a>!"
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2312,7 +1788,7 @@ msgstr ""
 "href=\"%(getting_organization_started_link)s\">trasladar tu organización a "
 "Zulip</a>."
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
@@ -2321,29 +1797,29 @@ msgstr ""
 "¿Tienes dudas? <a href=\"mailto:%(support_email)s\">Contáctanos</a> — "
 "¡Estaremos encantados de ayudarte!"
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr "%(realm_name)s en Zulip: Detalles de tu nueva organización"
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr "%(realm_name)s en Zulip: Detalles de tu nueva cuenta"
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr ""
 "Enhorabuena, acaba de crear una nueva organización de Zulip: %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr "Te haz unido a la organización Zulip %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
@@ -2352,7 +1828,7 @@ msgstr ""
 "Se usará la siguiente información para iniciar sesión en celular, Zulip web "
 "y aplicaciones de escritorio (%(apps_page_link)s):"
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
@@ -2361,7 +1837,7 @@ msgstr ""
 "Si eres nuevo en Zulip, ¡echa un vistazo a nuestra guía de introducción "
 "(%(getting_user_started_link)s)!"
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
@@ -2370,19 +1846,19 @@ msgstr ""
 "También disponemos de una guía para migrar tu organización a Zulip "
 "(%(getting_organization_started_link)s)."
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 "¿Tienes dudas? Contáctanos en %(support_email)s — ¡Estaremos encantados de "
 "ayudarte!"
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2391,17 +1867,17 @@ msgstr ""
 "Si tienes alguna duda, por favor contacta con el administrador de este "
 "servidor Zulip en el siguiente email %(support_email)s."
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr "Hola,"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2413,12 +1889,12 @@ msgstr ""
 "%(realm_url)s. Para confirmar esta actualización y establecer una contraseña "
 "para esta cuenta, haz clic a continuación:"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr "Confirmar y configurar contraseña"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2427,14 +1903,14 @@ msgstr ""
 "Si no solicitaste este cambio, por favor, envíanos un correo a "
 "%(support_email)s de inmediato."
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 msgid "Verify your email address for your Zulip demo organization"
 msgstr ""
 "Verifica tu dirección de correo electrónico para tu organización de "
 "demostración de Zulip"
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2443,8 +1919,8 @@ msgstr ""
 "Si no solicitaste este cambio, por favor, contáctanos inmediatamente en "
 "<%(support_email)s>."
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2455,33 +1931,33 @@ msgstr ""
 "de la cuenta de Zulip en %(realm_url)s de %(old_email)s a %(new_email)s. "
 "Para confirmar este cambio, haz clic a continuación:"
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr "Confirmar cambio de correo"
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr "Verifica tu dirección de correo para %(organization_host)s"
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr "Has solicitado crear una nueva organización Zulip:"
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr "Tipo de organización: %(organization_type)s"
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr "Te has registrado recientemente en Zulip. ¡Genial!"
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
@@ -2489,33 +1965,33 @@ msgstr ""
 "Toque el botón de abajo para crear la organización y registrar tu cuenta. Si "
 "lo deseas, podrás actualizar la información anterior."
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr "Haz click en el botón inferior para completar registro."
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr "Completar registro"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr "Crea tu organización Zulip"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr "Activar tu cuenta Zulip"
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr "Haz click en el botón inferior para completar registro."
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
@@ -2524,20 +2000,20 @@ msgstr ""
 "Tienes dudas o sugerencias? Envíanos un correo a %(support_email)s! — Nos "
 "encantaría ayudar!"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr "Gestionar preferencias de correo"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr "Desubscribirse de emails de marketing"
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
@@ -2546,17 +2022,17 @@ msgstr ""
 "Tu cuenta de Zulip en <a href=\"%(realm_url)s\">%(realm_url)s</a> ha sido "
 "desactivada, por lo que ya no podrás iniciar sesión."
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr "Los administradores suministraron el siguiente comentario:"
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr "Notificación de desactivación de cuenta en %(realm_name)s"
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
@@ -2565,11 +2041,11 @@ msgstr ""
 "Tu cuenta de Zulip en %(realm_url)s ha sido desactivada y ya no podrás "
 "iniciar sesión."
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr "Nuevos canales"
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2579,7 +2055,7 @@ msgstr ""
 "Tienes %(new_messages_count)s mensajes nuevos y hay %(new_streams_count)s "
 "canales nuevos en <a href=\"%(realm_url)s\">%(realm_name)s</a>."
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
@@ -2588,7 +2064,7 @@ msgstr ""
 "Tienes %(new_messages_count)s mensajes nuevos en <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
@@ -2597,8 +2073,8 @@ msgstr ""
 "Hay %(new_streams_count)s canales nuevos en <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because your organization <a "
@@ -2610,8 +2086,8 @@ msgstr ""
 "href=\"%(help_url)s\">oculta el contenido de los mensajes</a> en las "
 "notificaciones por correo electrónico."
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to <a "
@@ -2623,22 +2099,22 @@ msgstr ""
 "href=\"%(help_url)s\">ocultar el contenido del mensaje</a> en las "
 "notificaciones por correo electrónico."
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr ""
 "<a href=\"%(realm_url)s\">Inicia sesión</a> en Zulip para ponerte al día."
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr "Desubscribirse de los emails de digesto"
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr "Resumen de Zulip para %(realm_name)s"
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2647,18 +2123,18 @@ msgstr ""
 "Tienes %(new_messages_count)s mensajes nuevos y hay %(new_streams_count)s "
 "canales nuevos en %(realm_name)s."
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr "Tienes %(new_messages_count)s mensajes nuevos en %(realm_name)s."
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr "Hay %(new_streams_count)s canales nuevos en %(realm_name)s."
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because your organization hides "
@@ -2669,8 +2145,8 @@ msgstr ""
 "desactivó la vista de su contenido en las notificaciones por correo. Revise "
 "%(hide_content_url)s para más detalles."
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to hide "
@@ -2680,32 +2156,30 @@ msgstr ""
 "la vista de su contenido en las notificaciones por correo. Revisa "
 "%(help_url)s para más detalles."
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr "Inicia sesión en Zulip para ponerte al día: %(organization_url)s."
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr "Gestionar preferencias de correo:"
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr "Darse de baja de los resúmenes por correo electrónico:"
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr "Pez nadando"
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr "Gracias por tu solicitud!"
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
@@ -2714,8 +2188,7 @@ msgstr ""
 "Tu dirección de correo electrónico %(email)s tiene cuentas en las siguientes "
 "organizaciones de Zulip Cloud:"
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
@@ -2724,7 +2197,7 @@ msgstr ""
 "Tu dirección de correo %(email)stiene cuentas con las siguientes "
 "organizaciones de Zulip creadas por %(external_host)s:"
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
@@ -2733,21 +2206,17 @@ msgstr ""
 "Si tienes problemas para iniciar sesión, puedes <a "
 "href=\"%(help_reset_password_link)s\">restablecer tu contraseña</a>."
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 "Has solicitado una lista de cuentas de Zulip asociadas a esta dirección de "
 "correo electrónico."
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr "Lamentablemente, no se han encontrado cuentas de Zulip Cloud."
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
@@ -2756,7 +2225,7 @@ msgstr ""
 "Lamentablemente, no se han encontrado cuentas en las organizaciones de Zulip "
 "alojadas en %(external_host)s."
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2767,29 +2236,26 @@ msgstr ""
 "dirección de correo electrónico o <a href "
 "=\"%(help_logging_in_link)s\">probar otra forma</a> de encontrar tu cuenta."
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 "Si no reconoces esta solicitud, puedes ignorar este correo electrónico sin "
 "ningún problema."
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr "Tus cuentas de Zulip"
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr "No se han encontrado cuentas de Zulip"
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 "Si tienes problemas para iniciar sesión, puedes restablecer tu contraseña."
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
@@ -2799,12 +2265,12 @@ msgstr ""
 "(%(find_accounts_link)s) o probar otra forma de encontrar tu cuenta "
 "(%(help_logging_in_link)s)."
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr "Hola,"
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
@@ -2813,17 +2279,17 @@ msgstr ""
 "%(referrer_name)s quiere que te unas a ellos en Zulip &mdash; la herramienta "
 "de comunicación entre equipos diseñada para productividad."
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr "Para empezar, haz click en el botón inferior."
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr "%(referrer_full_name)s te invitó a unirte a %(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
@@ -2833,17 +2299,17 @@ msgstr ""
 "herramienta de comunicación para equipos diseñada con la productividad en "
 "mente."
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr "Para empezar, visita el enlace a continuación."
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr "Hola de nuevo,"
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
@@ -2853,13 +2319,13 @@ msgstr ""
 "unas a ellos en Zulip &mdash; la herramienta de comunicación de equipos "
 "diseñada exclusivamente para productividad."
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr "Este es el ultimo recordatorio que recibirás para esta invitación."
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
@@ -2868,12 +2334,12 @@ msgstr ""
 "Esta invitación caduca en dos días. Cuando esto ocurra, tendrás que pedirle "
 "a %(referrer_name)s que te envíe una nueva."
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr "Recordatorio: Únete a %(referrer_name)s en %(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2884,7 +2350,7 @@ msgstr ""
 "que te unas a Zulip, una herramienta de chat para el trabajo que realmente "
 "aumenta tu productividad."
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2893,7 +2359,7 @@ msgstr ""
 "Si tiene alguna duda, póngase en contacto con el administrador de este "
 "servidor a través de <a href=\"mailto:%(email)s\">%(email)s</a>."
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
@@ -2902,22 +2368,20 @@ msgstr ""
 "Tiene dudas o sugerencias? <a href=\"mailto:%(email)s\">Contáctenos</a>— Nos "
 "encanta ayudar!"
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr "Recibiste este correo porque fuiste mencionado."
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr "Recibiste esto porque @%(mentioned_user_group_name)sfue mencinoado."
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
@@ -2926,8 +2390,8 @@ msgstr ""
 "Recibes este mensaje porque se ha mencionado a todos los participantes del "
 "tema en #%(channel_name)s > %(topic_name)s."
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
@@ -2935,8 +2399,8 @@ msgstr ""
 "Recibiste esto porque tienes las menciones generales activadas para los "
 "temás que sigues."
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
@@ -2944,8 +2408,8 @@ msgstr ""
 "Recibes este mensaje porque se ha mencionado a todo el mundo en "
 "#%(channel_name)s."
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
@@ -2953,8 +2417,8 @@ msgstr ""
 "Recibiste esto porque tienes las menciones de correo activadas para los "
 "temas que sigues."
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
@@ -2963,7 +2427,7 @@ msgstr ""
 "Recibes este mensaje porque tienes activadas las notificaciones por correo "
 "electrónico para #%(channel_name)s."
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2974,7 +2438,7 @@ msgstr ""
 "%(realm_name)s Zulip</a>, o <a href=\"%(notif_url)s\">administra tus "
 "preferencias de correo</a>."
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
@@ -2983,7 +2447,7 @@ msgstr ""
 "<a href=\"%(narrow_url)s\">Ver o responder en %(realm_name)s Zulip</a> o <a "
 "href=\"%(notif_url)s\">administrar preferencias de correo</a>."
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
@@ -2992,7 +2456,7 @@ msgstr ""
 "<a href=\"%(narrow_url)s\">Responder en %(realm_name)s Zulip</a>, o <a "
 "href=\"%(notif_url)s\">administrar prefencias de correo</a>."
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
@@ -3001,42 +2465,42 @@ msgstr ""
 "No responder a este correo. Este servidor de Zulip no fue configurado para "
 "aceptar correos entrantes (<a href=\"%(url)s\">ayuda</a>)."
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr "Agrupar MDs con %(direct_message_group_display_name)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr "MDs con %(sender_str)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr "[resuelto] #%(channel_name)s > %(topic_name)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr "Nuevos mensajes"
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 "Responda a este correo directamente, o revíselo en %(realm_name)s Zulip:"
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr "Ver o responder en %(realm_name)sZulip:"
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr "Responder en %(realm_name)sZulip:"
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
@@ -3044,7 +2508,7 @@ msgstr ""
 "No responder a este corre. Este servidor de Zulip no fue configurado para "
 "recibir correos entrantes. Ayuda:"
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -3055,22 +2519,22 @@ msgstr ""
 "%(new_email)s. Si no fuiste tú quien solicitó este cambio, contáctanos de "
 "inmediato a %(support_email)s."
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr "Saludos,"
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr "El equipo de Zulip"
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr "Correo de Zulip cambiado por %(realm_name)s"
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -3081,7 +2545,7 @@ msgstr ""
 "%(new_email)s. Si no has solicitado este cambio, por favor, contáctanos "
 "inmediatamente en <%(support_email)s>."
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
@@ -3089,49 +2553,49 @@ msgstr ""
 "Organización: %(organization_url)s Hora: %(login_time)s Correo: "
 "%(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr ""
 "Hemos observado un inicio de sesion reciente para la siguiente cuenta Zulip."
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr "Organización: %(organization_link)s"
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr "Correo: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr "Hora: %(login_time)s"
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr "Dispositivo: %(device_browser)s en %(device_os)s."
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr "Dirección IP: %(device_ip)s"
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr ""
 "Si este inicio de sesión has sido tu, ¡perfecto! No se requiere acción de tu "
 "parte."
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3142,31 +2606,31 @@ msgstr ""
 "comprometida, por favor, <a href=\"%(reset_link)s\">cambia tu contraseña</a> "
 "o envíanos un correo de inmediato a %(support_email)s."
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr "Gracias,"
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr "Seguridad de Zulip"
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr "Desuscribirse de notificaciones de inicio de sesión"
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr "Nuevo inicio de sesión %(device_browser)s en %(device_os)s"
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr "Organización: %(organization_url)s"
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3177,7 +2641,7 @@ msgstr ""
 "comprometida, reinicia tu contraseña en %(reset_link)s o envíanos un correo "
 "inmediatamente a %(support_email)s."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -3188,7 +2652,7 @@ msgstr ""
 "consultar nuestra <a href=\"%(get_organization_started)s\">guía para migrar "
 "a Zulip</a> para empezar."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
@@ -3196,7 +2660,7 @@ msgstr ""
 "De cualquier forma, te dejamos algunos consejos de clientes que evalúan "
 "<i>cualquier</i> producto de chats de equipo:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
@@ -3205,12 +2669,12 @@ msgstr ""
 "<a href=\"%(invite_users)s\"><b>Invita a tu equipo</b></a> para explorar "
 "juntos y compartir sus perspectivas."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr "Usa la app para comentar tu experiencia."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -3222,7 +2686,7 @@ msgstr ""
 "forma de experimentar cómo una nueva aplicación te ayudará a comunicarte con "
 "tu equipo."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -3233,21 +2697,21 @@ msgstr ""
 "href=\"%(why_zulip)s\">eficiente</a>. Esperamos que estos consejos te "
 "permitan ponerlo a prueba junto a tu equipo."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr "Desubscribirse de los coreros de bienvenida de %(realm_name)s"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr "Eligiendo la aplicación de mensajería para tu equipo"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
@@ -3255,7 +2719,7 @@ msgstr ""
 "Si ya has decidido utilizar Zulip en tu organización, ¡bienvenido! Puedes "
 "consultar nuestra guía para dar el salto a Zulip y empezar a utilizarlo."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
@@ -3263,13 +2727,13 @@ msgstr ""
 "De cualquier forma, te dejamos consejos que oímos de nuestros clientes que "
 "evalúan cualquier producto de chat grupal:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
 msgstr "Invita a tu equipo a explorar juntos y compartir experiencias únicas."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
@@ -3279,7 +2743,7 @@ msgstr ""
 "de comunicación. Esta es la mejor forma de experimentar como una única "
 "aplicación puede ayudar a que se comuniquen mejor."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
@@ -3287,8 +2751,8 @@ msgstr ""
 "Zulip está diseñado para facilitar una comunicación eficaz, y esperamos que "
 "estos consejos ayuden a tu equipo a descubrirlo en la práctica."
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
@@ -3298,71 +2762,71 @@ msgstr ""
 "pueda adaptar a tus necesidades. Revisá esta guía de características clave "
 "de Zulip para organizaciones como la tuya!"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr "Consulta la guía de Zulip para empresas"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr "Consulta la guía de Zulip para proyectos de código abierto"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr "Consulta la guía de Zulip para el sector educativo"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr "Consulta la guía de Zulip para la investigación"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr "Consulta la guía de Zulip para eventos y conferencias"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr "Consulta la guía de Zulip para organizaciones sin ánimo de lucro"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr "Consulta la guía de Zulip para comunidades"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr "Guía de Zulip para empresas"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr "Guía de Zulip para proyectos de código abierto"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr "Guía de Zulip para el sector educativo"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr "Guía de Zulip para la investigación"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr "Guía de Zulip para eventos y conferencias"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr "Guía de Zulip para organizaciones sin ánimo de lucro"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr "Guía de Zulip para comunidades"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
@@ -3370,7 +2834,7 @@ msgstr ""
 "Aquí tienes algunos consejos para mantener organizadas tus conversaciones en "
 "Zulip mediante temas."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
@@ -3378,8 +2842,8 @@ msgstr ""
 "En Zulip, <b>los canales</b> determinan quién recibe un mensaje. <b>Los "
 "temas</b> indican de qué trata el mensaje."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
@@ -3388,12 +2852,12 @@ msgstr ""
 "mensaje en su contexto, independientemente del número de conversaciones que "
 "haya en marcha."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr "Canales y temas en la aplicación Zulip"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3405,11 +2869,11 @@ msgstr ""
 "los debates en curso. Para encontrar un buen nombre para el tema, piensa en "
 "cómo completar la frase: «Oye, ¿podemos hablar de…?»"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr "Ejemplos de temas cortos"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3422,17 +2886,17 @@ msgstr ""
 "href=\"%(rename_topics_link)s\">cambiar el nombre de los temas</a> o incluso "
 "<a href=\"%(move_channels_link)s\">mover un tema a otro canal</a>."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr "Ir a Zulip"
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr "Mantén tus conversaciones organizadas por temas"
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
@@ -3440,7 +2904,7 @@ msgstr ""
 "En Zulip, los canales determinan quién recibe un mensaje. Los temas indican "
 "de qué trata el mensaje."
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3453,8 +2917,8 @@ msgstr ""
 "nombre de los temas (%(rename_topics_link)s) o incluso trasladar un tema a "
 "otro canal (%(move_channels_link)s)."
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
@@ -3463,15 +2927,15 @@ msgstr ""
 "Alguien (quizás tú) ha solicitado una nueva contraseña para la cuenta de "
 "Zulip %(email)s en %(realm_url)s."
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr "Haz click en el botón inferior para reestablecer tu contraseña."
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr "Reestablecer contraseña"
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3482,18 +2946,18 @@ msgstr ""
 "desactivada. Puedes ponerte en contacto con un administrador de la "
 "organización para <a href=\"%(help_link)s\">reactivar tu cuenta</a>."
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr "No tienes cuenta en esa organización de Zulip."
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr "Tienes cuenta activa en la(s) siguiente(s) organización(es) de Zulip."
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
@@ -3501,22 +2965,22 @@ msgstr ""
 "Puedes intentar iniciar sesión o restablecer la contraseña en la(s) "
 "organización(es) mencionadas."
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr "Si no reconoces esta actividad, puedes ignorar este correo."
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr "%(realm_name)s solicito reestablecer su contraseña"
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr "Haz click en el enlace inferior para restablecer su contraseña."
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
@@ -3526,7 +2990,7 @@ msgstr ""
 "Puedes ponerte en contacto con un administrador de la organización para "
 "reactivar tu cuenta."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3537,7 +3001,7 @@ msgstr ""
 "de Zulip Cloud debido a facturas pendientes de pago. Las facturas pendientes "
 "de pago han sido anuladas."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
@@ -3546,7 +3010,7 @@ msgstr ""
 "Para seguir utilizando el plan Zulip Cloud Standard, actualiza tu cuenta de "
 "nuevo accediendo a %(upgrade_url)s."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
@@ -3555,8 +3019,8 @@ msgstr ""
 "Si crees que se trata de un error o necesitas más información, ponte en "
 "contacto con nosotros en %(support_email)s."
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip demo organization, %(realm_name)s, on "
@@ -3565,8 +3029,8 @@ msgstr ""
 "Has desactivado tu organización de demostración de Zulip, %(realm_name)s, el "
 "%(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
@@ -3575,8 +3039,8 @@ msgstr ""
 "Tu organización de demostración de Zulip, %(realm_name)s, fue desactivada "
 "por %(deactivating_owner)s el %(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
@@ -3585,8 +3049,8 @@ msgstr ""
 "Tu organización de demostración de Zulip, %(realm_name)s, se desactivó el "
 "%(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
@@ -3595,8 +3059,8 @@ msgstr ""
 "Has desactivado tu organización de Zulip, %(realm_name)s, el "
 "%(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
@@ -3605,8 +3069,8 @@ msgstr ""
 "Tu organización de Zulip, %(realm_name)s, fue desactivada por "
 "%(deactivating_owner)s el %(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
@@ -3614,16 +3078,16 @@ msgid ""
 msgstr ""
 "Tu organización de Zulip, %(realm_name)s, se desactivó el %(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 "Se han eliminado definitivamente todos los datos relacionados con esta "
 "organización."
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
@@ -3632,8 +3096,8 @@ msgstr ""
 "Todos los datos relacionados con esta organización se eliminarán "
 "definitivamente el %(deletion_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
@@ -3641,19 +3105,19 @@ msgstr ""
 "Si tiene alguna pregunta o duda, le rogamos que responda a este correo "
 "electrónico lo antes posible."
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr "Tu organización de Zulip %(realm_name)s ha sido desactivada"
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr "Estimado antiguo administrador de %(realm_name)s,"
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
@@ -3663,8 +3127,8 @@ msgstr ""
 "de demostración de Zulip, anteriormente desactivada, alojada en "
 "%(realm_url)s."
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
@@ -3673,16 +3137,16 @@ msgstr ""
 "Uno de tus administradores ha solicitado la reactivación de la organización "
 "de Zulip alojada en %(realm_url)s, que había sido desactivada anteriormente."
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr "Haz click en el botón inferior para reactivar su organización."
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr "Reactivar organización"
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
@@ -3690,19 +3154,19 @@ msgstr ""
 "Si esta solicitud fue un error, no ejecutar ninguna acción y este enlace "
 "expirara en 24 horas."
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip demo organization"
 msgstr "Reactiva tu organización de demostración de Zulip"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr "Reactiva tu organización de Zulip"
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr "Haz click en el enlace inferior para reactivar tu organización."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3711,18 +3175,18 @@ msgstr ""
 "Tanto tú como alguien en tu nombre ha solicitado un enlace de inicio de "
 "sesión para gestionar el plan de Zulip de <b>%(remote_server_hostname)s</b>."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 msgid "Click the button below to log in."
 msgstr "Haz clic en el botón de abajo para iniciar sesión."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr "Este enlace caducará en %(validity_in_hours)s horas."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
@@ -3731,11 +3195,11 @@ msgstr ""
 "¿Tienes alguna pregunta? <a href=\"%(billing_help_link)s\">Más información</"
 "a> o ponte en contacto con %(billing_contact_email)s."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr "Iniciar sesión en la gestión de planes de Zulip"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3744,12 +3208,12 @@ msgstr ""
 "Tanto tú como alguien en tu nombre ha solicitado un enlace de inicio de "
 "sesión para gestionar el plan de Zulip de %(remote_server_hostname)s."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr "Haz clic en el enlace siguiente para iniciar sesión."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
@@ -3758,7 +3222,7 @@ msgstr ""
 "¿Tienes alguna pregunta? Obtén más información en %(billing_help_link)s o "
 "ponte en contacto con %(billing_contact_email)s."
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
@@ -3767,16 +3231,16 @@ msgstr ""
 "Haz clic en el botón de abajo para confirmar tu correo electrónico e iniciar "
 "sesión en la gestión de planes de Zulip para <b>%(remote_realm_host)s</b>."
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr "Confirma y inicia sesión"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr "Confirma tu correo electrónico para gestionar tu plan de Zulip"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
@@ -3785,7 +3249,7 @@ msgstr ""
 "Haz clic en el enlace siguiente para confirmar tu correo electrónico e "
 "iniciar sesión en la gestión de planes de Zulip para %(remote_realm_host)s."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
@@ -3794,7 +3258,7 @@ msgstr ""
 "¡Tu solicitud de patrocinio de Zulip ha sido aprobada! Tu organización ha "
 "pasado al <a href=\"%(plans_link)s\">plan Comunidad de Zulip</a>."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
@@ -3803,13 +3267,13 @@ msgstr ""
 "Si pudieras <a href=\"%(link_to_zulip)s\">incluir a Zulip como patrocinador "
 "en tu sitio web</a>, ¡te lo agradeceríamos mucho!"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr ""
 "¡Se ha aprobado el patrocinio del plan comunitario para %(billing_entity)s!"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
@@ -3817,7 +3281,7 @@ msgstr ""
 "¡Tu solicitud de patrocinio de Zulip ha sido aprobada! Tu organización ha "
 "pasado al plan Zulip Community."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
@@ -3825,22 +3289,22 @@ msgstr ""
 "Si pudieras incluir a Zulip como patrocinador en tu página web, ¡te lo "
 "agradeceríamos mucho!"
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr "Busca tus cuentas"
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr "Encontrar tus cuentas de Zulip"
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 "¡Correos electrónicos enviados! A continuación se muestran las direcciones "
 "introducidas en la página anterior:"
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
@@ -3850,7 +3314,7 @@ msgstr ""
 "href=\"%(current_url)s\">buscar cuentas asociadas a otra dirección de correo "
 "electrónico</a>."
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
@@ -3859,7 +3323,7 @@ msgstr ""
 "direcciones URL de todas las organizaciones de Zulip Cloud en las que tengas "
 "cuentas activas."
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
@@ -3868,7 +3332,7 @@ msgstr ""
 "direcciones URL de todas las organizaciones de Zulip de este servidor en las "
 "que tengas cuentas activas."
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
@@ -3876,214 +3340,214 @@ msgstr ""
 "Si además has olvidado tu contraseña, puedes <a href=\"/help/change-your-"
 "password\">restablecerla</a>."
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr "Dirección de correo electrónico"
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "Encontrar cuentas"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr "Producto"
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr "Por qué Zulip"
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr "Características"
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr "Planes y precios"
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 msgid "Zulip Cloud"
 msgstr "Zulip Cloud"
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr "Autohospedaje"
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr "Seguridad"
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "Integraciones"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr "Aplicaciones para móvil y escritorio"
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr "Nueva organización"
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr "Soluciones"
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr "Negocios"
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr "Educación"
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr "Investigación"
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr "Eventos y conferencias"
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr "Proyectos de código abierto"
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr "Comunidades"
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr "Ingenieros"
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr "Testimonios de clientes"
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr "Comunidades abiertas"
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr "Recursos"
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr "Primeros pasos"
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr "Centro de ayuda"
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr "Chat de comunidad"
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr "Socios"
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr "Estado de Zulip Cloud"
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr "Pasándose a Zulip"
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr "Instalación de un servidor Zulip"
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr "Actualización de un servidor Zulip"
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr "Colaborar"
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr "Guía para colaboradores"
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr "Comunidad de desarrolladores"
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr "Traducción"
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr "GitHub"
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr "Sobre nosotros"
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr "Equipo"
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "Historial"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr "Valores"
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr "Empleos"
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr "Blog"
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr "Apoyar a Zulip"
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr "Mastodon"
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Bluesky handle"
 msgid "Bluesky"
 msgstr "Nombre de usuario de Bluesky"
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr "Desarrollado por <a href=\"https://zulip.com\">Zulip</a>"
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr "los Términos de Servicio"
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr "Política de privacidad"
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr "Atribuciones del sitio web"
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr "Más de %(integrations_count_display)s integraciones nativas."
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 msgid ""
 "And hundreds more through <a href=\"/integrations/zapier\">Zapier</a> and <a "
 "href=\"/integrations/ifttt\">IFTTT</a>."
@@ -4091,53 +3555,49 @@ msgstr ""
 "Y cientos más a través de <a href=\"/integrations/zapier\">Zapier</a> e <a "
 "href=\"/integrations/ifttt\">IFTTT</a>."
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr "Buscar integraciones"
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr "Integraciones propias"
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr "Webhooks de entrada"
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr "Bots interactivos"
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr "REST API"
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr "Correo inválido"
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr "No se permite el correo electrónico"
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr ""
 "La dirección de correo electrónico con la que intentas registrarte no es "
 "válida."
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4148,7 +3608,7 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>, no permite registrarse utilizando "
 "direcciones de correo electrónico con tu dominio de correo."
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4159,7 +3619,7 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>, no permite registrarse con "
 "direcciones de correo electrónico desechables."
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4170,24 +3630,24 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>, no permite registrarse con "
 "direcciones de correo electrónico que contengan el símbolo «+»."
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr "Por favor, regístrate usando una dirección de correo válida."
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr "Por favor, regístrate usando una dirección de correo permitida."
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr "No se ha encontrado ninguna organización"
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr "No hay ninguna organización de Zulip en <b>%(current_url)s</b>."
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -4199,7 +3659,7 @@ msgstr ""
 "%(support_email)s\">ponte en contacto con el servicio de asistencia de "
 "Zulip</a>."
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -4211,7 +3671,7 @@ msgstr ""
 "%(support_email)s\">ponte en contacto con los administradores de este "
 "servidor de Zulip</a>."
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
@@ -4220,61 +3680,61 @@ msgstr ""
 "<a href=\"%(current_url)s/serverlogin/\">Haz clic aquí</a> para acceder a la "
 "gestión de planes de tu servidor Zulip."
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr "Sesión de inicio de sesión no válida o caducada"
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr "Sesión de inicio de sesión no válida o caducada."
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr "Iniciar sesión en Zulip"
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 "Ya te has registrado con esta dirección de correo. Por favor, inicia sesión "
 "abajo."
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr "Correo electrónico o nombre de usuario"
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "Nombre de usuario"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr "¿Olvidaste la contraseña?"
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr "Inicia sesión con %(identity_provider)s"
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr "Ver sin tener una cuenta"
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 "¿Aún no tienes una cuenta? Para unirte a esta organización, necesitas que te "
 "inviten."
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr "No hay licencias disponibles"
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr "La organización no puede aceptar nuevos miembros en este momento"
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
@@ -4284,7 +3744,7 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a> porque todas las licencias de "
 "Zulip Cloud están en uso."
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
@@ -4292,19 +3752,19 @@ msgstr ""
 "Ponte en contacto con la persona que te invitó y pídele que aumente el "
 "número de licencias; después, vuelve a intentarlo."
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr "Ir al contenido principal"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr "Error de subdominio de autenticación"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr "Subdominio de autenticación"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -4319,16 +3779,15 @@ msgstr ""
 "sesión, lo más probable es que se trate de un error del servidor o de una "
 "configuración incorrecta."
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 msgid "Demo organizations disabled"
 msgstr "Organizaciones de demostración desactivadas"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr "Es necesario actualizar"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
@@ -4336,7 +3795,7 @@ msgstr ""
 "Estás utilizando una versión antigua de la aplicación de escritorio de Zulip "
 "que ya no es compatible."
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
@@ -4344,22 +3803,21 @@ msgstr ""
 "La función de actualización automática de esta versión antigua de la "
 "aplicación de escritorio de Zulip ya no funciona."
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr "Descarga la última versión."
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 "Has superado el límite de veces que un usuario puede realizar esta acción."
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr "Se requiere un enlace para crear la organización"
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -4372,12 +3830,11 @@ msgstr ""
 "multiple-organizations.html\">documentación</a> sobre cómo crear una nueva "
 "organización."
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr "El enlace para crear una organización ha caducado o no es válido"
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
@@ -4385,11 +3842,11 @@ msgstr ""
 "Lamentablemente, este enlace no es válido para crear una organización. Por "
 "favor, <a href=\"/new/\">obtén un nuevo enlace</a> e inténtalo de nuevo."
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr "Registro inesperado en el servidor de Zulip"
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -4401,17 +3858,16 @@ msgstr ""
 "en contacto con el servicio de asistencia de Zulip</a> para que te ayuden a "
 "resolver este problema."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr "Navegador no compatible"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr "Zulip no es compatible con %(browser_name)s."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
@@ -4420,7 +3876,7 @@ msgstr ""
 "Zulip es compatible con <a href=\"%(supported_browsers_page_link)s\">los "
 "navegadores modernos</a> como Firefox, Chrome y Edge."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
@@ -4428,21 +3884,20 @@ msgstr ""
 "También puedes utilizar la <a href=\"%(apps_page_link)s\">aplicación de "
 "escritorio de Zulip</a>."
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr "La cuenta está desactivada"
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 msgid "Finalize organization import"
 msgstr "Finalizar la importación de la organización"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 msgid "Organization import completed!"
 msgstr "¡Importación de la organización completada!"
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -4454,53 +3909,52 @@ msgstr ""
 "strong>). Selecciona una cuenta con la que asociar tu dirección de correo "
 "electrónico."
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 msgid "Select your account"
 msgstr "Selecciona tu cuenta"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 msgid "Create new account"
 msgstr "Crear una cuenta nueva"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr "La organización se ha reactivado con éxito"
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr "Tu organización se ha reactivado satisfactoriamente."
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr ""
 "El enlace de reactivación de la organización ha caducado o no es válido"
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr "El enlace para reactivar tu organización ha expirado o no es valido."
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr "Iniciar sesión en tu organización"
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr "tu-organización"
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr "¿Desconoces la URL de tu organización?"
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr "Encuentra tu organización."
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr "Siguiente"
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4510,11 +3964,11 @@ msgstr ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(org_creation_link)s\">Crea una organiación</a> si aún no tienes una."
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 msgid "Self-hosting Zulip?"
 msgstr "¿Alojar Zulip por cuenta propia?"
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4524,11 +3978,11 @@ msgstr ""
 "href=\"%(self_hosted_login_help)s\">iniciar sesión para gestionar los planes "
 "y la facturación.</a>"
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr "Reestablece tu contraseña"
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
@@ -4536,64 +3990,64 @@ msgstr ""
 "¿Has olvidado tu contraseña? No te preocupes, te enviaremos un enlace para "
 "restablecerla a la dirección de correo electrónico con la que te registraste."
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr "Enviar enlace de recuperación"
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr "Establecer una nueva contraseña"
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "Confirmar contraseña"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr ""
 "Lo sentimos, el link que has proporcionado es inválido o ya ha sido usado."
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr "La nueva contraseña se ha establecido correctamente"
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr "¡Ya has establecido una nueva contraseña!"
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr ""
 "Por favor, <a href=\"%(login_url)s\">inicia sesión</a> con tu nueva "
 "contraseña."
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr "Se ha enviado el correo electrónico para restablecer la contraseña"
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr "¡Reestablecimiento de contraseña enviado!"
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr ""
 "Comprueba tu correo electrónico en unos minutos para completar el proceso."
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr "Importar desde Slack"
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr "Progreso de la importación"
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr "Comprobando el estado de la importación…"
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4605,7 +4059,7 @@ msgstr ""
 "slack#import-your-data-into-zulip\"> proceso de importación de Zulip Cloud "
 "(a través del servicio de asistencia) </a> para completar la importación."
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4618,15 +4072,15 @@ msgstr ""
 "rel=\"noopener noreferrer\" target=\"_blank\">estas instrucciones</a> para "
 "obtener un <strong>token de OAuth del usuario del bot</strong>."
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr "Token de OAuth del usuario del bot de Slack"
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr "Sube tu archivo de exportación de Slack"
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
@@ -4636,20 +4090,20 @@ msgstr ""
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">estas instrucciones</a> "
 "para exportar tu historial de mensajes de Slack."
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr "Iniciar subida"
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr "Archivo de exportación cargado"
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr ""
 "¿Quién podrá ver las direcciones de correo electrónico de los demás usuarios?"
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
@@ -4659,11 +4113,11 @@ msgstr ""
 "visibility\" target=\"_blank\">modificar</a> la configuración de visibilidad "
 "de su correo electrónico al iniciar sesión."
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr "Iniciar importación"
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
@@ -4672,7 +4126,7 @@ msgstr ""
 "clic en el botón <b>Completar el registro</b> que aparece en tu correo "
 "electrónico."
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
@@ -4680,7 +4134,7 @@ msgstr ""
 "O bien <span id=\"cancel-slack-import\" tabindex=\"0\">crea una "
 "organización</span> sin importar datos."
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4692,7 +4146,7 @@ msgstr ""
 "rel=\"noopener noreferrer\" target=\"_blank\">procedimiento</a> para "
 "realizar importaciones a través del servicio de asistencia."
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4704,22 +4158,22 @@ msgstr ""
 "rel=\"noopener noreferrer\" target=\"_blank\">procedimiento</a> para "
 "importaciones en servidores propios."
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr "Selecciona una cuenta para la autenticación"
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr "<h1 class=\"get-started\">Selecciona una cuenta</h1>"
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 "Tu cuenta de GitHub también tiene direcciones de correo electrónico no "
 "verificadas asociadas."
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
@@ -4728,15 +4182,15 @@ msgstr ""
 "debes <a href=\"https://github.com/settings/emails\">verificarla con GitHub."
 "</a>"
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr "Error al darse de baja del correo electrónico"
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr "Petición de desuscripción de correo desconocida"
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
@@ -4744,7 +4198,7 @@ msgstr ""
 "¡Hola! Parece que has intentado darte de baja de algo, pero no reconocemos "
 "la URL."
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4755,12 +4209,11 @@ msgstr ""
 "href=\"mailto:%(support_email)s\">envíanos un correo electrónico</a> y ¡lo "
 "solucionaremos!"
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr "Ajustes de correo electrónico actualizados"
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
@@ -4770,7 +4223,7 @@ msgstr ""
 "Zulip %(subscription_type)s para <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a>."
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
@@ -4779,48 +4232,47 @@ msgstr ""
 "Puedes deshacer este cambio o revisar tus preferencias en tus <a "
 "href=\"%(realm_url)s/#settings/notifications\">ajustes de notificaciones</a>."
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr "Orden del mapeo inválido."
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr "Preguntas y debate sobre el uso de Zulip."
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr "Prueba Zulip aquí. :test_tube:"
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr "Para conversaciones de todo el equipo"
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr "inscripciones"
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr "{user} se ha unido a esta organización."
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr "¡{user} ha aceptado tu invitación para unirse a Zulip!"
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 "No se puede activar una cuenta provisional; pide al usuario que se registre."
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 msgid "Cannot reactivate a deleted user"
 msgstr "No se puede reactivar un usuario eliminado"
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
@@ -4828,26 +4280,25 @@ msgstr ""
 "No puedes modificar este campo. Ponte en contacto con un administrador para "
 "actualizarlo."
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr "Id de campo {id} no encontrado."
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr "Nombre de grupo de canales predeterminado no válido: «{group_name}»"
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 "El nombre predeterminado del grupo de canales es demasiado largo (límite: "
 "{max_length} caracteres)"
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
@@ -4855,12 +4306,12 @@ msgstr ""
 "El nombre predeterminado del grupo de canales «{group_name}» contiene "
 "caracteres NULL (0x00)."
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr "Grupo de canales predeterminado no válido {group_name}"
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
@@ -4868,12 +4319,12 @@ msgstr ""
 "«{channel_name}» es un canal predeterminado y no se puede añadir a "
 "«{group_name}»"
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr "El grupo de canales predeterminado «{group_name}» ya existe"
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
@@ -4882,7 +4333,7 @@ msgstr ""
 "El canal «{channel_name}» ya existe en el grupo de canales predeterminado "
 "«{group_name}»"
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
@@ -4891,12 +4342,12 @@ msgstr ""
 "El canal «{channel_name}» no se encuentra en el grupo de canales "
 "predeterminado «{group_name}»"
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr "Este grupo de canales predeterminado ya se llama «{group_name}»"
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
@@ -4905,7 +4356,7 @@ msgstr ""
 "puedes enviar en un día. Ya que haz alcanzado el límite, no se enviaron "
 "invitaciones."
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
@@ -4914,78 +4365,78 @@ msgstr ""
 "Pídeselo a un administrador de la organización, o a un usuario con más "
 "experiencia."
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 "Algunos correos electrónicos no se han validado, por lo que no hemos enviado "
 "ninguna invitación."
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr "No hemos podido invitar a nadie."
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr "Nada que cambiar"
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr "Los mensajes directos no se pueden mover a canales."
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr "Los mensajes directos no pueden tener temas."
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr "Modo de propagación no válido sin edición del tema"
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr "El chat general no se puede marcar como resuelto"
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 "No se puede modificar el contenido del mensaje mientras se cambia de canal"
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr "Los widgets no se pueden editar."
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr "Tu organización ha desactivado la edición de mensajes"
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr "No tienes permiso para editar este mensaje"
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr "El límite de tiempo para editar este mensaje ha pasado"
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr "{user} ha marcado este tema como resuelto."
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr "{user} ha marcado este tema como sin resolver."
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr "Este tema ha sido movido a {new_location} por {user}."
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr "Un mensaje ha sido movido de este tema a {new_location} por {user}."
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
@@ -4994,12 +4445,12 @@ msgstr ""
 "{changed_messages_count} mensajes fueron movidos de este tema {new_location} "
 "por {user}."
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr "Este tema ha sido trasladado aquí desde {old_location} por {user}."
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
@@ -5007,7 +4458,7 @@ msgstr ""
 "[Un mensaje]({message_link}) ha sido trasladado aquí desde {old_location} "
 "por {user}."
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
@@ -5016,67 +4467,64 @@ msgstr ""
 "{changed_messages_count} mensajes han sido trasladados aquí desde "
 "{old_location} por {user}."
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to resolve topics in this channel."
 msgstr "No tienes permiso para cerrar temas en este canal."
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr "El plazo para editar el asunto de este mensaje ha vencido."
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr "No tienes permiso para mover este mensaje"
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr "El plazo para editar el canal de este mensaje ha vencido"
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr "Indicador no válido: «{flag}»"
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr "Bandera no editable: «{flag}»"
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr "Operación de marca de mensaje no válida: «{operation}»"
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr "Mensaje(s) inválido(s)"
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr "No se pudo renderizar el mensaje"
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr "Se esperaba exactamente un canal"
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr "Tipo de datos no válido para el canal"
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr "Tipo de datos no válido para los destinatarios"
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 "Las listas de destinatarios pueden contener direcciones de correo "
 "electrónico o identificadores de usuario, pero no ambos."
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
@@ -5085,7 +4533,7 @@ msgstr ""
 "Tu bot {bot_identity} ha intentado enviar un mensaje al canal con el ID "
 "{channel_id}, pero no existe ningún canal con ese ID."
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -5096,7 +4544,7 @@ msgstr ""
 "{channel_name}, pero ese canal no existe. Haz clic [aquí]"
 "({new_channel_link}) para crearlo."
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
@@ -5105,29 +4553,29 @@ msgstr ""
 "Tu bot {bot_identity} ha intentado enviar un mensaje al canal "
 "{channel_name}. El canal existe, pero no tiene suscriptores."
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr "No tienes permiso para acceder a algunos de los destinatarios."
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr "Widgets: el programador de la API envió contenido JSON inválido"
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr "Widgets: {error_msg}"
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr "Se han realizado los siguientes cambios en tu cuenta."
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr "{user} ha realizado los siguientes cambios en tu cuenta."
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5138,27 +4586,25 @@ msgstr ""
 "- **Antiguo {field_name}:** {old_value}\n"
 "- **Nuevo {field_name}:** {new_value}\n"
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr "Ya existe un emoticono personalizado con ese nombre."
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr "Formato de imagen no válido"
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr "La lista ordenada no debe contener generadores de enlaces duplicados"
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 "La lista ordenada debe incluir todos los generadores de enlaces existentes "
 "exactamente una vez"
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
@@ -5167,41 +4613,41 @@ msgstr ""
 "Debes pasarte al plan {required_upgrade_plan_name} para poder utilizar este "
 "método de autenticación."
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 "Método de autenticación no válido: {name}. Los métodos válidos son: {methods}"
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 "El método de autenticación {name} no está disponible en tu plan actual."
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr "El canal de solicitud de moderación debe ser privado."
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr "El fragmento guardado no existe."
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr "El mensaje programado ya se ha enviado"
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 #, fuzzy
 #| msgid "Reminder does not exist"
 msgid "Reminder could not be sent."
 msgstr "El recordatorio no existe"
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr "No se ha podido enviar el mensaje a la hora prevista."
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
@@ -5210,38 +4656,38 @@ msgstr ""
 "El mensaje que programaste para {delivery_datetime} no se ha enviado debido "
 "al siguiente error:"
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr "[Ver mensajes programados](#scheduled)"
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr "El canal ya está desactivado"
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr "El canal #**{channel_name}** se ha archivado."
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr "El canal no está desactivado actualmente"
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr "El canal {channel_name} ya existe"
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr "El canal es privado y no tiene suscriptores"
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr "El canal #**{channel_name}** ya no está archivado."
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
@@ -5250,7 +4696,7 @@ msgstr ""
 "{user} ha cambiado los [permisos de acceso]({help_link}) de este canal de "
 "**{old_policy}** a **{new_policy}**."
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -5264,42 +4710,40 @@ msgstr ""
 "* **Anterior**: {old_setting_description}\n"
 "* **Nuevo**: {new_setting_description}\n"
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 "{user_name} ha cambiado el nombre del canal {old_channel_name} por "
 "{new_channel_name}."
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr "Sin descripción."
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr "{user} ha cambiado la descripción de este canal."
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr "Descripción anterior"
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr "Nueva descripción"
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr "Para siempre"
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr "{number_of_days} días"
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
@@ -5308,12 +4752,12 @@ msgstr ""
 "Los mensajes de este canal se eliminarán automáticamente {number_of_days} "
 "días después de su envío."
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr ""
 "A partir de ahora, los mensajes de este canal se conservarán indefinidamente."
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -5330,26 +4774,26 @@ msgstr ""
 "\n"
 "{summary_line}"
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr "Automático"
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr "*{empty_topic_display_name}*: tema permitido"
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr "No hay ningún tema *{empty_topic_display_name}*"
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr "Solo se permite el tema *{empty_topic_display_name}*"
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
@@ -5358,73 +4802,63 @@ msgstr ""
 "{user_name} ha cambiado el ajuste «¿Permitir publicar en el tema *chat "
 "general*?» de {old_topics_policy} a {new_topics_policy}."
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr "No puedes adjuntar un mensaje secundario a este mensaje."
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr "ID de usuario no válido {user_id}"
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr "El grupo de usuarios «{group_name}» ya existe."
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr "Permisos insuficientes"
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr "Esta API no está disponible a los bots de webhook de entrada."
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr "Cuenta no asociada con este subdominio"
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr "Este endpoint no acepta peticiones de bots."
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr "Debes ser un administrador del servidor"
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr "Este endpoint requiere autentificación HTTP básica."
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr "Cabecera de autorización inválida para la autentificación básica"
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr "Falta la cabecera de autorización para la autentificación básica"
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr "Los bots de webhook solo pueden acceder a los webhooks"
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr "Correo electrónico o contraseña incorrectos."
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
@@ -5433,42 +4867,41 @@ msgstr ""
 "Tu cuenta {username} ha sido desactivada. Ponte en contacto con el "
 "administrador de tu organización para reactivarla."
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr "La contraseña es demasiado débil."
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr "El subdominio necesita tener una longitud de 3 caracteres o superior."
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr "El subdominio no puede empezar o terminar con un '-'."
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr "El subdominio solo puede tener letras minúsculas, números, y '-'."
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr "El subdominio ya está en uso. Por favor, elige uno diferente."
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr "Subdominio reservado. Por favor, elige uno diferente."
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr "Por favor, usa tu dirección de correo electrónico real."
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr ""
 "La organización a la que estás intentando unirte usando {email} no existe."
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
@@ -5476,13 +4909,13 @@ msgstr ""
 "Por favor, solicita una invitación para {email} del administrador de la "
 "organización."
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 "No se puede unirte a la organización: la autenticación mediante contraseña "
 "no está habilitada."
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
@@ -5491,13 +4924,13 @@ msgstr ""
 "Tu dirección de correo electrónico, {email}, no está en uno de los dominios "
 "permitidos para el registro de cuentas en esta organización."
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr ""
 "Las direcciones de correo electrónico que contienen símbolos + no están "
 "permitidas en esta organización."
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
@@ -5508,32 +4941,31 @@ msgstr ""
 "invitó y pídele que aumente el número de licencias; después, vuelve a "
 "intentarlo."
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr "¡Se ha comprobado que eres un usuario humano!"
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr "Comprobando que no eres un bot…"
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 msgid "Challenges are not enabled."
 msgstr "Los desafíos no están habilitados."
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr "La validación ha fallado. Inténtalo de nuevo."
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "Nueva contraseña"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr "Confirmación de la nueva contraseña"
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "You're making too many attempts to sign in. Try again in "
@@ -5543,7 +4975,7 @@ msgstr ""
 "de {retry_after_string} o ponte en contacto con el administrador de tu "
 "organización para obtener ayuda."
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
@@ -5551,91 +4983,89 @@ msgstr ""
 "Tu contraseña ha sido desactivada porque es demasiado débil. Restablece tu "
 "contraseña para crear una nueva."
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr "Token"
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 "Consejo: Puedes introducir varias direcciones de correo electrónico "
 "separadas por comas."
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr "Por favor, introduce como máximo 10 correos."
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr "No se pudo encontrar la organización de Zulip."
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr "Correo electrónico no válido «{email}»"
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr "Falta el tema"
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr "No se puede enviar a varios canales"
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr "Canal no disponible"
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr "El mensaje debe tener destinatarios"
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr "Tipo de mensaje inválido"
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr "Adjunto inválido"
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr ""
 "Un error ocurrió al eliminar el adjunto. Por favor, inténtalo de nuevo más "
 "adelante."
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr "El mensaje debe tener destinatarios!"
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name can't be empty."
 msgstr "El nombre de la carpeta del canal no puede estar vacío."
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr ""
 "Carácter no válido en el nombre de la carpeta del canal, en la posición "
 "{position}."
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr "El nombre de la carpeta del canal ya está en uso"
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 msgid "Invalid channel folder ID"
 msgstr "ID de carpeta de canal no válido"
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 msgid "Configure owner account email address."
 msgstr ""
 "Configura la dirección de correo electrónico de la cuenta del propietario."
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5648,70 +5078,70 @@ msgstr ""
 "eliminará automáticamente el {deletion_time}, a menos que se [convierta en "
 "una organización permanente]({convert_demo}).\n"
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, python-brace-format
 msgid "{var_name} is not Base64 encoded"
 msgstr "{var_name} no está codificado en Base64"
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 msgid "Invalid `device_id`"
 msgstr "`device_id` no válido"
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr "Resumen de {service_name}"
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr "El dominio no puede estar vacío."
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr "El dominio debe tener al menos un punto (.)"
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr "El dominio es demasiado largo"
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr "El dominio no puede empezar o acabar con un punto (.)"
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr "No se permiten '.' consecutivos."
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr "Los subdominios no pueden empezar o terminar con un '-'."
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr "Los dominios solo pueden tener letras, números, '.' y '-'."
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr "La marca de tiempo no puede ser negativa."
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr "El tema no puede contener bytes nulos"
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 "Se debe especificar exactamente un ID de canal para los mensajes de canal"
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr "El usuario ha deshabilitado la sincronización de borradores."
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr "El borrador no existe"
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5722,88 +5152,88 @@ msgstr ""
 "por correo electrónico de notificación de mensajes:\n"
 "{error_message}"
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr "Correo electrónico sin asunto"
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr "Abre Zulip para ver el contenido oculto"
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr "Notificaciones de {service_name}"
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr "Dirección inválida."
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr "Fuera de tu dominio."
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr ""
 "Las direcciones de correo electrónico que contienen símbolos + no están "
 "permitidas."
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr "Reservado para bots de sistema."
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr "{email} ya tiene una cuenta"
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr "Ya tiene una cuenta."
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr "La cuenta ha sido desactivada."
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr "El emoji «{emoji_name}» no existe"
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr "Emoticono personalizado inválido."
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr "Nombre de emoticono personalizado inválido."
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr "El emoticono personalizado ha sido desactivado."
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr "Código de emoticono inválido."
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr "Nombre de emoticono inválido."
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr "Tipo de emoticono inválido."
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr "Debes ser un administrador de la organización o el autor del emoticono"
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr "Los nombres de los emojis deben terminar en una letra o un número."
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
@@ -5811,63 +5241,63 @@ msgstr ""
 "Los nombres de los emojis solo deben contener letras minúsculas en inglés, "
 "números, espacios, guiones y guiones bajos."
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr "Falta el nombre del emoji"
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr "No se pudo ubicar la cola de eventos"
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr "Sesión no iniciada: autentificación API o sesión de usuario requerida"
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr "El canal «{channel_name}» ya existe"
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr "El canal «{stream}» no existe"
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr "El canal con el ID «{stream_id}» no existe"
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr "Combinación de parámetros no admitida: {parameters}"
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 "{required_parameter} es obligatorio cuando se establece {set_parameter}."
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr "propietario de la organización"
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr "usuario"
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr "No se puede desactivar la única {entity}."
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr "Sentencia de inclusión de markdown inválido {include_statement}"
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
@@ -5875,35 +5305,34 @@ msgstr ""
 "Se ha superado el límite de uso de la API; consulta https://zulip.com/api/"
 "http-headers#rate-limiting-response-headers"
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr "JSON malformado"
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr "Debes ser un administrador de la organización"
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr "Debe ser un propietario de la organización"
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Must be an organization owner"
 msgid "Must be a bot user"
 msgstr "Debe ser un propietario de la organización"
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr "Tu nombre de usuario o contraseña son incorrectos"
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr "Esta organización ha sido desactivada"
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
@@ -5911,24 +5340,24 @@ msgstr ""
 "El servicio de notificaciones push móviles de tu organizacion ha sido "
 "desactivado"
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr ""
 "La autenticación por contraseña ha sido desactivado en esta organización"
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr "Tu contraseña ha sido inhabilitada y debe ser establecida de nuevo"
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr "Clave de API inválida"
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr "Formato inválido de clave de API"
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
@@ -5937,27 +5366,26 @@ msgstr ""
 "El evento «{event_type}» no es compatible actualmente con el webhook "
 "«{webhook_name}»; se ignora"
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 "No se ha podido analizar la solicitud: ¿Ha generado {webhook_name} este "
 "evento?"
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr "Usuario no autenticado"
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr "Subdominio inválido"
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr "No tienes permiso para iniciar conversaciones por mensaje directo."
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
@@ -5965,12 +5393,12 @@ msgid ""
 msgstr ""
 "En este canal no está permitido enviar mensajes a {empty_topic_display_name}."
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr "En este canal solo se permite el tema {empty_topic_display_name}."
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
@@ -5980,19 +5408,19 @@ msgstr ""
 "estar en el tema {empty_topic_display_name}. Considera la posibilidad de "
 "cambiar el nombre o eliminar otros temas."
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr "Los mensajes directos están deshabilitados para esta organización."
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr "Esta conversación no incluye ningún usuario que pueda autorizarla."
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr "Acceso denegado"
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
@@ -6001,15 +5429,15 @@ msgstr ""
 "Solo tienes permiso para mover los {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} mensajes más recientes de este tema."
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr "Ya existe la reacción."
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr "No existe esa reacción."
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
@@ -6018,241 +5446,241 @@ msgstr ""
 "contacto con el servicio de asistencia de Zulip para que te ayuden a "
 "resolver este problema."
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr "Organización no registrada"
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr "No tienes permiso para utilizar menciones con comodines en este canal."
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr "No tienes permiso para utilizar menciones con comodines en este tema."
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr "El valor de «{field_name}» no coincide con el valor esperado."
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr "«{setting_name}» debe ser un grupo de usuarios del sistema."
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr "No se puede desactivar un grupo de usuarios que está en uso."
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr "No tienes permiso para administrar este canal."
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr "No tienes permiso para cambiar los canales predeterminados."
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr "Esa dirección de correo electrónico ya está en uso."
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr "La fecha de entrega prevista debe ser futura."
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr "«bouncer_public_key» no válido"
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr "La solicitud ha caducado"
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr "«encrypted_push_registration» no válido"
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 "El servidor no está configurado para utilizar el servicio de notificaciones "
 "push."
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Already has an account."
 msgid "Atlassian account ID"
 msgstr "Ya tiene una cuenta."
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 msgid "Behance username"
 msgstr "Nombre de usuario de Behance"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 msgid "Bitbucket username"
 msgstr "Nombre de usuario de Bitbucket"
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr "Nombre de usuario de Bluesky"
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 msgid "Codeberg username"
 msgstr "Nombre de usuario de Codeberg"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr "Etiqueta de Discord"
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 msgid "Dribbble username"
 msgstr "Nombre de usuario en Dribbble"
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 msgid "Facebook username"
 msgstr "Nombre de usuario de Facebook"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr "Nombre de usuario de GitHub"
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 msgid "GitLab username"
 msgstr "Usuario de GitLab"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 msgid "Instagram username"
 msgstr "Usuario de Instagram"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr "Nombre del perfil de LinkedIn"
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 msgid "Mastodon profile"
 msgstr "Perfil de Mastodon"
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 msgid "Medium username"
 msgstr "Usuario de Medium"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 msgid "Pinterest username"
 msgstr "Usuario de Pinterest"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 msgid "Reddit username"
 msgstr "Usuario de Reddit"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 msgid "Snapchat username"
 msgstr "Usuario de Snapchat"
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 msgid "Threads username"
 msgstr "Usuario de Threads"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 msgid "TikTok username"
 msgstr "Usuario de TikTok"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 msgid "Twitch username"
 msgstr "Usuario de Twitch"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 msgid "X username"
 msgstr "Usuario de X"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr "Identificador de YouTube"
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr "Tipo de cuenta externa inválida"
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr "Frameworks de integraciones"
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 msgid "Video calling"
 msgstr "Videollamada"
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr "Integración continua"
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr "Atención al cliente"
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr "Despliegue"
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr "Entretenimiento"
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr "Comunicación"
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr "Finanzas"
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr "Recursos humanos"
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr "Mercadotecnia"
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr "Miscelánea"
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr "Seguimiento"
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr "Gestión de proyectos"
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr "Productividad"
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr "Control de versiones"
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr "El mensaje no puede estar vacío"
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr "El mensaje no puede contener bytes nulos"
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr "No está permitido mencionar el grupo de usuarios «{user_group_name}»."
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr "{other_users} y {last_user}"
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
@@ -6261,7 +5689,7 @@ msgstr ""
 "{reporting_user_mention} ha denunciado un mensaje enviado por "
 "{reported_user_mention} el {reported_message_date_sent}."
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
@@ -6270,7 +5698,7 @@ msgstr ""
 "{reporting_user_mention} ha denunciado un mensaje enviado por "
 "{reported_user_mention} a {recipient_user} el {reported_message_date_sent}."
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
@@ -6280,71 +5708,71 @@ msgstr ""
 "{reported_user_mention} a {list_of_direct_message_recipients} el "
 "{reported_message_date_sent}."
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr "Mensaje original en {channel_message_link}"
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr "[Mensaje original]({direct_message_link})"
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "{fullname} moderation"
 msgstr "Moderación de {fullname}"
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr "Operador de filtro inválido: {desc}"
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr "Combinación de operadores de filtrado no válida: {desc}"
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr "Operadores «with» duplicados."
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr "Operador «with» no válido"
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr "Falta el argumento «anchor»."
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor_date' argument."
 msgstr "Falta el argumento «anchor_date»."
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr "Enlace no válido"
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr "El operador {operator} no es compatible."
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr "El operando {operand} no es compatible."
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 msgid "Navigation view does not exist."
 msgstr "La vista de navegación no existe."
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr "Nota de {admin_group_syntax}:"
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6355,7 +5783,7 @@ msgstr ""
 "Para obtener más información, consulta nuestra [guía sobre cómo usar Zulip "
 "en clase]({getting_started_url})!\n"
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6366,7 +5794,7 @@ msgstr ""
 "Para obtener más información, consulta nuestra [guía de introducción]"
 "({getting_started_url})!\n"
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6377,7 +5805,7 @@ msgstr ""
 "También disponemos de una guía para [configurar Zulip para una clase]"
 "({organization_setup_url}).\n"
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6388,7 +5816,7 @@ msgstr ""
 "También disponemos de una guía para [trasladar tu organización a Zulip]"
 "({organization_setup_url}).\n"
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6403,7 +5831,7 @@ msgstr ""
 "eliminada** el {deletion_global_time}, a menos que se [convierta en\n"
 "una organización permanente]{convert_demo_organization_help_url}.\n"
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
@@ -6414,7 +5842,7 @@ msgstr ""
 "Las encontrarás\n"
 "en tu [Bandeja de entrada](/#inbox).\n"
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6426,7 +5854,7 @@ msgstr ""
 "({navigation_tour_video_url}) para obtener una breve descripción general de "
 "la aplicación.\n"
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6451,7 +5879,7 @@ msgstr ""
 "{demo_organization_text}\n"
 "\n"
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
@@ -6462,7 +5890,7 @@ msgstr ""
 "apps/).\n"
 "Zulip también funciona muy bien en el navegador.\n"
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -6474,7 +5902,7 @@ msgstr ""
 "(/help/change-your-profile-picture)\n"
 "y editar tu [información de perfil](/help/edit-your-profile).\n"
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -6493,7 +5921,7 @@ msgstr ""
 "Zulip\n"
 "en tus [Preferencias](#settings/preferences).\n"
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6510,7 +5938,7 @@ msgstr ""
 "\n"
 "[Explora y suscríbete a canales]({settings_link}).\n"
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -6541,7 +5969,7 @@ msgstr ""
 "los temas que se están\n"
 "tratando.\n"
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -6557,7 +5985,7 @@ msgstr ""
 "Pulsa `?` en cualquier momento para ver una [guía rápida](#keyboard-"
 "shortcuts).\n"
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -6577,7 +6005,7 @@ msgstr ""
 "información sobre spoilers,\n"
 "horas globales y mucho más.\n"
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6593,7 +6021,7 @@ msgstr ""
 "zulip),\n"
 "o explora el [centro de ayuda](/help/) para obtener más información.\n"
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6604,7 +6032,7 @@ msgstr ""
 "¡Puedes charlar conmigo todo lo que quieras! Para\n"
 "obtener ayuda, prueba con uno de estos mensajes: {bot_commands}\n"
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6623,7 +6051,7 @@ msgstr ""
 "o incluso mover un tema [a otro canal]"
 "({move_content_another_channel_help_url}).\n"
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
@@ -6632,7 +6060,7 @@ msgstr ""
 ":point_right: Intenta mover este mensaje a otro tema y volver a traerlo "
 "aquí.\n"
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6655,12 +6083,11 @@ msgstr ""
 "lateral izquierda\n"
 "y más arriba.\n"
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr "¡bienvenido a Zulip!"
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -6672,7 +6099,7 @@ msgstr ""
 "contexto,\n"
 "sin importar cuántas otras conversaciones haya en marcha.\n"
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
@@ -6683,7 +6110,7 @@ msgstr ""
 "#inbox) para ver si hay otras\n"
 "conversaciones con mensajes no leídos.\n"
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -6695,7 +6122,7 @@ msgstr ""
 "izquierda y haz clic\n"
 "en el botón `+` situado junto a su nombre.\n"
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -6706,7 +6133,7 @@ msgstr ""
 "Ponle un título a tu conversación. Intenta completar la frase: «Hola,\n"
 "¿podemos hablar de…?»\n"
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
@@ -6714,7 +6141,7 @@ msgstr ""
 "\n"
 ":point_right: Intenta iniciar una nueva conversación en este canal.\n"
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6725,7 +6152,7 @@ msgstr ""
 ":point_right:  Utiliza este tema para probar [las funciones de mensajería de "
 "Zulip]({format_message_help_url}).\n"
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6761,7 +6188,7 @@ msgstr ""
 "\n"
 "```\n"
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
@@ -6771,7 +6198,7 @@ msgstr ""
 "Este tema de **saludos** es un lugar ideal para decir «hola» :wave: a tus "
 "compañeros de equipo.\n"
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
@@ -6781,105 +6208,105 @@ msgstr ""
 ":point_right: Haz clic en este mensaje para iniciar un nuevo mensaje en la "
 "misma conversación.\n"
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr "moviendo mensajes"
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr "experimentos"
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr "iniciar una conversación"
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr "saludos"
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr "JSON no válido en la respuesta"
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr "Formato de respuesta no válido"
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr "Token vacío o de longitud inválida"
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr "Token APNS inválido"
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr "Opción GCM no válida para el bouncer: prioridad {priority!r}"
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr "Opciones GCM no válidas para el bouncer: {options}"
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr "El token no existe"
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr "{full_name} mencionó a @{user_group_name}:"
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr "{full_name} te ha mencionado:"
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr "{full_name} mencionó a todos:"
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "Nuevo mensaje"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr "Notificación de prueba"
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr "Esta es una notificación de prueba de {realm_name} ({realm_url})."
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr "No se reconoce el dispositivo"
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr "El dispositivo no es reconocido por el push bouncer"
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr "No hay ningún dispositivo push registrado activo"
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 "Se ha producido un error de red al conectarse al servicio de notificaciones "
 "push de Zulip."
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 "Se ha producido un error interno del servidor en el servicio de "
 "notificaciones push de Zulip. Inténtalo de nuevo más tarde."
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
@@ -6888,11 +6315,11 @@ msgstr ""
 "en el servidor; ponte en contacto con el administrador del servidor o vuelve "
 "a intentarlo más tarde."
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 msgid "Invalid `push_key`"
 msgstr "`push_key` no válido"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
@@ -6900,32 +6327,30 @@ msgstr[0] "{secs}{nbsp}segundo"
 msgstr[1] "{secs}{nbsp}segundos"
 msgstr[2] "{secs}{nbsp}segundos"
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr "Tipo de datos no válido para el ID del canal"
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr "Usuario no autorizado para esta petición"
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr "«{email}» ya no utiliza Zulip."
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr "No puedes enviar mensajes directos fuera de tu organización."
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr "Longitud máxima de la nota de recordatorio: {max_length} caracteres"
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
@@ -6934,11 +6359,11 @@ msgstr ""
 "Has solicitado un recordatorio para el siguiente mensaje. Nota:\n"
 " > {note}"
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr "Has solicitado un recordatorio para el siguiente mensaje."
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
@@ -6947,11 +6372,11 @@ msgstr ""
 "Has solicitado un recordatorio para el siguiente mensaje directo. Nota:\n"
 " > {note}"
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr "Has solicitado un recordatorio para el siguiente mensaje directo."
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
@@ -6960,14 +6385,14 @@ msgstr ""
 "{user_silent_mention} ha [enviado]({conversation_url}) un {widget} en "
 "{topic_pretty_link}."
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 "{user_silent_mention} [dijo]({conversation_url}) en {topic_pretty_link}:"
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
@@ -6976,7 +6401,7 @@ msgstr ""
 "{user_silent_mention} ha [enviado]({conversation_url}) un {widget} a "
 "{list_of_recipient_mentions}."
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
@@ -6985,352 +6410,339 @@ msgstr ""
 "{user_silent_mention} [dijo]({conversation_url}) a "
 "{list_of_recipient_mentions}:"
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr "Te has [enviado]({conversation_url}) un {widget}."
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr "Te [has enviado]({conversation_url}) una nota a ti mismo:"
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 msgid "Reminder does not exist"
 msgstr "El recordatorio no existe"
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr "Error del servidor de notificaciones push: {error}"
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr "No puedo decidir entre los argumentos '{var_name1}' y '{var_name2}'"
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr "Falta el argumento '{var_name}'"
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr "Valor erróneo para '{var_name}': {bad_value}"
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr "El mensaje programado no existe"
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr "Seguridad de la cuenta de {service_name}"
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr "Un canal predeterminado no puede ser privado."
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr "Los canales públicos de la web no están habilitados."
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr "No tienes permiso para publicar en este canal."
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr "No tienes permiso para enviar mensajes al canal «{channel_name}»"
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 msgid "You do not have permission to create new topics in this channel."
 msgstr "No tienes permiso para crear nuevos temas en este canal."
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr "ID de canal no válido"
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr "Nombre de canal no válido «{channel_name}»"
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr "El canal o canales ({channel_names}) no existen"
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr "No existe el grupo de canales predeterminado con el ID «{group_id}»."
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr "El nombre del canal no puede estar vacío."
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr ""
 "El nombre del canal es demasiado largo (límite: {max_length} caracteres)."
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr "Carácter no válido en el nombre del canal, en la posición {position}."
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr "¡Carácter no válido en el tema, en la posición {position}!"
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr "No hay datos de suscriptores disponibles para este canal"
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr "No se pueden recuperar los suscriptores del canal privado"
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr "No se pudo decodificar imagen; ¿subiste un archivo de imagen?"
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr "El tamaño de la imagen excede el límite."
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr "La imagen está dañada o cortada"
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr "{var_name} no es un valor booleano"
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} does not have the expected format"
 msgstr "{var_name} no tiene el formato esperado"
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr "{var_name} no es una fecha"
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr "{var_name} no es un diccionario"
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr "{var_name} no válido"
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr "El argumento «{argument}» en {var_name} es inesperado"
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr "{var_name} no es un número flotante"
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr "{var_name} es demasiado pequeño"
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr "{var_name} no es un número entero"
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr "{var_name} no es un JSON válido"
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr "{var_name} es demasiado grande"
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr "{var_name} no es una lista"
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr "{var_name} es demasiado largo (límite: {max_length} caracteres)"
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr "{var_name} es demasiado corto."
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr "{var_name} no es una cadena"
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr "{var_name} tiene un formato no válido"
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr "{var_name} no tiene una longitud de {length}"
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr "{var_name} es demasiado largo (límite: {max_length} elementos)"
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr "{var_name} es demasiado corto (mínimo {min_length} elementos)"
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr "{var_name} no puede estar en blanco"
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr "{var_name} no válido: {msg}"
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr "Falta el campo {var_name}: {msg}"
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr "Carga útil malformada"
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr "No figura en la lista de valores posibles"
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr "No es una URL"
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr "No es una zona horaria reconocida"
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr "{var_name} no es un código de color hexadecimal válido"
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr "{setting_name} no válido"
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr "No es un entero sin signo de 32 bits válido"
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr "La subida excedería el límite de subidas de tu organización."
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr "El tamaño de la imagen supera el límite"
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr "El grupo de usuarios está desactivado."
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr "Grupo de usuarios inválido"
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {user_group_id}"
 msgstr "ID de grupo de usuarios no válido: {user_group_id}"
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr "Nombre de grupo del sistema no válido."
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr "ID de grupo de usuarios no válido: {group_id}"
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 "El ajuste «{setting_name}» no se puede aplicar al grupo «role:internet»."
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr "El ajuste «{setting_name}» no se puede aplicar al grupo «role:nobody»."
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 "El ajuste «{setting_name}» no se puede aplicar al grupo «role:everyone»."
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 "El ajuste «{setting_name}» no se puede aplicar al grupo «{group_name}»."
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr "¡El nombre del grupo de usuarios no puede estar vacío!"
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr ""
 "El nombre del grupo de usuarios no puede superar los {max_length} caracteres."
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr "El nombre del grupo de usuarios no puede comenzar por «{prefix}»."
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
@@ -7339,7 +6751,7 @@ msgstr ""
 "'{setting_name}' debe estar restringido a los administradores de la "
 "organización para los grupos utilizados en 'workplace_users_group'."
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
@@ -7348,195 +6760,192 @@ msgstr ""
 "administradores de la organización cuando 'workplace_users_group' incluya "
 "grupos definidos por el usuario."
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr "El cliente no paso valores nuevos."
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 "El cliente debe proporcionar el parámetro «emoji_name» si proporciona "
 "«emoji_code» o «reaction_type»."
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr "¡Nombre demasiado largo!"
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 msgid "Name must not be empty!"
 msgstr "¡El nombre no puede estar vacío!"
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr "¡Caracteres inválidos en el nombre!"
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr "¡Formato no válido!"
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr "En esta organización es obligatorio utilizar nombres únicos."
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr "El nombre ya está en uso."
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr "Nombre o nombre de usuario erróneo"
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr "Integración no válida «{integration_name}»."
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr "Faltan los siguientes parámetros de configuración: {keys}"
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr "Valor {value} de la clave {key} no válido ({error})"
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr "¡Datos de configuración inválidos!"
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr "Tipo de bot inválido"
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr "Tipo de interfaz inválido"
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr "ID de usuario no válido: {user_id}"
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr "No existe ese bot"
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr "No existe ese usuario"
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr "El usuario está desactivado"
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr "{item} no puede estar vacío."
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr ""
 "{var_name} tiene una longitud incorrecta de {length}; debería ser "
 "{target_length}"
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr ""
 "{var_name} no es una cadena de fecha y hora conforme a la norma ISO 8601"
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr "{container} debería contener exactamente {length} elementos"
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr "Falta la clave {key_name} en {var_name}"
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr "Argumentos no esperados: {keys}"
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr "{var_name} no es un tipo permitido"
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr "{variable} != {expected_value} ({value} es incorrecto)"
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr "{var_name} no es una URL"
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr "El patrón de URL debe contener «%(username)s»."
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr "'{item}' no puede estar vacío."
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr "El campo no debe contener opciones duplicadas."
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr "'{value}' no es una opción válida para '{field_name}'."
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr "{var_name} no es una cadena ni una lista de números enteros"
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr "{var_name} no es una cadena ni un entero"
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr "{var_name} no tiene longitud"
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr "Falta {var_name}"
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr "«PresetUrlOption» desconocido: {config}"
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr "Falta la cabecera '{header}' del evento HTTP"
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr "El algoritmo «{algorithm}» no es compatible."
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
@@ -7544,11 +6953,11 @@ msgstr ""
 "Falta el secreto del webhook. Por favor, configura el webhook_secret al "
 "generar la URL."
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr "La verificación de la firma del webhook ha fallado."
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
@@ -7556,94 +6965,94 @@ msgstr ""
 "'workplace_users_group' debe ser un grupo cuya composición solo puedan "
 "gestionar los administradores de la organización."
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr "Debería haber una barra al principio del zcomando."
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr "No existe ese comando: {command}"
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 "`zulip_update_announcements_stream` se ha desactivado de forma inesperada."
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr "Error CSRF: {reason}"
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr "Configuración incorrecta del proxy inverso: {proxy_reason}"
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr "ID de usuario no válidos: {invalid_ids}"
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr "El usuario con el ID {user_id} está desactivado"
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr "El usuario con el ID {user_id} es un bot"
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr "Menú desplegable"
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr "Texto breve"
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr "Párrafo"
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr "Fecha"
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr "Cuenta externa"
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr "Pronombres"
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr "Nadie"
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr "Miembros de pleno derecho"
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "Miembros"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr "Todos en la internet"
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr "Campo de conversión automática no válido: falta el carácter '}'."
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: empty field name."
 msgstr "Campo de conversión automática no válido: nombre de campo vacío."
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
@@ -7651,52 +7060,52 @@ msgstr ""
 "El grupo %(name)r del campo de conversión automática no aparece en el patrón "
 "del generador de enlaces."
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr "Expresión regular incorrecta: {regex}"
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr "Error de expresión regular desconocido"
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr "Plantilla de URL no válida."
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 msgid "Example input does not match the linkifier pattern."
 msgstr ""
 "El ejemplo introducido no se ajusta al patrón del generador de enlaces."
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr "El texto de ejemplo no coincide con el campo de conversión automática."
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 "El grupo %(name)r de la plantilla de URL no aparece en el patrón del "
 "generador de enlaces."
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 "El grupo %(name)r del patrón del generador de enlaces no aparece en la "
 "plantilla de la URL."
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 "Una plantilla de URL alternativa no puede ser igual a la plantilla de URL."
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr "Las plantillas de URL alternativas deben ser únicas."
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in alternative URL template is not present in linkifier "
@@ -7705,7 +7114,7 @@ msgstr ""
 "El grupo %(name)r de la plantilla de URL alternativa no aparece en el patrón "
 "del generador de enlaces."
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in linkifier pattern is not present in alternative URL "
@@ -7714,341 +7123,338 @@ msgstr ""
 "El grupo %(name)r del patrón del generador de enlaces no aparece en la "
 "plantilla de la URL alternativa."
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr "Emoticonos unicode"
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "Emoticonos personalizados"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr "Emoticonos extra de Zulip"
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr "Caracteres inválidos en el nombre del emoticono"
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr "Caracteres no válidos en el lenguaje Pygments"
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr "Falta la variable «code» en la plantilla de la URL"
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr "«code» debe ser la única variable presente en la plantilla de la URL"
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr "taller"
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr "general"
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr "eventos del canal"
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr "Spam"
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr "Acoso"
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr "Contenido inapropiado"
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr "Incumple las normas de la comunidad"
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr "Otra razón"
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr "Novedades de Zulip"
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr ""
 "Disponible en Zulip Cloud Standard. Actualiza tu cuenta para acceder a esta "
 "función."
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr ""
 "Disponible en Zulip Cloud Plus. Actualiza tu cuenta para acceder a esta "
 "función."
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr "Desactivado"
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr "Permitir GIF con clasificación G (para todos los públicos)"
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr ""
 "Permitir GIF con clasificación PG (recomendado para todos los públicos)"
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 "Permitir GIF con clasificación PG-13 (recomendado para mayores de 13 años)"
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr "Permitir GIF con clasificación R (restringida)"
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr "Público en Web"
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "Público"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr "Historia compartida, privada"
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr "Historia protegida, privada"
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr "Administradores, moderadores, miembros e invitados"
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr "Administradores, moderadores y miembros"
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr "Administradores y moderadores"
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr "Solo administradores"
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr "Usuario desconocido"
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr "Propietario de la organización"
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr "Administrador de la organización"
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr "Moderador"
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "Miembro"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "Invitado"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr "Dirección IP desconocida"
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr "un sistema operativo desconocido"
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr "Un navegador desconocido"
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr "Falta el argumento 'queue_id'"
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr "Falta el argumento 'last_event_id'"
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr "¡Ya se ha eliminado un evento más reciente que {event_id}!"
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr "El evento {event_id} no se encontraba en esta cola"
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr "ID de cola de eventos incorrecto: {queue_id}"
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 msgid "Failed to generate challenge"
 msgstr "Error al generar el desafío"
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr "La autenticación JWT no está habilitada para esta organización"
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr "Ningún token web JSON se ha pasado en la petición"
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr "Token JSON web erróneo"
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr ""
 "No se ha especificado ninguna dirección de correo electrónico en las "
 "reclamaciones del token web JSON"
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr "Subdominio requerido"
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr "La contraseña es incorrecta."
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr "Debes eliminar todos los canales de esta carpeta para archivarla."
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr "No se encontró una entrada válida del User-Agent en la petición"
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr "El nombre no puede estar vacío."
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr "El campo debe tener al menos una opción."
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr ""
 "El tipo de campo no es compatible con la visualización en el resumen del "
 "perfil."
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for use for user matching."
 msgstr "Este tipo de campo no es compatible con la búsqueda de usuarios."
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr "Tipo de campo inválido."
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 "En el resumen del perfil solo se pueden mostrar 2 campos de perfil "
 "personalizados."
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr "Ya existe un campo con ese nombre."
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr "El campo personalizado predeterminado no se puede actualizar."
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr "El punto final no está disponible en el entorno de producción."
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr "DevAuthBackend no está habilitado."
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr "Parámetro «{key}» no válido para una solicitud anónima"
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr "La base de datos está vacía"
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr "No se puede consultar postgresql"
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr "No se puede conectar con rabbitmq"
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr "No se puede consultar rabbitmq"
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr "No se puede consultar redis"
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr "No se puede escribir en memcached"
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr "No se puede consultar memcached"
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr "No existe esa invitación"
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 msgid "Invitation already used or deactivated."
 msgstr "La invitación ya se ha utilizado o se ha desactivado."
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr "La invitación ya ha sido revocada"
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 "El ID del canal {channel_id} no es válido. No se ha enviado ninguna "
 "invitación."
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr "No tienes permiso para suscribir a otros usuarios a canales."
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr "Debes especificar al menos una dirección de correo."
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
@@ -8056,102 +7462,100 @@ msgstr ""
 "Algunas de esas direcciones ya están usando Zulip, por lo que no les hemos "
 "enviado una invitación. ¡Enviamos invitaciones a todos los demás!"
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr ""
 "El historial de edición de mensajes está desactivado en esta organización"
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr "No tienes permiso para eliminar este mensaje"
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr "El límite de tiempo para eliminar este mensaje ha pasado"
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr "El mensaje ya fue eliminado"
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr "Se han solicitado demasiados mensajes (máximo {max_messages})."
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr "El punto de referencia solo se puede excluir al final del intervalo"
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr "No existe ningún tema llamado «{topic}»"
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr "Se necesita una explicación."
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 msgid "Message reporting is not enabled in this organization."
 msgstr "La notificación de mensajes no está habilitada en esta organización."
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr "Falta el remitente"
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr ""
 "El mirroring no esta permitido con los IDs de usuario de los destinatarios"
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr "Mensaje reflejado inválido"
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr "Las funciones de IA no están activadas en este servidor."
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr "Se ha alcanzado el límite mensual de créditos de IA."
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr "No hay mensajes en la conversación que resumir"
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr "No puedes silenciarte a ti mismo"
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr "El usuario ya está silenciado"
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr "El usuario no está silenciado"
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr "Las vistas integradas no pueden tener un nombre personalizado."
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr "Las vistas personalizadas deben tener un nombre válido."
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 msgid "Navigation view already exists."
 msgstr "La vista de navegación ya existe."
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr "onboarding_step desconocido: {onboarding_step}"
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -8162,38 +7566,38 @@ msgstr ""
 "Me pediste que viéramos el [vídeo de bienvenida a Zulip]"
 "({navigation_tour_video_url}) más tarde. ¿Te viene bien ahora?\n"
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr "La disponibilidad no está soportada por los usuarios de bots."
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr "No hay datos de presencia para {user_id_or_email}"
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr "Estado no válido: {status}"
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 msgid "You do not have permission to manage plans and billing."
 msgstr "No tienes permiso para gestionar planes y facturación."
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr "El servidor no utiliza el servicio de notificaciones push"
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr "Error devuelto por el bouncer: {result}"
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr "No se ha preparado el secreto de verificación"
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
@@ -8201,19 +7605,19 @@ msgstr ""
 "Faltan parámetros: debe proporcionar todos los campos de claves de envío, "
 "todos los campos de tokens o ambos."
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr "No hay ningún registro de push para el que rotar la clave."
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr "El proceso de registro del dispositivo ya está en marcha."
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr "No hay ningún registro de push para el que se deba rotar el token."
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
@@ -8221,38 +7625,38 @@ msgstr ""
 "Al menos uno de los siguientes arguments debe estar presente: emoji_name, "
 "emoji_code"
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr ""
 "En esta organización, los confirmaciones de lectura están desactivadas."
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr "Idioma no válido «{language}»"
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr "Al menos un método de autentificación debe ser activado."
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr "video_chat_provider inválido {video_chat_provider}"
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr "gif_rating_policy no válido {gif_rating_policy}"
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 "La organización no puede beneficiarse de precios reducidos para usuarios que "
 "no pertenezcan al entorno de trabajo."
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
@@ -8260,17 +7664,17 @@ msgstr ""
 "Los precios con descuento para usuarios de entornos de trabajo no se pueden "
 "activar con el plan con descuento actual."
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr "Debe ser una organización de demostración."
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 "La hora de eliminación de los datos de la organización de demostración no es "
 "válida."
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
@@ -8278,7 +7682,7 @@ msgstr ""
 "La fecha de eliminación de los datos no debe ser posterior a "
 "{max_allowed_days} días."
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
@@ -8286,47 +7690,47 @@ msgstr ""
 "La fecha de eliminación de los datos debe ser, como mínimo, "
 "{min_allowed_days} días a partir de ahora."
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr "Dominio no válido: {error}"
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr "El dominio {domain} ya forma parte de tu organización."
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr "No se ha encontrado ninguna entrada para el dominio {domain}."
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr "Debes subir exactamente un archivo."
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr "Solo los administradores pueden anular los emojis predeterminados."
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr "El archivo subido supera el límite permitido de {max_size} MiB"
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr ""
 "En esta organización no está permitida la exportación de datos, tanto "
 "públicos como privados."
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr "Excedió el limite de la tasa."
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
@@ -8336,57 +7740,57 @@ msgstr ""
 "automáticamente. Solicita una exportación manual poniéndote en contacto con "
 "{email}."
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr "ID de exportación de datos inválida"
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr "Exportación ya eliminada"
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr "La exportación ha fallado, no hay nada que eliminar"
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr "La exportación aún está en curso"
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr "Debes subir exactamente un icono."
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr "Generador de enlaces no encontrado."
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr "Debes subir exactamente un logo."
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Invalid character in language: {character}"
 msgstr "Carácter no válido en el idioma: {character}"
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Language '{language}' is not allowed."
 msgstr "El idioma '{language}' no está permitido."
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr "Entorno de prueba no válido"
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr "No es posible cancelar la importación una vez que ha comenzado."
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr "Sin autenticar"
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
@@ -8395,124 +7799,123 @@ msgstr ""
 "cierras esta pestaña, puedes volver aquí a través del enlace «Completar el "
 "registro» que encontrarás en tu correo electrónico."
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 msgid "Importing messages…"
 msgstr "Importando mensajes…"
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr "Importando datos de archivos adjuntos…"
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr "Importando datos de Slack convertidos…"
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr "Finalizando la importación…"
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr "¡Hecho!"
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 "No hay usuarios que coincidan con la dirección de correo electrónico "
 "indicada."
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 msgid "Your name"
 msgstr "Tu nombre"
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr ""
 "Es necesario indicar un destinatario al actualizar el tipo de mensaje "
 "programado."
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 "Se requiere un tema al actualizar el tipo de mensaje programado en el canal."
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr "Formato de solicitud no válido"
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr "DSN no válido"
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr "Los canales privados no se pueden establecer como predeterminados."
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr "Debes pasar \"new_description\" o \"new_group_name\"."
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr "Valor inválido para \"op\". Especifica uno entre \"add\" o \"remove\"."
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr "Parámetros inválidos"
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr "Es necesario tener acceso al contenido del canal."
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr "El canal ya tiene ese nombre."
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr "Nada que hacer. Especifica al menos uno de \"add\" o \"delete\"."
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr "{user_full_name} te ha suscrito a {channel_name}."
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr "{user_full_name} te ha suscrito a los siguientes canales:"
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr "No se puede acceder al canal ({channel_name})."
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr "{user_name} ha creado los siguientes canales: {new_channels}."
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr "{user_name} ha creado un nuevo canal {new_channels}."
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr "nuevos canales"
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr "Canal **público en la web** creado por {user_name}. **Descripción:**"
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr "Canal **público** creado por {user_name}. **Descripción:**"
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
@@ -8520,7 +7923,7 @@ msgstr ""
 "Canal **privado de historial compartido** creado por {user_name}. "
 "**Descripción:**"
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
@@ -8529,26 +7932,26 @@ msgstr ""
 "Canal **privado de historial protegido** creado por {user_name}. "
 "**Descripción:**"
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr "{property} no es un valor booleano"
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr "Propiedad de suscripción desconocida: {property}"
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr "No estás suscrito al canal con el ID {channel_id}"
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr "JSON inválido para el submensaje"
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
@@ -8557,7 +7960,7 @@ msgstr ""
 "El archivo supera el tamaño máximo de carga ({max_size} MiB) permitido por "
 "el plan de tu organización."
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
@@ -8566,7 +7969,7 @@ msgstr ""
 "El archivo supera el tamaño máximo de carga configurado en este servidor "
 "({max_size} MiB)."
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
@@ -8575,56 +7978,55 @@ msgstr ""
 "El archivo subido supera el tamaño máximo permitido para las importaciones "
 "({max_file_size} MiB)."
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 "El usuario ha desactivado las notificaciones de escritura para los mensajes "
 "del canal"
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr "Falta el argumento 'to'"
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr "Lista 'to' vacía"
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr ""
 "El usuario ha desactivado las notificaciones de escritura para los mensajes "
 "directos"
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr "<p>Este archivo no existe o ha sido eliminado.</p>"
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr "<p>No estás autorizado a ver este archivo.</p>"
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr "Token no válido"
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr "Nombre de archivo no válido"
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr "Debes especificar un archivo a subir"
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr "Solo puedes subir un archivo a la vez"
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr "No se han proporcionado datos nuevos"
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
@@ -8632,32 +8034,32 @@ msgstr ""
 "No hay nada que hacer. Especifica al menos una de las siguientes opciones: "
 "«add», «delete», «add_subgroups» o «delete_subgroups»."
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr "{user_full_name} te ha añadido al grupo {group_name}."
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr "{user_full_name} te ha eliminado del grupo {group_name}."
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr "El usuario {user_id} ya forma parte de este grupo"
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr "No hay ningún miembro «{user_id}» en este grupo de usuarios"
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr "El grupo de usuarios {group_id} ya es un subgrupo de este grupo."
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
@@ -8666,7 +8068,7 @@ msgstr ""
 "El grupo de usuarios {user_group_id} ya es un subgrupo de uno de los "
 "subgrupos indicados."
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
@@ -8675,102 +8077,102 @@ msgstr ""
 "permitir que solo los administradores de la organización gestionen su "
 "composición."
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr "El grupo de usuarios {group_id} no es un subgrupo de este grupo."
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr "En esta organización no se pueden cambiar los avatares."
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr ""
 "Los cambios de dirección de correo electrónico están desactivados en esta "
 "organización."
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr "default_language no válido"
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr "Sonido de notificación no válido «{notification_sound}»"
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr ""
 "Periodo de agrupación de correos electrónicos no válido: {seconds} segundos"
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr "Es necesario indicar los user_ids o group_ids."
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr "No se puede modificar este ajuste para otros usuarios."
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr "Tu contraseña de Zulip está gestionada en LDAP"
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr "¡Contraseña incorrecta!"
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr ""
 "¡Estás intentando demasiadas veces! Vuelve a intentarlo en "
 "{retry_after_string}."
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr "La nueva contraseña es demasiado poco segura!"
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr "Debes subir exactamente un avatar."
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr "El tema no está silenciado"
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr "No se puede desactivar al único propietario de la organización"
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 msgid "User is not allowed to delete other user's messages."
 msgstr "Los usuarios no pueden borrar los mensajes de otros usuarios."
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 "El usuario no tiene permiso para modificar las direcciones de correo "
 "electrónico de los usuarios"
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 "No se puede eliminar el permiso de propietario del único propietario de la "
 "organización."
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr "La nueva dirección de correo electrónico no es válida."
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr "Error en el valor del nuevo correo electrónico: {message}"
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 msgid ""
 "Can't change bot email until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
@@ -8779,25 +8181,25 @@ msgstr ""
 "FAKE_EMAIL_DOMAIN esté correctamente configurado.\n"
 "Ponte en contacto con el administrador del servidor."
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 msgid "Email address already in use"
 msgstr "La dirección de correo electrónico ya está en uso"
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr "Fallo al cambiar el propietario, no existe ese usuario"
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr "Fallo al cambiar el propietario, ese usuario está desactivado"
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr ""
 "Fallo al cambiar el propietario, los bots no pueden ser propietarios de "
 "otros bots"
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
@@ -8805,134 +8207,134 @@ msgstr ""
 "No se pueden crear bots hasta que FAKE_EMAIL_DOMAIN se configure.\n"
 "Por favor, contacta al administrador del sistema."
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr "Los bots integrados no están activados."
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr "Nombre del bot integrado inválido."
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr "El usuario no tiene permiso para crear usuarios"
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr ""
 "La dirección de correo electrónico «{email}» no está permitida en esta "
 "organización"
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr ""
 "Las direcciones de correo electrónico desechables no están disponibles en "
 "esta organización"
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} access token"
 msgstr "Token de acceso de {provider_name} no válido"
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} call"
 msgstr "No se ha podido crear la llamada {provider_name}"
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} credentials have not been configured"
 msgstr "Las credenciales de {provider_name} no se han configurado"
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} credentials"
 msgstr "Credenciales de {provider_name} no válidas"
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr "Error al conectarse al servidor {provider_name}: {reason}"
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error authenticating to the {provider_name} server"
 msgstr "Error al autenticarse en el servidor {provider_name}"
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr "El servidor {provider_name} ha devuelto un error inesperado: {status}"
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} session identifier"
 msgstr "Identificador de sesión de {provider_name} no válido"
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr "Correo electrónico de un usuario desconocido de Zoom"
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} public room."
 msgstr "No se ha podido crear la sala pública {provider_name}."
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr "Firma no válida."
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{full_name}'s Zulip room"
 msgstr "La sala de Zulip de {full_name}"
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 "No se admiten los proyectos que utilicen este proveedor de control de "
 "versiones"
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr "Payload invalido"
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr "Petición webhook desconocida"
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr "El tema no puede estar vacío"
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr "El contenido no puede estar vacío"
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr "No se puede gestionar la carga útil de Jotform"
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr "Entrada JSON malformada"
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr "Falta la clave «events» en la carga útil"
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr "Error: parámetro channels_map_to_topics distinto de 0 o 1"
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr "Acción de webhook de WordPress desconocida: {hook}"
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
@@ -8941,79 +8343,79 @@ msgstr ""
 "La exportación de tus datos ha finalizado. [Ver y descargar exportaciones]"
 "({export_settings_link})."
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr "El código de verificación ha caducado"
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr "El secreto de verificación no es válido"
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr "El secreto de verificación tiene un formato incorrecto"
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr "El secreto de verificación corresponde a un nombre de host diferente"
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr "Dominio inválido para el bouncer de notificaciones push"
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr "Debe validarse con una clave de API válida del servidor de Zulip"
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr "UUID no válido"
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr "Tipo de token inválido"
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 "{hostname} contiene componentes no válidos (por ejemplo, ruta, consulta, "
 "fragmento)."
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr "{hostname} no es un nombre de host válido"
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr "{hostname} aún no está registrado"
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 "Dirección de correo electrónico del administrador del servidor no válida: "
 "{email_reason}"
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr "example.com no es un dominio de correo electrónico válido."
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr "{domain} no es válido porque no tiene ningún registro MX"
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr "{domain} no existe"
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
@@ -9023,29 +8425,29 @@ msgstr ""
 "Inténtalo de nuevo más tarde o ponte en contacto con {support_email} para "
 "obtener ayuda."
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr "No se ha encontrado ningún registro para este nombre de host"
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr "El servidor ha informado de que no dispone de clave de verificación."
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 "Se ha recibido un código de estado inesperado del servidor: {status_code}"
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr "Falta el ios_app_id"
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr "Falta el user_id o el user_uuid"
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
@@ -9054,48 +8456,48 @@ msgstr ""
 "Tu plan no permite enviar notificaciones push. Motivo indicado por el "
 "servidor: {reason}"
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr "Tu plan no permite enviar notificaciones push."
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr "Propiedad no válida {property}"
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr "Tipo de evento no válido."
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr "Los datos no están ordenados."
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr "Se ha detectado un registro duplicado."
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr "Datos del registro de auditoría malformados"
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr "Debes reestablecer tu contraseña."
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr "Falta el parámetro id_token"
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 msgid "Missing idp param"
 msgstr "Falta el parámetro idp"
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr "OTP inválida"
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr "No se pueden utilizar «mobile_flow_otp» y «desktop_flow_otp» a la vez."
 

--- a/locale/et/LC_MESSAGES/django.po
+++ b/locale/et/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 18:58+0000\n"
 "Last-Translator: Priit Jõerüüt <jrthwlate@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Estonian <https://hosted.weblate.org/projects/zulip/django/et/"
@@ -18,50 +18,50 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr ""
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr ""
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr ""
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr ""
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr ""
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr ""
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -70,7 +70,7 @@ msgid ""
 "users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -78,7 +78,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than one user to join."
 msgstr ""
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -86,7 +86,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than two users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -94,7 +94,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than three users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -103,148 +103,147 @@ msgid ""
 "({billing_page_link}) is greater than the current number of users."
 msgstr ""
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr ""
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr ""
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
 "(minimum {min_licenses})."
 msgstr ""
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
 "page. To complete the upgrade, please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr ""
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr ""
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr ""
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr ""
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr ""
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr ""
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
 msgstr ""
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
 msgstr ""
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
 "licenses."
 msgstr ""
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
 "billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr ""
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr ""
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr ""
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -254,100 +253,97 @@ msgid ""
 "we would really appreciate it!"
 msgstr ""
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
 "{support_email}"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr ""
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr ""
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr ""
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
 "%(support_email)s\">contact support</a>."
 msgstr ""
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr ""
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
 msgstr ""
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr ""
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
 msgstr ""
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr ""
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr ""
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
 msgstr ""
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -355,289 +351,270 @@ msgid ""
 "a> with any questions."
 msgstr ""
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
 "a> for support."
 msgstr ""
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
 "href=\"%(troubleshooting_url)s\">Zulip server troubleshooting guide</a>."
 msgstr ""
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr ""
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr ""
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr ""
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr ""
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr ""
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr ""
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr ""
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr ""
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr ""
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr ""
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr ""
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr ""
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr ""
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr ""
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr ""
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr ""
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr ""
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr ""
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr ""
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr ""
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr ""
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr ""
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr ""
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr ""
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr ""
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr ""
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr ""
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr ""
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr ""
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr ""
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
 "%(old_email_html_tag)s to %(new_email_html_tag)s"
 msgstr ""
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr ""
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
 msgstr ""
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr ""
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr ""
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -648,19 +625,19 @@ msgid ""
 "server."
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -668,788 +645,297 @@ msgid ""
 "%(support_email)s'>contact support</a> with any questions."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, python-format
 msgid "You can try again in %(retry_after_string)s."
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr ""
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr ""
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr ""
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr ""
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr ""
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr ""
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr ""
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr ""
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr ""
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr ""
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr ""
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr ""
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr ""
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr ""
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 msgid "Zulip for open source"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 msgid "Message with code"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
 msgstr ""
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 msgid "Get started"
 msgstr ""
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
 "continue."
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1457,78 +943,77 @@ msgid ""
 "from Zulip."
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
 msgstr ""
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr ""
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr ""
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr ""
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr ""
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr ""
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr ""
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr ""
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
 msgstr ""
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1536,208 +1021,201 @@ msgid ""
 "href=\"%(doc_url)s\">documentation</a>."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, python-format
 msgid "No account found for %(email)s."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 msgid "Try Zulip in a demo organization"
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 msgid "Try Zulip"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid "Import chat history?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1745,123 +1223,122 @@ msgid ""
 "noreferrer\">after you join</a>."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "Salasõna"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr ""
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">Terms of Service</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr ""
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr ""
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -1869,45 +1346,45 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 msgid ""
 "This organization has been deactivated, and all organization data has been "
 "deleted."
 msgstr ""
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
 "inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
 "administrators</a> to inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 msgid "This organization has been deactivated."
 msgstr ""
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
 "%(support_email)s\">contact Zulip support</a> to reactivate it."
 msgstr ""
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -1915,165 +1392,164 @@ msgid ""
 "reactivate it."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr ""
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr ""
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
 "<b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
 "href=\"%(apps_page_link)s\">mobile and desktop</a> apps:"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
 "href=\"%(getting_user_started_link)s\">getting started guide</a>!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2081,83 +1557,83 @@ msgid ""
 "Zulip</a>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
 "to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
 "desktop apps (%(apps_page_link)s):"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
 "(%(getting_user_started_link)s)!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
 "(%(getting_organization_started_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2165,32 +1641,32 @@ msgid ""
 "password for this account, please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr "Kinnita ja lisa salasõna"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "%(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 msgid "Verify your email address for your Zulip demo organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "<%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2198,113 +1674,113 @@ msgid ""
 "please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
 "— we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
 "deactivated, and you will no longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr ""
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2312,22 +1788,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because your organization <a "
@@ -2335,8 +1811,8 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to <a "
@@ -2344,39 +1820,39 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr ""
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because your organization hides "
@@ -2384,81 +1860,74 @@ msgid ""
 "details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to hide "
 "message content in email notifications. See %(help_url)s for more details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr ""
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
 "organizations:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
 "organizations hosted by %(external_host)s:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
 "href=\"%(help_reset_password_link)s\">reset your password</a>."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
 "%(external_host)s."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2466,97 +1935,94 @@ msgid ""
 "to find your account."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
 "try another way to find your account (%(help_logging_in_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
 "communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr ""
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
 "-- the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
 "Zulip &mdash; the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
 "to ask %(referrer_name)s for another one."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2564,72 +2030,70 @@ msgid ""
 "productivity."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at <a href=\"mailto:%(email)s\">%(email)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
 "%(email)s\">Contact us</a> — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
 "#%(channel_name)s > %(topic_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2637,68 +2101,68 @@ msgid ""
 "preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails (<a href=\"%(url)s\">help</a>)."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2706,22 +2170,22 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2729,52 +2193,52 @@ msgid ""
 "immediately at <%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2782,31 +2246,31 @@ msgid ""
 "contact us immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2814,7 +2278,7 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -2822,25 +2286,25 @@ msgid ""
 "Zulip</a> to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
 "with you and share their unique perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -2848,7 +2312,7 @@ msgid ""
 "experience how a new chat app will help your team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -2856,148 +2320,148 @@ msgid ""
 "action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
 "team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
 "organizations like yours!"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3005,11 +2469,11 @@ msgid ""
 "about…?”"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3018,23 +2482,23 @@ msgid ""
 "href=\"%(move_channels_link)s\">move a topic to a different channel</a>."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3043,23 +2507,23 @@ msgid ""
 "(%(move_channels_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
 "%(email)s on %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr "Oma salasõna lähtestamiseks klõpsa järgnevat nuppu."
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr "Lähtesta salasõna"
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3067,46 +2531,46 @@ msgid ""
 "href=\"%(help_link)s\">reactivate your account</a>."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
 "You can contact an organization administrator to reactivate your account."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3114,539 +2578,535 @@ msgid ""
 "have been voided."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
 "to %(upgrade_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip demo organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip demo organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip demo organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for <b>%(remote_server_hostname)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 msgid "Click the button below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for %(remote_server_hostname)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
 "management for <b>%(remote_realm_host)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
 "management for %(remote_realm_host)s."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the <a href=\"%(plans_link)s\">Zulip Community plan</a>."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
 "website</a>, we would really appreciate it!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
 msgstr ""
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
 "accounts for another email address</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr ""
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr ""
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr ""
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr ""
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr ""
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 msgid "Zulip Cloud"
 msgstr ""
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr ""
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr ""
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr ""
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr ""
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr ""
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr ""
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr ""
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr ""
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr ""
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr ""
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr ""
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr ""
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr ""
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr ""
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr ""
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr ""
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr ""
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr ""
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr ""
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr ""
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr ""
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr ""
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr ""
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr ""
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr ""
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr ""
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr ""
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr ""
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr ""
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr ""
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr ""
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr ""
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 msgid "Bluesky"
 msgstr ""
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr ""
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr ""
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr ""
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 msgid ""
 "And hundreds more through <a href=\"/integrations/zapier\">Zapier</a> and <a "
 "href=\"/integrations/ifttt\">IFTTT</a>."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3654,7 +3114,7 @@ msgid ""
 "emails with your email domain."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3662,7 +3122,7 @@ msgid ""
 "disposable email addresses."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3670,24 +3130,24 @@ msgid ""
 "emails that contain \"+\"."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3695,7 +3155,7 @@ msgid ""
 "%(support_email)s\">contact Zulip support</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3703,89 +3163,89 @@ msgid ""
 "%(support_email)s\">contact this Zulip server's administrators</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
 "management for your Zulip server."
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr ""
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr ""
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr ""
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr ""
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr "Kas oled oma salasõna unustanud?"
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr ""
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr ""
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> because all Zulip Cloud licenses are in use."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -3794,42 +3254,40 @@ msgid ""
 "or misconfiguration."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 msgid "Demo organizations disabled"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -3837,22 +3295,21 @@ msgid ""
 "organization for more information."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -3860,44 +3317,42 @@ msgid ""
 "Zulip support</a> for assistance in resolving this issue."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
 "a> like Firefox, Chrome, and Edge."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 msgid "Finalize organization import"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 msgid "Organization import completed!"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -3905,52 +3360,51 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 msgid "Select your account"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 msgid "Create new account"
 msgstr ""
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr ""
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -3958,81 +3412,81 @@ msgid ""
 "have one yet."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 msgid "Self-hosting Zulip?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">log in to manage plans and billing.</a>"
 msgstr ""
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr "Lähtesta oma salasõna"
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
 msgstr ""
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "Korda salasõna"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr ""
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr ""
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr ""
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr ""
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr ""
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4040,7 +3494,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4049,57 +3503,57 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr ""
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4107,7 +3561,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4115,40 +3569,40 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4156,300 +3610,294 @@ msgid ""
 "away!"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
 "href=\"%(realm_url)s/#settings/notifications\">notification settings</a>."
 msgstr ""
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr ""
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr ""
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr ""
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr ""
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr ""
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr ""
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr ""
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 msgid "Cannot reactivate a deleted user"
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr ""
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr ""
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr ""
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr ""
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
 msgstr ""
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
 msgstr ""
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr ""
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr ""
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr ""
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr ""
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr ""
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr ""
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr ""
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr ""
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr ""
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr ""
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
 "{new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
 "{user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to resolve topics in this channel."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr ""
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr ""
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr ""
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr ""
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr ""
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
 "but there is no channel with that ID."
 msgstr ""
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4457,36 +3905,36 @@ msgid ""
 "it."
 msgstr ""
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
 "The channel exists but does not have any subscribers."
 msgstr ""
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr ""
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr ""
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr ""
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4494,107 +3942,105 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
 "authentication method."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr ""
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 msgid "Reminder could not be sent."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
 "the following error:"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr ""
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr ""
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr ""
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr ""
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr ""
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
 "**{old_policy}** to **{new_policy}**."
 msgstr ""
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -4603,51 +4049,49 @@ msgid ""
 "* **New**: {new_setting_description}\n"
 msgstr ""
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr ""
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr ""
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr ""
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr ""
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr ""
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr ""
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 msgstr ""
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr ""
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -4658,283 +4102,269 @@ msgid ""
 "{summary_line}"
 msgstr ""
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr ""
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr ""
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr ""
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr ""
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr ""
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr ""
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr ""
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr ""
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr ""
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr ""
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr ""
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
 "organization administrator to reactivate it."
 msgstr ""
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr "Salasõna on liiga kehv."
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr ""
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr ""
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr ""
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr ""
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr ""
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr ""
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
 "to register for accounts in this organization."
 msgstr ""
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr ""
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 msgid "Challenges are not enabled."
 msgstr ""
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "Uus salasõna"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr "Uue salasõna kinnitus"
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "You're making too many attempts to sign in. Try again in "
 "{retry_after_string} or contact your organization administrator for help."
 msgstr ""
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
 msgstr ""
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr ""
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr ""
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr ""
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr ""
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr ""
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr ""
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr ""
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr ""
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr ""
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr ""
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr ""
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name can't be empty."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 msgid "Invalid channel folder ID"
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 msgid "Configure owner account email address."
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4943,69 +4373,69 @@ msgid ""
 "organization]({convert_demo}).\n"
 msgstr ""
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, python-brace-format
 msgid "{var_name} is not Base64 encoded"
 msgstr ""
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 msgid "Invalid `device_id`"
 msgstr ""
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr ""
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr ""
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr ""
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr ""
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr ""
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr ""
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr ""
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr ""
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr ""
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr ""
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5013,593 +4443,591 @@ msgid ""
 "{error_message}"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr ""
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr ""
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr ""
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr ""
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr ""
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr ""
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr ""
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr ""
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr ""
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr ""
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr ""
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr ""
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr ""
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
 msgstr ""
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr ""
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr ""
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr ""
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr ""
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr ""
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr ""
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr ""
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr ""
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 msgid "Must be a bot user"
 msgstr ""
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr "Sinu kasutajanimi või salasõna on vigased"
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr ""
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr ""
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
 "webhook; ignoring"
 msgstr ""
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr ""
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr ""
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr ""
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr ""
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} most recent messages in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr ""
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr ""
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
 msgstr ""
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr ""
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr ""
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr ""
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr ""
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr ""
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 msgid "Atlassian account ID"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 msgid "Behance username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 msgid "Bitbucket username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 msgid "Codeberg username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 msgid "Dribbble username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 msgid "Facebook username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 msgid "GitLab username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 msgid "Instagram username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 msgid "Mastodon profile"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 msgid "Medium username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 msgid "Pinterest username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 msgid "Reddit username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 msgid "Snapchat username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 msgid "Threads username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 msgid "TikTok username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 msgid "Twitch username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 msgid "X username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr ""
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr ""
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 msgid "Video calling"
 msgstr ""
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr ""
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr ""
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr ""
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr ""
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr ""
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr ""
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr ""
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr ""
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr ""
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr ""
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr ""
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr ""
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr ""
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr ""
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "{fullname} moderation"
 msgstr ""
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr ""
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr ""
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor_date' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr ""
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 msgid "Navigation view does not exist."
 msgstr ""
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5607,7 +5035,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5615,7 +5043,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5623,7 +5051,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5631,7 +5059,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5641,14 +5069,14 @@ msgid ""
 "a permanent organization]({convert_demo_organization_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
 "them in your [Inbox](/#inbox).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5656,7 +5084,7 @@ msgid ""
 "({navigation_tour_video_url}) for a quick app overview.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5671,14 +5099,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -5686,7 +5114,7 @@ msgid ""
 "and edit your [profile information](/help/edit-your-profile).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -5697,7 +5125,7 @@ msgid ""
 "experience in your [Preferences](#settings/preferences).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5708,7 +5136,7 @@ msgid ""
 "[Browse and subscribe to channels]({settings_link}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -5725,7 +5153,7 @@ msgid ""
 "discussed.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -5734,7 +5162,7 @@ msgid ""
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -5746,7 +5174,7 @@ msgid ""
 "times, and more.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5756,7 +5184,7 @@ msgid ""
 "or browse the [help center](/help/) to learn more!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5764,7 +5192,7 @@ msgid ""
 "get help, try one of the following messages: {bot_commands}\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5776,13 +5204,13 @@ msgid ""
 "({move_content_another_channel_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5796,12 +5224,11 @@ msgid ""
 "and above.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr ""
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -5809,14 +5236,14 @@ msgid ""
 "no matter how many other conversations are going on.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
 "conversations with unread messages.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -5824,7 +5251,7 @@ msgid ""
 "the `+` button next to its name.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -5832,13 +5259,13 @@ msgid ""
 "can we chat about…?”\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5846,7 +5273,7 @@ msgid ""
 "({format_message_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5866,1322 +5293,1299 @@ msgid ""
 "```\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
 "teammates.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
 "conversation.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr ""
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr ""
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr ""
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr ""
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 msgid "Invalid `push_key`"
 msgstr ""
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr ""
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr ""
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr ""
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 msgid "Reminder does not exist"
 msgstr ""
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr ""
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr ""
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr ""
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr ""
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr ""
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr ""
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr ""
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr ""
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 msgid "You do not have permission to create new topics in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr ""
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr ""
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr ""
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr ""
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr ""
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr ""
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} does not have the expected format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr ""
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr ""
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr ""
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {user_group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr ""
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr ""
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr ""
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr ""
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr ""
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 msgid "Name must not be empty!"
 msgstr ""
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr ""
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr ""
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr ""
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr ""
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr ""
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr ""
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr ""
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr ""
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr ""
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr ""
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr ""
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr ""
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr ""
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr ""
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr ""
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr ""
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr ""
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr ""
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr ""
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr ""
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr ""
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr ""
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr ""
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr ""
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr ""
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr ""
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr ""
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr ""
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr ""
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr ""
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr ""
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr ""
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr ""
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr ""
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr ""
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr ""
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr ""
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: empty field name."
 msgstr ""
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr ""
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr ""
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 msgid "Example input does not match the linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in alternative URL template is not present in linkifier "
 "pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in linkifier pattern is not present in alternative URL "
 "template."
 msgstr ""
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr ""
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr ""
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr ""
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr ""
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr ""
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr ""
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr ""
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr ""
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr ""
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr ""
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr ""
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr ""
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr ""
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr ""
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr ""
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr ""
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr ""
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr ""
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr ""
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr ""
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr ""
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr ""
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr ""
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr ""
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr ""
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr ""
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr ""
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr ""
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr ""
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 msgid "Failed to generate challenge"
 msgstr ""
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr ""
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr ""
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr ""
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr ""
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr ""
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr "Salasõna pole õige."
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for use for user matching."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr ""
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr ""
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr ""
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr ""
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr ""
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr ""
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr ""
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr ""
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 msgid "Invitation already used or deactivated."
 msgstr ""
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr ""
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr ""
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr ""
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
 msgstr ""
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr ""
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr ""
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr ""
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr ""
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr ""
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr ""
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr ""
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr ""
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 msgid "Message reporting is not enabled in this organization."
 msgstr ""
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr ""
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr ""
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr ""
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr ""
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr ""
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr ""
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr ""
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr ""
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr ""
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 msgid "Navigation view already exists."
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7189,856 +6593,854 @@ msgid ""
 "later. Is this a good time?\n"
 msgstr ""
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr ""
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr ""
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 msgid "You do not have permission to manage plans and billing."
 msgstr ""
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr ""
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr ""
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr ""
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr ""
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr ""
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr ""
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr ""
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr ""
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr ""
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr ""
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr ""
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr ""
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr ""
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr ""
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr ""
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr ""
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr ""
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr ""
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr ""
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Invalid character in language: {character}"
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Language '{language}' is not allowed."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr ""
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr ""
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 msgid "Importing messages…"
 msgstr ""
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 msgid "Your name"
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr ""
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr ""
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr ""
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr ""
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr ""
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr ""
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr ""
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr ""
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr ""
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr ""
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr ""
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr ""
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr ""
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
 "**"
 msgstr ""
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr ""
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr ""
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr ""
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr ""
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr ""
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr ""
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr ""
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr ""
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr ""
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr ""
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr ""
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr ""
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr ""
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 msgstr ""
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr ""
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr ""
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
 "subgroups."
 msgstr ""
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr ""
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr ""
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr ""
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr "Sonu Zulipi salasõna hallatakse LDAP-teenuses"
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr "Vale salasõna!"
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr ""
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr "Uus salasõna on liiga kehv!"
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr ""
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr ""
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr ""
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 msgid "User is not allowed to delete other user's messages."
 msgstr ""
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr ""
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr ""
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 msgid ""
 "Can't change bot email until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 msgstr ""
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 msgid "Email address already in use"
 msgstr ""
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr ""
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr ""
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr ""
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 msgstr ""
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr ""
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr ""
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr ""
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr ""
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr ""
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} access token"
 msgstr ""
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} call"
 msgstr ""
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} credentials have not been configured"
 msgstr ""
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} credentials"
 msgstr ""
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr ""
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error authenticating to the {provider_name} server"
 msgstr ""
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr ""
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} session identifier"
 msgstr ""
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr ""
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} public room."
 msgstr ""
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr ""
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{full_name}'s Zulip room"
 msgstr ""
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr ""
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr ""
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr ""
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr ""
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr ""
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr ""
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr ""
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr ""
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr ""
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
 "({export_settings_link})."
 msgstr ""
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr ""
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr ""
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr ""
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr ""
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr ""
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr ""
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr ""
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr ""
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr ""
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr ""
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr ""
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr ""
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
 "try again later or reach out to {support_email} for assistance."
 msgstr ""
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr ""
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr ""
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr ""
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr ""
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
 "server: {reason}"
 msgstr ""
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr ""
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr ""
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr ""
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr ""
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr ""
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr ""
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr ""
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr ""
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 msgid "Missing idp param"
 msgstr ""
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr ""
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr ""

--- a/locale/fa/LC_MESSAGES/django.po
+++ b/locale/fa/LC_MESSAGES/django.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 19:41+0000\n"
 "Last-Translator: Goudarz Jafari <me@goudarzjafari.com>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/zulip/django/fa/"
@@ -28,50 +28,50 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "کاربران مهمان دسترسی ندارند"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "سازمان نامعتبر است"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr "کانال‌های عمومی"
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr "کانال‌های خصوصی"
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr "پیام خصوصی"
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr "پیام جمعی"
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr "کانال‌های گم‌شده در نمودار: {chart_name}"
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr "نام نمودار ناشناخته: {chart_name}"
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr "تاریخ شروع پس از تاریخ پایان است. شروع: {start} ، پایان: {end}"
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr "داده های تحلیلی در دسترس نیست. لطفا با ادمین سرور تماس بگيريد."
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -83,7 +83,7 @@ msgstr ""
 "[افزایش تعداد مجوزها]({billing_page_link}) یا [حذف کاربران غیرفعال]"
 "({deactivate_user_help_page_link})، امکان عضویت کاربران جدید را فراهم کنید."
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -94,7 +94,7 @@ msgstr ""
 "({billing_page_link}) یا  [حذف کاربران غیرفعال]"
 "({deactivate_user_help_page_link})، اجازه عضویت کاربران جدید را ایجاد کنید."
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -105,7 +105,7 @@ msgstr ""
 "({billing_page_link}) یا [حذف کاربران غیرفعال]"
 "({deactivate_user_help_page_link})، اجازه عضویت کاربران جدید را ایجاد کنید."
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -116,7 +116,7 @@ msgstr ""
 "({billing_page_link}) یا [حذف کاربران غیرفعال]"
 "({deactivate_user_help_page_link})، اجازه عضویت کاربران جدید را ایجاد کنید."
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -129,28 +129,27 @@ msgstr ""
 "مجوزها برای دوره صورتحساب فعلی و بعدی]({billing_page_link}) از تعداد کاربران "
 "فعلی بیشتر است."
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr "سازمان شما مجوز زولیپ کافی ندارد. دعوتنامه‌ها ارسال نشدند."
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
 msgstr "سازمان شما مجوزهای زولیپ کافی برای تغییر نقش کاربر مهمان ندارد."
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr "نام‌نویسی غیرفعال است"
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr "سرور راه دور نامعتبر است."
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
@@ -159,7 +158,7 @@ msgstr ""
 "شما باید برای تمام کاربران فعال در سازمان خود مجوز خریداری کنید (حداقل "
 "{min_licenses})."
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
@@ -168,42 +167,42 @@ msgstr ""
 "فاکتورهای با بیش از {max_licenses} مجوز، امکان پردازش از این صفحه را ندارند، "
 "برای تکمیل به‌روزرسانی، با {email} تماس بگیرید."
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr "روش پرداختی در فایل وجود ندارد."
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr "{brand} در {last4} به پایان می‌رسد"
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr "چنین روش پرداختی وجود ندارد. لطفاً با {email} مکاتبه کنید."
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr "مشکلی پیش آمده. لطفاً با {email} مکاتبه کنید."
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "مشکلی وجود دارد. لطفا دوباره صفحه را بارگذاری کنید."
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr "مشکلی وجود دارد. لطفا چند لحظه صبر کرده و دوباره تلاش کنید."
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr "لطفاً قبل از شروع آزمایش رایگان، یک کارت اعتباری اضافه کنید."
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr "لطفاً یک کارت اعتباری اضافه کنید تا برنامه‌ریزی ارتقا انجام شود."
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
@@ -211,18 +210,18 @@ msgstr ""
 "امکان به روزرسانی این طرح نیست. این طرح منقضی شده و با طرح جدیدتری جابجا شده "
 "است."
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr "امکان به‌روزرسانی این طرح نیست. این طرح پایان یافته است."
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 "نمی‌توان محوزها را در دوره فعلی صورتحساب، برای طرح آزمایشی رایگان به‌روزرسانی "
 "کرد."
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
@@ -230,17 +229,17 @@ msgstr ""
 "امکان به‌روزرسانی مجوزها به صورت غیر اتوماتیک نیست. طرح شما بر روی حالت "
 "مدیریت اتوماتیک مجوزها است."
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr "طرح شما بر روی {licenses} مجوز، در دوره فاکتور جاری است."
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr "شما نمی‌توانید در دوره فاکتور جاری تعدا مجوزها را کاهش دهید."
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
@@ -248,7 +247,7 @@ msgstr ""
 "نمی‌توانید مجوزها را برای دوره صورتحساب بعدی، برای یک طرح که در حال کاهش است، "
 "تغییر دهید."
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
@@ -257,7 +256,7 @@ msgstr ""
 "طرح شما در حال حاضر برای به روزرسانی با {licenses_at_next_renewal} مجوز، "
 "برنامه‌ریزی شده است."
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
@@ -266,27 +265,27 @@ msgstr ""
 "شما در حال حاضر {licenses_at_next_renewal} مجوز برای دوره صورتحساب بعدی، "
 "خریده‌اید."
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr "چیزی برای تغییر نیست"
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr "مشتری برای این سازمان نیست!"
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr "جلسه پیدا نشد"
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr "هدف پرداخت پیدا نشد"
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr "ارسال stripe_session_id یا stripe_invoice_id"
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -301,20 +300,19 @@ msgstr ""
 "اگر بتوانید {begin_link}زولیپ را به عنوان اسپانسر در وب‌سایت خود فهرست "
 "کنید{end_link}، ما بسیار سپاسپگزار خواهیم بود!"
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr "پارامتر 'تایید شده' الزامی است"
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr "توکن دسترسی به صورت‌حساب منقضی شده است."
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr "توکن دسترسی به صورتحساب نامعتبر"
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
@@ -323,38 +321,37 @@ msgstr ""
 "نمی‌توان داده‌های صورت‌حساب را بین سرور و حوزه تطبیق داد. لطفاً با "
 "{support_email} تماس بگیرید"
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr "حساب کاربری هنوز وجود ندارد."
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr "برای ادامه دادن مراحل، باید شرایط خدمات را بپذیرید."
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr "این zulip_org_id با سیستم مدیریت صورتحساب زولیپ ثبت نشده است."
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr "کلید zulip_org_key برای این zulip_org_id نامعتبر است."
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr "نام‌نویسی کارساز شما غیرفعال شده است."
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "خطا"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr "صفحه پیدا نشد (۴۰۴)"
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
@@ -363,11 +360,11 @@ msgstr ""
 "اگر این خطا غیرمنتظره است می‌توانید <a href=\"mailto:%(support_email)s\">با "
 "پشتیبانی تماس بگیرید</a>."
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr "دسترسی مجاز نیست (403)"
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
@@ -375,11 +372,11 @@ msgstr ""
 "درخواست شما نمی‌تواند انجام شود چون مرورگر اطلاعات مورد نیاز برای اعتبارسنجی "
 "دسترسی شما را نفرستاده است. برای حل این مشکل:"
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr "مطمئن شوید که مرورگر شما برای این سایت اجازه استفاده از کوکی را می‌دهد."
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
@@ -387,16 +384,15 @@ msgstr ""
 "تنظیمات حریم خصوصی مرورگر یا اکستنشن‌هایی که Referer headers را برای این "
 "سایت، مسدود می‌کنند، کنترل کنید."
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr "متد معتبر نیست (۴۰۵)"
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr "خطای داخلی در سرور"
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
@@ -404,7 +400,7 @@ msgstr ""
 "چیزی اشتباه پیش رفت، بابت اون متاسفیم! ما از مشکل آگاهیم و در حال کار برای "
 "رفع آن هستیم. پس از کار دوباره زولیپ به طور خودکار بارگیری می شود."
 
-#: templates/500.html:27
+#: templates/500.html
 #, fuzzy, python-format
 #| msgid ""
 #| "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -419,13 +415,13 @@ msgstr ""
 "\">لیستی از اکانت‌های زولیپ ابری خود دریافت کنید</a> یا <a href=\"mailto:"
 "%(support_email)s\">با پشتیبانی زولیپ تماس بگیرید</a>."
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -443,7 +439,7 @@ msgstr ""
 "سرور تماس بگیرید</a>.\n"
 "                            "
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
@@ -452,136 +448,134 @@ msgstr ""
 "اگر شما ادمین این سرور هستید ممکن است بخواهید این را ببینید <a "
 "href=\"%(troubleshooting_url)s\">راهنمای عیب‌یابی سرور زولیپ</a>."
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr "تجزیه و تحلیل %(target_name)s | زولیپ"
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr "تحلیل‌ها طی ۲۴ ساعت پس از ایجاد سازمان به طور کامل در دسترس خواهند بود."
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr "تحلیل زولیپ برای %(target_name)s"
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr "خلاصه سازمان"
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr "تعداد کاربران"
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr "کاربران فعال در ۱۵ روز گذشته"
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr "تعداد مهمانان"
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr "تعداد کل پیام‌ها"
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr "تعداد پیام‌ها در ۳۰ روز گذشته"
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr "حافظه فایل استفاده شده"
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "کاربران فعال"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr "فعال‌های روزانه"
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr "فعال های طی 15 روز"
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr "همه کاربران"
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "کاربران"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr "پیام های ارسالی براساس نوع دریافت کننده"
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "من"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "همه"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "هفته اخیر"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "ماه اخیر"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "آخرین سال"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "همه زمان‌ها"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr "پیام های ارسال شده به مرور زمان"
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "روزانه"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "هفتگی"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr "تجمعی"
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "افراد"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "ربات‌ها"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr "پیام های ارسال شده به مرور زمان"
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr "پیام های ارسال شده توسط کاربر"
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr "آخرین به روز سانی"
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
@@ -589,15 +583,15 @@ msgstr ""
 "یک به‌روزرسانی کامل نمودارها در هر روز اتفاق می‌افتد. نمودار “پیام‌ها‌ی ارسال "
 "شده در طول زمان” هر ساعت یک مرتبه به روز رسانی می‌شوند."
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr "ایمیل تغییر کرد"
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr "ایمیل تغییر کرد!"
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
@@ -606,21 +600,21 @@ msgstr ""
 "تایید می‌شود که ایمیل مرتبط با اکانت زولیپ شما تغییر کرده است از "
 "%(old_email_html_tag)s به %(new_email_html_tag)s"
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr "آدرس ایمیل خود را تایید کنید"
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr "لینک تایید وجود ندارد"
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr "اوپس، ما نمی‌توانیم لینک تایید شما را در سیستم پیدا کنیم."
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
@@ -629,27 +623,27 @@ msgstr ""
 "به هرحال برای ما ایمیلی به آدرس %(support_email_html_tag)s بفرستید و ما  به "
 "زودی مشکل را برطرف خواهیم کرد."
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr "لینک تایید منقضی یا غیرفعال شده است."
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr "اوپس، لینک تایید منقضی یا غیرفعال شده است."
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr "لطفاً برای یک لینک تأیید جدید با ادمین سازمان خود تماس بگیرید."
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr "لینک تایید نادرست است"
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr "اوپس،‌ این لینک تایید نادرست است."
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
@@ -657,72 +651,55 @@ msgstr ""
 "مطمئن شوید که لینک تایید را به درستی در مرورگر کپی کرده‌اید. اگر هنوز مشکل "
 "دارید، احتمالاً مشکل از طرف ماست. متأسفیم."
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr "صورتحساب"
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr "بستن پنجره"
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr "بیخیال شو"
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr "تنزل نسخه"
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "لغو کردن"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr "تایید"
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr "لغو ارتقا"
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr "وضعیت قبض‌ها"
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr "نام‌نویسی کارساز غیرفعال شود؟"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr "مدیریت طرح در دسترس نیست"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -738,7 +715,7 @@ msgstr ""
 "hosted-billing#log-in-to-billing-management\">دستور العمل‌های ورود</a> نگاه "
 "کنید تا طرح زولیپ سرور خودر را مدیریت کنید."
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
@@ -746,7 +723,7 @@ msgstr ""
 "برای انتقال طرح از سرور به این سازمان یا سوال‌های دیگر، <a href=\"mailto:"
 "{{ support_email }}\">با پشتیبانی تماس بگیرید</a>."
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
@@ -754,7 +731,7 @@ msgstr ""
 "مدیریت طرح برای این سرور در دسترس نیست زیرا حداقل یک سازمان میزبانی شده در "
 "این سرور، یک طرح فعال دارد."
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -765,736 +742,246 @@ msgstr ""
 "a> برای مدیریت طرح سازمان یا <a href='mailto:%(support_email)s'>تماس با "
 "پشتیبانی</a> برای مطرح کردن سوالات."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr "از حد مجاز گذشت"
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr "از حد مجاز گذشت."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr "شما به حداکثر دفعات مجازی رسیده‌اید که این عملیات می‌تواند اجرا شود."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, fuzzy, python-format
 #| msgid "You can try again in %(retry_after)s seconds."
 msgid "You can try again in %(retry_after_string)s."
 msgstr "شما می‌توانید %(retry_after)s ثانیه دیگر دوباره تلاش کنید."
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr "به‌روزرسانی"
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr "ارسال فاکتور و شروع دوره آزمایشی رایگان"
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr "ارسال فاکتور"
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr "بازکردن پوشه انجمن‌ها"
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr "فیلتر. با دسته‌بندی"
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "همه"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr "دسته‌بندی‌ها"
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr "10,000 پیام"
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr "نامحدود"
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr "فایل‌های تا 10 مگ"
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr "فایل‌های تا 1 گیگ"
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr "پشتیبانی شده"
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr "خودمدیریتی"
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr "برای سازمان‌ها با حداکثر 10 کاربر"
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr "حداقل 25 کاربر"
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr "موجود نیست"
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr "جامعه توسعه‌دهنده زولیپ"
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr "به یک کاربر متصل شوید"
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr "وصل شدن به عنوان یک خود-میزبان"
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr "وصل شده به عنوان یک مشارکت‌کننده"
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "ایجاد سازمان"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr "دریافت یک دمو"
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr "زولیپ خود-میزبان"
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr "درخواست اسپانسرشیپ"
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr "قیمت‌های آموزشی"
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr "مشاهده قیمت‌ها"
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr "زولیپ برای کسب و کار"
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Zulip guide for open-source projects"
 msgid "Zulip for open source"
 msgstr "راهنمای زولیپ برای پروژه‌های متن باز را ببینید"
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "start a conversation"
 msgid "Screenshot of Zulip conversation"
 msgstr "شروع یک مکالمه"
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Messages sent over time"
 msgid "Message with code"
 msgstr "پیام های ارسال شده به مرور زمان"
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr "لینک"
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr "تماس با پشتیبانی"
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr "از"
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr "سازمان"
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr "موضوع"
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr "پیام"
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr "تایید"
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr "تشکر بابت تماس با ما"
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr "تشکر بابت تماس با ما!"
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr "ما به زودی با شما تماس خواهیم گرفت."
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
@@ -1502,13 +989,13 @@ msgstr ""
 "می‌توانید پاسخ‌هایی برای سوال‌های رایج پیدا کنید <a href=\"/help/\">مرکز "
 "کمک‌رسانی زولیپ</a>."
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 #, fuzzy
 #| msgid "Getting started"
 msgid "Get started"
 msgstr "شروع"
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
@@ -1517,49 +1004,48 @@ msgstr ""
 "این چت تیمی الان بر روی زولیپ ابری میزبانی می‌شود.لطفاً برای ادامه دادن<a "
 "href=\"https://zulip.com/policies/terms\">قوانین سرویس زولیپ</a> را بپذیرید."
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr "یا به جای آن از یکی از تلفن های پشتیبان خود استفاده کنید:"
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr "بعنوان آخرین ابزار می‌توانید از یک توکن پشتیبان استفاده کنید:"
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr "استفاده از توکن پشتیبان"
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr "پذیرفتن قوانین سرویس"
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr "به زولیپ خوش آمدید"
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "ایمیل"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr "من را در خبرنامه کم‌ترافیک زولیپ مشترک کن (چند ایمیل در سال)"
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr "ادامه"
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr "آدرس ایمیل خود را تایید کنید"
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1569,7 +1055,7 @@ msgstr ""
 "برای تکمیل ثبت نام، حساب ایمیل (<span class=\"user_email semi-"
 "bold\">%(email)s</span>) خود را برای یک ایمیل تأیید از زولیپ بررسی کنید."
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
@@ -1578,30 +1064,30 @@ msgstr ""
 "می‌توانیم <a href=\"#\" id=\"resend_email_link\">دوباره این ایمیل را بفرستیم</"
 "a>."
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr "نمایش عمومی {org_name} | تیم چت زولیپ"
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr "بدون ورود به سیستم، کانال‌های عمومی موجود در {org_name} را مرور کنید."
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
@@ -1609,39 +1095,38 @@ msgstr ""
 "اگر این پیام در صفحه باقی ماند، صفحه را دوباره <a class=\"reload-"
 "lnk\">بارگیری</a> کنید."
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 "خطا در بارگیری زولیپ. سعی کنید صفحه را <a class=\"reload-lnk\">دوباره "
 "بارگیری</a> کنید."
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr "هیچ مکالمه‌ای با فیلترهای شما منطبق نیست."
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr "این صفحه هنوز در حال بارگذاری پیام‌هاست."
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr "بارگذاری بیشتر"
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr "تماس ویدئویی تمام شد"
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr "شما اکنون می‌توانید این پنجره را ببندید"
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr "خطای پیکربندی"
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
@@ -1650,7 +1135,7 @@ msgstr ""
 "سیستم شوید. لطفاً از EmailAuthBackend برای ایجاد سازمان خود استفاده کنید و "
 "سپس دوباره امتحان کنید."
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1660,73 +1145,71 @@ msgstr ""
 "این سرور برای استفاده از اعلان فشاری، تنظیم نشده است. برای دستورالعمل تنظیم "
 "اعلان فشاری لطفاً <a href=\"%(doc_url)s\">مستندات</a> را ببینید."
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr "اکانت پیدا نشد"
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr "حساب کاربری زولیپ یافت نشد."
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, fuzzy, python-format
 #| msgid "Your account email: %(email)s"
 msgid "No account found for %(email)s."
 msgstr "ایمیل حساب شما: %(email)s"
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr "با یک حساب کاربری دیگر وارد شوید"
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr "به نام‌نویسی ادامه دهید"
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Must be a demo organization."
 msgid "Try Zulip in a demo organization"
 msgstr "باید یک سازمان آزمایشی باشد."
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Try Zulip now"
 msgid "Try Zulip"
 msgstr "الان زولیپ را امتحان کنید"
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "ایجاد سازمان جدید"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr "یک سازمان جدید در زولیپ ايجاد کنید"
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr "آدرس ایمیل خود را وارد کنید"
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr "ایمیل شما"
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
@@ -1736,11 +1219,11 @@ msgstr ""
 "import-from-mattermost\">Mattermost</a>, یا <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr "اولین بار چطور در مورد زولیپ شنیده‌اید؟"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
@@ -1748,42 +1231,41 @@ msgstr ""
 "این مقدار فقط وقتی استفاده می‌شود که شما برای یک طرح، ثبت نام کرده باشید، که "
 "در این صورت برای تیم زولیپ ارسال خواهد شد."
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr "یک گزینه را انتخاب کنید"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr "لطفا توضیح دهید"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr "کجا این آگهی را دیده‌اید؟"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr "کدام سازمان؟"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr "کدام یکی؟"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr "یکی را انتخاب کنید"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr "نوع سازمان"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr "زبان سازمان"
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 #, fuzzy
 #| msgid ""
 #| "\n"
@@ -1806,74 +1288,70 @@ msgstr ""
 "a>.\n"
 "                "
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 #, fuzzy
 #| msgid "Private, shared history"
 msgid "Import chat history?"
 msgstr "سابقه به اشتراک گذاشته شده، خصوصی"
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr "نام سازمان"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "URL سازمان"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr "از %(external_host)s استفاده کنید"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "یا"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "نام‌نویسی"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "ورود به زولیپ"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr "شما برای عضویت در این سازمان نیاز به دعوت دارید."
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr "نام‌نویسی با %(identity_provider)s"
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr "آیا حساب کاربری دارید؟"
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "ورود"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr "پیکربندی حریم خصوصی آدرس ایمیل"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
@@ -1881,7 +1359,7 @@ msgstr ""
 "زولیپ به شما اجازه می‌دهد که کنترل کنید کدام نقش‌ها در سازمان می‌توانند آدرس "
 "ایمیل شما را ببینند."
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
@@ -1889,11 +1367,11 @@ msgstr ""
 "آیا می‌خواهید تنظیمات حریم خصوصی ایمیل خود را نسبت به آنچه به صورت پیش‌فرض "
 "برای این سازمان پیکربندی شده، تغییر دهید؟"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr "چه کسی می تواند به آدرس ایمیل شما دسترسی داشته باشد"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1904,103 +1382,102 @@ msgstr ""
 "configure-email-visibility\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">عضو شدن</a> تغییر دهید."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr "ادمین‌های این سازمان زولیپ می‌توانند این آدرس ایمیل را ببینند."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
 msgstr "ادمین‌ها و مدیران این سازمان زولیپ می‌توانند این آدرس ایمیل را ببینند."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr "هیچ کس در این سازمان زولیپ نمی‌تواند این آدرس ایمیل را ببیند."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr "سایر کاربران در این سازمان زولیپ می‌توانند این آدرس ایمیل را ببینند."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "تغییر دادن"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr "نام‌نویسی"
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr "سازمان خود را بسازید"
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr "حساب خود را بسازید"
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr "<p>جزییات حساب کاربری خود را وارد کنید تا نام‌نویسی کامل شود.</p>"
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr "سازمان شما"
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr "حساب شما"
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr "تنظیمات را وارد نکن"
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr "وارد کردن تنظیمات از حساب کاربری موجود در زولیپ"
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr "نام کامل شما"
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "نام"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr "حساب کاربری شما به این شکل در زولیپ نمایش داده می‌شود."
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "کلمه عبور"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr "کلمه عبور LDAP یا اکتیو دایرکتوری خود را وارد کنید."
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 "این برای برنامه‌های موبایل و سایر ابزارهایی که به یک کلمه عبور نیاز دارند "
 "استفاده می شود."
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr "قدرت کلمه عبور"
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr "به چه چیز علاقمندید؟"
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
@@ -2009,15 +1486,15 @@ msgstr ""
 "من موافق <a href=\"%(root_domain_url)s/policies/terms\" target=\"_blank\" "
 "rel=\"noopener noreferrer\">قوانین سرویس</a> هستم."
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr "سازمان غیرفعال"
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr "سازمان منتقل شد"
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
@@ -2026,7 +1503,7 @@ msgstr ""
 "این سازمان به <a href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</"
 "a> منتقل شد."
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -2034,7 +1511,7 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid ""
@@ -2042,7 +1519,7 @@ msgid ""
 "deleted."
 msgstr "این سازمان غیرفعال شده است "
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2058,7 +1535,7 @@ msgstr ""
 "%(support_email)s\">با پشتیبانی زولیپ تماس بگیرید</a>.\n"
 "                            "
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2076,13 +1553,13 @@ msgstr ""
 "سرور تماس بگیرید</a>.\n"
 "                            "
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid "This organization has been deactivated."
 msgstr "این سازمان غیرفعال شده است "
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -2092,14 +1569,14 @@ msgstr ""
 "%(support_email)s\">با پشتیبانی زولیپ تماس بگیرید</a> تا دوباره آن را فعال "
 "کنید."
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -2110,15 +1587,15 @@ msgstr ""
 "%(support_email)s\">با ادمین‌های این سازمان زولیپ تماس بگیرید</a> تا دوباره "
 "آن را فعال کنید."
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr "پایان ورود اپ دسکتاپ"
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr "پایان ورود دسکتاپ"
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
@@ -2126,109 +1603,108 @@ msgstr ""
 "از مرورگر وب برای تکمیل ورود استفاده کنید، سپس به اینجا برگردید تا توکن خود "
 "را جایگذاری کنید."
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr "توکن را اینجا جایگذاری کنید"
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr "پایان"
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr "توکن اشتباه"
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr "توکن پذیرفته شد. در حال وارد شدن…"
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr "ورود به اپ دسکتاپ"
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 "این توکن ورود را کپی کنید و به اپ زولیپ خود برگردید تا مراحل ورود تکمیل شود:"
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "رونوشت"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr "سپس می‌توانید این پنجره را ببندید"
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr "یا در مرورگر ادامه بدهید."
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr "کاربر ناشناس"
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr "مالک"
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "ادمین‌ها"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr "مدیران"
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr "کاربران مهمان"
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "کاربران معمولی"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr "ارسال ایمیل‌ها به یک حساب ایمیل دیگر"
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "بستن"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "به روز رسانی"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr "زولیپ"
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr "هضم"
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
 "<b>%(realm_name)s</b>."
 msgstr "تبریک، شما یک سازمان جدید زولیپ ساخته‌اید: <b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr "به زولیپ خوش آمدید!"
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr "شما عضو سازمان زولیپ<b>%(realm_name)s</b> شده‌اید."
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
@@ -2237,36 +1713,36 @@ msgstr ""
 "شما از اطلاعات زیر برای وارد شده به زولیپ تحت وب و اپ‌های <a "
 "href=\"%(apps_page_link)s\">موبایل و دسکتاپ</a> استفاده خواهید کرد:"
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr "آدرس سازمان: %(organization_url)s"
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr "نام کاربری شما: %(ldap_username)s"
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr "از حساب کاربری LDAP خودتان برای ورود استفاده کنید"
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr "ایمیل حساب شما: %(email)s"
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr "رفتن به سازمان"
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
@@ -2275,7 +1751,7 @@ msgstr ""
 "اگر در زولیپ تازه‌کار هستید،<a href=\"%(getting_user_started_link)s\">راهنمای "
 "شروع</a>!"
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2285,7 +1761,7 @@ msgstr ""
 "ما همچنین یک <a href=\"%(getting_organization_started_link)s\">راهنما برای "
 "انتقال سازمان شما به زولیپ</a> داریم."
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
@@ -2294,28 +1770,28 @@ msgstr ""
 "سوال دارید؟ <a href=\"mailto:%(support_email)s\">با ما تماس بگیرید</a> — ما "
 "دوست داریم کمک کنیم!"
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr "%(realm_name)s در زولیپ : جزئیات سازمان جدید شما"
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr "%(realm_name)s در زولیپ : جزئیات سازمان جدید شما"
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr "تبریک، شما یک سازمان جدید زولیپ ساخته‌اید: %(realm_name)s"
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr "شما عضو سازمان %(realm_name)s در زولیپ شده‌اید."
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
@@ -2324,7 +1800,7 @@ msgstr ""
 "شما از اطلاعات زیر برای ورود به زولیپ تحت وب،‌ اپ موبایل و اپ دسکتاپ استفاده "
 "خواهید کرد (%(apps_page_link)s):"
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
@@ -2333,7 +1809,7 @@ msgstr ""
 "اگر در زولیپ جدید هستید راهنمای شروع ما را نگاه کنید "
 "(%(getting_user_started_link)s)!"
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
@@ -2342,18 +1818,18 @@ msgstr ""
 "ما همچنین یک راهنما برای انتقال سازمان شما به زولیپ داریم "
 "(%(getting_organization_started_link)s)."
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 "سوال دارید؟ با ما تماس بگیرید %(support_email)s — ما دوست داریم کمک کنیم!"
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2362,17 +1838,17 @@ msgstr ""
 "اگر هر سوالی دارید، لطفاً با ادمین این سرور به آدرس %(support_email)s تماس "
 "بگیرید."
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr "سلام،"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2383,12 +1859,12 @@ msgstr ""
 "سازمان زولیپ شما در %(realm_url)s اضافه کنیم. برای تایید این به‌روزرسانی و "
 "تعیین یک کلمه عبور برای این حساب، این پایین کلیک کنید."
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr "تأیید و ثبت کلمه عبور"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2397,14 +1873,14 @@ msgstr ""
 "اگر شما برای این تغییر درخواست نداده‌اید، سریعاً با ما تماس بگیرید "
 "%(support_email)s"
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 #, fuzzy
 #| msgid "Verify your new email address for your demo Zulip organization"
 msgid "Verify your email address for your Zulip demo organization"
 msgstr "آدرس ایمیل جدید خود را برای سازمان آزمایشی زولیپ خود تأیید کنید"
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2413,8 +1889,8 @@ msgstr ""
 "اگر شما درخواست این تغییر را نداده اید لطفا سریعا در (%(support_email)s) با "
 "ما تماس بگیرید"
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2424,33 +1900,33 @@ msgstr ""
 "ما درخواستی برای تغییر آدرس ایمیل حساب کاربری زولیپ %(realm_url)s از "
 "%(old_email)s به %(new_email)s دریافت کرده‌ایم. برای تایید تغییرات، کلیک کنید:"
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr "تایید تغییر ایمیل"
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr "آدرس ایمیل جدید خود را برای %(organization_host)s تأیید کنید"
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr "شما یک سازمان زولیپ جدید درخواست کرده‌اید:"
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr "نوع سازمان: %(organization_type)s"
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr "شما اخیراً عضو زولیپ شده‌اید. بسیار هم عالی!"
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
@@ -2458,33 +1934,33 @@ msgstr ""
 "بر روی دکمه زیر کلیک کنید تا سازمان شما ثبت شده و اکانت شما ساخته شود. شما "
 "می‌توانید اطلاعات بالا را بعداً به‌روزرسانی کنید."
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr "برای تکمیل نام‌نویسی روی دکمه زیر کلیک کنید."
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr "تکمیل نام‌نویسی"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr "سازمان زولیپ خود را بسازید"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr "فعال‌سازی حساب کاربری زولیپ شما"
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr "برای تکمیل نام‌نویسی روی پیوند زیر کلیک کنید."
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
@@ -2493,20 +1969,20 @@ msgstr ""
 "آیا سوال یا بازخوردی برای به اشتراک گذاشتن دارید؟ با ما تماس بگیرید "
 "%(support_email)s — ما دوست داریم کمک کنیم!"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr "مدیریت اولویت‌های ایمیل"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr "لغو اشتراک از ایمیل‌های بازاریابی"
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
@@ -2515,17 +1991,17 @@ msgstr ""
 "اکانت زولیپ شما بر روی <a href=\"%(realm_url)s\">%(realm_url)s</a> غیرفعال "
 "شده و شما دیگر نمی‌توانید وارد شوید."
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr "ادمین‌ها نظر زیر را ارائه کرده‌اند:"
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr "آگاه‌سازی غیرفعال شدن حساب کاربری در %(realm_name)s"
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
@@ -2534,11 +2010,11 @@ msgstr ""
 "حساب زولیپ شما بر روی%(realm_url)s غیرفعال شده است و دیگر نمی‌توانید وارد "
 "شوید."
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr "کانال‌های جدید"
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2546,22 +2022,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because your organization has "
@@ -2577,8 +2053,8 @@ msgstr ""
 "class=\"content_disabled_help_link\" href=\"%(help_url)s\">نمایش محتوای پیام "
 "در اطلاع رسانی ایمیلی</a> را غیرفعال کرده است."
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because you have disabled <a "
@@ -2593,40 +2069,40 @@ msgstr ""
 "class=\"content_disabled_help_link\" href=\"%(alert_notif_url)s\">نمایش "
 "محتوای پیام در اطلاع‌رسانی ایمیلی</a> را غیرفعال کرده‌اید."
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, fuzzy, python-format
 #| msgid "Click here to log in to Zulip and catch up."
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr "برای ورود به زولیپ و پیگیری اینجا کلیک کنید."
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr "لغو اشتراک از ایمیل‌های خلاصه"
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr "خلاصه‌های زولیپ برای %(realm_name)s"
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2643,8 +2119,8 @@ msgstr ""
 "در اطلاع‌رسانی ایمیلی را غیرفعال کرده‌است.\n"
 "برای جزییات بیشتر %(hide_content_url)s را ببنید.\n"
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2660,33 +2136,31 @@ msgstr ""
 "در اطلاع‌رسانی ایمیلی را غیرفعال کرده‌اید.\n"
 "برای جزییات بیشتر %(alert_notif_url)s را ببنید.\n"
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, fuzzy, python-format
 #| msgid "Click here to log in to Zulip and catch up: %(organization_url)s."
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr "برای ورود و پیگیری اینجا کلیک کنید: %(organization_url)s."
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr "مدیریت اولویت‌های ایمیل:"
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr "لغو اشتراک ایمیل‌های خلاصه:"
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr "ماهی شناگر"
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr "تشکر برای درخواست شما!"
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
@@ -2694,8 +2168,7 @@ msgid ""
 msgstr ""
 "آدرس ایمیل شما %(email)s دارای حساب کاریری در سازمان‌های زولیپی زیر است:"
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
@@ -2704,7 +2177,7 @@ msgstr ""
 "آدرس ایمیل شما %(email)s دارای حساب کاریری در سازمان زولیپی است که بر روی "
 "%(external_host)s میزبانی می‌شود:"
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
@@ -2713,19 +2186,15 @@ msgstr ""
 "اگر برای وارد شدن مشکل دارید، می‌توانید <a "
 "href=\"%(help_reset_password_link)s\">کلمه عبور خود را تغییر دهید</a>."
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr "شما لیستی از اکانت‌های زولیپ مرتبط با این ایمیل را درخواست کرده‌اید."
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr "متاسفانه هیچ حساب ابری زولیپ پیدا نشد."
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
@@ -2734,7 +2203,7 @@ msgstr ""
 "متاسفانه هیچ حساب کاربری در سازمان زولیپی که بر روی %(external_host)s "
 "میزبانی می‌شود، پیدا نشد."
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2745,28 +2214,25 @@ msgstr ""
 "با ایمیل دیگری کنترل کنید، یا <a href =\"%(help_logging_in_link)s\">روش "
 "دیگری</a> برای پیدا کردن حساب کاربری خود امتحان کنید."
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 "اگر شما این درخواست را متوجه نمی شوید می‌توانید با خیال راحت این ایمیل را "
 "ناديده بگیرید."
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr "حساب‌های زولیپ شما"
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr "اکانت زولیپ پیدا نشد"
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr "اگر برای وارد شدن مشکل دارید، می‌توانید کلمه عبور خود را تغییر دهید."
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
@@ -2776,12 +2242,12 @@ msgstr ""
 "(%(find_accounts_link)s)، یا روش دیگری را برای پیدا کردن حساب کاربری خود "
 "پیدا کنید (%(help_logging_in_link)s)."
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr "سلام،"
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
@@ -2790,19 +2256,19 @@ msgstr ""
 "%(referrer_name)s علاقمند است که شما به آنها در زولیپ بپیوندید —ابزار ارتباط "
 "تیمی، طراحی شده برای بهره‌وری"
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr "برای شروع روی دکمه زیر کلیک کنید."
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 "%(referrer_full_name)s از شما دعوت کرده است که به %(referrer_realm_name)s "
 "بپیوندید"
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
@@ -2811,17 +2277,17 @@ msgstr ""
 "%(referrer_full_name)s (%(referrer_email)s) می خواهند شما آنها را در زولیپ "
 "-- ابزار طراحی شده برای بهره‌وری تیم؛ عضو کنید."
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr "برای شروع روی لینک زیر کلیک کنید."
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr "سلام دوباره،"
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
@@ -2830,13 +2296,13 @@ msgstr ""
 "این یک یادآوری دوستانه است که %(referrer_name)s از شما خواسته است تا به "
 "زولیپ بپیوندید  — ابزار ارتباط تیمی، طراحی شده برای بهره‌وری"
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr "این آخرین یادآوری است که برای این دعوت دریافت می کنید."
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
@@ -2845,12 +2311,12 @@ msgstr ""
 "این دعوت طی دو روز آینده منقضی خواهد شد، اگر دعوت منقضی شود می بایست از "
 "%(referrer_name)s یک دعوت دیگر بخواهید."
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr "یادآوری: %(referrer_name)s را در %(referrer_realm_name)s عضو کن"
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2860,7 +2326,7 @@ msgstr ""
 "این یک یادآوری دوستانه است که %(referrer_name)s (%(referrer_email)s) از شما "
 "می خواهند شما آنها را در زولیپ -- ابزار طراحی شده برای بهره‌وری تیم؛ عضو کنید."
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2869,7 +2335,7 @@ msgstr ""
 "اگر سؤالی دارید، لطفاً با ادمین‌های این سرور زولیپ در آدرس <a href=\"mailto:"
 "%(email)s\">%(email)s</a> تماس بگیرید."
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
@@ -2878,13 +2344,13 @@ msgstr ""
 "آیا سؤال یا بازخوردی برای به اشتراک گذاشتن دارید؟ <a href=\"mailto:"
 "%(email)s\">با ما تماس بگیرید</a> — ما دوست داریم کمک کنیم!"
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr "شما این را دریافت کرده‌اید چرا که به صورت شخصی به شما اشاره شده‌است."
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
@@ -2892,10 +2358,8 @@ msgstr ""
 "شما این را دریافت کرده‌اید چرا که به @%(mentioned_user_group_name)s  اشاره‌ "
 "شده‌است."
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
@@ -2904,8 +2368,8 @@ msgstr ""
 "شما این پیغام را دریافت کرده‌اید چرا که به همه کاربران در #%(channel_name)s > "
 "%(topic_name)s اشاره شده است."
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
@@ -2913,8 +2377,8 @@ msgstr ""
 "شما این را دریافت می کنید زیرااعلان برای  اشاره‌های وایلدکارت را برای "
 "موضوعاتی که دنبال می‌کنید فعال کرده‌اید."
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
@@ -2922,8 +2386,8 @@ msgstr ""
 "شما این را دریافت کرده‌اید چرا که به همه افراد در #%(channel_name)s اشاره "
 "شده‌است."
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
@@ -2931,8 +2395,8 @@ msgstr ""
 "شما این را دریافت می‌کنید زیرا اعلان‌های ایمیلی را برای موضوعاتی که دنبال "
 "می‌کنید فعال کرده‌اید."
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
@@ -2941,7 +2405,7 @@ msgstr ""
 "شما این را دریافت کرده‌اید چرا که اطلاع‌رسانی ایمیلی برای #%(channel_name)s "
 "فعال شده‌است."
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2952,7 +2416,7 @@ msgstr ""
 "%(realm_name)s ببینید</a>، یا <a href=\"%(notif_url)s\">اولویت‌های ایمیل را "
 "مدیریت کنید</a>."
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
@@ -2961,7 +2425,7 @@ msgstr ""
 "<a href=\"%(narrow_url)s\">در زولیپ %(realm_name)s ببینید یا پاسخ دهید</a>، "
 "یا <a href=\"%(notif_url)s\">اولویت‌های ایمیل را مدیریت کنید</a>."
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
@@ -2970,7 +2434,7 @@ msgstr ""
 "<a href=\"%(narrow_url)s\">در زولیپ %(realm_name)s پاسخ دهید</a>، یا <a "
 "href=\"%(notif_url)s\">اولویت‌های ایمیل را مدیریت کنید</a>."
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
@@ -2979,41 +2443,41 @@ msgstr ""
 "به این ایمیل پاسخ ندهید. این سرور زولیپ برای دریافت پاسخ ایمیل‌ها پیکربندی "
 "نشده است (<a href=\"%(url)s\">راهنما</a>)."
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr "پیام مستقیم گروهی با %(direct_message_group_display_name)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr "پیام مستقیم به %(sender_str)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr "[حل‌شده] #%(channel_name)s > %(topic_name)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr "پیام‌های جدید"
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr "به این ایمیل مستقیم پاسخ دهید یا آن را در زولیپ %(realm_name)s ببینید:"
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr "مشاهده یا پاسخ دادن در زولیپ %(realm_name)s:"
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr "پاسخ‌دادن در زولیپ %(realm_name)s:"
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
@@ -3021,7 +2485,7 @@ msgstr ""
 "به این ایمیل پاسخ ندهید. این سرور زولیپ برای دریافت پاسخ ایمیل‌ها پیکربندی "
 "نشده است. راهنما:"
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -3032,22 +2496,22 @@ msgstr ""
 "است. اگر شما این تغییر را نداده‌اید لطفاً سریعا با ما به آدرس "
 "%(support_email)sتماس بگیرید."
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr "بهترین٬"
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr "زولیپ تیم"
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr "ایمیل زولیپ به %(realm_name)s تغییر کرد"
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -3058,52 +2522,52 @@ msgstr ""
 "شما درخواست این تغییر را نداده اید لطفا سریعاً در <%(support_email)s> به ما "
 "اطلاع دهید."
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 msgstr "سازمان:‌%(organization_url)s زمان: %(login_time)s ایمیل: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr "ما اخیرا متوجه یک ورود به این حساب کاربری زولیپ شدیم."
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr "سازمان: %(organization_link)s"
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr "ایمیل: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr "زمان: %(login_time)s"
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr "دستگاه: %(device_browser)s بر روی %(device_os)s."
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr "آدرس آی پی: %(device_ip)s"
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr "اگر این شما بوده اید، خوب است! نیازی نیست کار دیگری انجام دهید."
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3114,31 +2578,31 @@ msgstr ""
 "گرفته باشد، لطفاً <a href=\"%(reset_link)s\">کلمه عبور خود را بازنشانی</a> "
 "کنید یا سریعاً با ما تماس بگیرید %(support_email)s."
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr "ممنون،"
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr "امنیت زولیپ"
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr "لغو اطلاع رسانی های ورود"
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr "ورود جدید از %(device_browser)s بر روی %(device_os)s"
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr "سازمان: %(organization_url)s"
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3149,7 +2613,7 @@ msgstr ""
 "معرض خطر قرار گرفته باشد لطفا کلمه عبور خود را در %(reset_link)s مجدداً تنظیم "
 "کنید یا سریعاً به ما در آدرس %(support_email)s اطلاع دهید."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -3160,7 +2624,7 @@ msgstr ""
 "شروع می‌توانید از <a href=\"%(get_organization_started)s\">راهنمای ما برای "
 "انتقال سازمان شما به زولیپ</a> استفاده کنید."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
@@ -3168,7 +2632,7 @@ msgstr ""
 "در غیر این صورت، در اینجا توصیه‌هایی وجود دارد که اغلب از مشتریان برای "
 "ارزیابی <i>هر محصول</i> چت تیمی می‌شنویم:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
@@ -3177,12 +2641,12 @@ msgstr ""
 "<a href=\"%(invite_users)s\"><b>هم‌تیمی‌های خود را دعوت کنید</b></a> تا با شما "
 "کشف کنند و دیدگاه‌های منحصر به فرد خود را به اشتراک بگذارند."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr "از خود برنامه برای گپ زدن درباره برداشت‌های خود استفاده کنید."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -3194,7 +2658,7 @@ msgstr ""
 "این است که چگونه یک برنامه چت جدید به تیم شما کمک می‌کند تا ارتباط برقرار "
 "کنید."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -3205,21 +2669,21 @@ msgstr ""
 "ایجاد می‌کند</a>، و امیدواریم این نکات به تیم شما کمک کند تا آن را در عمل "
 "تجربه کنند."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr "لغو ایمیل‌های خوش آمد گویی برای %(realm_name)s"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr "انتخاب نرم‌افزار مکالمه برای تیم شما"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
@@ -3227,7 +2691,7 @@ msgstr ""
 "اگر تصمیم گرفته‌اید از زولیپ برای سازمان خود استفاده کنید، خوش آمدید! برای "
 "شروع می‌توانید از راهنمای ما برای انتقال سازمان خود به زولیپ استفاده کنید."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
@@ -3235,7 +2699,7 @@ msgstr ""
 "در غیر این صورت، در اینجا توصیه‌هایی وجود دارد که اغلب از مشتریان برای "
 "ارزیابی هر محصول چت تیمی می‌شنویم:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
@@ -3243,7 +2707,7 @@ msgstr ""
 "از هم تیمی‌های خود دعوت کنید تا با شما کشف کنند و دیدگاه‌های منحصر به فرد خود "
 "را به اشتراک بگذارند."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
@@ -3253,7 +2717,7 @@ msgstr ""
 "کنید. این تنها راه برای تجربه واقعی این است که چگونه یک برنامه چت جدید به "
 "تیم شما کمک می‌کند تا ارتباط برقرار کنید."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
@@ -3261,8 +2725,8 @@ msgstr ""
 "زولیپ به گونه‌ای طراحی شده است که ارتباط کارآمدی را ایجاد می‌کند، و امیدواریم "
 "این نکات به تیم شما کمک کند تا آن را در عمل تجربه کنند."
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
@@ -3272,71 +2736,71 @@ msgstr ""
 "اینکه چطور برای نیازهای شما مناسب است،‌ کمک کنیم. این راهنمای ویژگی‌های کلیدی "
 "زولیپ برای سازمان‌های مانند خودتان را نگاه کنید ."
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr "راهنمای زولیپ برای کسب و کارها را ببینید"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr "راهنمای زولیپ برای پروژه‌های متن باز را مشاهده کنید"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr "راهنمای زولیپ برای آموزش را ببینید"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr "راهنمای زولیپ برای پژوهش را ببینید"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr "راهنمای زولیپ برای رویدادها و کنفرانس‌ها را مشاهده کنید"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr "راهنمای زولیپ برای غیرانتفاعی‌ها را ببینید"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr "راهنمای زولیپ برای انجمن‌ها را ببینید"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr "راهنمای زولیپ برای کسب و کارها"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr "راهنمای زولیپ برای پروژه‌های متن باز را ببینید"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr "راهنمای زولیپ برای آموزش"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr "راهنمای زولیپ برای پژوهش"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr "راهنمای زولیپ برای رویدادها و کنفرانس‌ها را مشاهده کنید"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr "راهنمای زولیپ برای غیر انتفاعی‌ها"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr "راهنمای زولیپ برای انجمن‌ها"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
@@ -3344,7 +2808,7 @@ msgstr ""
 "اینجا چند نکته برای سازماندهی مکالمات زولیپ شما توسط موضوعات مختلف، ارائه "
 "شده است."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
@@ -3352,8 +2816,8 @@ msgstr ""
 "در زولیپ <b>کانال</b> مشخص می‌کند که چه کسی یک پیام را دریافت خواهد کرد. "
 "<b>موضوع</b> به شما می‌گوید که پیام درباره چه چیزی است."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
@@ -3361,12 +2825,12 @@ msgstr ""
 "با استفاده از موضوعات، شما می توانید هر بار یک مکالمه زولیپ را بخوانید. شما "
 "هر پیام را در متن خواهید دید و مهم نیست که چه بحث‌های مختلفی در جریان باشد."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr "کانال‌ها و موضوعات در اپ زولیپ"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3378,11 +2842,11 @@ msgstr ""
 "مناسب برای یک موضوع، سعی کنید این جمله را کامل کنید: ”میشه در مورد ... صحبت "
 "کنیم؟“"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr "مثال هایی از موضوعات کوتاه"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3396,17 +2860,17 @@ msgstr ""
 "href=\"%(move_channels_link)s\">جابجاکردن یک موضوع به یک کانال دیگر</a>، "
 "بسیار ساده است."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr "رفتن به زولیپ"
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr "مکالمات خود را به کمک موضوعات سازماندهی کنید"
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
@@ -3414,7 +2878,7 @@ msgstr ""
 "در زولیپ کانال مشخص می‌کند که چه کسی یک پیام را دریافت خواهد کرد. موضوع به "
 "شما می‌گوید که پیام درباره چه چیزی است."
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3427,8 +2891,8 @@ msgstr ""
 "(%(rename_topics_link)s) و یا حتی جابجاکردن یک موضوع به یک کانال دیگر "
 "(%(move_channels_link)s)، بسیار ساده است."
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
@@ -3437,15 +2901,15 @@ msgstr ""
 "کسی (احتمالاً خود شما) برای حساب کاربری زولیپ %(email)s بر روی %(realm_url)s، "
 "درخواست کلمه عبور جدید کرده‌است."
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr "برای تنظیم مجدد کلمه عبور بر روی دکمه زیر کلیک کنید."
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr "تنظیم مجدد کلمه عبور"
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3456,42 +2920,42 @@ msgstr ""
 "شده است. شما می‌توانید با ادمین‌های سازمان برای <a "
 "href=\"%(help_link)s\">دوباره فعال کردن حساب</a> خودتان، تماس بگیرید."
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr "شما در این سازمان زولیپ حساب کاربری ندارید."
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr "شما در این سازمان (ها) حساب کاربری فعال ندارید:"
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
 msgstr ""
 "شما می توانید در سازمان (ها) بالا وارد شوید یا کلمه عبور خود را تغییر دهید."
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 "اگر شما این فعالیت را متوجه نمی شوید می توانید با خیال راحت این ایمیل را "
 "ناديده بگیرید."
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr "درخواست تغییر کلمه عبور برای %(realm_name)s"
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr "بر روی لینک زیر کلیک کنید تا کلمه عبور خود را مجدد تنظیم کنید"
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
@@ -3500,7 +2964,7 @@ msgstr ""
 "شما قبلاً یک حساب کاربری در %(realm_url)s داشته‌اید، اما غیرفعال شده است. شما "
 "می‌توانید با یک ادمین سازمان تماس بگیرید تا دوباره حساب کاربری شما فعال شود."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3510,7 +2974,7 @@ msgstr ""
 "سازمان شما،%(organization_name_with_link)s، به خاطر فاکتورهای پرداخت نشده به "
 "طرح رایگان زولیپ ابری تنزل داده شده است. فاکتورهای پرداخت‌ نشده باطل شده است."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
@@ -3519,7 +2983,7 @@ msgstr ""
 "برای ادامه دادن طرح استاندارد زولیپ ابری، با رفتن به %(upgrade_url)s زدوباره "
 "ارتقا بدهید. ."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
@@ -3528,8 +2992,8 @@ msgstr ""
 "اگر فکر می‌کنید اشتباهی رخ داده و نیازمند جزییات بیشتر هستید لطفاً با ما تماس "
 "بگیرید %(support_email)s."
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "You have deactivated your Zulip organization, %(realm_name)s, on "
@@ -3541,8 +3005,8 @@ msgstr ""
 "شما سازمان زولیپ %(realm_name)sرا در تاریخ %(localized_date)s، غیرفعال "
 "کرده‌اید."
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "Your Zulip organization, %(realm_name)s, was deactivated by "
@@ -3554,8 +3018,8 @@ msgstr ""
 "سازمان زولیپ %(realm_name)s توسط %(deactivating_owner)s در تاریخ "
 "%(localized_date)s غیرفعال شده‌است."
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "Your Zulip organization, %(realm_name)s, was deactivated on "
@@ -3566,8 +3030,8 @@ msgid ""
 msgstr ""
 "سازمان زولیپ %(realm_name)s در تاریخ %(localized_date)s غیرفعال شده‌است."
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
@@ -3576,8 +3040,8 @@ msgstr ""
 "شما سازمان زولیپ %(realm_name)sرا در تاریخ %(localized_date)s، غیرفعال "
 "کرده‌اید."
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
@@ -3586,8 +3050,8 @@ msgstr ""
 "سازمان زولیپ %(realm_name)s توسط %(deactivating_owner)s در تاریخ "
 "%(localized_date)s غیرفعال شده‌است."
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
@@ -3595,14 +3059,14 @@ msgid ""
 msgstr ""
 "سازمان زولیپ %(realm_name)s در تاریخ %(localized_date)s غیرفعال شده‌است."
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr "تمام داده‌های مرتبط با این سازمان به صورت دائمی حذف شدند."
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
@@ -3611,26 +3075,26 @@ msgstr ""
 "تمام داده‌های مرتبط با این سازمان در تاریخ %(deletion_date)s به صورت دائمی "
 "حذف خواهند شد."
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr "اگر سوال یا نگرانی دارید، در اسرع وقت به این ایمیل پاسخ دهید."
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr "سازمان زولیپ %(realm_name)s غیرفعال شده‌است"
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr "ادمین‌های قبلی عزیز %(realm_name)s."
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "One of your administrators requested reactivation of the previously "
@@ -3642,8 +3106,8 @@ msgstr ""
 "یکی‌ از ادمین‌های  شما درخواست فعال‌سازی سازمان زولیپ غیرفعال‌شده شما بر روی "
 "%(realm_url)s، را داده است."
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
@@ -3652,16 +3116,16 @@ msgstr ""
 "یکی‌ از ادمین‌های  شما درخواست فعال‌سازی سازمان زولیپ غیرفعال‌شده شما بر روی "
 "%(realm_url)s، را داده است."
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr "ب روی دکمه زیر کلیک کنید تا سازمان خود را مجدد فعال کنید."
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr "فعال سازی مجدد سازمان"
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
@@ -3669,21 +3133,21 @@ msgstr ""
 "اگر درخواست اشتباه است می توانید اقدامی نکنید و این لینک بعد از 24 ساعت "
 "منقضی می شود."
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Reactivate your Zulip organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "دوباره فعال‌سازی سازمان زولیپ شما"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr "دوباره فعال‌سازی سازمان زولیپ شما"
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr "بر روی لینک زیر کلیک کنید تا سازمان خود را مجدد فعال کنید"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3692,20 +3156,20 @@ msgstr ""
 "شما یا کسی به نمایندگی شما، درخواستی برای دریافت لینک ورود به مدیریت طرح "
 "زولیپ برای <b>%(remote_server_hostname)s</b> داده است."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, fuzzy
 #| msgid "Click the link below to log in."
 msgid "Click the button below to log in."
 msgstr "برای ورود، روی لینک زیر کلیک کنید."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr "این لینک در %(validity_in_hours)s ساعت منقضی می‌شود."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
@@ -3714,11 +3178,11 @@ msgstr ""
 "سوال دارید؟ <a href=\"%(billing_help_link)s\">بیشتر بدانید</a> یا با "
 "%(billing_contact_email)s تماس بگیرید."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr "ورود به مدیریت طرح‌های زولیپ"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3727,12 +3191,12 @@ msgstr ""
 "شما یا کسی به نمایندگی شما، درخواستی برای دریافت لینک ورود به مدیریت طرح "
 "زولیپ برای %(remote_server_hostname)s داده است."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr "برای ورود، روی لینک زیر کلیک کنید."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
@@ -3741,7 +3205,7 @@ msgstr ""
 "سوال دارید؟ در %(billing_help_link)s بیشتر بدانید یا با ایمیل  "
 "%(billing_contact_email)s تماس بگیرید."
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
@@ -3750,16 +3214,16 @@ msgstr ""
 "کلیک کنید تا ایمیل خود را تأیید کنید و وارد مدیریت طرح زولیپ برای "
 "<b>%(remote_realm_host)s</b> شوید."
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr "تأیید و ورود به سیستم"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr "تأیید ایمیل برای مدیریت طرح زولیپ"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
@@ -3768,7 +3232,7 @@ msgstr ""
 "برای تأیید ایمیل خود و ورود به مدیریت طرح زولیپ %(remote_realm_host)s،  روی "
 "لینک زیر کلیک کنید."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
@@ -3777,7 +3241,7 @@ msgstr ""
 "درخواست شما برای حمایت از زولیپ تایید شده است! سازمان شما به <a "
 "href=\"%(plans_link)s\">طرح جامعه زولیپ</a> ارتقا یافته است."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
@@ -3786,12 +3250,12 @@ msgstr ""
 "اگر شما بتوانید <a href=\"%(link_to_zulip)s\">زولیپ را به عنوان یک حامی در "
 "وبسایت خود لیست کنید</a>، ما واقعاً از آن قدردانی می‌کنیم!"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr "طرح حمایت از جامعه برای %(billing_entity)s تأیید شد!"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
@@ -3799,7 +3263,7 @@ msgstr ""
 "درخواست شما برای حمایت از زولیپ تایید شده است! سازمان شما به طرح جامعه زولیپ "
 "ارتقا یافته است."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
@@ -3807,20 +3271,20 @@ msgstr ""
 "اگر بتوانید زولیپ را به عنوان یک حامی در وبسایت خود لیست کنید، واقعاً قدردانی "
 "می‌کنیم!"
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr "یافتن حساب‌های شما"
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr "حساب های کاربری خود را پیدا کنید"
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr "ایمیل‌ها ارسال شد! آدرس‌های ارائه شده در صفحه قبل در زیر فهرست شده‌اند:"
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
@@ -3829,7 +3293,7 @@ msgstr ""
 "اگر ایمیلی دریافت نکردید، می‌توانید <a href=\"%(current_url)s\">حساب‌های "
 "کاربری برای ایمیل دیگری را جستجو کنید</a>."
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
@@ -3837,7 +3301,7 @@ msgstr ""
 "ایمیل خود را وارد کنید تا ایمیلی با آدرس‌های سازمان‌های ابری زولیپ دریافت کنید "
 "که در آن‌ها حساب کاربری فعال دارید."
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
@@ -3845,7 +3309,7 @@ msgstr ""
 "ایمیل خود را وارد کنید تا ایمیلی با آدرس‌های سازمان‌های زولیپ روی این سرور "
 "دریافت کنید که در آن‌ها حساب کاربری فعال دارید."
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
@@ -3853,216 +3317,216 @@ msgstr ""
 "اگر کلمه عبور خود را فراموش کرده‌اید می‌توانید <a href=\"/help/change-your-"
 "password\">کلمه عبور جدید تعیین کنید</a>."
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr "آدرس ایمیل"
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "پیدا کردن حساب‌های کاربری"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr "محصول"
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr "چرا زولیپ؟"
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr "ویژگی‌ها"
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr "طرح‌ها و قیمت‌ها"
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Zulip Cloud status"
 msgid "Zulip Cloud"
 msgstr "وضعیت ابر زولیپ"
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr "خود-میزبانی"
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr "امنیت"
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "یکپارچه‌سازی‌ها"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr "برنامه های موبایل و کامپیوتر"
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr "سازمان جدید"
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr "راهکارها"
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr "کسب و کار"
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr "آموزش"
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr "پژوهش"
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr "رویدادها و کنفرانس‌ها"
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr "پروژه‌های متن باز"
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr "انجمن‌ها"
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr "داستان‌های خریداران"
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr "انجمن‌های باز"
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr "منابع"
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr "شروع"
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr "مرکز کمک رسانی"
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr "گفتگوی انجمن"
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr "وضعیت ابر زولیپ"
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr "انتقال به زولیپ"
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr "نصب یک سرور زولیپ"
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr "ارتقا یک سرور زولیپ"
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr "مشارکت"
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr "راهنمای مشارکت"
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr "انجمن توسعه‌دهندگان"
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr "ترجمه"
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr "گیتهاب"
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr "در باره ما"
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr "تیم"
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "تاریخچه"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr "ارزش‌ها"
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr "شغل‌ها"
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr "وبلاگ"
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr "پشتیبانی زولیپ"
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr "Mastodon"
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Values"
 msgid "Bluesky"
 msgstr "ارزش‌ها"
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr "قدرت گرفته از <a href=\"https://zulip.com\">زولیپ</a>"
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr "شرایط سرویس"
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr "سیاست حریم خصوصی"
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr "ارجاعات وب‌سایت"
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr "بیش از %(integrations_count_display)s یکپارچه سازی بومی"
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 #, fuzzy
 #| msgid ""
 #| "And hundreds more through <a href=\"/integrations/doc/zapier\">Zapier</a> "
@@ -4074,51 +3538,47 @@ msgstr ""
 "و صدها مورد بیشتر از طریق <a href=\"/integrations/doc/zapier\">Zapier</a> و "
 "<a href=\"/integrations/doc/ifttt\">IFTTT</a>."
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr "جستجوی یکپارچه‌سازی‌ها"
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr "یکپارچه‌سازی‌های سفارشی"
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr "وب‌هوک‌های ورودی"
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr "ربات‌های تعاملی"
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr "API رست"
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr "ایمیل نامعتبر"
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr "ایمیل مجاز نیست"
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr "آدرس ایمیلی که تلاش می‌کنید با آن ثبت نام کنید، معتبر نیست."
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4129,7 +3589,7 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>، اجازه ثبت نام با استفاده از دامین "
 "ایمیل شما را نمی‌دهد."
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4140,7 +3600,7 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>، اجازه ثبت نام با آدرس‌های ایمیل "
 "یک‌بار مصرف را نمی‌دهد."
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4151,24 +3611,24 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>، اجازه نمی‌دهد با آدرس ایمیل‌های "
 "شامل \"+\" در آن ثبت نام کنید."
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr "لطفاً به کمک یک ایمیل معتبر ثبت نام کنید."
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr "لطفاً به کمک یک آدرس ایمیل مجاز ثبت نام کنید."
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr "سازمانی یافت نشد"
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr "هیچ سازمان زولیپی در <b>%(current_url)s</b> نیست."
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -4179,7 +3639,7 @@ msgstr ""
 "\">لیستی از اکانت‌های زولیپ ابری خود دریافت کنید</a> یا <a href=\"mailto:"
 "%(support_email)s\">با پشتیبانی زولیپ تماس بگیرید</a>."
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -4190,7 +3650,7 @@ msgstr ""
 "\">لیستی از اکانت‌های زولیپ ابری خود دریافت کنید</a> یا <a href=\"mailto:"
 "%(support_email)s\">با ادمین‌های این سرور زولیپ تماس بگیرید</a>."
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
@@ -4199,60 +3659,60 @@ msgstr ""
 "<a href=\"%(current_url)s/serverlogin/\">اینجا کلیک کنید</a> تا به مدیریت "
 "دسترسی‌ها برای سرور زولیپ خود وصل شوید."
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr "جلسه ورود نامعتبر یا منقضی شده است"
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr "سشن ورود نامعتبر است یا منقضی شده."
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr "ورود به زولیپ"
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 "شما هم اکنون با این آدرس ایمیل ثبت نام هستید، لطفا در قسمت پایین وارد شوید."
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr "ایمیل یا نام کاربری"
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "نام کاربری"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr "کلمه عبور خود را فراموش کرده اید؟"
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr "ورود با %(identity_provider)s"
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr "مشاهده بدون حساب کاربری"
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 "هنوز حساب کاربری ندارد؟ برای متصل شدن به این سازمان نیاز دارید که برای شما "
 "دعوتنامه ارسال شود."
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr "مجوزی وجود ندارد"
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr "سازمان الان نمی‌تواند عضو جدیدی قبول کند"
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
@@ -4262,7 +3722,7 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a> متصل شوند چرا که تمام مجوزهای "
 "زولیپ ابری در حال استفاده هستند."
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
@@ -4270,19 +3730,19 @@ msgstr ""
 "لطفاً با فردی که شما را دعوت کرده‌است تماس بگیرید تا تعداد مجوزها را افزایش "
 "دهند، سپس دوباره تلاش کنید."
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr "رد شدن و رفتن به محتوای اصلی"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr "خطای اعتبارسنجی زیردامنه"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr "اعتبارسنجی زیردامنه"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -4296,47 +3756,45 @@ msgstr ""
 "ورود، در این صفحه گیر کرده‌اید احتمالاً به خاطر خطای سرور یا پیکربندی نادرست "
 "آن است."
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 #, fuzzy
 #| msgid "No organization found"
 msgid "Demo organizations disabled"
 msgstr "سازمانی یافت نشد"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr "به‌روزرسانی لازم است"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr "شما نسخه قدیمی زولیپ دسکتاپ را استفاده می‌کنید که دیگر پشتیبانی نمی‌شود."
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 "ویژگی به‌روزرسانی خودکار در این نسخه قدیمی زولیپ دسکتاپ دیگر کار نمی‌کند."
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr "دانلود آخرین نسخه"
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 "شما به حداکثر دفعات مجازی رسیده‌اید که یک کاربر می‌تواند این عملیات را اجرا "
 "کند."
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr "نیازمند لینک ایجاد سازمانی"
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -4348,12 +3806,11 @@ msgstr ""
 "production/multiple-organizations.html\">مستندات</a> ساخت یک سازمان جدید را "
 "ببینید."
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr "لینک ایجاد سازمان نامعتبر است یا منقضی شده است"
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
@@ -4361,11 +3818,11 @@ msgstr ""
 "متاسفانه این یک لینک معتبر برای ساخت سازمان جدید نیست. لطفاً یک <a href=\"/"
 "new/\">لینک جدید</a> بگیرید و دوباره تلاش کنید."
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr "نام‌نویسی غیرمنتظره کارساز زولیپ"
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -4376,17 +3833,16 @@ msgstr ""
 "است. لطفاً برای کمک در حل این مشکل با <a href=\"mailto:"
 "%(support_email)s\">پشتیبانی زولیپ تماس بگیرید</a>."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr "مرورگر پشتیبانی نشده"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr "%(browser_name)s توسط زولیپ پشتیبانی نمی‌شود."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
@@ -4395,7 +3851,7 @@ msgstr ""
 "زولیپ <a href=\"%(supported_browsers_page_link)s\">مروگرهای مدرن</a> را "
 "پشتیبانی می‌کند مانند فایرفاکس، کروم و اج."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
@@ -4403,25 +3859,24 @@ msgstr ""
 "شما همچنین می‌توانید <a href=\"%(apps_page_link)s\">اپ دسکتاپ زولیپ</a> را "
 "استفاده کنید."
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr "حساب کاربری غیر فعال می شود"
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Invalid organization"
 msgid "Finalize organization import"
 msgstr "سازمان نامعتبر است"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Organization moved"
 msgid "Organization import completed!"
 msgstr "سازمان منتقل شد"
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -4429,56 +3884,55 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Select your account"
 msgstr "حساب خود را بسازید"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Create new account"
 msgstr "حساب خود را بسازید"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr "سازمان دوباره با موفقیت فعال شد"
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr "سازمان شما با موفقیت دوباره فعال شد."
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr "لینک دوباره فعالسازی سازمان نامعتبر است یا منقضی شده است"
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr "لینک فعالسازی مجدد سازمان یا منقضی شده است یا نامعتبر است."
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr "ورود به سازمان خودتان"
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr "سازمان شما"
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr "URL سازمان خود را نمی دانید؟"
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr "سازمان خود را پیدا کنید."
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr "بعدی"
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4488,13 +3942,13 @@ msgstr ""
 "اگر هنوز سازمانی ندارید، <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(org_creation_link)s\">یک سازمان جدید بسازید</a>."
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 #, fuzzy
 #| msgid "Self-host Zulip"
 msgid "Self-hosting Zulip?"
 msgstr "زولیپ خود-میزبان"
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, fuzzy, python-format
 #| msgid ""
 #| "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4507,11 +3961,11 @@ msgstr ""
 "اگر هنوز سازمانی ندارید، <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(org_creation_link)s\">یک سازمان جدید بسازید</a>."
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr "تنظیم مجدد کلمه عبورتان"
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
@@ -4519,62 +3973,62 @@ msgstr ""
 "کلمه عبور خود را فراموش کرده‌اید؟ مشکلی نیست، ما یک لینک برای بازنشانی کلمه "
 "عبور به ایمیلی که با آن ثبت نام کرده‌اید، می‌فرستیم."
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr "ارسال لینک تنظیم مجدد"
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr "تنظیم یک کلمه عبور جدید"
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "تایید کلمه عبور"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr "متاسفانه لینکی که دارید یا نامعتبر است یا قبلا استفاده شده است."
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr "کلمه عبور جدید با موفقیت تعیین شد"
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr "شما یک کلمه عبور جدید تعیین کردید!"
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr "لطفا با کلمه عبور جدید خود <a href=\"%(login_url)s\">وارد شوید</a>."
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr "ایمیل بازنشانی کلمه عبور ارسال شد"
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr "تنطیم مجدد کلمه عبور ارسال شد!"
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr "در چند دقیقه آینده ایمیل خود را چک کنید تا فرآیند تکمیل شود."
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 #, fuzzy
 #| msgid "Export still in progress"
 msgid "Import progress"
 msgstr "خروجی گرفتن هنوز در جریان است"
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4582,7 +4036,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4591,60 +4045,60 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 #, fuzzy
 #| msgid ""
 #| "Nobody in this Zulip organization will be able to see this email address."
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr "هیچ کس در این سازمان زولیپ نمی‌تواند این آدرس ایمیل را ببیند."
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4652,7 +4106,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4660,20 +4114,20 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr "انتخاب حساب برای اعتبارسنجی"
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr "<h1 class=\"get-started\"> انتخاب حساب کاربری </h1>"
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr "حساب گیتهاب شما همچنان دارای آدرس‌های ایمیل تأیید نشده مرتبط با آن است."
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
@@ -4681,15 +4135,15 @@ msgstr ""
 "برای استفاده از یکی از اینها برای ورود به زولیپ باید <a href=\"https://"
 "github.com/settings/emails\">با گیتهاب تأیید کنید</a>."
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr "خطا در لغو ثبت‌نام ایمیل"
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr "درخواست لغو عضویت از ایمیل نامشخص"
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
@@ -4697,7 +4151,7 @@ msgstr ""
 "سلام! به نظر می‌رسد که تلاش کرده‌اید از جایی لغو اشتراک کنید، اما ما URL را "
 "تشخیص نمی‌دهیم."
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4708,12 +4162,11 @@ msgstr ""
 "href=\"mailto:%(support_email)s\">به ما ایمیل بزنید</a> تا ما این موضوع را "
 "بررسی کنیم!"
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr "تنظیمات ایمیل به روزرسانی شد"
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
@@ -4722,7 +4175,7 @@ msgstr ""
 "شما با موفقیت از ایمیل‌های %(subscription_type)s زولیپ برای <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a> لغو اشتراک کردید."
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
@@ -4732,50 +4185,49 @@ msgstr ""
 "href=\"%(realm_url)s/#settings/notifications\">تنظیمات اطلاع‌رسانی</a> "
 "بازنگری کنید."
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr "طرح سفارش نامعتبر است."
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr "سوال‌ها و گفتگو‌ها در مورد استفاده از زولیپ."
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr "زولیپ را اینجا تجربه کنید: :test_tube:"
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr "برای مکالمه‌های در سطح تیم"
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr "عضویت‌ها"
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr "{user} به این سازمان وارد شد."
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr "{user} دعوت شما را برای پیوستن به زولیپ پذیرفت!"
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 "نمی توان یک حساب نگهدارنده را فعال کرد. از کاربر بخواهید در عوض، ثبت نام کند."
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 #, fuzzy
 #| msgid "Cannot deactivate user group in use."
 msgid "Cannot reactivate a deleted user"
 msgstr "نمی‌توان گروه کاربری که درحال استفاده است، غیرفعال کرد."
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
@@ -4783,35 +4235,34 @@ msgstr ""
 "شما اجازه ندارید این فیلد را تغییر دهید. برای به‌روزرسانی آن، با یکی از "
 "ادمین‌ها تماس بگیرید."
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr "فیلد شناسه {id} یافت نشد."
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr "نام نامعتبر برای گروه پیش‌فرض کانال  '{group_name}'"
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr "نام گروه کانال پیش‌فرض بسیار طولانی است (محدودیت: {max_length} کاراکتر)"
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr "نام گروه پیش‌فرض کانال '{group_name}' شامل کاراکترهای نال (0x00) است."
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr "نامعتبر بودن گروه پیش‌فرض کانال {group_name}"
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
@@ -4819,12 +4270,12 @@ msgstr ""
 "کانال '{channel_name}' یک کانال پیش‌فرض است و نمی‌تواند به '{group_name}' "
 "اضافه شود"
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr "گروه پیش‌فرض کانال با نام '{group_name}' از قبل گرفته شده است"
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
@@ -4833,7 +4284,7 @@ msgstr ""
 "کانال '{channel_name}' در حال حاضر در گروه کانال پیش‌فرض '{group_name}' وجود "
 "دارد"
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
@@ -4842,12 +4293,12 @@ msgstr ""
 "کانال '{channel_name}' در حال حاضر در گروه کانال پیش‌فرض '{group_name}' وجود "
 "ندارد"
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr "نام این گروه پیش‌فرض کانال از قبل '{group_name}' بوده است"
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
@@ -4855,7 +4306,7 @@ msgstr ""
 "برای محافظت کاربران، زولیپ تعدا دعوتنامه‌ای را که در یک روز می‌توانید بفرستید، "
 "محدود کرده است. چون به این محدودیت رسیده‌اید هیچ دعوتنامه‌ای ارسال نشد."
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
@@ -4863,75 +4314,75 @@ msgstr ""
 "حساب کاربری شما جدیدا ايجاد شده است و نمی‌توانید در این سازمان دعوت ارسال "
 "کنید. از یک ادمین سازمان یا یک کاربر با تجربه تر بخواهید."
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr "برخی از ایمیل ها معتبر نیستند، بنابراین هیچ دعوتی ارسال نشد."
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr "دیگر نمی توانیم بیش از این دعوت داشته باشیم."
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr "تغییری وجود ندارد"
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr "پیام‌های مستقیم نمی‌توانند به کانال‌ها منتقل شوند."
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr "پیام مستقیم نمی‌تواند موضوع داشته باشد."
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr "propagate_mode بدون ویرایش موضوع نامعتبر است"
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr "گفت‌وگوی عمومی را نمی‌توان به عنوان حل‌شده علامت‌گذاری کرد"
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr "محتوای پیام، در هنگام تغییر کانال، قابل تغییر نیست"
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr "ابزارک‌ها قابل اصلاح نیستند."
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr "سازمان شما ویرایش پیام را غیرفعال کرده است"
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr "شما دسترسی ویرایش این پیام را ندارید"
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr "محدوده زمان ویرایش این پیام گذشته است"
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr "{user} این موضوع را به حل شده تبدیل کرد."
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr "{user} این موضوع را به حل‌نشده تبدیل کرد."
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr "این موضوع توسط {user} به {new_location} جابجا شده‌است."
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr "یک پیام از این موضوع توسط {user} به {new_location} منتقل شد."
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
@@ -4940,18 +4391,18 @@ msgstr ""
 "تعداد {changed_messages_count} پیام از این موضوع توسط {user} به "
 "{new_location} منتقل شد."
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr "این موضوع توسط {user} از {old_location} جابجا شده‌است."
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 msgstr "[یک پیام]({message_link}) توسط {user} از  {old_location} جابجا شد."
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
@@ -4960,69 +4411,66 @@ msgstr ""
 "تعداد {changed_messages_count} پیام توسط  {user} از  {old_location} به اینجا "
 "منتقل شد."
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 #, fuzzy
 #| msgid "You do not have permission to post in this channel."
 msgid "You don't have permission to resolve topics in this channel."
 msgstr "شما اجازه ندارید در این کانال پست ارسال کنید."
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr "محدوده زمانی برای ویرایش موضوع این پیام گذشته است."
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr "شما اجازه ندارید این پیام را جابجا کنید"
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr "محدوده زمانی برای ویرایش کانال این پیام گذشته است"
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr "پرچم نامعتبر: '{flag}'"
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr "پرچم‌ غیر قابل اصلاح: '{flag}'"
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr "عملکرد پرچم پیام نامعتبر است: '{operation}'"
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr "پیام‌(های) نامعتبر"
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr "امکان پردازش پیام وجود ندارد"
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr "فقط دقیقاً یک کانال مورد انتظار بود"
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr "نوع داده نامعتبر برای کانال"
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr "نوع داده برای گیرندگان نامعتبر است"
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 "فهرست گیرندگان ممکن است شامل یکی از دو مورد ایمیل یا شناسه کاربری باشد، نه "
 "هردو آنها."
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
@@ -5031,7 +4479,7 @@ msgstr ""
 "ربات شما {bot_identity} سعی کرده پیامی به کانال با شناسه {channel_id} ارسال "
 "کند، اما کانالی با آن شناسه وجود ندارد."
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -5042,7 +4490,7 @@ msgstr ""
 "بفرستد، اما این کانال وجود ندارد. [اینجا]({new_channel_link}) کلیک کنید تا "
 "این کانال ایجاد شود."
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
@@ -5051,30 +4499,30 @@ msgstr ""
 "ربات شما {bot_identity} سعی کرده پیامی به کانال {channel_name} ارسال کند. "
 "کانال وجود دارد اما هیچ مشترکی ندارد."
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr "شما اجازه ندارید به برخی گیرندگان دسترسی داشته باشید."
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr "گجت ها: API برنامه نویسی، محتوای Json نامعتبری ارسال کرده است"
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr "ابزارک‌ها: {error_msg}"
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, fuzzy, python-brace-format
 #| msgid "{user_name} created the following channels: {new_channels}."
 msgid "{user} has made the following changes to your account."
 msgstr "{user_name} این کانال‌‌ها را ایجاد کرد: {new_channels}."
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5082,25 +4530,23 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr "یک ایموجی سفارشی با این نام قبلا تعریف شده است."
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr "فرمت تصویر نامعتبر"
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr "لیست مرتب‌شده نباید حاوی پیونددهنده تکراری باشد"
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr "لیست مرتب شده باید تمام پیونددهنده‌های موجود را دقیقاً یک بار شمارش کند"
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
@@ -5109,39 +4555,39 @@ msgstr ""
 "لازم است که شما به طرح {required_upgrade_plan_name} ارتقا بدهید تا بتوانید "
 "از این روش اعتبارسنجی استفاده کنید."
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr "روش اعتبارسنجی نامعتبر: {name}. روش‌های معتبر عبارتند از: {methods}"
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr "روش اعتبارسنجی {name} در طرح جاری شما در دسترس نیست."
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr "کانال درخواست مدیریت باید خصوصی باشد."
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr "قطعه کد ذخیره شده وجود ندارد."
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr "پیام برنامه‌ریزی شده قبلاً ارسال شده‌است"
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder could not be sent."
 msgstr "توکن وجود ندارد"
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr "پیام نمی‌تواند در زمان برنامه‌ریزی شده ارسال شود."
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
@@ -5150,40 +4596,40 @@ msgstr ""
 "پیامی که برای {delivery_datetime} برنامه‌ریزی کرده بودید به دلیل خطای زیر "
 "ارسال نشد:"
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr "[مشاهده پیام‌های برنامه‌ریزی شده](#scheduled)"
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr "این کانال قبلاً غیرفعال شده‌است"
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, fuzzy, python-brace-format
 #| msgid "Channel {channel_name} has been archived."
 msgid "Channel #**{channel_name}** has been archived."
 msgstr "کانال  {channel_name} بایگانی شده‌است."
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr "کانال در حال حاضر غیرفعال نیست"
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr "کانال با نام {channel_name}  وجود دارد"
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr "کانال خصوصی است و مشترکی ندارد"
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, fuzzy, python-brace-format
 #| msgid "Channel {channel_name} has been archived."
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr "کانال  {channel_name} بایگانی شده‌است."
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
@@ -5192,7 +4638,7 @@ msgstr ""
 "{user} برای این کانال [مجوزهای دسترسی]({help_link}) را از **{old_policy}** "
 "به  **{new_policy}** تغییر داد."
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -5205,42 +4651,40 @@ msgstr ""
 "* **قدیم**: {old_setting_description}\n"
 "* **جدید**: {new_setting_description}\n"
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 "{user_name} نام کانال را از  {old_channel_name} به {new_channel_name} تغییر "
 "داد."
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr "بدون توضیح"
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr "{user} شرح این کانال را تغییر داد."
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr "شرح قدیمی"
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr "شرح جدید"
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr "همیشگی"
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr "{number_of_days} روز"
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
@@ -5249,11 +4693,11 @@ msgstr ""
 "پیام‌های این کانال الان به صورت اتوماتیک پس از {number_of_days} روز پس از "
 "ارسال آن‌ها، حذف خواهند شد."
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr "پیام‌های موجود در این کانال اکنون برای همیشه حفظ خواهند شد."
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -5270,99 +4714,89 @@ msgstr ""
 "\n"
 "{summary_line}"
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr "شما نمی‌توانید یک زیرپیام به این پیام متصل کنید."
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr "شناسه کاربری نامعتبر {user_id}"
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr "گروه کاربری '{group_name}' از قبل وجود دارد"
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr "دسترسی کافی ندارید"
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr "این API برای ربات های با وب هوک ورودی امکان پذیر نیست."
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr "حساب کاربری ارتباطی با زیردامنه ندارد"
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr "این پایانه درخواست های ربات ها را قبول نمی کند"
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr "باید یک ادمین سرور باشید"
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr "این پایانه نیاز به احراز هویت پایه ای HTTP دارد."
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr "هدر مجوز برای احراز هویت پایه ای نامعتبر است"
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr "فاقد هدر مجوز برای احراز هویت پایه ای است"
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr "ربات های وب هوک تنها می توانند به وب هوک ها دسترسی داشته باشند"
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr "ایمیل یا کلمه عبور نادرست"
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
@@ -5371,51 +4805,50 @@ msgstr ""
 "حساب کاربری شما {username} غیر فعال شده است. لطفاً برای فعال کردن مجدد آن با "
 "ادمین سازمان تماس بگیرید."
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr "کلمه عبور بسیار ضعیف است."
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr "طول زیردامنه باید 3 یا بیشتر باشد."
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr "زیردامنه نمی‌تواند با '-' شروع شود."
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr "زیردامنه تنها می‌تواند شامل حروف کوچک، اعداد و '-' باشد."
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr "زیردامنه الان در حال استفاده است. لطفا یکی دیگر را انتخاب کنید."
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr "زیردامنه محفوظ است. لطفا یکی دیگر را انتخاب کنید."
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr "لطفا از آدرس ایمیل واقعی خود استفاده کنید."
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr "سازمانی که قصد عضویت در آن با استفاده از {email} را دارید وجود ندارد."
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr "لطفاً از ادمین سازمان درخواست یک دعوت برای {email} کنید."
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
@@ -5424,11 +4857,11 @@ msgstr ""
 "آدرس ایمیل شما، {email}، در هیچکدام از دامنه‌های تعریف شده برای ثبت نام حساب "
 "های کاربری در این سازمان، نیست."
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr "آدرس‌های ایمیل شامل + در این سازمان مجاز نیستند."
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
@@ -5438,34 +4871,33 @@ msgstr ""
 "استفاده شده‌اند. لطفاً با کسی که شما را دعوت کرده است تماس بگیرید و بخواهید که "
 "تعداد مجوزها را افزایش دهند، سپس دوباره تلاش کنید."
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 #, fuzzy
 #| msgid "Embedded bots are not enabled."
 msgid "Challenges are not enabled."
 msgstr "ربات های تعبیه شده فعال نیستند."
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "کلمه عبور جدید"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr "تأیید کلمه عبور جدید"
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "You're making too many attempts to sign in. Try again in {seconds} "
@@ -5477,7 +4909,7 @@ msgstr ""
 "شما دفعات زیادی برای ورود به سیستم تلاش کردید. بعد از {seconds} دوباره "
 "امتحان کنید یا برای دریافت راهنمایی با ادمین سازمان خود تماس بگیرید."
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
@@ -5485,95 +4917,93 @@ msgstr ""
 "کلمه عبور شما غیرفعال شده است چرا که بیش از حد ساده بود. کلمه عبور خود را "
 "بازنشانی کنید و یک کلمه عبور جدید تعیین کنید."
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr "توکن"
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 "راهنما: شما می‌توانید چندین آدرس ایمیل را که با ویرگول جدا شده باشند وارد "
 "کنید."
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr "لطفا حداکثر 10 ایمیل وارد کنید."
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr "ما نمی‌توانیم این سازمان زولیپ را پیدا کنیم."
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr "ایمیل نامعتبر '{email}'"
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr "موضوع وجود ندارد"
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr "امکان ارسال به چند کانال وجود ندارد"
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr "کانال گمشده"
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr "پیام باید دریافت کننده داشته باشد"
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr "نوع پیام اشتباه است"
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr "پیوست اشتباه است"
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr "هنگام حذف پیوست خطایی رخ داد. لطفا بعدا دوباره تلاش کنید."
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr "پیام باید دریافت کننده داشته باشد!"
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Channel name can't be empty."
 msgid "Channel folder name can't be empty."
 msgstr "نام کانال نمی‌تواند خالی باشد."
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid character in channel name, at position {position}."
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr "کاراکترهای نامعتبر در نام کانال، در موقعیت {position}."
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Channel name is already in use."
 msgid "Channel folder name already in use"
 msgstr "نام کانال قبلاً استفاده شده‌است."
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Invalid channel ID"
 msgid "Invalid channel folder ID"
 msgstr "شناسه نامعتبر کانال"
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 #, fuzzy
 #| msgid "Confirm your email address"
 msgid "Configure owner account email address."
 msgstr "آدرس ایمیل خود را تایید کنید"
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "\n"
@@ -5590,72 +5020,72 @@ msgstr ""
 "توجه کنید که این یک [سازمان آزمایشی]({demo_organization_help_url}) است و \n"
 "ظرف 30 روز **به صورت خودکار حدف می‌شود**.\n"
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a date"
 msgid "{var_name} is not Base64 encoded"
 msgstr "{var_name} یک تاریخ نیست"
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 #, fuzzy
 #| msgid "Invalid emoji code."
 msgid "Invalid `device_id`"
 msgstr "کد ایموجی اشتباه است."
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr "خلاصه {service_name}"
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr "دامنه نمی‌تواند خالی باشد."
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr "دامنه باید حداقل یک نقطه (.) داشته باشد."
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr "دامنه خیلی طولانی است"
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr "دامنه نمی‌تواند با یک نقطه (.) شروع یا ختم شود"
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr "'.' های متوالی مجاز نیستند."
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr "زیردامنه‌ها نمی‌توانند با یک '-' شروع یا ختم شوند."
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr "دامنه تنها می‌تواند شامل حروف، اعداد، '.' و '-' ها باشد."
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr "مهر زمانی نباید منفی باشد."
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr "موضوع نباید حاوی بایت نال باشد"
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr "باید دقیقاً 1 شناسه کانال برای پیام های کانال مشخص شود"
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr "کاربر همگام‌سازی پیش نویس‌ها را غیرفعال کرده است."
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr "پیش‌نویس وجود ندارد"
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5666,86 +5096,86 @@ msgstr ""
 "ایمیلی:\n"
 "{error_message}"
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr "ایمیل بدون موضوع"
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr "برای دیدن محتوای اسپویلر، زولیپ را باز کنید"
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr "اطلاع‌رسانی‌های {service_name}"
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr "آدرس نامعتبر است."
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr "خارج از دامنه شما است."
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr "آدرس های ایمیل شامل + مجاز نیستند."
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr "برای ربات‌های سیستم رزرو شده است."
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr "ایمیل {email} یک حساب کاربری دارد"
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr "قبلاً یک حساب کاربری دارد."
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr "حساب کاربری غیر فعال شده است."
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr "ایموجی '{emoji_name}' موجود نیست"
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr "ایموجی سفارشی اشتباه است."
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr "نام ایموجی سفارشی اشتباه است."
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr "این ایموجی سفارشی غیر فعال شده است."
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr "کد ایموجی اشتباه است."
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr "نام ایموجی اشتباه است."
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr "نوع ایموجی اشتباه است."
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr "باید یک ادمین سازمان یا مالک ایموجی باشید"
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr "نام ایموجی‌ها باید با یک حرف یا یک عدد تمام شود"
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
@@ -5753,119 +5183,118 @@ msgstr ""
 "نام ایموجی ها باید فقط شامل حروف کوچک انگلیسی، اعداد، فاصله، خط تیره و زیرخط "
 "باشد."
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr "نام ایموجی گم شده است"
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr "امکان تخصیص صف برای رویداد وجود ندارد"
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr "در سامانه نیستید: احراز هویت API یا نشست کاربر لازم است"
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, fuzzy, python-brace-format
 #| msgid "Channel named {channel_name} already exists"
 msgid "Channel '{channel_name}' already exists"
 msgstr "کانال با نام {channel_name}  وجود دارد"
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr "کانال '{stream}' وجود ندارد"
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr "کانال با شناسه '{stream_id}' وجود ندارد"
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr "ترکیب پشتیبانی‌نشده پارمتر‌ها: {parameters}"
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr "مالک سازمان"
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr "کاربر"
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr "امکان غیر فعال کردن تنها {entity} وجود ندارد"
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr "مارک‌داون نامعتبر در بیانیه وجود دارد:‌ {include_statement}"
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr "Json نادرست"
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr "باید یک ادمین سازمان باشید"
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr "باید یک مالک سازمان باشد"
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Must be an organization owner"
 msgid "Must be a bot user"
 msgstr "باید یک مالک سازمان باشد"
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr "نام کاربری یا کلمه عبور شما صحیح نیست"
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr "این سازمان غیرفعال شده است"
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr "ثبت نام سرویس اعلان فشاری موبایل برای سرور شما غیرفعال شده است"
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr "اعتبارسنجی کلمه عبور در این سازمان غیرفعال شده است"
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr "کلمه عبور شما غیرفعال شده و باید دوباره تعیین شود"
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr "کلید API اشتباه"
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr "کلید API نادرست"
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
@@ -5874,57 +5303,56 @@ msgstr ""
 "رویداد '{event_type}' در حال حاضر توسط وب هوک {webhook_name} پشتیبانی "
 "نمی‌شود. نادیده گرفتن"
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 "تجزیه درخواست ممکن نیست: آیا {webhook_name} این رویداد را ایجاد کرده است؟"
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr "کاربر اعبتارسنجی نشد"
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr "زیردامنه نامعتبر است"
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr "شما مجوز ندارید تا مکالمات پیام مستقیم را شروع کنید."
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr "پیام‌های مستقیم در این سازمان غیر فعال شده‌اند."
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr "این مکالمه شامل هیچ کاربری نمی شود که بتواند آن را مجاز کند."
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr "دسترسی محدود"
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
@@ -5933,15 +5361,15 @@ msgstr ""
 "شما فقط مجاز هستید که {total_messages_in_topic}/"
 "{total_messages_allowed_to_move} پیام اخیر در این موضوع را جابجا کنید."
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr "واکنش هم اکنون وجود دارد."
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr "واکنش وجود ندارد"
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
@@ -5949,366 +5377,366 @@ msgstr ""
 "سازمان شما در یک سرور زولیپ متفاوت ثبت شده است. لطفاً برای کمک در حل این مشکل "
 "با پشتیبانی زولیپ تماس بگیرید."
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr "سازمان ثبت نشد"
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr "شما اجازه استفاده از اشاره‌های وایلدکارت را در این کانال ندارید."
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr "شما اجازه استفاده از اشاره‌های وایلدکارت را در این موضوع ندارید."
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, fuzzy, python-brace-format
 #| msgid "'old' value does not match the expected value."
 msgid "'{field_name}' value does not match the expected value."
 msgstr "مقدار قدیمی با مقدار مورد انتظار مطابقت ندارد."
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr "'{setting_name}' باید یک گروه کاربری سیستمی باشد."
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr "نمی‌توان گروه کاربری که درحال استفاده است، غیرفعال کرد."
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr "شما مجوز مدیریت این کانال را ندارید."
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr "شما اجازه تغییر کانال‌های پیش‌فرض را ندارید."
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr "ایمیل در حال استفاده است"
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr "برنامه‌ریزی زمان ارسال باید در آینده باشد."
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr "encrypted_push_registration نامعتبر است"
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Server doesn't use the push notification service"
 msgid "Server is not configured to use push notification service."
 msgstr "سرور از سرویس اعلان فشاری استفاده نمی‌کند"
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Already has an account."
 msgid "Atlassian account ID"
 msgstr "قبلاً یک حساب کاربری دارد."
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Behance username"
 msgstr "نام یا نام کاربری نادرست است"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Bitbucket username"
 msgstr "نام کاربری گیتهاب"
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Codeberg username"
 msgstr "نام کاربری توییتر"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Dribbble username"
 msgstr "نام کاربری گیتهاب"
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Facebook username"
 msgstr "نام یا نام کاربری نادرست است"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr "نام کاربری گیتهاب"
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "GitLab username"
 msgstr "نام کاربری گیتهاب"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Instagram username"
 msgstr "نام کاربری توییتر"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Mastodon"
 msgid "Mastodon profile"
 msgstr "Mastodon"
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Medium username"
 msgstr "نام کاربری گیتهاب"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Pinterest username"
 msgstr "نام کاربری توییتر"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Reddit username"
 msgstr "نام کاربری گیتهاب"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Snapchat username"
 msgstr "نام کاربری گیتهاب"
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Threads username"
 msgstr "نام کاربری توییتر"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "TikTok username"
 msgstr "نام کاربری توییتر"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Twitch username"
 msgstr "نام کاربری توییتر"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "نام کاربری"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr "نوع حساب کاربری خارجی نامعتبر است"
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr "چارچوب‌های یکپارچه‌سازی"
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 #, fuzzy
 #| msgid "Video call ended"
 msgid "Video calling"
 msgstr "تماس ویدئویی تمام شد"
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr "یکپارچه سازی پیوسته"
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr "پشتیبانی مشتری"
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr "استقرار"
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr "سرگرمی"
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr "ارتباط"
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr "مالی"
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr "منابع انسانی"
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr "بازاریابی"
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr "متفرقه"
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr "رصدکردن"
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr "مدیریت پروژه"
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr "بهره وری"
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr "کنترل نسخه"
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr "پیام نباید خالی باشد"
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr "پیام نباید شامل بایت های نال (خالی) باشد"
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr "شما اجازه ندارید به گروه کاربری '{user_group_name}' اشاره کنید."
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{fullname} moderation"
 msgstr "{full_name} به شما اشاره کرده:"
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr "عملگر محدودسازی اشتباه است: {desc}"
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr "ترکیب اپراتورهای محدود‌کننده نامعتبر است: {desc}"
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr "اپراتور 'with' دوبار استفاده شده"
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr "اپراتور  'with'  نامعتبر است"
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr "مقدار 'anchor' موجود نیست."
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 #, fuzzy
 #| msgid "Missing 'anchor' argument."
 msgid "Missing 'anchor_date' argument."
 msgstr "مقدار 'anchor' موجود نیست."
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr "لنگر نامعتبر"
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr "اپراتور {operator} پشتیبانی نمی‌شود."
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr "اپراتور {operand} پشتیبانی نمی‌شود."
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 #, fuzzy
 #| msgid "Confirmation link does not exist"
 msgid "Navigation view does not exist."
 msgstr "لینک تایید وجود ندارد"
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6319,7 +5747,7 @@ msgstr ""
 "برای آشنایی بیشتر، [راهنمای استفاده از زولیپ برای کلاس]"
 "({getting_started_url}) را نگاه کنید!\n"
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6329,7 +5757,7 @@ msgstr ""
 "\n"
 "برای آشنایی بیشتر، [راهنمای شروع]({getting_started_url}) را نگاه کنید!\n"
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6340,7 +5768,7 @@ msgstr ""
 "ما همچنین راهنمایی برای [راه‌اندازی زولیپ برای یک کلاس]"
 "({organization_setup_url}) داریم.\n"
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6351,7 +5779,7 @@ msgstr ""
 "ما همچنین راهنمایی برای [انتقال سازمان خودتان به زولیپ]"
 "({organization_setup_url}) داریم.\n"
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "\n"
@@ -6369,7 +5797,7 @@ msgstr ""
 "توجه کنید که این یک [سازمان آزمایشی]({demo_organization_help_url}) است و \n"
 "ظرف 30 روز **به صورت خودکار حدف می‌شود**.\n"
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
@@ -6379,7 +5807,7 @@ msgstr ""
 "من برای کمک به شروع، چند مکالمه را آماده کرده‌ام. می‌توانی\n"
 "آن‌ها را در [صندوق ورودی](/#inbox) خود، پیدا کنی.\n"
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6390,7 +5818,7 @@ msgstr ""
 "شما همیشه می‌توانید برای مرور سریع، به [ویدیوی یه زولیپ خوش آمدید]"
 "({navigation_tour_video_url}) برگردید.\n"
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6414,7 +5842,7 @@ msgstr ""
 "{demo_organization_text}\n"
 "\n"
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
@@ -6424,7 +5852,7 @@ msgstr ""
 "می‌توانید [برنامه‌های موبایل و دسک‌تاپ](/apps/) را [دانلود کنید](/apps/).\n"
 "زولیپ همچنین در یک مرورگر عالی کار می‌کند.\n"
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -6436,7 +5864,7 @@ msgstr ""
 "پروفایل](#settings/profile)\n"
 "بروید و [اطلاعات پروفایل](/help/edit-your-profile) خود را ویرایش کنید.\n"
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -6455,7 +5883,7 @@ msgstr ""
 "را\n"
 "در [اولویت‌ها](#settings/preferences)ی شخصی خود تغییر دهید.\n"
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6472,7 +5900,7 @@ msgstr ""
 "\n"
 "[کانال‌ها را مرور کنید و مشترک شوید]({settings_link}).\n"
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -6501,7 +5929,7 @@ msgstr ""
 "[مکالمات اخیر](#recent) را نگاه کنید تا فهرستی از موضوعات در جریان را \n"
 "ببینید.\n"
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -6517,7 +5945,7 @@ msgstr ""
 "علامت `?` را هر زمان که فشار دهید یک [برگه تقلب](#keyboard-shortcuts) صفحه "
 "کلید را خواهید دید.\n"
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -6536,7 +5964,7 @@ msgstr ""
 "[برگه تقلب](#message-formatting) را ببینید تا بیشتر با لو‌دهنده‌ها، \n"
 "زمان‌های جهانی و چیزهای دیگر آشنا شوید.\n"
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "\n"
@@ -6557,7 +5985,7 @@ msgstr ""
 "[راهنمای شروع](/help/getting-started-with-zulip) را نگاه کنید,\n"
 "یا [مرکز کمک](/help/)  را برای یادگرفتن بیشتر، مرور کنید!\n"
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6568,7 +5996,7 @@ msgstr ""
 "هر چقدر که بخواهید می‌توانید با من گفتگو کنید! برای\n"
 "دریافت کمک، یکی از پیام‌های زیر را امتحان کنید: {bot_commands}\n"
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6587,7 +6015,7 @@ msgstr ""
 "یا [جابجایی موضوع به کانال دیگر]({move_content_another_channel_help_url})، "
 "ساده است.\n"
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
@@ -6596,7 +6024,7 @@ msgstr ""
 ":point_right: تلاش کنید این پیام را به موضوع دیگری انتفال دهید و دوباره "
 "برگردانید.\n"
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6620,12 +6048,11 @@ msgstr ""
 " قرار دارد همانطور که در در منوی کناری و در بالا \n"
 "مشاهده می‌کنید.\n"
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr "به زولیپ خوش آمدید!"
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -6637,7 +6064,7 @@ msgstr ""
 "خودش،\n"
 "فارغ از اینکه چند مکالمه دیگر در جریان باشد.\n"
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
@@ -6647,7 +6074,7 @@ msgstr ""
 ":point_right: وقتی آماده بودید، [صندوق ورودی](/#inbox) خود را برای سایر\n"
 "مکالمات با پیام‌های خوانده نشده، کنترل کنید.\n"
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -6658,7 +6085,7 @@ msgstr ""
 "برای شروع یک مکالمه جدید، یک کانال را در نوار کناری سمت چپ انتخاب کنید و \n"
 "روی دکمه `+` کنار نام آن کلیک کنید..\n"
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -6670,7 +6097,7 @@ msgstr ""
 "کردن این جمله فکر کنید:\n"
 " “سلام، می‌توانیم در مورد ... صحبت کنیم؟”\n"
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
@@ -6678,7 +6105,7 @@ msgstr ""
 "\n"
 ":point_right: تلاش کنید در این کانال یک مکالمه شروع کنید..\n"
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6689,7 +6116,7 @@ msgstr ""
 ":point_right:  از این موضوع برای آزمایش [ویژگی‌های پیام‌رسانی زولیپ]"
 "({format_message_help_url}) استفاده کنید.\n"
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6724,7 +6151,7 @@ msgstr ""
 "\n"
 "```\n"
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
@@ -6734,7 +6161,7 @@ msgstr ""
 "این موضوع **خوش‌آمدگویی** جای فوق‌العاده‌ای برای “سلام” کردن و  :wave: با تیم "
 "است.\n"
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
@@ -6744,902 +6171,884 @@ msgstr ""
 ":point_right: بر روی این پیام کلیک کنید تا یک پیام جدید در همان مکالمه شروع "
 "شود.\n"
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr "جابجایی پیام‌ها"
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr "تجربیات"
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr "شروع یک مکالمه"
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr "خوشامدگویی‌ها"
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr "جیسون نامعتبر در پاسخ"
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr "فرمت پاسخ نامعتبر"
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr "طول توکن نادرست است یا توکن خالی است"
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr "توکن APNS اشتباه است"
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr "گزینه GCM نامعتبر برای bouncer: اولویت {priority!r}"
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr "گزینه‌های GCM نامعتبر برای بانسر:  {options}"
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr "توکن وجود ندارد"
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr "{full_name} به @{user_group_name} اشاره کرده:"
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr "{full_name} به شما اشاره کرده:"
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr "{full_name} به همه اشاره کرده:"
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "پیام جدید"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr "اعلان آزمایشی"
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr "این یک اعلان آزمایشی از طرف {realm_name} ({realm_url}) است."
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr "دستگاه شناسایی نشد"
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr "دستگاه توسط push bouncer شناسایی نشد"
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 #, fuzzy
 #| msgid "Server doesn't use the push notification service"
 msgid "Network error while connecting to Zulip push notification service."
 msgstr "سرور از سرویس اعلان فشاری استفاده نمی‌کند"
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 #, fuzzy
 #| msgid "Server doesn't use the push notification service"
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr "سرور از سرویس اعلان فشاری استفاده نمی‌کند"
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 #, fuzzy
 #| msgid "Invalid API key"
 msgid "Invalid `push_key`"
 msgstr "کلید API اشتباه"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr "داده نامعتبر برای شناسه کانال"
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr "کاربر اجازه این درخواست را ندارد"
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr "'{email}' دیگر از زولیپ استفاده نمی‌کند."
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr "شما نمی‌توانید پیام های مستقیم را خارج از سازمان خود ارسال کنید."
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "Channel name too long (limit: {max_length} characters)."
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr "نام کانال بیش از حد طولانی است (محدودیت:‌ {max_length} کاراکتر)."
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder does not exist"
 msgstr "توکن وجود ندارد"
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr "خطای bouncer اعلان فشاری: {error}"
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr "امکان تشخیص بین آرگومان های '{var_name1}' و '{var_name2}' وجود ندارد"
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr "آرگومان '{var_name}' خالی است"
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr "مقدار '{var_name}' نادرست است: {bad_value}"
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr "پیام برنامه‌ریزی شده وجود ندارد"
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr "امنیت اکانت {service_name}"
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr "یک کانال پیش‌فرض نمی‌تواند خصوصی باشد."
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr "کانال‌های عمومی وب فعال نیستند."
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr "شما اجازه ندارید در این کانال پست ارسال کنید."
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr "برای ارسال مطلب در کانال '{channel_name}' تایید اعتبار نشده است"
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 #, fuzzy
 #| msgid "You do not have permission to post in this channel."
 msgid "You do not have permission to create new topics in this channel."
 msgstr "شما اجازه ندارید در این کانال پست ارسال کنید."
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr "شناسه نامعتبر کانال"
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr "نام نامعتبر برای کانال '{channel_name}'"
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr "کانال(ها) ({channel_names}) وجود ندارند"
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr "گروه کانال پیش‌فرض با شناسه '{group_id}' وجود ندارد."
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr "نام کانال نمی‌تواند خالی باشد."
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr "نام کانال بیش از حد طولانی است (محدودیت:‌ {max_length} کاراکتر)."
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr "کاراکترهای نامعتبر در نام کانال، در موقعیت {position}."
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr "کاراکتر نامعتبر در نام موضوع وجود دارد، در موقعیت {position}!"
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr "داده‌های مشترکین این کانال در دسترس نیست"
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr "گرفتن مخاطبان کانال خصوصی امکان‌پذیر نبود"
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr "امکان بازکردن تصویر وجود ندارد؛ آیا یک فایل تصویری بارگذاری کردید؟"
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr "اندازه تصویر بیش از حدمجاز است."
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr "تصویر خراب یا کوتاه شده است"
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr "{var_name} یک مقدار بولی نیست"
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} does not have a length"
 msgid "{var_name} does not have the expected format"
 msgstr "{var_name} یک طول مشخص ندارد"
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr "{var_name} یک تاریخ نیست"
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr "{var_name} یک دیکشنری نیست"
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr "{var_name} نامعتبر"
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr "آرگومان \"{argument}\" در  {var_name} غیرمنتظره است"
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr "{var_name} عدد اعشاری نیست"
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr "{var_name} زیادی کوتاه است"
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr "{var_name} عدد صحیح نیست"
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr "{var_name} یک جیسون معتبر نیست"
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr "{var_name} زیادی بلند است"
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr "{var_name} یک لیست نیست"
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr "{var_name} خیلی طولانی است (محدودیت: {max_length} کاراکتر)"
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr "{var_name} بسیار کوتاه است."
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr "{var_name} یک رشته حروف نیست"
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr "{var_name} دارای فرمت نامعتبر است"
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr "{var_name} به طول {length} نیست"
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr "{var_name} خیلی طولانی است (محدودیت: {max_length} کاراکتر)"
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr "{var_name} خیلی طولانی است (محدودیت: {max_length} کاراکتر)"
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr "{var_name} نمی‌تواند خالی باشد"
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr "نامعتبر {var_name}: {msg}"
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr "فیلد {var_name} پیدا نشد: {msg}"
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr "بارگذاری بدشکل"
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr "در لیست مقادیر مجاز، موجود نیست"
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr "یک URL نیست"
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr "منطقه زمانی شناخته شده ای نیست"
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr "{var_name} یک کد رنگ هگز معتبر نیست"
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr "{setting_name} نامعتبر"
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr "بارگذاری از حد تعیین شده برای سازمان بیش تر است."
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr "ابعاد تصویر از حد لازم بزرگتر است"
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr "گروه کاربری غیر فعال شده است."
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr "گروه کاربر اشتباه است"
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid user group ID: {group_id}"
 msgid "Invalid user group ID: {user_group_id}"
 msgstr "شناسه گروه کاربری نامعتبر: {group_id}"
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr "نام گروه سیستمی، نامعتبر است."
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr "شناسه گروه کاربری نامعتبر: {group_id}"
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr "تنظیم '{setting_name}' را نمی‌توان روی گروه 'role:internet' تنظیم کرد."
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr "تنظیم '{setting_name}' را نمی‌توان روی گروه 'role:nobody' تنظیم کرد."
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr "تنظیم '{setting_name}' را نمی‌توان روی گروه 'role:everyone' تنظیم کرد."
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr "تنظیم '{setting_name}' را نمی‌توان روی گروه  '{group_name}'  تنظیم کرد."
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr "گروه کاربری نمی‌تواند خالی باشد!"
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr "نام گروه نمی‌تواند از {max_length} کاراکتر فراتر رود."
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr "نام گروه نمی‌تواند با کاراکتر '{prefix}' آغاز شود."
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr "کلاینت هیچ مقدار جدیدی وارد نکرده است."
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 "اگر مشتری emoji_code یا reagim_type را ارسال کند، باید emoji_name را هم "
 "ارسال کند."
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr "نام خیلی طولانی است!"
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 #, fuzzy
 #| msgid "Message must not be empty"
 msgid "Name must not be empty!"
 msgstr "پیام نباید خالی باشد"
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr "کاراکترهای اشتباه در نام وجود دارد!"
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr "فرمت نامعتبر!"
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr "نام‌های منحصربفرد در این سازمان ضروری هستند."
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr "نام قبلا استفاده شده است."
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr "نام یا نام کاربری نادرست است"
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr "ادغام نامعتبر '{integration_name}'."
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr "پارامتر‌های گمشده پیکربندی:‌ {keys}"
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr "خطای کلید {key} مقدار {value} نامعتبر ({error})"
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr "اطلاعات پیکربندی اشتباه است!"
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr "نوع ربات اشتباه است"
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr "نوع رابط اشتباه است"
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr "شناسه کاربر نامعتبر: {user_id}"
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr "چنین رباتی وجود ندارد"
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr "چنین کاربری وجود ندارد"
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr "کاربر غیرفعال شده است"
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr "{item} نمی تواند خالی باشد."
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr "{var_name} طول نادرست {length} را دارد که باید {target_length} باشد"
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a string"
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr "{var_name} یک رشته حروف نیست"
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr "{container} باید دقیقاً {length} عضو داشته باشد"
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr "مقدار {key_name} از {var_name} گم شده است"
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr "آرگومان غیرمنتظره: {keys}"
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr "{var_name} یک نوع داده مجاز نیست"
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr "{variable} != {expected_value} ({value} اشتباه است)"
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr "{var_name} یک URL نیست"
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr "قالب آدرس باید شامل '%(username)s' باشد."
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr "'{item}' نمی تواند خالی باشد."
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr "فیلد نباید دارای گزینه‌های تکراری باشد."
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr "'{value}' یک گزینه صحیح برای '{field_name}' نیست."
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr "{var_name} یک فهرست از رشته حروف یا اعداد صحیح نیست"
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr "{var_name} از نوع رشته حروف یا عدد صحیح نیست"
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr "{var_name} یک طول مشخص ندارد"
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr "{var_name} گم شده است"
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr "هدر HTTP برای '{header}' خالی است"
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, fuzzy, python-brace-format
 #| msgid "Operator {operator} not supported."
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr "اپراتور {operator} پشتیبانی نمی‌شود."
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr "در ابتدای zcommand باید یک اسلش باشد."
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr "چنین دستوری وجود ندارد:‌ {command}"
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 "`zulip_update_announcements_stream` به طور غیرمنتظره‌ای غیرفعال شده است."
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr "خطای CSRF: {reason}"
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr "پیکربندی غلط ریورس پروکسی: {proxy_reason}"
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr "شناسه کاربری نامعتبر: {invalid_ids}"
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr "کاربر با شناسه {user_id} غیر فعال شده است"
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr "کاربر با شناسه {user_id} یک ربات است"
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr "تاریخ"
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr "حساب کاربری خارجی"
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr "ضمایر"
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr "هیچ کس"
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr "اعضای کامل"
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "اعضا"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr "همه بر روی اینترنت"
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Invalid characters in emoji name"
 msgid "Invalid auto-conversion field: empty field name."
 msgstr "کاراکترهای اشتباه در نام ایموجی وجود دارد"
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr "گروه %(name)r در قالب URL در الگوی پیونددهنده وجود ندارد."
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr "رگولار اکسپرشن بد: {regex}"
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr "خطای رگولار اکسپرشن ناشناخته"
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr "قالب آدرس نامعتبر"
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid "Example input does not match the linkifier pattern."
 msgstr "گروه %(name)r در قالب URL در الگوی پیونددهنده وجود ندارد."
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr "گروه %(name)r در قالب URL در الگوی پیونددهنده وجود ندارد."
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr "گروه %(name)r در الگوی پیونددهنده در الگوی URL وجود ندارد."
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid ""
@@ -7647,7 +7056,7 @@ msgid ""
 "pattern."
 msgstr "گروه %(name)r در قالب URL در الگوی پیونددهنده وجود ندارد."
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgid ""
@@ -7655,334 +7064,331 @@ msgid ""
 "template."
 msgstr "گروه %(name)r در الگوی پیونددهنده در الگوی URL وجود ندارد."
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr "ایموجی یونیکد"
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "ایموجی سفارشی"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr "ایموجی‌های بیشتر زولیپ"
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr "کاراکترهای اشتباه در نام ایموجی وجود دارد"
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr "کاراکترهای نامعتبر در زبان پیگمنت"
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr "متغیر مورد نیاز \"code\" در قالب URL وجود ندارد"
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr "متغیر \"code\" باید تنها متغیر موجود در قالب URL باشد"
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr "سندباکس"
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr "عمومی"
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr "رویدادهای کانال"
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr "به‌روزرسانی‌های زولیپ"
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr ""
 "در زولیپ کلود استاندارد در دسترس است. ارتقا دهید تا دسترسی داشته باشید."
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr "بر روی زولیپ ابری پلاس در دسترس است. ارتقا دهید تا دسترسی داشته باشید."
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr "گیف‌های رده G (مخاطبان عمومی) مجاز هستند"
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr "گیف‌های رده PG (تخت نظر والدین) مجاز هستند"
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr "گیف‌های رده PG-13 مجاز است (زیر نظر والدین - زیر ۱۳ سال)"
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr "گیف‌های با رده R (محدودشده) مجاز باشد"
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr "وب-عمومی"
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "عمومی"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr "سابقه به اشتراک گذاشته شده، خصوصی"
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr "سابقه محافظت شده، خصوصی"
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr "ادمین‌ها، مدیران، اعضا و مهمان‌ها"
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr "ادمین‌ها، مدیران و اعضا"
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr "ادمین‌ها و مدیران"
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr "فقط ادمین‌ها"
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr "کاربر ناشناس"
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr "مالک سازمان"
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr "ادمین سازمان"
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr "مجری"
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "عضو"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "مهمان"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr "آدرس آی پی ناشناخته"
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr "یک سیستم عامل ناشناخته"
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr "یک مرورگر ناشناخته"
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr "آرگومان 'شناسه صف' خالی است"
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr "آرگومان 'شناسه آخرین رویداد' خالی است"
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr "یک رویداد جدیدتر از {event_id} قبلاً پاک شده است!"
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr "رویداد {event_id} در این صف نبود"
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr "شناسه ردیف رویداد بد: {queue_id}"
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 #, fuzzy
 #| msgid "Failed to create Zoom call"
 msgid "Failed to generate challenge"
 msgstr "ساخت تماس زوم ناموفق بود"
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr "اعتبارسنجی JWT برای این سازمان فعال نشده است"
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr "هیچ توکن وب JSON در درخواست وجود ندارد"
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr "توکن وب JSON خراب است"
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr "هیچ ایمیلی در اظهاریه توکن وب JSON مشخص نشده است"
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr "زیردامنه الزامی است"
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr "کلمه عبور غلط است"
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr "هدر User-Agent در درخواست خالی است"
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr "برچسب نمی تواند خالی باشد."
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr "فیلد باید حداقل یک انتخاب داشته باشد."
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr "نوع فیلد برای نمایش در خلاصه پروفایل، پشتیبانی نمی‌شود."
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 #, fuzzy
 #| msgid "Field type not supported for display in profile summary."
 msgid "Field type not supported for use for user matching."
 msgstr "نوع فیلد برای نمایش در خلاصه پروفایل، پشتیبانی نمی‌شود."
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr "نوع فیلد اشتباه است."
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr "فقط 2 فیلد سفارشی پروفایل را می‌توان در خلاصه پروفایل نمایش داد."
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr "یک فیلد با این برجسب قبلا تعریف شده است."
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr "فیلد سفارشی پیش فرض نمی تواند به روز رسانی شود."
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr "این نقط پایانی در تولید نهایی موجود نیست"
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr "DevAuthBackend فعال نشده"
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr "پارامتر '{key}' برای درخواست‌های ناشناس، نامعتبر است"
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr "پایگاه داده خالی است"
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr "نمی‌توان درخواست به پستگرس ارسال کرد"
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr "امکان اتصال به ربیت ام کیو نیست"
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr "نمی‌توان درخواست به ربیت ام کیو ارسال کرد"
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr "نمی‌توان درخواست به ردیس ارسال کرد"
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr "امکان نوشتن در memcached نیست"
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr "نمی‌توان درخواست به ممکش ارسال کرد"
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr "چنین دعوتی وجود ندارد"
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 #, fuzzy
 #| msgid "Invitation has already been revoked"
 msgid "Invitation already used or deactivated."
 msgstr "دعوت قبلاً لغو شده‌است"
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr "دعوت قبلاً لغو شده‌است"
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr "شناسه نامعتبر کانال {channel_id}. دعوتنامه‌ای فرستاده نشد."
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr "شما مجوز ندارید کاربران دیگر را به کانال‌های این سازمان اضافه کنید."
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr "شما باید حداقل یک آدرس ایمیل مشخص کنید."
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
@@ -7990,108 +7396,106 @@ msgstr ""
 "برخی از این آدرس ها قبلا از زولیپ استفاده کرده اند، بنابراین برای آنها دعوت "
 "ارسال نکردیم. برای بقیه دعوت ارسال شد!"
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr "تاریخچه ویرایش پیام در این سازمان غیرفعال است"
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr "شما دسترسی حذف این پیام را ندارید"
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr "محدوده زمانی برای حذف این پیام گذشته است"
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr "پیام قبلا حذف شده است"
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr "درخواست‌های زیاد برای پیام‌ها ارسال شده (حداکثر درخواست {max_messages})."
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr "لنگر فقط در انتهای محدوده قابل حذف است"
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr "چنین موضوعی وجود ندارد '{topic}'"
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Channel content access is required."
 msgid "An explanation is required."
 msgstr "دسترسی به محتوای کانال الزامی است."
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Zephyr mirroring is not allowed in this organization"
 msgid "Message reporting is not enabled in this organization."
 msgstr "آیینه سازی Zephyr در این سازمان مجاز نیست"
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr "ارسال کننده خالی است"
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr "آیینه کردن برای شناسه کاربرهای دریافت کننده مجاز نیست"
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr "پیام آیینه شده اشتباه است"
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr "ویژگی‌های هوش مصنوعی روی این سرور فعال نشده‌اند."
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr "به سقف ماهانه برای اعتبار هوش مصنوعی رسیده است."
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr "پیامی در این مکالمه برای خلاصه‌کردن وجود ندارد"
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr "نمی‌توان خود را بی‌صدا کرد"
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr "کاربر قبلاً بی‌صدا شده است"
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr "کاربر بی‌صدا نیست"
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 #, fuzzy
 #| msgid "{hostname} is not a valid hostname"
 msgid "Custom views must have a valid name."
 msgstr "{hostname} یک نام میزبان معتبر نیست"
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 #, fuzzy
 #| msgid "Reaction already exists."
 msgid "Navigation view already exists."
 msgstr "واکنش هم اکنون وجود دارد. "
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr "مرحله ورود ناشناخته: {onboarding_step}"
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -8102,357 +7506,356 @@ msgstr ""
 "شما خواسته بودید که [ویدئوی به زولیپ خوش آمدید]({navigation_tour_video_url}) "
 "را بعدا نگاه کنید، آیا الان وقت مناسبی است؟\n"
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr "وضعیت حضور برای کاربران ربات پشتیبانی نمی شود."
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr "هیچ داده حضوری برای {user_id_or_email} وجود ندارد"
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr "وضعیت نامعتبر: {status}"
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 #, fuzzy
 #| msgid "You do not have permission to change default channels."
 msgid "You do not have permission to manage plans and billing."
 msgstr "شما اجازه تغییر کانال‌های پیش‌فرض را ندارید."
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr "سرور از سرویس اعلان فشاری استفاده نمی‌کند"
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr "خطای برگشت داده شده از بانسر: {result}"
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr "رمز اعتبارسنجی یا Verification secret آماده نشده است"
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr "حداقل یکی از آرگومان های زیر باید باشند: نام ایموجی، کد ایموجی"
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr "رسید خوانده‌شدن، در این سازمان غیرفعال شده است."
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr "زبان نامعتبر '{language}'"
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr "حداقل یک روش احرازهویت باید فعال باشد."
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr "تأمین‌کننده تماس تصویری نامعتبر {video_chat_provider}"
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid giphy_rating {giphy_rating}"
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr "giphy_rating نامعتبر {giphy_rating}"
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr "باید یک سازمان آزمایشی باشد."
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr "زمان حذف داده‌ها باید حداکثر {max_allowed_days} روز دیگر در آینده باشد."
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr "زمان حذف داده‌ها باید حداقل {min_allowed_days} روز دیگر در آینده باشد."
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr "دامنه نامعتبر: {error}"
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr "دامنه {domain} در حال حاضر بخشی از سازمان شماست"
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr "هیچ ورودی برای دامنه {domain} پیدا نشد."
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr "شما باید دقیقا یک فایل بارگذاری کنید."
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr "فقط ادمین‌ها می‌توانند ایموجی‌های پیش‌نویس را تغییر بدهند."
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr "فایل آپلود شده بزرگتر از حد مجاز {max_size} مگابایت است"
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 #, fuzzy
 #| msgid "JWT authentication is not enabled for this organization"
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr "اعتبارسنجی JWT برای این سازمان فعال نشده است"
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr "از محدودیت نرخ گذشته است."
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr "شناسه خروجی اطلاعات اشتباه است"
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr "خروجی قبلا حذف شده است"
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr "خروجی گرفتن انجام نشد، چیزی برای پاک کردن نیست"
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr "خروجی گرفتن هنوز در جریان است"
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr "شما باید دقیقا یک آیکون بارگذاری کنید."
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr "پیوند‌دهنده یافت نشد."
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr "شما باید دقیقا یک لوگو بارگذاری کنید."
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid characters in pygments language"
 msgid "Invalid character in language: {character}"
 msgstr "کاراکترهای نامعتبر در زبان پیگمنت"
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid language '{language}'"
 msgid "Language '{language}' is not allowed."
 msgstr "زبان نامعتبر '{language}'"
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr "زمین بازی نامعتبر"
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "User not authenticated"
 msgid "Unauthenticated"
 msgstr "کاربر اعبتارسنجی نشد"
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "moving messages"
 msgid "Importing messages…"
 msgstr "جابجایی پیام‌ها"
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "Your full name"
 msgid "Your name"
 msgstr "نام کامل شما"
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr "هنگام به‌روزرسانی نوع پیام برنامه‌ریزی‌شده، گیرنده مورد نیاز است."
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 "هنگام به‌روزرسانی نوع پیام‌برنامه‌ریزی‌شده برای کانال، موضوع مورد نیاز است."
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr "قالب درخواست نامعتبر"
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr "DSN نامعتبر"
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr "کانال‌های خصوصی نمی‌توانند پیش‌فرض باشند."
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr ""
 "شما باید یکی از پارامترهای \"توضیحات جدید\" یا \"نام گروه جدید\" را وارد "
 "کنید."
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr ""
 "مقدار \"op\" اشتباه است. یکی از مقادیر \"add\" یا \"remove\" را استفاده کنید."
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr "پارامترهای نامعتبر"
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr "دسترسی به محتوای کانال الزامی است."
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr "کانال در حال حاضر همین نام را دارد."
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr ""
 "کاری برای انجام نیست. حداقل یک مورد از \"add\" یا \"delete\" را مشخص کنید."
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, fuzzy, python-brace-format
 #| msgid "{user_full_name} subscribed you to the channel {channel_name}."
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr "کاربر {user_full_name} شما را عضو کانال {channel_name} کرد."
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr "کاربر {user_full_name} شما را عضو کانال‌های زیر کرد:"
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr "دسترسی به کانال ({channel_name}) ممکن نیست."
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr "{user_name} این کانال‌‌ها را ایجاد کرد: {new_channels}."
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr "{user_name} یک کانال جدید ایجاد کرد {new_channels}."
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr "کانال‌های جدید"
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, fuzzy, python-brace-format
 #| msgid "**{policy}** channel created by {user_name}. **Description:**"
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr "**{policy}** کانال ساخته شده توسط {user_name}. **شرح:**"
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, fuzzy, python-brace-format
 #| msgid "**{policy}** channel created by {user_name}. **Description:**"
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr "**{policy}** کانال ساخته شده توسط {user_name}. **شرح:**"
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, fuzzy, python-brace-format
 #| msgid "**{policy}** channel created by {user_name}. **Description:**"
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr "**{policy}** کانال ساخته شده توسط {user_name}. **شرح:**"
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, fuzzy, python-brace-format
 #| msgid "**{policy}** channel created by {user_name}. **Description:**"
 msgid ""
@@ -8460,26 +7863,26 @@ msgid ""
 "**"
 msgstr "**{policy}** کانال ساخته شده توسط {user_name}. **شرح:**"
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr "{property} یک مقدار بولی نیست"
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr "ویژگی عضویت ناشناخته: {property}"
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr "عضو کانال با شناسه {channel_id} نیست"
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr "Json برای پیام زیرمجموعه اشتباه است"
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
@@ -8488,7 +7891,7 @@ msgstr ""
 "طبق طرح سازمان شما، حجم فایل بزرگتر از حداکثر حجم آپلود ({max_size} MiB) "
 "مجاز است."
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
@@ -8497,7 +7900,7 @@ msgstr ""
 "فایل بزرگتر از حداکثر حجم آپلود پیکربندی شده برای این سرور ({max_size} MiB) "
 "است."
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "Uploaded file is larger than the allowed limit of {max_file_size} MiB"
@@ -8506,52 +7909,51 @@ msgid ""
 "MiB)."
 msgstr "فایل آپلود شده بزرگتر از حد مجاز {max_file_size} مگابایت است "
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr "کاربر اطلاع‌رسانی تایپ برای پیام‌های کانال را غیرفعال کرده‌است"
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr "ارگومان 'گیرندگان' گمشده"
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr "لیست 'گیرندگان' خالی"
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr "کاربر اطلاع‌رسانی نوشتن را برای پیام‌های مستقیم، غیر فعال کرده است"
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr "<p>این فایل وجود ندارد یا پاک شده است.</p>"
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr "<p>شما مجاز به دیدن این فایل نیستید.</p>"
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr "توکن نامعتبر"
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr "نام فایل نامعتبر"
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr "شما باید برای بارگذاری یک فایل مشخص کنید"
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr "شما هر دفعه تنها می توانید یک فایل بارگذاری کنید"
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr "اطلاعات جدیدی وجود ندارد"
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
@@ -8559,32 +7961,32 @@ msgstr ""
 "کاری برای انجام نیست. حداقل یک مورد از \"add\"،  \"delete\"،  "
 "\"add_subgroups\" یا  \"delete_subgroups\" را مشخص کنید."
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr "{user_full_name} شما را به گروه {group_name} اضافه کرد."
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr "{user_full_name} شما را از گروه {group_name} حذف کرد."
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr "کاربر {user_id} در حال حاضر عضو این گروه است"
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr "هیچ عضو '{user_id}' در این گروه کاربری نیست"
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr "گروه کاربری {group_id} در حال حاضر یک زیرگروه این گروه است."
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
@@ -8593,103 +7995,103 @@ msgstr ""
 "گروه کاربری {user_group_id} در حال حاضر زیرگروه یکی از زیرگروه‌های تصویب شده "
 "است."
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr "گروه کاربری {group_id} در حال حاضر یک زیرگروه این گروه نیست."
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr "تغییر آواتار در این سازمان غیرفعال است."
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr "تغییر آدرس ایمیل در این سازمان غیرفعال است."
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr "زبان پیش‌فرض نامعتبر"
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr "صدای اطلاع رسانی نامعتبر است '{notification_sound}'"
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr "دوره دسته‌بندی ایمیل نامعتبر: {seconds} ثانیه"
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr "کلمه عبور زولیپ شما در LDAP مدیریت می‌شود"
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr "کلمه عبور اشتباه است!"
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, fuzzy, python-brace-format
 #| msgid "You're making too many attempts! Try again in {seconds} seconds."
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr "شما بیش از حد تلاش کرده‌اید! {seconds} ثانیه دیگر دوباره تلاش کنید."
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr "کلمه عبور جدید بسیار ضعیف است!"
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr "شما باید دقیقا یک آواتار بارگذاری کنید."
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr "موضوع بی صدا نیست"
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr "امکان غیرفعال کردن تنها مالک سازمان وجود ندارد"
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Nobody in this Zulip organization will be able to see this email address."
 msgid "User is not allowed to delete other user's messages."
 msgstr "هیچ کس در این سازمان زولیپ نمی‌تواند این آدرس ایمیل را ببیند."
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr "کاربر مجاز به تغییر ایمیل‌های کاربری نیست"
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr "دسترسی‌های مالک را نمی‌توان از تنها مالک سازمان حذف کرد."
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr "ایمیل جدید نامعتبر است."
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr "خطا در ایمیل جدید: {message}"
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
@@ -8702,25 +8104,25 @@ msgstr ""
 "ندارد.\n"
 "لطفا با ادمین سرور خود تماس بگیرید."
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 #, fuzzy
 #| msgid "Email is already in use."
 msgid "Email address already in use"
 msgstr "ایمیل در حال استفاده است"
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr "تغییر مالک انجام نشد، چنین کاربری وجود ندارد"
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr "تغییر مالک انجام نشد، کاربر غیرفعال است"
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr "تغییر مالک انجام نشد، ربات ها نمی توانند مالک ربات هاب دیگر باشند"
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
@@ -8729,140 +8131,140 @@ msgstr ""
 "ندارد.\n"
 "لطفا با ادمین سرور خود تماس بگیرید."
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr "ربات های تعبیه شده فعال نیستند."
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr "نام ربات تعبیه شده اشتباه است."
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr "این کاربر برای ساخت کاربران جدید مجاز نیست"
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr "ایمیل'{email}' در این سازمان مجاز نیست"
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr "آدرس های ایمیل قابل نمایش در این سازمان مجاز نیستند"
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom access token"
 msgid "Invalid {provider_name} access token"
 msgstr "توکن دسترسی به زوم نامعتبر"
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} call"
 msgstr "ساخت تماس زوم ناموفق بود"
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Zoom credentials have not been configured"
 msgid "{provider_name} credentials have not been configured"
 msgstr "اعتبارسنجی زوم پیکربندی نشده است"
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom credentials"
 msgid "Invalid {provider_name} credentials"
 msgstr "اعتبارسنجی زوم نامعتبر"
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error connecting to the BigBlueButton server."
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr "خطا در اتصال به سرور BigBlueButton"
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error authenticating to the BigBlueButton server."
 msgid "Error authenticating to the {provider_name} server"
 msgstr "خطا در اعتبارسنحی در سرور BigBlueButton."
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "BigBlueButton server returned an unexpected error."
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr "سرور BigBlueButton یک خطای غیرمنتظره برگرداند."
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom session identifier"
 msgid "Invalid {provider_name} session identifier"
 msgstr "معرف جلسه زوم نامعتبر"
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr "ایمیل ناشناس کاربر Zoom"
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} public room."
 msgstr "ساخت تماس زوم ناموفق بود"
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr "امضا نامعتبر."
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{full_name}'s Zulip room"
 msgstr "{full_name} به شما اشاره کرده:"
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 "پروژه‌هایی که از این ارائه‌دهنده سیستم کنترل نسخه استفاده می‌کنند، پشتیبانی "
 "نمی‌شوند"
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr "بار درخواست اشتباه است"
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr "درخواست وب هوک ناشناخته است"
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr "موضوع نمی تواند خالی باشد"
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr "محتوا نمی تواند خالی باشد"
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr "قادر به مدیریت بار داده Jotform نیست"
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr "ورودی JSON قالب درستی ندارد"
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr "کلید رویدادها در محموله گم شده است"
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr "خطا: پارامتر channels_map_to_topics مقداری غیر از 0 و 1 است"
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr "عملیات وبهوک وردپرس ناشناخته است: {hook}"
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
@@ -8871,75 +8273,75 @@ msgstr ""
 "خروجی گرفتن از داده‌های شما کامل شد. [مشاهده و دانلود خروجی‌ها]"
 "({export_settings_link})."
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr "رمز اعتبارسنجی منقضی شده است"
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr "رمز اعتبارسنجی نامعتبر است"
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr "رمز اعتبارسنجی ناقص است"
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr "رمز اعتبارسنجی برای نام میزبان متفاوتی است"
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr "زیردامنه نامعتبر برای اعلان‌های فشاری"
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr "باید با کلید صحیح API سرور زولیپ اعتبارسنجی شود"
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr "UUID نامعتبر"
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr "نوع توکن نامعتبر است"
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr "{hostname} شامل اجزای نامعتبر (مانند مسیر، کوئری، قطعه کد) است."
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr "{hostname} یک نام میزبان معتبر نیست"
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr "{hostname} هنوز ثبت نشده است"
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr "{domain} نامعتبر است به خاطر آنکه رکورد MX ندارد"
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr "{domain} موجود نیست"
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
@@ -8948,29 +8350,29 @@ msgstr ""
 "محدودیت‌های جهانی استفاده از این نقطه پایانی، تمام شده است. لطفاً بعداً دوباره "
 "امتحان کنید یا برای کمک با {support_email} تماس بگیرید."
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr "نام‌نویسی برای این نام میزبان یافت نشد"
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr "میزبان گزارش داد که هیچ رمز اعتبارسنجی ندارد."
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, fuzzy, python-brace-format
 #| msgid "Error response received from the host: {status_code}"
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr "پاسخ خطا از میزبان دریافت شد: {status_code}"
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr "ios_app_id گم شده است"
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr "شناسه کاربری یا uuid کاربر گم شده است"
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
@@ -8979,50 +8381,50 @@ msgstr ""
 "طرح شما، اجازه نمی‌دهد که اعلان فشاری بفرستید. دلایل ارائه شده توسط سرور: "
 "{reason}"
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr "طرح شما اجازه ارسال اعلان‌های فشاری را نمی‌دهد."
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr "دارایی نامعتبر {property}"
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr "نوع رویداد نامعتبر است."
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr "داده خارج از ترتیب است."
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr "نام‌نویسی تکراری تشخیص داده شد."
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr "گزارش لاگ داده‌ها نادرست است"
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr "لازم است که کلمه عبور خود را جایگزین کنید."
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr "پارامتر id_token گم شده"
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 #, fuzzy
 #| msgid "Missing id_token parameter"
 msgid "Missing idp param"
 msgstr "پارامتر id_token گم شده"
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr "OTP اشتباه است"
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr "نمی توان از mobile_flow_otp و desktop_flow_otp با هم استفاده کرد."
 

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-04-27 14:57+0000\n"
 "Last-Translator: Flammie A Pirinen <flammie@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/zulip/django/fi/"
@@ -29,53 +29,53 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.17.1-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "Ei sallittu vieraille"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "Virheellinen organisaatio"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr "Julkiset kanavat"
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr "Yksityiset kanavat"
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr "Yksityisviestit"
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr "Suorat ryhmäviestit"
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr "Puuttuva kanava kaaviolle: {chart_name}"
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr "Tuntematon kaavion nimi: {chart_name}"
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr ""
 "Aloitusaika on myöhemmin kuin lopetusaika. Aloitus:{start}, Lopetus: {end}"
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr ""
 "Analytiikan tietoja ei ole saatavilla. Ota yhteyttä palvelimesi "
 "järjestelmänvalvojaan."
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -88,7 +88,7 @@ msgstr ""
 "[poista käytöstä passiiviset käyttäjät]({deactivate_user_help_page_link}), "
 "jotta uudet käyttäjät voivat liittyä."
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -100,7 +100,7 @@ msgstr ""
 "käyttäjät]({deactivate_user_help_page_link}) mahdollistaaksesi useamman kuin "
 "yhden käyttäjän liittymisen."
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -112,7 +112,7 @@ msgstr ""
 "käyttäjät]({deactivate_user_help_page_link}) mahdollistaaksesi useamman kuin "
 "kahden käyttäjän liittymisen."
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -124,7 +124,7 @@ msgstr ""
 "käyttäjät]({deactivate_user_help_page_link}) mahdollistaaksesi useamman kuin "
 "kolmen käyttäjän liittymisen."
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -137,14 +137,14 @@ msgstr ""
 "[lisenssejä nykyisellä ja seuraavalla laskutuskaudella]({billing_page_link}) "
 "on enemmän kuin käyttäjiä."
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr ""
 "Organisaatiolla ei ole tarpeeksi Zulip-lisenssejä. Kutsuja ei lähetetty."
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
@@ -152,16 +152,15 @@ msgstr ""
 "Organisaatiolla ei ole tarpeeksi Zulip-lisenssejä vieraskäyttäjän roolin "
 "vaihtamiseksi."
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr "Rekisteröityminen on poistettu käytöstä"
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr "Virheellinen etäpalvelin."
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
@@ -170,7 +169,7 @@ msgstr ""
 "Kaikille aktiivisille käyttäjille pitää olla ostettuna lisenssit tässä "
 "organisaatiossa (vähintään {min_licenses})."
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
@@ -180,59 +179,59 @@ msgstr ""
 "sivun kautta. Viimeistelläksesi palvelupakettisi päivityksen, ota yhteyttä "
 "{email}."
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr "Ei maksutapaa tiedostossa."
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr "{brand} päättyy {last4}"
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr "Tuntematon maksutapa. Ota yhteyttä {email}."
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr "Jotain meni pieleen. Lähetä meille sähköpostia osoitteeseen {email}."
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "Jotain meni pieleen. Lataa sivu uudestaan."
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr "Jotain meni pieleen. Odota hetki ja lataa sivu uudestaan."
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr "Lisää luottokortti ennen maksuttoman kokeilun aloittamista."
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr "Lisää luottokortti aikataulun päivittämiseksi."
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
 msgstr "Tilausta ei voi päivittää. Tilaus on vanhentunut ja korvattu uudella."
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr "Tilauksen päivitys epäonnistui. Tilaus on päättäynyt."
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 "Ei voitu päivittää lisenssejä nykyiselle laskutuskaudelle maksuttomassa "
 "tilauksessa."
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
@@ -240,18 +239,18 @@ msgstr ""
 "Lisenssien manuaalinen päivitys epäonnistui. Tilauksesi on asetettu "
 "automaattiseen lisenssienhallintaan."
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr ""
 "Tilauksesi löytyy jo lisensseistä {licenses} nykyiseltä laskutusjaksolta."
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr "Et voi vähentää lisenssejä nykyiseltä laskutusjaksolta."
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
@@ -259,7 +258,7 @@ msgstr ""
 "Ei voitu vaihtaa lisenssejä seuraavalle laskutuskaudelle kun tilausta "
 "vähennetään."
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
@@ -268,7 +267,7 @@ msgstr ""
 "TIlauksesi uudistaminen on jo ajastettu seuraavien lisenssien osalta "
 "{licenses_at_next_renewal}."
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
@@ -276,27 +275,27 @@ msgid ""
 msgstr ""
 "Olet jo ostanut {licenses_at_next_renewal} lisenssejä ensi laskutuskaudelle."
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr "Ei mitään muutettavaa."
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr "Tälle organisaatiolle ei ole asiakasta!"
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr "Istuntoa ei löytynyt"
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr "Maksutarkoitusta ei löytynyt"
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr "Anna stripe_session_id tai stripe_invoide_id"
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -311,20 +310,19 @@ msgstr ""
 "Jos voisitte {begin_link}mainita zulipin sponsorina "
 "verkkosivuillanne{end_link} olisimme siitä hyvin kiitollisia!"
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr "Parametri confirmed puuttuu"
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr "Laskutuksen access token on vanhentunut."
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr "Virheellinen laskutuksen access token."
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
@@ -333,40 +331,39 @@ msgstr ""
 "Ei voitu hoitaa laskutusta palvelimelle ja alueelle. Ota yhteys "
 "sähköpostilla: {support_email}"
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr "Käyttäjätiliä ei ole olemassa vielä."
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr "Käyttöehdot pitää hyväksyä että voi jatkaa."
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 "Tämä zulip_org_id ei ole rekisteröitynä Zulipin "
 "rahoituksenhallintasysteemissä."
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr "Virheellinen zulip_org_key tälle zulip_org_id:lle."
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr "Palvelimesi rekisteröinti on poistettu käytöstä."
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "Virhe"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr "Sivua ei löytynyt (404)"
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
@@ -375,11 +372,11 @@ msgstr ""
 "Jos tämä on odottamaton virhe voit <a href=\"mailto:"
 "%(support_email)s\">ottaa yhteyttä Zulipin tukeen</a>."
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr "Pääsy kielletty (403)"
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
@@ -387,11 +384,11 @@ msgstr ""
 "Pyyntöä ei voitu toteuttaa koska selain ei lähettänyt tunnisteita "
 "tunnistautumista varten. Ratkaise ongelma:"
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr "Varmista että selain hyväksyy evästeitä tälle sivulle."
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
@@ -399,16 +396,15 @@ msgstr ""
 "Tarkista selaimen yksityisyysasetukset ja lisäosat jotka blokkaavat Referer-"
 "otsakkeita ja poista ne käytöstä tällä sivulla."
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr "Menetelmä ei sallittu (405)"
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr "Palvelimen sisäinen virhe"
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
@@ -416,7 +412,7 @@ msgstr ""
 "Jotain meni pieleen. Ongelma on tiedossa ja sitä korjataan parhaillaan. "
 "Zulip uudelleenlatautuu kun ongelmat on ratkaistu."
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -426,14 +422,14 @@ msgstr ""
 "Katso <a href=\"%(status_url)s/accounts/find/\">Zulip-pilven tila</a> tai <a "
 "href=\"mailto:%(support_email)s\">ota yhteys Zulipin tukeen</a>."
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 "Jotain meni pieleen. Zulip latautuu uudelleen kun ongelma on ratkaistu."
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
@@ -442,7 +438,7 @@ msgstr ""
 "<a href=\"mailto:%(support_email)s\">ottaa yhteyttä palvelimen\n"
 "ylläpitoon</a> tukea varten."
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
@@ -451,137 +447,135 @@ msgstr ""
 "Jos ylläpidät palvelint, voit lukea <a "
 "href=\"%(troubleshooting_url)s\">Zulipin virheohjetta</a>."
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr "analytiikkaa kohteelle %(target_name)s | Zulip"
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 "Analytiikka on täysin käytössä 24 tuntia organisaation luomisen jälkeen."
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr "Zulipin analytiikka organisaatiolle %(target_name)s"
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr "Organisaation yhteenveto"
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr "Käyttäjämäärä"
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr "Viime 15 päivän aktiiviset käyttäjät"
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr "Vieraiden lukumäärä"
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr "Viestien määrä"
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr "Viestien määrä viimeiseltä 30 päivältä"
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr "Tiedostotilaa käytössä"
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "Aktiivisia käyttäjiä"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr "Päivittäiset aktiiviset"
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr "15 päivän aikana aktiiviset"
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr "Käyttäjiä yhteensä"
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "Käyttäjät"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr "Viestit vastaanottajan tyypin mukaan"
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "Minä"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "Kaikki"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "Viime viikko"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "Viime kuukausi"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "Viime vuosi"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "Koko ajalta"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr "Viestit aikajaksolla"
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "Päivittäin"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "Viikottain"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr "Kumulatiivinen"
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "Ihmiset"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "Botit"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr "Luetut viestit aikajaksolla"
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr "Viestit sovelluksittain"
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr "Viimeisin päivitys"
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
@@ -589,15 +583,15 @@ msgstr ""
 "Kaikkien kaavioiden täydellinen päivitys tapahtuu kerran päivässä. “Viestit "
 "aikajaksolla” kaavio päivitetään kerran tunnissa."
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr "Sähköposti muutettu"
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr "Sähköposti vaihdettu!"
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
@@ -606,48 +600,48 @@ msgstr ""
 "Tämä varmistaa, että sähköpostiosoite Zulip tunnuksellesi on vaihtunut "
 "osoitteesta %(old_email_html_tag)s osoitteeksi %(new_email_html_tag)s"
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr "Vahvistetaan sähköpostiosoitetta"
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr "Vahvistuslinkkiä ei ole"
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr "Hupsista. Emme löytäneet varmistuslinkkiäsi järjestelmästämme."
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 msgstr "Laita sähköpostia %(support_email_html_tag)s ja asiaa selvitetään."
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr "Vahvistuslinkki on vanhentunut tai poistettu käytöstä"
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr "Hupsista. Varmistuslinkki on vanhentunut tai poistettu käytöstä."
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr "Ota yhteyttä järjestelmänvalvojaasi saadaksesi uusi linkki."
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr "Vahvistuslinkki on viallinen"
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr "Hupsista. Varmistuslinkki on virheellinen."
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
@@ -655,72 +649,55 @@ msgstr ""
 "Varmista, että kopioit linkin oikein selaimeesi. Jos näet tämän sivun "
 "uudelleen, kyseessä lienee meidän virheemme. Olemme pahoillamme."
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr "Laskutus"
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr "Sulje näkymä"
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr "Älä välitä"
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr "Alenna"
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "Peruuta"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr "Vahvista"
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr "Peruuta kallistus"
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr "Laskutusstatus"
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr "Poistetaanko palvelimen aktivointi?"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr "Maksusuunnitelma ei ole saatavilla"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -736,7 +713,7 @@ msgstr ""
 "href=\"https://zulip.com/help/self-hosted-billing#log-in-to-billing-"
 "management\">loki ohjeissa</a> ylläpitäjälle suunnitelma Zulip-palvelimelle."
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
@@ -744,7 +721,7 @@ msgstr ""
 "Siirrä suunnitelma palvelimelta tälle organisaatiolle tai muita kysymyksiä, "
 "<a href=\"mailto:{{ support_email }}\">ota yhteys tukeen</a>."
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
@@ -752,7 +729,7 @@ msgstr ""
 "Suunnitelmanhallinta tälle palvelimelle ei ole saatavilla koska "
 "organisaatiolla joka ylläpitää palvelinta on jo suunnitelma."
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -763,729 +740,239 @@ msgstr ""
 "billing\">Kirjaudu sisään</a> maksujen hallintaan organisaation puolelta tai "
 "<a href='mailto:%(support_email)s'>ota yhteyttä tukeen</a> kysymysten kanssa."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr "Käyttötiheysraja ylitetty"
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr "Raja-arvo ylitetty."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr "Palvelin on ylittänyt enimmäismäärän näitä toimintoja."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, python-format
 msgid "You can try again in %(retry_after_string)s."
 msgstr "Voit yrittää uudelleen %(retry_after_string)s."
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr "Päivitys"
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr "Lähetä lasku ja aloita ilmainen kokeilu"
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr "Lähetä lasku"
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr "Avaa yhteisöhakemisto"
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr "Suodata kategorioittain"
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "Kaikki"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr "Kategoriat"
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr "10000 viestiä"
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr "Rajoittamaton"
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr "Tiedostot yli 10 megaa"
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr "tiedostot yli 1 gigan"
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr "Tuettu"
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr "Itse-hallittu"
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr "Organisaatioille 10 käyttäjäään asti"
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr "vähintään 25 käyttäjää"
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr "Ei saatavilla"
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr "Zulip kehitysyhteisö"
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr "Liity käyttäjänä"
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr "Liity itseisännöijäksi"
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr "Liity osallistujaksi"
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "Luo organisaatio"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr "Hae demo"
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr "Isännöi omaa Zulipia"
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr "Pyydä sponsorointia"
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr "Koulutuksen hinnoittelu"
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr "Katso hinnoittelu"
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr "Zulip yrityksille"
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 msgid "Zulip for open source"
 msgstr "Zulip avoimen lähdekoodin projekteille"
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr "Silmälaseilla varustettu koira kannettavan kanssa"
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation"
 msgstr "Kuvakaappaus Zulip keskustelusta"
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr "Kuvakaappaus Zulip-keskustelusta sentry-botin kanssa"
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr "Kuvakaappaus Zulip saapuneet-näkymästä"
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr "Avaa kannettava jonka sisällä on kirja"
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr "Kaksi kättä kasaa palapeliä"
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 msgid "Message with code"
 msgstr "Viestit jossa on koodi"
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr "Ukkonen"
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr "Linkki"
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr "Laivan ratas"
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr "Ota yhteyttä tukeen"
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr "Lähettäjä"
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr "Organisaatio"
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr "Aihe"
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr "Viesti"
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr "Lähetä"
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr "Kiitos viestistäsi"
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr "Kiitos yhteydenotosta!"
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr "Ollaan yhteyksissä pian."
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
@@ -1493,11 +980,11 @@ msgstr ""
 "Lisätietoja on yleisissä kysymyksissä <a href=\"/help/\">Zulipin "
 "ohjekeskuksessa</a>."
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 msgid "Get started"
 msgstr "Aloita"
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
@@ -1506,51 +993,50 @@ msgstr ""
 "Tätä tiimichattia isännöidään nyt Zulip Cloudissa. Hyväksy <a href=\"https://"
 "zulip.com/policies/terms\">Zulipin käyttöehdo</a>t jatkaaksesi."
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr "Tai vaihtoehtoisesti, käytä jotakin varapuhelintasi:"
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr "Viimeisenä ratkaisuna voit käyttää varakoodia:"
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr "Käytä varakoodia"
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr "Hyväksy käyttöehdot"
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr "Tervetuloa Zulipiin"
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "Sähköposti"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr ""
 "Tilaa minulle Zulipin vähäliikenteinen uutiskirje (muutama sähköposti "
 "vuodessa)."
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr "Jatka"
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr "Vahvista sähköpostiosoitteesi"
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1561,7 +1047,7 @@ msgstr ""
 "class=\"user_email semi-bold\">%(email)s</span>) tulleen hyväksyntäviestin "
 "ohjeita Zulipilta."
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
@@ -1569,24 +1055,24 @@ msgstr ""
 "Jollet löydä hyväksyntäviestiä Saapuneet-laatikosta tai roskapostin seasta "
 "<a href=\"#\" id=\"resend_email_link\">lähetä viesti uudelleen</a>."
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr "Julkinen näkymä {org_name} | Zulipin ryhmäkeskustelu"
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 "Selaa julkisia kanavia organisaatiolta {org_name} kirjautumatta sisään."
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr "Koska selain on vanha tai tukematon, Zulip ei välttämättä toimi."
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
@@ -1596,45 +1082,44 @@ msgstr ""
 "href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Lataa uusin versio.</a>"
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
 msgstr ""
 "Jos tämä viesti ei häviä, <a class=\"reload-lnk\">lataa sivu uudelleen</a>."
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 "Virhe ladattaessa. Kokeile <a class=\"reload-lnk\">ladata sivu uudelleen</a>."
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr "Ei keskusteluja jotka vastaavat suodattimia."
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr "Tämä näkymää lataa yhä viestejä."
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr "Lataa lisää"
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr "Videopuhelu loppui"
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr "Voit sulkea tämän ikkunan."
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr "Asetusvirhe"
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
@@ -1642,7 +1127,7 @@ msgstr ""
 "Yritettiiin kirjautua LDAPpiin luomatta organisaatiota Ensin pitää valita "
 "EmailAuthBackend organisaatiolle ja sitten voi yrittää uudelleen."
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1652,33 +1137,32 @@ msgstr ""
 "Tämä palvelin ei ole asetettu työntöilmoituksia varten. Lisätietoja "
 "työntöilmoituksista <a href=\"%(doc_url)s\">ohjeissa</a>."
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr "Tiliä ei löydy"
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr "Zulip-tiliä ei löydy."
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, python-format
 msgid "No account found for %(email)s."
 msgstr "Sähköpostia ei löytynyt: %(email)s"
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr "Kirjaudu toisella tilillä"
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr "Jatka rekisteröintiin"
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 msgid "Try Zulip in a demo organization"
 msgstr "Kokeile Zulipia demo-organisaatiolla"
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
@@ -1687,19 +1171,19 @@ msgstr ""
 "Sähköposti ei ole pakollinen. <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">Tai luo uusi organisaatio</a>."
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 msgid "Try Zulip"
 msgstr "Kokeile Zulippia"
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "Luo uusi organisaatio"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr "Luo uusi Zulip-organisaatio"
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
@@ -1708,16 +1192,15 @@ msgstr ""
 "Tai <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">Luo demo-organisaatio</a> – sähköpostia ei tarvita."
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr "Syötä sähköpostiosoitteesi"
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr "Sähköpostisi"
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
@@ -1727,11 +1210,11 @@ msgstr ""
 "import-from-mattermost\">Mattermost</a>, tai <a href=\"/help/import-from-"
 "rocketchat\">RocketChat</a>."
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr "Missä kuulit Zulipista ensin?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
@@ -1739,42 +1222,41 @@ msgstr ""
 "Tätä käytetään vain jos ostat tilauksen jolloin se lähetetään Zulipin "
 "tiimille."
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr "Valitse vaihtoehto"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr "Kuvaile"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr "Missä näit mainoksen?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr "Mikä organisaatio?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr "Mikä?"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr "Valitse yksi"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr "Organisaation tyyppi"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr "Organisaation kieli"
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
@@ -1784,72 +1266,68 @@ msgstr ""
 "mattermost\">Mattermost</a>,\n"
 "tai <a href=\"/help/import-from-rocketchat\">RocketChat</a>."
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid "Import chat history?"
 msgstr "Tuodaanko chatti-historia?"
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr "Organisaation nimi"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "Organisaation URL"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr "Käytä %(external_host)s"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "TAI"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "Rekisteröidy"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "Rekisteröidy Zulipiin"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr "Tarvitset kutsun voidaksesi liittyä tähän organisaatioon."
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr "Rekisteröidy käyttäen tarjoajaa %(identity_provider)s"
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr "Onko tili jo olemassa?"
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "Kirjaudu"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr "Aseta sähköpostin yksityisyys"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
@@ -1857,18 +1335,18 @@ msgstr ""
 "Zulipissa voi valita millä rooleilla organisaatiossa näkee "
 "sähköpostiosoitteesi."
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
 msgstr ""
 "Muutetaanko oletusyksityisyysasetusta sähköpostille tälle organisaatiolle."
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr "Kuka voi lukea sähköpostiosoitteet"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1879,13 +1357,13 @@ msgstr ""
 "email-visibility\" target=\"_blank\" rel=\"noopener noreferrer\">liittymisen "
 "jälkeen</a>."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr "Adminstaattorit näkevät tämän sähköpostiosoitteen."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
@@ -1893,13 +1371,13 @@ msgstr ""
 "Adminstraattorit ja moderaattorit tässä Zulip-organisaatiossa näkevät tämän "
 "sähköpostiosoitteen."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 "Kukaan täss Zulip-organisaatiossa ei pusty näkemään tätä sähköpostiosoitetta."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
@@ -1907,80 +1385,79 @@ msgstr ""
 "Muut käyttäjät tässä Zulip-organisaatiossa pystyvät näkemään tämän "
 "sähköpostiosoitteen."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "Muuta"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr "Rekisteröityminen"
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr "Luo organisaatiosi"
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr "Luo tilisi"
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr "<p>Anna tilin tiedot rekisteröinnin viimeistelemiseksi.</p>"
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr "Organisaatiosi"
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr "Tilisi"
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr "Don&rsquo;t tuo asetukset"
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr "Tuo asetukset olemassa olevalta Zulip-tililtä"
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr "Koko nimi"
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "Nimi"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr "Tämä on miten tili näytetään Zulipissa."
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "Salasana"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr "Syötä sinun LDAP/Active Directory salasana."
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 "Tätä käytetään mobiilisovelluksiin ja muihin työkaluihin jotka tarvitsevat "
 "salasanan."
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr "Salasanan vahvuus"
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr "Mistä olet kiinnostunut?"
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
@@ -1989,15 +1466,15 @@ msgstr ""
 "Suostun <a href=\"%(root_domain_url)s/policies/terms\" target=\"_blank\" "
 "rel=\"noopener noreferrer\">käyttöehtoihin</a>."
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr "Käytöstä poistettu organisaatio"
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr "Organisaatio siirtyi"
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
@@ -2006,7 +1483,7 @@ msgstr ""
 "Organisaatio on muuttanut kohteeseen <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -2017,7 +1494,7 @@ msgstr ""
 "id=\"deactivated-org-auto-redirect\">uuteen osoitteeseen</a> <span "
 "id=\"deactivated-org-auto-redirect-countdown\">5</span> sekunnissa."
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 msgid ""
 "This organization has been deactivated, and all organization data has been "
 "deleted."
@@ -2025,7 +1502,7 @@ msgstr ""
 "Tämä organisaatio on poistettu käytöstä ja kaikki organisaation data on "
 "poistettu."
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
@@ -2035,7 +1512,7 @@ msgstr ""
 "tiedustellaksesi tämän osoitteen uudelleenkäytöstä uuden organisaation "
 "kanssa."
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
@@ -2045,11 +1522,11 @@ msgstr ""
 "palvelimen\n"
 "ylläpitoon</a> tukea varten."
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 msgid "This organization has been deactivated."
 msgstr "Tämä organisaatio on poistettu käytöstä."
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -2059,7 +1536,7 @@ msgstr ""
 "%(support_email)s\">ottaa yhteyttä Zulipin tukeen</a> "
 "uudelleenaktivoimiseksi."
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
@@ -2068,7 +1545,7 @@ msgstr ""
 "Jos olet organisaation jäsen, ja haluat tietoa siitä miksi se on "
 "deaktivoitu, kysy organisaation admineilta suoraan."
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -2079,15 +1556,15 @@ msgstr ""
 "%(support_email)s\">ottaa yhteyttä Zulipin palvelimen ylläpitoon</a> "
 "uudeelleenaktivoimiseksi."
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr "Viimeistele työpöytäsovelluskirjautuminen"
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr "Viimeistele työpöytäkirjautuminen"
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
@@ -2095,110 +1572,109 @@ msgstr ""
 "Käytä selainta viimeistelläksesi kirjautuminen, palaa sitten tänne ja liitä "
 "kirjautumiskoodisi."
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr "Liitä koodi tähän"
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr "Viimeistele"
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr "Virheellinen token."
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr "Token hyväksytty, kirjaudutaan sisään…"
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr "Kirjaudu työpöutäsovelluksella"
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 "Kopioi tämä kirjautumiskoodi ja palaa Zulip sovellukseesi viimeistelläksesi "
 "sisäänkirjautuminen:"
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "Kopio"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr "Voit sitten sulkea tämän ikkunan."
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr "Tai, jatka selaimessasi."
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr "Anonyymi käyttäjä"
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr "Omistajat"
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "Järjestelmänvalvojat"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr "Moderaattorit"
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr "Vieraskäyttäjät"
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "Normaalit käyttäjät"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr "Edelleenlähetä sähköpostiviestit sähköpostitillle"
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "Sulje"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "Päivitä"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr "Zulip"
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr "Tiivistelmä"
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
 "<b>%(realm_name)s</b>."
 msgstr "Olet nyt luonut uuden Zulip-organisaation: <b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr "Tervetuloa Zulipiin."
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr "Olet liittynyt Zulip-organisaatioon <b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
@@ -2207,36 +1683,36 @@ msgstr ""
 "Käytä seuraavia tietoja Zulipiin kirjautumiseksi verkossa, <a "
 "href=\"%(apps_page_link)s\">mobiili- ja työpöytäsovelluksilla</a>:"
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr "Organisaation URL: %(organization_url)s"
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr "Käyttäjänimesi: %(ldap_username)s"
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr "Käytä LDAP-tunnustasi kirjautuaksesi sisään"
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr "Sähköpostisi: %(email)s"
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr "Mene organisaatioon"
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
@@ -2245,7 +1721,7 @@ msgstr ""
 "Jos Zulip on uusi, tutustu <a "
 "href=\"%(getting_user_started_link)s\">aloitusohjeeseen</a>,-"
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2256,35 +1732,35 @@ msgstr ""
 "href=\"%(getting_organization_started_link)s\">organisaation muuttamista "
 "Zulipiin varten</a>."
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
 "to help!"
 msgstr "Kysymyksiä? <a href=\"mailto:%(support_email)s\">Ota yhteys</a>."
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr "%(realm_name)sZulipissa: Organisaatiotiedot"
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr "%(realm_name)sZulipissa: Uudet tilitiedot"
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr "Olet luonut uuden Zulip-organisaation: %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr "Liityttiin Zulip-organisaatioon: %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
@@ -2293,7 +1769,7 @@ msgstr ""
 "Käytä seuraavia tietoja kirjautuessasi Zulipiin verkossa, mobiililla tai "
 "työpöytäsovelluksella (%(apps_page_link)s):"
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
@@ -2302,7 +1778,7 @@ msgstr ""
 "Jos olet uusi Zulip-käyttäjä, tutustu aloitusohjeeseen "
 "(%(getting_user_started_link)s)"
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
@@ -2311,17 +1787,17 @@ msgstr ""
 "Meillä on myös ohje organisaation muuttamiseksi Zulipiiin "
 "(%(getting_organization_started_link)s)."
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr "Kysymyksiä? Ota yhteys sähköpostilla %(support_email)s."
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2330,17 +1806,17 @@ msgstr ""
 "Jos sinulla on kysymyksiä niin ota yhteyttä tämän Zulip-palvelimen "
 "ylläpitoon sähköpostilla %(support_email)s."
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr "Hei,"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2351,12 +1827,12 @@ msgstr ""
 "organisaatiolle %(realm_url)s. Vahvista päivitys ja aseta salasana tilille "
 "alta:"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr "Vahvista ja aseta salasana"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2365,12 +1841,12 @@ msgstr ""
 "Jollet pyytänyt tätä muutosta itse, ota pikimmiten yhteyttä "
 "%(support_email)s."
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 msgid "Verify your email address for your Zulip demo organization"
 msgstr "vahvista sähköpostiosoite Zulipin demo-organisaatiollesi"
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2379,8 +1855,8 @@ msgstr ""
 "Jollet pyytänyt tätä muutosta itse, ota pikimmiten yhteyttä "
 "<%(support_email)s>."
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2390,34 +1866,34 @@ msgstr ""
 "Saimme pyynnön sähköpostiosoitteen muuttamistesta Zulip-tilin%(realm_url)s "
 "osoitteesta %(old_email)s osoitteeseen %(new_email)s. Vahvista alta:"
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr "Vahvista sähköpostin vaihto"
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr ""
 "Vahvista uusi sähköpostiosoitteesi organisaatiolle %(organization_host)s"
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr "Olet pyytänyt uutta Zulip-organisaatiota:"
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr "Organisaation tyyppi: %(organization_type)s"
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr "Kirjauduit Zulipin käyttäjäksi hiljattain, hienoa."
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
@@ -2425,53 +1901,53 @@ msgstr ""
 "Paina allaolevaa nappia luodaksesi organisaation ja rekisteröidäksesi tilin. "
 "Voit päivittää ylläolevat tiedot tarvittaessa."
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr "Allaolevalla napilla viet rekisteröinnin loppuun."
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr "Vie rekisteröinti päätökseen"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr "Luo Zulip-organisaatiosi"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr "Aktivoi Zulip-tilisi"
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr "Allaolevalla napilla viet rekisteröinnin loppuun."
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
 "— we'd love to help!"
 msgstr "Onko kysymyksiä tai kommentteja? Lähetä sähköpostia: %(support_email)s"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr "Muokkaa sähköpostiasetuksia"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr "Peru sähköpostitilaus markkinointiviestien osalta"
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
@@ -2480,17 +1956,17 @@ msgstr ""
 "Zulip-tilisi on <a href=\"%(realm_url)s\">%(realm_url)s</a>deaktivoitu ja "
 "sille ei voi kirjautua."
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr "Adminit jättivät seuraavan kommentin:"
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr "Huomautus tilin deaktivoinnista %(realm_name)s"
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
@@ -2498,11 +1974,11 @@ msgid ""
 msgstr ""
 "Zulip-tili kohteessa %(realm_url)s on deaktivoitu ja sille ei voi kirjautua."
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr "Uudet kanavat"
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2512,7 +1988,7 @@ msgstr ""
 "Sinulle on %(new_messages_count)s uutta viestiä, ja %(new_streams_count)s "
 "uutta kanavaa kohteessa <a href=\"%(realm_url)s\">%(realm_name)s</a>."
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
@@ -2521,7 +1997,7 @@ msgstr ""
 "Sinulle on %(new_messages_count)s uutta viestiä kohteessa <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
@@ -2530,8 +2006,8 @@ msgstr ""
 "Kohteessa <a href=\"%(realm_url)s\">%(realm_name)s</a> on "
 "%(new_streams_count)s uutta kanavaa."
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because your organization <a "
@@ -2542,8 +2018,8 @@ msgstr ""
 "class=\"content_disabled_help_link\" href=\"%(help_url)s\">piilottanut "
 "viestien sisällön näyttämisen sähköposti-ilmoituksissa</a>."
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to <a "
@@ -2554,21 +2030,21 @@ msgstr ""
 "class=\"content_disabled_help_link\" href=\"%(help_url)s\">viestien sisällön "
 "näyttämisen sähköposti-ilmoituksissa</a>."
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr "<a href=\"%(realm_url)s\">Kirjaudu sisään</a> Zulipiin."
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr "Peru sähköpostitilaus kokoelmaviestien osalta"
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr "Zulip-koonti kohteelle %(realm_name)s"
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2577,19 +2053,19 @@ msgstr ""
 "Sinulle on %(new_messages_count)s uutta viestiä ja %(new_streams_count)s "
 "uutta kanavaa kohteessa %(realm_name)s."
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 "Sinulle on %(new_messages_count)s uutta viestiä kohteessa %(realm_name)s."
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr "Kohteessa %(realm_name)s on %(new_streams_count)s uutta kanavaa."
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because your organization hides "
@@ -2600,8 +2076,8 @@ msgstr ""
 "piilottanut viestin sisällön näkymisen sähköposti-ilmoituksissa. Katso "
 "lisätietoja %(hide_content_url)s."
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to hide "
@@ -2611,33 +2087,31 @@ msgstr ""
 "sisällön näyttämisen sähköposti-ilmoituksissa. Lisätietoja osoitteessa "
 "%(help_url)s."
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr ""
 "Kirjaudu Zulipiiin ja selaa lukemattomia viestejä: %(organization_url)s."
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr "Muokkaa sähköpostiasetuksia:"
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr "Peru sähköpostitilaus kokoelmaviestien osalta:"
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr "Uiva kala"
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr "Kiitos pyynnöstäsi!"
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
@@ -2646,8 +2120,7 @@ msgstr ""
 "Sähköpostisoitteellasi %(email)s on tilejä seuraavissa Zulip Cloud -"
 "organisaatioissa:"
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
@@ -2656,7 +2129,7 @@ msgstr ""
 "Sähköpostiosoitteellasi %(email)s on tilejä seuraavissa Zulip-"
 "organisaatioissa, joita isännöi %(external_host)s:"
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
@@ -2665,19 +2138,15 @@ msgstr ""
 "Jos sisäänkirjautumisessa on ongelmia voit <a "
 "href=\"%(help_reset_password_link)s\">nollata salasanan</a>."
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr "Olet hakenut luetteloa Zulip-tileistä tälle sähköpostiosoitteelle."
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr "Valitettavasti Zulip Cloud -tilejä ei löytynyt."
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
@@ -2686,7 +2155,7 @@ msgstr ""
 "Valitettavasti, Zulip-organisaatioita ei löytynyt kohteesta "
 "%(external_host)s."
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2697,29 +2166,26 @@ msgstr ""
 "sähköpostilla tai <a href =\"%(help_logging_in_link)s\">kokeilla eri tapaa</"
 "a> löytää tilejä."
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 "Jollet tunnista tätä pyyntö voit turvallisesti jättää tämän sähköpostin "
 "huomiotta."
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr "Zulip tilisi"
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr "Zulip-tilejä ei löytynyt"
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 "Jos sisäänkirjautimisessa on ongelmia voit kokeilla nollata salasanasi."
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
@@ -2728,12 +2194,12 @@ msgstr ""
 "Voit etsiä tilejä toisilla sähköpostisoitteilla (%(find_accounts_link)s) tai "
 "kokeilla muita keinoja löytää tiliä (%(help_logging_in_link)s)."
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr "Heippa,"
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
@@ -2742,17 +2208,17 @@ msgstr ""
 "%(referrer_name)s toivoo, että liittyisit seuraan Zulipissa &mdash; "
 "tuottavuuteen suunnitellussa viestintätyökalussa."
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr "Aloita alla olevasta napista."
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr "%(referrer_full_name)s kutsui sinut liittymään %(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
@@ -2761,17 +2227,17 @@ msgstr ""
 "%(referrer_full_name)s (%(referrer_email)s) toivoo, että liittyisit seuraan "
 "Zulipissa -- tuottavuuteen suunnitellussa viestintätyökalussa."
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr "Aloittaaksesi vieraile allaolevassa osoitteessa."
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr "Hei taas,"
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
@@ -2780,13 +2246,13 @@ msgstr ""
 "Ystävällinen muistutus: %(referrer_name)s toivoo, että liittyisit seuraan "
 "Zulipissa &mdash; tuottavuuteen suunnitellussa viestintätyökalussa."
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr "Tämä on viimeinen muistutus tähän kutsuun liittyen."
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
@@ -2795,13 +2261,13 @@ msgstr ""
 "Tämä kutsu vanhenee kahdessa päivässä. Jos kutsu vanhenee, sinun täytyy "
 "pyytää että %(referrer_name)skutsuu sinut uudestaan."
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr ""
 "Muistutus: liity %(referrer_name)s seuraan kohteessa%(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2812,7 +2278,7 @@ msgstr ""
 "liittyisit seuraan Zulipissa -- tuottavuuteen suunnitellussa "
 "viestintätyökalussa."
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2821,7 +2287,7 @@ msgstr ""
 "Jos sinulla on kysymyksiä, niin ota yhteyttä tämän Zulip-palvelimen "
 "ylläpitoon sähköpostilla <a href=\"mailto:%(email)s\">%(email)s</a>."
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
@@ -2830,22 +2296,20 @@ msgstr ""
 "Onko kysymyksiä tai kommentteja? <a href=\"mailto:%(email)s\">Ota yhteyttä</"
 "a>."
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr "Saat tämän viestin koska sinut mainittiin nimeltä."
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr "Saat tämän viestin koska @%(mentioned_user_group_name)s mainittiin."
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
@@ -2854,8 +2318,8 @@ msgstr ""
 "Sait tämän viestin koska kaikki osanottajat mainittiin keskustelussa "
 "%(channel_name)s > %(topic_name)s."
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
@@ -2863,16 +2327,16 @@ msgstr ""
 "Sait tämän viestin koska sinulla on jokerimerkityt maininnat käytössä "
 "seuratuille aiheille."
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 "Sait tämän viestin koska kaikki mainittiin kanavalla #%(channel_name)s."
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
@@ -2880,8 +2344,8 @@ msgstr ""
 "Sait tämän viestin koska sähköposti-ilmoitukset ovat käytössä seuratuille "
 "aiheille."
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
@@ -2890,7 +2354,7 @@ msgstr ""
 "Sait tämän viestin koska sähköposti-ilmoitukset ovat käytössä kanavalle "
 "%(channel_name)s."
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2901,7 +2365,7 @@ msgstr ""
 "%(realm_name)s Zulipissa</a>, tai <a href=\"%(notif_url)s\">muokkaa "
 "sähköpostiasetuksia</a>."
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
@@ -2910,7 +2374,7 @@ msgstr ""
 "<a href=\"%(narrow_url)s\">Katso tätä viestiä %(realm_name)sZulipissa </a>, "
 "tai <a href=\"%(notif_url)s\">muokkaa sähköpostiasetuksia</a>."
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
@@ -2919,7 +2383,7 @@ msgstr ""
 "<a href=\"%(narrow_url)s\">Vastaa %(realm_name)s Zulipissa</a> tai <a "
 "href=\"%(notif_url)s\">muokkaa sähköpostiasetuksia</a>."
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
@@ -2928,41 +2392,41 @@ msgstr ""
 "Älä vastaa tähän sähköpostiin. Tätä Zulip-palvelinta ei ole määritetty "
 "vastaanottamaan saapuvia sähköposteja. (<a href=\"%(url)s\">ohjeita</a>)."
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr "Ryhmäviestit joukolle %(direct_message_group_display_name)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr "YVt käyttäjältä %(sender_str)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr "[ratkaistu] #%(channel_name)s > %(topic_name)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr "Uudet viestit"
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr "Vastaa viestiin suoraan tai katsele sitä %(realm_name)s Zulipissa:"
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr "Katso tai vasta a%(realm_name)sZulipissa:"
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr "Vastaa %(realm_name)s Zulipissa"
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
@@ -2970,7 +2434,7 @@ msgstr ""
 "Älä vastaa tähän sähköpostiin. Tätä Zulip-palvelinta ei ole määritetty "
 "vastaanottamaan sähköpostia. Auta:"
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2981,22 +2445,22 @@ msgstr ""
 "%(new_email)s. Jos et pyytänyt tätä muutosta itse, ota pikimmiten yhteyttä "
 "%(support_email)s."
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr "Parhain terveisin,"
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr "Zulip-tiimi"
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr "Zulip-sähköposti vaihdettu organisaatiolle %(realm_name)s"
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -3007,7 +2471,7 @@ msgstr ""
 "%(new_email)s. Jos et pyytänyt tätä muutosta, ota meihin välittömästi "
 "yhteyttä osoitteessa <%(support_email)s>."
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
@@ -3015,48 +2479,48 @@ msgstr ""
 "Organisaatio: %(organization_url)s Aika: %(login_time)s Sähköposti: "
 "%(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr "Olemme havainneet hiljattain kirjautumisen seuraavalle Zulip-tilille."
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr "Organisaatio: %(organization_link)s"
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr "Sähköposti: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr "Aika: %(login_time)s"
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr "Laite: %(device_browser)s ja käyttöjärjestelmä: %(device_os)s."
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr "IP-osoite: %(device_ip)s"
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr ""
 "Jos tämä on sinun kirjautumisesi, kaikki on hyvin, eikä siihen tarvitse "
 "reagoida mitenkään."
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3067,32 +2531,32 @@ msgstr ""
 "vaarantunut, <a href=\"%(reset_link)s\">vaihda salasanasi</a> tai ota meihin "
 "yhteyttä välittömästi osoitteessa %(support_email)s."
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr "Kiitokset,"
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr "Zulip-tietoturva"
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr "Peru kirjautumisilmoitukset"
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr ""
 "Uusi kirjautuminen selaimella %(device_browser)s laitteella %(device_os)s"
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr "Organisaatio: %(organization_url)s"
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3103,7 +2567,7 @@ msgstr ""
 "vaarantunut, vaihda salasanasi osoitteessa %(reset_link)s tai ota meihin "
 "yhteyttä välittömästi osoitteella %(support_email)s."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -3113,7 +2577,7 @@ msgstr ""
 "Jos olet jo päättänyt Zulipista organisaatiollesi tervetuloa. Voit lukea <a "
 "href=\"%(get_organization_started)s\">muutto-ohjetta Zulipiin</a> aluksi."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
@@ -3121,7 +2585,7 @@ msgstr ""
 "Muutoin, tässä on jotain vinkkejä joita olemme kuulleet käyttäjiltä jotka "
 "arvioivat <i>mitä vain</i> ryhmäviestituotteita:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
@@ -3130,12 +2594,12 @@ msgstr ""
 "<a href=\"%(invite_users)s\"><b>Kutsu työtoverisi</b></a> tutkimaan ja "
 "jakamaan perspektiivejään."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr "Käytä sovellusta keskustellaksesi kokemuksistanne."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -3146,7 +2610,7 @@ msgstr ""
 "työryhmäsi kanssa, ilman muita keskustelusovelluksia. Tällä tavoin voit "
 "kokeilla miten uusi keskusteluohjelma auttaa kommunikoinnissa."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -3156,21 +2620,21 @@ msgstr ""
 "Zulip on suunniteltu <a href=\"%(why_zulip)s\">tehokkaaseen kommunikaatioon</"
 "a> ja toivomme että nämä vinkit auttavat ryhmääsi kokemaan sen."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr "Peru tervetulosähköpostitilaus kohteessa %(realm_name)s"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr "Keskusteluohjelman valinta ryhmällesi"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
@@ -3178,7 +2642,7 @@ msgstr ""
 "Jos olet jo päätynyt Zulipiin organisaatiollesi tervetuloa. Voit lukea "
 "ohjeita muuttamisesta aluksi."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
@@ -3186,13 +2650,13 @@ msgstr ""
 "Muutoin, tässä on jotain vinkkejä joita olemme kuulleet käyttäjiltä jotka "
 "arvioivat mitä vain ryhmäviestituotteita:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
 msgstr "Kutsu työtoverisi tutkimaan ja jakamaan perspektiivejään."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
@@ -3202,7 +2666,7 @@ msgstr ""
 "keskustelusovelluksia. Tällä tavoin voit kokeilla miten uusi "
 "keskusteluohjelma auttaa kommunikoinnissa."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
@@ -3210,8 +2674,8 @@ msgstr ""
 "Zulip on suunniteltu tehokkaaseen kommunikaatioon ja toivomme että nämä "
 "vinkit auttavat ryhmääsi kokemaan sen."
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
@@ -3220,71 +2684,71 @@ msgstr ""
 "Kun aloitat Zulipin käyttöä, opastamme sovittamaan sen tarpeisiisi. Tässä "
 "oppaasse on Zulipin keskeiset ominasuudet organisaatiotasi varten."
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr "Katso Zulipin ohje yrityksille"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr "Katso Zulipin ohjeet avoimen lähdekoodin projekteille"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr "Katso Zulipin ohjeet kouluille"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr "Katos Zulipin ohjeet tutkijoille"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr "Katso Zulipin ohjeet tapahtumille ja konferensseille"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr "Katso Zulipin ohjeet voittoa tavoittelemattomille yrityksille"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr "Katso Zulipin ohjeet yhteisöille"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr "Zulipin ohje yrityksille"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr "Zulipin ohje avoimen lähdekoodin projekteille"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr "Zulipin ohje kouluille"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr "Zulipin ohje tutkijoille"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr "Zulipin ohje tapahtumille ja konferensseille"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr "Zulipin ohje voittoa tavoittelmattomille yrityksille"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr "Zulipin ohje yhteisöille"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
@@ -3292,7 +2756,7 @@ msgstr ""
 "Tässä on jotain vihjeitä Zulipin keskutelujen järjestyksesssä pitämiseksi "
 "aiheilla."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
@@ -3300,8 +2764,8 @@ msgstr ""
 "Zulipissa <b>kanavat</b> määrittelevät kuka saa viestin. <b>Aiheet</b> "
 "määrittelevät mitä viesti koskee."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
@@ -3309,12 +2773,12 @@ msgstr ""
 "Aiheilla voit lukea Zulipin viestejä keskustelu kerrallaan. Näet joka "
 "viestin aiheyhteydessään, riippumatta siitä montako keskustelua on menossa."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr "Kanavat ja eiheet Zulipin sovelluksessa"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3325,11 +2789,11 @@ msgstr ""
 "aiheen. Tällä tavoin keskustelu ei sotke menossa olevia keskusteluja. Hyvä "
 "aiheen nimi yleensä täydentää esim. lauseen \"Voitaisiinko keskustella...?\""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr "Esimerkkejä lyhyistä aiheista"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3343,17 +2807,17 @@ msgstr ""
 "href=\"%(move_channels_link)s\">siirtäminen toiselle kanavalle</a> on "
 "helppoa."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr "Siirry Zulipiin"
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr "Pidä keskustelut järjestyksessä aiheilla"
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
@@ -3361,7 +2825,7 @@ msgstr ""
 "Zulipissa, kanavilla määritellään kuka saa viesti. Aiheet määrittelevät mitä "
 "viesti koskee."
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3374,8 +2838,8 @@ msgstr ""
 "(%(rename_topics_link)s) tai siirtäminen toiselle kanavalle "
 "(%(move_channels_link)s) on helppoa."
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
@@ -3384,15 +2848,15 @@ msgstr ""
 "Joku (ehkä sinä) pyysi uutta salasanaa Zulip-tilille %(email)s osoitteessa "
 "%(realm_url)s."
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr "Alla olevalla napilla voi asettaa uuden salasanan."
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr "Aseta uusi salasana"
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3403,18 +2867,18 @@ msgstr ""
 "poistettu käytöstä. Voit ottaa yhteyttä organisaation järjestelmänvalvojaan "
 "<a href=\"%(help_link)s\">aktivoidaksesi tilisi uudelleen</a>."
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr "Sinulla ei ole Zulip-tiliä tässä organisaatiossa."
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr "Sinulla ei ole aktiivista tiliä seuraavissa organisaatio(i)ssa."
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
@@ -3422,23 +2886,23 @@ msgstr ""
 "Voit kokeilla kirjautua sisään tai vaihtaa salasanasi ylläolevaan "
 "organisaatioon (tai organisaatioihin)."
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 "Jos et tunnista tätä toimintaa, voit jättää tämän sähköpostin huomiotta."
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr "Salasanan nollauspyyntö organisaatiolle %(realm_name)s"
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr "Alla olevasta linkistä voi asettaa uuden salasanan."
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
@@ -3447,7 +2911,7 @@ msgstr ""
 "Sinulla oli aiemmin tili osoitteessa %(realm_url)s, mutta se on deaktivoitu. "
 "Ota yhteys organisaation administraattoriin uudelleenaktivoimiseksi."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3458,7 +2922,7 @@ msgstr ""
 "Ilmainen tilaus maksamattomien laskujen vuoksi. Maksamattomat laskut on "
 "mitätöity."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
@@ -3467,7 +2931,7 @@ msgstr ""
 "Jos haluat jatkaa Zulip Cloud Standard -tilausta, päivitä uudelleen "
 "siirtymällä osoitteeseen %(upgrade_url)s."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
@@ -3476,8 +2940,8 @@ msgstr ""
 "Jos tämä oli mielestäsi virhe tai tarvitset lisätietoja, ota meihin yhteyttä "
 "osoitteella %(support_email)s."
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip demo organization, %(realm_name)s, on "
@@ -3486,8 +2950,8 @@ msgstr ""
 "Olet deaktivoinut Zulipin demo-organisaation. %(realm_name)s kohteessa "
 "%(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
@@ -3496,8 +2960,8 @@ msgstr ""
 "Zulip-organisaatiosi %(realm_name)s on deaktivoitu käyttäjän "
 "%(deactivating_owner)s toimesta ajalla %(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
@@ -3505,8 +2969,8 @@ msgid ""
 msgstr ""
 "Zulip-organisaatiosoi %(realm_name)s deaktivoitiin ajalla %(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
@@ -3515,8 +2979,8 @@ msgstr ""
 "Olet deaktivoinut Zulip-organisaation. %(realm_name)s kohteessa "
 "%(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
@@ -3525,24 +2989,24 @@ msgstr ""
 "Zulip-organisaatios %(realm_name)s on deaktivoitu käyttäjän "
 "%(deactivating_owner)s toimesta ajalla %(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr "Zulip-organisaatiosoi %(realm_name)s deaktivoitiin %(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 "Kaikki data joka on liitetty tähän organisaatioon on peruuttamattomasti "
 "poistettu."
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
@@ -3551,8 +3015,8 @@ msgstr ""
 "Kaikki data joka on liitetty organisaatioon poistetaan peruuttamattomasti "
 "%(deletion_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
@@ -3560,19 +3024,19 @@ msgstr ""
 "Jos sinylla on kysymyksiä tai huolia, vastaa tähän viestiin niin pian kuin "
 "mahdolllistsa."
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr "Zulip-organisaatiosi %(realm_name)s on deaktivoitu"
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr "Parahin aiempi järjestelmänvalvoja osoitteessa %(realm_name)s,"
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
@@ -3581,8 +3045,8 @@ msgstr ""
 "Administraattorisi on pyytänyt uudelleenaktivoimista aiemmin deaktivoidulle "
 "organisaatiolle kohteessa %(realm_url)s."
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
@@ -3591,16 +3055,16 @@ msgstr ""
 "Administraattorisi on pyytänyt uudelleenaktivoitumista aiemmin "
 "deaktivoidulle organisaatiolle kohteessa %(realm_url)s."
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr "Alla oleva linkki uudelleenaktivoi organisaatiosi."
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr "Uudelleenaktivoi organisaatio"
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
@@ -3608,19 +3072,19 @@ msgstr ""
 "Jos pyyntö oli virhe, voit olla tekemättä mitään ja tämä linkki vanhenee 24 "
 "tunnissa."
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip demo organization"
 msgstr "Uudelleenaktivoi Zulipin demo-organisaatio"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr "Uudelleenaktivoi Zulip-organisaatio"
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr "Alla oleva linkki uudelleenaktivoi organisaation."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3629,18 +3093,18 @@ msgstr ""
 "Joko sinä, tai joku muu, on pyytänyt lähetettäväksi linkin Zulipin tilausten "
 "määrittelyyn palvelimelle <b>%(remote_server_hostname)s</b>."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 msgid "Click the button below to log in."
 msgstr "Napsauta alla olevaa nappia sisään kirjautumiseksi."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr "Tämä linkki vanhenee %(validity_in_hours)s tunnissa."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
@@ -3649,11 +3113,11 @@ msgstr ""
 "Kysymyksiä? <a href=\"%(billing_help_link)s\">Lue lisää</a> tai ota "
 "yhteyttä: %(billing_contact_email)s."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr "Kirjaudu Zulipin tilauksenhallintaan"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3662,12 +3126,12 @@ msgstr ""
 "Joko sinä, tai joku muu, on pyytänyt lähetettäväksi linkin Zulipin tilausten "
 "määrittelyyn palvelimelle %(remote_server_hostname)s."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr "Napsauta alla olevaa linkkiä sisään kirjautumiseksi."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
@@ -3676,7 +3140,7 @@ msgstr ""
 "Kysymyksiä? Lue lisää sivulta %(billing_help_link)s tai ota yhteyttä: "
 "%(billing_contact_email)s."
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
@@ -3685,16 +3149,16 @@ msgstr ""
 "Paina alla olevaa nappia sähköpostin vahvistamiseksi ja kirjaudu sisään "
 "Zulipin tilauksenhallintaan palvelimelle <b>%(remote_realm_host)s</b>."
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr "Vahvista ja kirjaudu sisään"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr "Vahvista sähköposti Zulipin tilauksenhallintaan"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
@@ -3703,7 +3167,7 @@ msgstr ""
 "Paina alla olevaa linkkiä sähköpostin vahvistamiseksi ja kirjaudu sisään "
 "Zulipin tilauksenhallintaan palvelimelle %(remote_realm_host)s."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
@@ -3712,7 +3176,7 @@ msgstr ""
 "Hakemuksesi Zulipin sponsoroinnille on hyväksytty. Organisaatiosi on "
 "nostettu tasolle <a href=\"%(plans_link)s\">Zulip Community plan</a>."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
@@ -3721,12 +3185,12 @@ msgstr ""
 "Jos voit <a href=\"%(link_to_zulip)s\">mainita Zulipin sponsorina "
 "sivuillasi</a> niin se olisi oikein arvostettavaa."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr "Yhteisötason sponsorointi hyväksytty käyttäjälle %(billing_entity)s."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
@@ -3734,7 +3198,7 @@ msgstr ""
 "Hakemus Zulipin sponsoroinnille on hyväksytty. Organisaatiosi on päivitetty "
 "Zulipin yhteisösuunnitelmaan."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
@@ -3742,20 +3206,20 @@ msgstr ""
 "Jos voisit mainita Zulipin sponsorina sivuillasi niin se olisi oikein "
 "arvostettavaa."
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr "Etsi tilejäsi"
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr "Löydä Zulip-tilisi"
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr "Sähköposti lähetetty. Osoitteet edellisellä sivulla olivat:"
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
@@ -3764,7 +3228,7 @@ msgstr ""
 "Jollet saa viestiä voit <a href=\"%(current_url)s\">hakea tilejä toisille "
 "osoitteille</a>."
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
@@ -3772,7 +3236,7 @@ msgstr ""
 "Anna sähköpostiosoite saadaksesi viesti jossa on URL kaikille Zulip-pilven "
 "organisaatioille joissa olet mukana."
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
@@ -3780,7 +3244,7 @@ msgstr ""
 "Anna sähköpostiosoite saadaksesis viesti jossa on URL kaikille Zulip-"
 "organisaatioille tällä palvelimella joissa olet mukana."
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
@@ -3788,214 +3252,214 @@ msgstr ""
 "Jos olet unohtanut salasanan, <a href=\"/help/change-your-password\">palauta "
 "se tästä</a>."
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr "Sähköpostiosoite"
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "Etsi tilejä"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr "Tuote"
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr "Miksi Zulip"
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr "Ominaisuudet"
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr "Suunnitelmat ja hinnat"
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 msgid "Zulip Cloud"
 msgstr "Zulipin pilvi"
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr "Itseisännöinti"
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr "Tietoturva"
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "Integraatiot"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr "Työpöytä- ja mobiilisovellukset"
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr "Uusi organisaatio"
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr "Ratkaisut"
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr "Yritykset"
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr "Koulutus"
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr "Tutkimustyö"
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr "Tapahtumat ja konferenssit"
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr "Avoimen lähdekoodin projektit"
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr "Yhteisöt"
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr "Insinöörit"
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr "Asiakkaiden tarinoita"
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr "Avoimet yhteisöt"
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr "Resurssit"
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr "Aloittaminen"
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr "Tukikeskus"
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr "Yhteisöchatti"
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr "Partnerit"
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr "Zulipin pilven tila"
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr "Siirry Zulipiin"
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr "Zulip palvelimen asennus"
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr "Zulip palvelimen päivitys"
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr "Osallistuminen"
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr "Osallistumisohje"
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr "Kehitysyhteisö"
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr "Käännökset"
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr "GitHub"
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr "Tietoa meistä"
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr "Tiimi"
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "Historia"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr "Arvot"
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr "Työpaikat"
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr "Blogi"
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr "Tue Zulipia"
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr "Mastodon"
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Values"
 msgid "Bluesky"
 msgstr "Arvot"
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr "<a href=\"https://zulip.com\">Zulip</a> käytössä"
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr "Käyttöehdot"
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr "Tietosuojakäytäntö"
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr "Verkkosivuattribuutioita"
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr "Yli %(integrations_count_display)s natiivia integraatiota."
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 #, fuzzy
 #| msgid ""
 #| "And hundreds more through <a href=\"/integrations/doc/zapier\">Zapier</a> "
@@ -4007,51 +3471,47 @@ msgstr ""
 "Ja satoja lisää seuraavista palveluista: <a href=\"/integrations/doc/"
 "zapier\">Zapier</a> ja <a href=\"/integrations/doc/ifttt\">IFTTT</a>."
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr "Etsi integraatioita"
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr "Mukautetut integraatiot"
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr "Saapuvat webhookit"
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr "Interaktiiviset botit"
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr "REST API"
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr "Virheellinen sähköposti"
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr "Sähköposti ei ole sallittu"
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr "Sähköpostiosoite jolla yrität kirjautua ei ole kelvollinen."
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4061,7 +3521,7 @@ msgstr ""
 "Organisaatio johon yritit liittyä <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> ei salli kirjautimista tästä sähköpostiosoitteesta."
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4072,7 +3532,7 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a> ei salli kirjautumisia "
 "kertakäyttöisistä sähköpostiosoitteista."
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4082,24 +3542,24 @@ msgstr ""
 "Organisaatio johon yritit liittyä <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> ei salli sähköpostiosoitteita joissa on +."
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr "Kirjaudu toimivalla sähköpostiosoitteella."
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr "Kirjaudu sallitulla sähköpostiosoitteella."
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr "Ei organisaatioita löytynyt"
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr "Ei Zulip-organsiaatioita osoitteissa <b>%(current_url)s</b>."
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -4110,7 +3570,7 @@ msgstr ""
 "lista Zulip-pilvitileistä</a> tai <a href=\"mailto:%(support_email)s\">ota "
 "yhteys Zulipin tukeen</a>."
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -4121,7 +3581,7 @@ msgstr ""
 "lista tileistäsi</a> tällä palvelimella tai <a href=\"mailto:"
 "%(support_email)s\">*ota yhteys Zulip-palvelimen administraattoreihin</a>."
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
@@ -4130,60 +3590,60 @@ msgstr ""
 "<a href=\"%(current_url)s/serverlogin/\">Paina tästä</a> niiin pääset "
 "suunnitelmanhallintaan Zulip-palvelimellasi."
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr "Viallinen tai vanhentunut kirjautumisistunto"
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr "Virheellinen tai vanhentunut istunto."
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr "Kirjaudu Zulipiin"
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 "Olet jo rekisteröitynyt tällä sähköpostiosoitteella. Kirjaudu sisään alta."
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr "Sähköposti tai käyttäjätunnus"
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "Käyttäjätunnus"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr "Unohtuiko salasana?"
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr "Kirjaudu käyttäen %(identity_provider)s"
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr "Katsele ilman tiliä"
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 "Eikö sinulla ole tiliä vielä? Tarvitsen kutsun liittyäksesi tähän "
 "organisaatioon."
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr "Ei lisenssejä saatavilla"
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr "Organisaatio ei voi ottaa vastaan uusia jäseniä tällä hetkellä"
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
@@ -4193,7 +3653,7 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a> koska kaikkia Zulip-pilvilisenssit "
 "on käytetty."
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
@@ -4201,19 +3661,19 @@ msgstr ""
 "Ottakaa yhteys henkilöön joka lähetti kutsun ja pyytäkää häntä ostamaan "
 "lisää lisenssejä, ja yrittämään uudestaan."
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr "Hyppää sisältöön"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr "Vahvennusalidomainvirhe"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr "Varmennusalidomain"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -4225,43 +3685,41 @@ msgstr ""
 "eikä tänne pääse muuten. Jos tulit tänne suoraan osoite oli varmaan väärin. "
 "Jos vahvistautuminen on jumissa, vika on palvelimessa."
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 msgid "Demo organizations disabled"
 msgstr "Demo-organisaatiot pois käytöstä"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr "Päivitys vaaditaan"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr "Käytössä vanha versio Zulip Desktopista jota ei tueta."
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 "Automaattiset päivitykset tässä versiossa Zulip Desktoppia eivät enää toimi."
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr "Lataa viimeisin versio."
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr "Olet ylittänyt enimmäismäärän näitä toimintoja käyttäjälle."
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr "Organisaationluontilinkki tarvitaan"
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -4273,12 +3731,11 @@ msgstr ""
 "en/stable/production/multiple-organizations.html\">ohjeista</a> miten uusi "
 "organisaation luodaan."
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr "Organisaationluontilinkki on vanhentunut tai viallinen"
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
@@ -4286,11 +3743,11 @@ msgstr ""
 "Tämä ei ole toimiva linkki organisaation luomiseksi. Hae <a href=\"/new/"
 "\">uusi linkki</a> ja yritä uudestaan."
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr "Odottamaton Zulip-palvelimen rekisteröinti"
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -4301,17 +3758,16 @@ msgstr ""
 "href=\"mailto:%(support_email)s\">Ota yhteys Zulipin tukeen</a> tässä "
 "asiassa."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr "Tukematon selain"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr "Zulip ei tue selainta %(browser_name)s."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
@@ -4320,7 +3776,7 @@ msgstr ""
 "Zulip tukee <a href=\"%(supported_browsers_page_link)s\">moderneja selaimia</"
 "a> kuten Firefoxia, Chromea tai Edgeä."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
@@ -4328,21 +3784,20 @@ msgstr ""
 "Voit myös kokeilla <a href=\"%(apps_page_link)s\">Zulipin "
 "työpöytäsovellusta</a>."
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr "Tili on poistettu käytöstä"
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 msgid "Finalize organization import"
 msgstr "Viimeistele organisaation tuonti"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 msgid "Organization import completed!"
 msgstr "Organisaation tuonti valmistui"
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -4353,52 +3808,51 @@ msgstr ""
 "vahvistettuun sähköpostiosoitteeseesi (<strong>%(verified_email)s</strong>). "
 "Valitse tili jonka kanssa sähköpostiosoite yhdistetään."
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 msgid "Select your account"
 msgstr "Valitse tilisi"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 msgid "Create new account"
 msgstr "Luo uusi tili"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr "Organisaatio uudelleenaktivoitu"
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr "Organisaatiosi on onnistuneesti aktivoitu uudelleen."
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr "Organisaationuudelleenaktivointilinkki vanhenutunt tai viallinen"
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr "Organisaation aktivointilinkki on vanhentunut tai virheellinen."
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr "Kirjaudu organisaatioosi"
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr "your-organization"
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr "Etkö tiedä organisaatiosi URL-osoitetta?"
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr "Etsi organisaatiosi."
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr "Seuraava"
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4409,11 +3863,11 @@ msgstr ""
 "href=\"%(org_creation_link)s\">Luo uusi organisaatio</a> jollei sinulla ole "
 "vielä."
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 msgid "Self-hosting Zulip?"
 msgstr "Itse hostattu Zulip?"
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4423,11 +3877,11 @@ msgstr ""
 "href=\"%(self_hosted_login_help)s\">kirjautua sisään hallitatksesi "
 "suunnitelmia ja laskutusta.</a>"
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr "Aseta uusi salasanasi"
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
@@ -4435,62 +3889,62 @@ msgstr ""
 "Unohtuiko salasana? Lähetämme linkin jolla voi nollata salasanan siihen "
 "sähköpostiin jolla rekisteröidyit."
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr "Lähetä nollauslinkki"
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr "Aseta uusi salasana"
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "Vahvista salasana"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr ""
 "Valitettavasti linkki, jonka annoit on virheellinen tai se on jo käytetty."
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr "Uusi salasnaa asetettu"
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr "Olet asettanut uuden salasanan."
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr "<a href=\"%(login_url)s\">Kirjaudu</a>käyttäen uutta salasanaasi."
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr "Salasananresetointiviesti lähetetty"
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr "Salasanan uudelleenasetussähköposti lähetetty!"
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr ""
 "Viimeistele prosessi tarkistamalla sähköpostisi muutaman minuutin kuluttua."
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr "Tuo Slackistä"
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr "Viennin edistyminen"
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr "Tarkastetaan tuonnin tilaa…"
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4501,7 +3955,7 @@ msgstr ""
 "com/help/import-from-slack#import-your-data-into-zulip\">Zulip-pilven (tuen "
 "kautta) tuomiseksi</a> viimeistelläksesi tuomisen."
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4514,15 +3968,15 @@ msgstr ""
 "rel=\"noopener noreferrer\" target=\"_blank\">näitä ohjeita</a> jotta saat "
 "<strong>OAuth-tokenin bottikäytäjälle</strong>."
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr "Slack-bottikäyttäjän OAuth-token"
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr "Lähetä Slack-vientitiedostosi"
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
@@ -4532,19 +3986,19 @@ msgstr ""
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">näitä ohjeita</a> jotta "
 "voit tuoda Slack-viestihistoriaviennin."
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr "Aloita lataus"
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr "Lähetä vientitiedosto"
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr "Kuka pystyu näkemään käyttäjien sähköpostiosoitteita?"
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
@@ -4554,11 +4008,11 @@ msgstr ""
 "visibility\" target=\"_blank\">muuttaa</a> sähköpostinäkyvyysasetuksia "
 "sisäänkirjautuneina."
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr "Aloita tuonti"
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
@@ -4566,7 +4020,7 @@ msgstr ""
 "Voit poistua. Tälle sivulle voi aina palata <br /> klikkaamalla "
 "<b>Viimeisetele rekisteröinti</b>-nappia sähköpostissa."
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
@@ -4574,7 +4028,7 @@ msgstr ""
 "Tai <span id=\"cancel-slack-import\" tabindex=\"0\">luo organisaatio</span> "
 "ilman datan tuontia."
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4585,7 +4039,7 @@ msgstr ""
 "href=\"/help/import-from-slack#import-your-data-into-zulip\" rel=\"noopener "
 "noreferrer\" target=\"_blank\">prosessia</a> tuen avulla."
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4596,21 +4050,21 @@ msgstr ""
 "href=\"/help/import-from-slack#import-your-data-into-zulip\" rel=\"noopener "
 "noreferrer\" target=\"_blank\">prosessia</a> itseḧostatuille vienneille."
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr "Valitse tili autentikointia varten"
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr "<h1 class=\"get-started\">Valitse tili</h1>"
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 "GitHub-tililläsi on myös vahvistamattomia sähköpostiosoitteita liitettynä."
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
@@ -4618,21 +4072,21 @@ msgstr ""
 "Kirjautuaksesi jollakin näistä Zulipiin, sinun tulee ensin <a href=\"https://"
 "github.com/settings/emails\">vahvistaa se GitHubissa.</a>"
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr "Virhe sähköpostin kirjautumisen poistossa"
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr "Tuntematon sähköpostitilauksen perumispyyntö"
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
 msgstr "Yritit perua tilauksen jostain, mutta tämä osoite ei ole tunnettu."
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4643,12 +4097,11 @@ msgstr ""
 "href=\"mailto:%(support_email)s\">lähetä sähköpostia meille</a> jotta tämä "
 "saadaan korjatuksi."
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr "Sähköpostin asetukset päivitetty"
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
@@ -4657,7 +4110,7 @@ msgstr ""
 "Peruit tilauksen Zulipin %(subscription_type)s -sähkoposteille palvelimella "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
@@ -4666,114 +4119,112 @@ msgstr ""
 "Voit perua tämän muutoksen tai muuttaa asetuksia <a href=\"%(realm_url)s/"
 "#settings/notifications\">ilmoitusasetuksista</a>."
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr "Virheellinen order mapping."
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr "Kysymyksiä ja keskusteluja Zulipin käytöstä."
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr "Testaa Zulipia tässä :test_tube:"
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr "Ryhmäkeskusteluille"
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr "ilmoittautumiset"
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr "{user} liittyi tähän organisaatioon."
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr "{user} hyväksyi kutsusi liittyä Zulipiin!"
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 "Ei voitu aktivoida paikanpitäjätiliä, pyydä käyttäjää kirjautumaan sen "
 "sijaan."
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 msgid "Cannot reactivate a deleted user"
 msgstr "Poistettua käyttäjää ei voi reaktivoida."
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr "Tätä kenttää ei voi muuttaa. Ota yhteyttä ylläpitoon muuttamiseksi."
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr "Kenttä id {id} ei löydy."
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr "Virheellinen oletuskanavaryhmän nimi {group_name}"
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr "Oletuskanavaryhmän nimi on liian pitkä (yläraja; {max_length} merkkiä)"
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr "Oletuskanavan ryhmän nimi {group_name} sisältää NULL-merkkejä (0x00)."
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr "Virheellinen oletuskanavaryhmä {group_name}"
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 "{channel_name} on oletuskanava eikä sitä voi lisätä ryhmään {group_name}"
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr "Oletuskanavan ryhmä {group_name} on jo olemassa"
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr "Kanava {channel_name} on jo oletuskanavan ryhmässä {group_name}"
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr "Kanava {channel_name} ei ole oletuskanavaryhmässä {group_name}"
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr "Oeltuskanavaryhmä on jo nimetty {group_name}"
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
@@ -4781,7 +4232,7 @@ msgstr ""
 "Käyttäjien suojaamiseksi Zulip rajoittaa yhdessä päivässä lähetettävien "
 "kutsujen määrää. Koska olet saavuttanut rajan, kutsuja ei lähetetty."
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
@@ -4789,79 +4240,79 @@ msgstr ""
 "Tilisi on liian uusi jotta voisit lähettää kutsuja tähän organisaatioon. "
 "Kysy organisaation järjestelmänvalvojalta tai kokeneemmalta käyttäjältä."
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 "Joitain sähköposteja ei saatu vahvistettua, joten yhtään kutsua ei lähetetty."
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr "Emme kyenneet kutsumaan ketään."
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr "Ei mitään muutettavaa"
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr "Suoria viestejä ei voi siirtää kanaville."
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr "Suorilla viesteillä ei voi olla aiheita."
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr "Virheellinen propagate_mode ilman aiheen muokkausta"
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr "Chattiä ei voi merkitä ratkaistuksi"
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr "Ei voida muuttaa viestin sisältöä kanavaa muutettaessa"
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr "Widgettiä ei voi editoida."
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr "Organisaatiosi on ottanut viestien muokkauksen pois päältä"
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr "Sinulla ei ole oikeuksia muokata tätä viestiä"
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr "Tämän viestin muokkaamisen aikaraja on ohitettu"
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr "{user} on merkinnyt tämän aiheen ratkaistuksi."
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr "{user} on merkinnyt tämän aiheen ratkaisemattomaksi."
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr ""
 "Tämä aihe on siirretty paikkaan {new_location} käyttäjän {user} toimesta."
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr ""
 "Viesti tästä aiheesta on siirretty paikkaan {new_location} käyttäjän {user} "
 "toimesta."
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
@@ -4870,13 +4321,13 @@ msgstr ""
 "{changed_messages_count} viestiä tästä aiheesta on siirretty paikkaan "
 "{new_location} käyttäjän {user} toimesta."
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr ""
 "Tämä aihe on siirretty paikasta {old_location} käyttäjän {user} toimesta."
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
@@ -4884,7 +4335,7 @@ msgstr ""
 "[Viesti]({message_link}) siirrettiin tänne paikasta {old_location} käyttäjän "
 "{user} toimesta."
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
@@ -4893,67 +4344,64 @@ msgstr ""
 "{changed_messages_count} viestiä on siirretty tänne paikasta {old_location} "
 "käyttäjän {user} toimesta."
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to resolve topics in this channel."
 msgstr "Sinulla ei ole oikeuksia ratkaista viestiä tällä kanavalla."
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr "Tämän viestin aiheen muokkaamisen aikaraja on ohitettu."
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr "Sinulla ei ole oikeuksia siirtää tätä viestiä"
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr "Tämän viestin kanavan muokkaamisen aikaraja on ohitettu"
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr "Virheellinen lippu: {flag}"
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr "Lippua ei voi muokata: {flag}"
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr "Virheellinen viestin lippuoperaatio: {operation}"
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr "Virheellinen viesti(t)"
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr "Viestiä ei kyetä esittämään"
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr "Odotettiin täsmälleen yhtä kanavaa"
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr "Virheellinen tietotyyppi kanavalle"
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr "Virheellinen tieto vastaanottajille"
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 "Vastaanottajalista voi sisältää sähköpostiosoitteita tai käyttäjätunnuksia, "
 "mutta ei molempia."
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
@@ -4962,7 +4410,7 @@ msgstr ""
 "Bottisi {bot_identity} yritti lähettää viestiä kanvatunnukselle "
 "{channel_id}, mutta kanavaa tällä tunnuksella ei ole olemassa."
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4973,7 +4421,7 @@ msgstr ""
 "mutta tätä kanavaa ei ole olemassa. Voit luoda sen napsauttamalla [tästä]"
 "({new_channel_link})."
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
@@ -4982,29 +4430,29 @@ msgstr ""
 "Bottisi {bot_identity} yritti lähettää viestiä kanavalle {channel_name}. "
 "Kanava on olemassa mutta sillä ei ole yhtään tilaajaa."
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr "Sinulla ei ole lupaa nähdä joitain vastaanottajista."
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr "Widgetit: API-ohjelmoija lähetti virheellisen JSON-sisällön"
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr "Widgetit: {error_msg}"
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr "Seuraavat muutokset on tehty tilillesi."
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr "{user} teki seuraavat muutokset tilillesi."
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5015,25 +4463,23 @@ msgstr ""
 "- **Vanha {field_name}:** {old_value}\n"
 "- **Uusi {field_name}:** {new_value}\n"
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr "Samanniminen mukautettu emoji on jo olemassa."
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr "Viallinen kuvamuoto"
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr "Järjestetty lista ei voi sisältää kaksoiskappaleita linkittimistä"
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr "Järjestetyn listan on sisällettävä kaikki linkittimet tasan kerran"
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
@@ -5041,78 +4487,78 @@ msgid ""
 msgstr ""
 "Tätä vahvistusmenetelmää varten ptiää ostaa {required_upgrade_plan_name}."
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 "Virheellinen vahvennusmenetelmä: {name}. Sallitut menetelmät: {methods}"
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr "Vahvistusmenetelmä {name} ei ole saatavilla tässä tilauksessa."
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr "Moderointipyyntökanavan on oltava yksityinen."
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr "Tallennettu leike ei ole olemassa."
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr "Ajastettu viesti oli jo lähetetty"
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 #, fuzzy
 #| msgid "Reminder does not exist"
 msgid "Reminder could not be sent."
 msgstr "Muistutus ei ole olemassa"
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr "Viestiä ei voitu lähettää ajastettuun aikaan."
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
 "the following error:"
 msgstr "Viestiä jonka ajastit {delivery_datetime} ei lähetetty koska:"
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr "[Näytä ajastetut viestit](#scheduled)"
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr "Kanava on jo deaktivoitu"
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr "Kanava #**{channel_name}** on arkistoitu."
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr "Kanava ei ole vielä deaktivoitu"
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr "Kanava nimellä {channel_name} on jo olemassa"
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr "Kanava on yksityinen eikä sillä ole tilaajia"
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr "Kanava #**{channel_name}** on poistettu arkistoinnista."
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
@@ -5121,7 +4567,7 @@ msgstr ""
 "{user} muutti kanavan [käyttöoikeudet]({help_link}) arvosta **{old_policy}** "
 "arvoon **{new_policy}**."
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -5134,41 +4580,39 @@ msgstr ""
 "* **Vanhat**: {old_setting_description}\n"
 "* **Uudet**: {new_setting_description}\n"
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 "{user_name} muutti kanavan {old_channel_name} nimeksi {new_channel_name}."
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr "Ei kuvausta."
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr "{user} muutti tämän kanavan kuvausta."
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr "Vanha kuvaus"
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr "Uusi kuvaus"
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr "Ikuisesti"
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr "{number_of_days} days"
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
@@ -5177,11 +4621,11 @@ msgstr ""
 "Tämän kanavan viestit poistetaan automaattisesti {number_of_days} päivää "
 "lähettämisen jälkeen."
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr "Tällä kanavalla viestit säilytetään nyt ikuisesti."
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -5197,26 +4641,26 @@ msgstr ""
 "\n"
 "{summary_line}"
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr "Automaattinen"
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr "*{empty_topic_display_name}* aihe sallittu"
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr "Ei *{empty_topic_display_name}* aihetta"
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr "Vain *{empty_topic_display_name}* aihe sallittu"
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
@@ -5225,73 +4669,63 @@ msgstr ""
 "{user_name} muutti asetusta ”Sallitaanko *general chat* aihe?” asetuksesta "
 "{old_topics_policy} asetukseen {new_topics_policy}."
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr "Et voi liittää tähän viestiin alaviestiä."
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr "Virheellinen käyttäjätunnus {user_id}"
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr "Käyttäjäryhmä {group_name} on jo olemassa."
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr "Riittämättömät oikeudet"
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr "Tämä API ei ole käytettävissä sisään tuleville webhook-boteille."
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr "Tiliä ei ole liitetty aliverkkotunnukseen"
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr "Tämä päätepiste ei hyväksy bottipyyntöjä."
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr "On oltava järjestelmänvalvoja"
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr "Tämä päätepiste vaatii HTTP basic authenticationin."
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr "Virheellinen valtuutusotsikko basic auth:lle"
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr "Puuttuva Basic-valtuutusotsikko"
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr "Webhook-botit voivat päästä vain webhookeihin"
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr "Viallinen sähköposti tai salasana."
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
@@ -5300,56 +4734,55 @@ msgstr ""
 "Tilisi {username} on poistettu käytöstä. Ota yhteyttä organisaatiosi "
 "järjestelmänvalvojaan aktivoidaksesi tilisi uudelleen."
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr "Salasana on liian heikko."
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr "Aliverkkotunnuksen pitää olla pituudeltaan 3 tai suurempi."
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr "Aliverkkotunnus ei voi alkaa taikka loppua '-' merkkiin."
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr ""
 "Aliverkkotunnus voi sisältää vain pieniä kirjaimia, numeroita, ja '-' "
 "merkkejä."
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr "Alidomain on jo käytössä, valitse joku toinen."
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr "Aliverkkotunnus on varattu, valitse toinen."
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr "Käytä oikeaa sähköpostiosoitettasi."
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr ""
 "Organisaatio johon yrität liittyä käyttäen {email} osoitetta ei ole olemassa."
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr "Pyydä organisaation järjestelmänvalvojalta kutsu {email} osoitteelle."
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 "Ei voi liittyä organisaatioon. salasana-autentikaatiota ei ole otettu "
 "käyttöön."
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
@@ -5358,11 +4791,11 @@ msgstr ""
 "Sähköpostiosoitteesi {email} ei ole verkkotunnuksesta joista on sallittu "
 "rekisteröityminen tähän organisaatioon."
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr "Sähköpostiosoitteessa ei saa olla + -merkkiä tässä organisaatiossa."
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
@@ -5372,32 +4805,31 @@ msgstr ""
 "lisenssit ovat käytössä. Ota yhteyttä kutsujaan ja pyydä häntä lisäämään "
 "lisenssien määrää ja yritä sitten uudelleen."
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr "Vahvistettiin että olet ihmiskäyttäjä."
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr "Vahvistetaan ettet ole botti…"
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 msgid "Challenges are not enabled."
 msgstr "Haasteet botit eivät ole käytössä."
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr "Vahvistus epäonnistui, yritä uudestaan."
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "Uusi salasana"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr "Uuden salasanan vahvistaminen"
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "You're making too many attempts to sign in. Try again in "
@@ -5407,7 +4839,7 @@ msgstr ""
 "{retry_after_string} tai ota yhteyttä organisaatiosi järjestelmänvalvojaan "
 "saadaksesi apua."
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
@@ -5415,85 +4847,83 @@ msgstr ""
 "Salasanasi on poistettu käytöstä, koska se on liian heikko. Nollaa "
 "salasanasi luodaksesi uusi."
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr "Valtuus"
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 "Vinkki: Voit syöttää useamman sähköpostiosoitteen erottelemalla ne pilkuin."
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr "Lisää korkeintaan 10 sähköpostia."
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr "Zulip-organisaatiota ei löytynyt."
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr "Virheellinen sähköposti {email}"
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr "Puuttuva aihe"
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr "Ei voida lähettää useammalle kanavalle"
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr "Puuttuva kanava"
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr "Viestillä täytyy olla vastaanottajia"
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr "Virheellinen viestityyppi"
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr "Virheellinen liite"
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr "Virhe tapahtui liitettä poistettaessa. Yritä myöhemmin uudelleen."
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr "Viestillä tulee olla vastaanottajiat!"
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name can't be empty."
 msgstr "Kanavakansion nimi ei voi olla tyhjä."
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr "Virheellinen merkki kanavakansion nimessä kohdassa {position}."
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr "Kanavakansion nimi on jo käytössä"
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 msgid "Invalid channel folder ID"
 msgstr "Viallinen kanavakansion tunnus"
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 msgid "Configure owner account email address."
 msgstr "Aseta tilisi sähköpostiosoite."
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5506,73 +4936,73 @@ msgstr ""
 "poistetaan  automaattisesti {deletion_time}, jolle sitä [muunneta\n"
 "pysyväksi]({convert_demo}).\n"
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, python-brace-format
 msgid "{var_name} is not Base64 encoded"
 msgstr "{var_name} ei ole Base64-koodattu"
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 #, fuzzy
 #| msgid "Invalid emoji code."
 msgid "Invalid `device_id`"
 msgstr "Virheellinen emojin koodi."
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr "{service_name} kokoelma"
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr "Verkkotunnus ei voi olla tyhjä."
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr "Verkkotunnuksen pitää sisältää ainakin yksi piste (.)"
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr "Domain on liian pitkä"
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr "Verkkotunnus ei voi alkaa tai loppua pisteeseen (.)"
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr "Peräkkäiset '.' merkit eivät ole sallittuja."
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr "Aliverkkotunnukset eivät voi alkaa tai loppua '-' merkkiin."
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr ""
 "Verkkotunnukset voivat sisältää vain kirjaimia, numeroita, '.' ja '-' "
 "merkkejä."
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr "Timestamp ei saa olla negatiivinen."
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr "Aihe ei saa sisältää tyhjiä tavuja"
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr "Tasan 1 kanavatunnus kanavaviesteille"
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr "Käyttäjä on poistanut käytöstä luonnosten synkronoinnin."
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr "Luonnosta ei löydy"
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5583,86 +5013,86 @@ msgstr ""
 "sähköpostin vastaus:\n"
 "{error_message}"
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr "Sähköpostiviesti ilman aihetta"
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr "Avaa Zulip nähdäksesi spoilerin sisällön"
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr "{service_name} ilmoitukset"
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr "Virheellinen osoite."
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr "Verkkotunnuksesi ulkopuolella."
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr "Sähköpostiosoitteessa ei saa olla + -merkkiä."
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr "Varattu järjestelmän boteille."
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr "{email}:lla on jo tili"
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr "Omistaa jo tilin."
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr "Tämä tili on poistettu käytöstä."
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr "Emojia {emoji_name} ei ole olemassa"
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr "Virheellinen mukautettu emoji."
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr "Virheellinen mukautetun emojin nimi."
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr "Tämä mukautettu emoji on poistettu käytöstä."
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr "Virheellinen emojin koodi."
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr "Virheellinen emojin nimi."
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr "Virheellinen emojin tyyppi."
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr "On oltava organisaation järjestelmänvalvoja tai emojin tekijä"
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr "Emojien nimien pitää loppua kirjaimeen tai numeroon."
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
@@ -5670,119 +5100,118 @@ msgstr ""
 "Emojien nimien pitää sisältää vain englanninkielisiä kirjaimia numeroita, "
 "välilyöntejä, viivoja ja alaviivoja."
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr "Emojin nimi puuttuu"
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr "Tapahtumajonoa ei pystytty allokoimaan"
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr "Ei kirjautuneena: API-todennus tai käyttäjäistunto vaditaan"
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr "Kanava ’{channel_name}’ on jo olemassa"
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr "Kanavaa {stream} ei ole olemassa"
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr "Kanavaa {stream_id} ei ole"
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr "Parametriyhdistelmää ei tueta: {parameters}"
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr "Organisaation omistaja"
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr "käyttäjä"
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr "Ei voida poistaa käytöstä viimeistä {entity}."
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr "Virheellinen Markdown include-lause: {include_statement}"
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr "Virheellisesti muotoiltu JSON"
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr "On oltava organisaation järjestelmänvalvoja"
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr "On oltava organisaation omistaja"
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Must be an organization owner"
 msgid "Must be a bot user"
 msgstr "On oltava organisaation omistaja"
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr "Käyttäjätunnuksesi tai salasanasi on väärin"
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr "Tämä organisaatio on poistettu käytöstä"
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr ""
 "Palvelimesi mobiili push-ilmoituspalvelun rekisteröinti on poistettu käytöstä"
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr "Salasanatodennus on poistettu käytöstä tässä organisaatiossa"
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr "Salasanasi on poistettu käytöstä ja tulee asettaa uudelleen"
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr "Virheellinen API-avain"
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr "Virheellisesti muodostettu API avain"
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
@@ -5790,25 +5219,24 @@ msgid ""
 msgstr ""
 "Tapahtumaa {event_type} ei tueta webhookille {webhook_name}: ohitettiin"
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr "Pyyntöä ei voi jäsentää: loiko {webhook_name} tämän tapahtuman?"
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr "Käyttäjä ei ole kirjautunut"
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr "Virheellinen aliverkkotunnus"
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr "Ei oikeuksia aloittaa yksityisviestikeskustelua."
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
@@ -5817,12 +5245,12 @@ msgstr ""
 "Viestien lähetys aiheeseen {empty_topic_display_name} ei ole sallittu tällä "
 "kanavalla."
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr "Vain aihe {empty_topic_display_name} on sallittu tällä kanavalla."
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
@@ -5832,19 +5260,19 @@ msgstr ""
 "jotta tämä asetus voidaan ottaa käyttöön. Uudelleennimeä tai poista muut "
 "aiheet."
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr "Yksityisviestit on poistettu käytöstä tässä organisaatiossa."
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr "Tässä keskustelussa ei ole käyttäjiä jotka voisivat sallia sen."
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr "Pääsy estetty"
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
@@ -5853,15 +5281,15 @@ msgstr ""
 "Sinulla on oikeudet siirtää vain {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} tuoreinta viestiä tässä aiheessa."
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr "Reaktio on jo olemassa."
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr "Reaktiota ei ole olemassa."
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
@@ -5869,271 +5297,271 @@ msgstr ""
 "Organisaatiosi on rekisteröity toiselle Zulip-palvelimelle. Ota yhteys "
 "Zulipin tukeen tämän ratkaisemiseksi."
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr "Organisaatiota ei ole rekisteröity"
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr "Sinulla ei ole oikeuksia käyttää jokerimainintoja tällä kanavalla."
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr "Sinulla ei ole oikeuksia käyttää jokerimainintoja tässä aiheessa."
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr "’{field_name}’ arvo ei vastaa odotuksenmukaista"
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr "{setting_name} on oltava järjestelmäkäyttäjäryhmä."
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr "Käytössä olevaa ryhmää ei voi poistaa käytöstä."
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr "Sinulla ei ole oikeuksia ylläpitää kanavaa."
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr "Sinulla ei ole oikeuksia vaihtaa oletuskanavaa."
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr "Sähköpostiosoite on jo käytössä."
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr "Ajastetun lähetyksen ajan pitää olla tulevaisuudessa."
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr "Virheellinen bouncer_public_key"
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr "Pyyntö vanhentunut"
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr "Virheellinen encrypted_push_registration"
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr "Palvelin ei ole asetettu käyttämään push-ilmoituspalvelua"
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Already has an account."
 msgid "Atlassian account ID"
 msgstr "Omistaa jo tilin."
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Behance username"
 msgstr "Sopimaton nimi tai käyttäjätunnus"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Bitbucket username"
 msgstr "Githubkäyttäjänimi"
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Codeberg username"
 msgstr "Twitterkäyttäjänimi"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Dribbble username"
 msgstr "Githubkäyttäjänimi"
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Facebook username"
 msgstr "Sopimaton nimi tai käyttäjätunnus"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr "Githubkäyttäjänimi"
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "GitLab username"
 msgstr "Githubkäyttäjänimi"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Instagram username"
 msgstr "Twitterkäyttäjänimi"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Mastodon"
 msgid "Mastodon profile"
 msgstr "Mastodon"
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Medium username"
 msgstr "Githubkäyttäjänimi"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Pinterest username"
 msgstr "Twitterkäyttäjänimi"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Reddit username"
 msgstr "Githubkäyttäjänimi"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Snapchat username"
 msgstr "Githubkäyttäjänimi"
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Threads username"
 msgstr "Twitterkäyttäjänimi"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "TikTok username"
 msgstr "Twitterkäyttäjänimi"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Twitch username"
 msgstr "Twitterkäyttäjänimi"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "Käyttäjätunnus"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr "Virheellinen ulkoinen tilityyppi"
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr "Integraatio frameworkit"
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 msgid "Video calling"
 msgstr "Videopuhelu"
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr "Jatkuva integraatio"
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr "Asiakastuki"
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr "Käyttöönotto"
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr "Viihde"
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr "Kommunikaatio"
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr "Talous"
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr "Ihmisresurssit"
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr "Markkinointi"
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr "Sekalaiset"
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr "Monitorointi"
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr "Projektinhallinta"
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr "Tuottavuus"
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr "Versionhallinta"
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr "Viesti ei saa olla tyhjä"
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr "Viesti ei saa sisältää tyhjiä tavuja"
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr "Sinulla ei ole lupaa mainita käyttäjäryhmää {user_group_name}."
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "{reporting_user_mention} reported a DM sent by {reported_user_mention} to "
@@ -6145,7 +5573,7 @@ msgstr ""
 "{reporting_user_mention} ilmoitti YV:t jotka lähetti {reported_user_mention} "
 "käyttäjille {recipient_mentions}, ja {last_user_mention}."
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "{reporting_user_mention} reported a DM sent by {reported_user_mention} to "
@@ -6157,7 +5585,7 @@ msgstr ""
 "{reporting_user_mention} ilmoitti YV:t jotka lähetti {reported_user_mention} "
 "käyttäjille {recipient_mentions}, ja {last_user_mention}."
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "{reporting_user_mention} reported a DM sent by {reported_user_mention} to "
@@ -6169,73 +5597,73 @@ msgstr ""
 "{reporting_user_mention} ilmoitti YV:t jotka lähetti {reported_user_mention} "
 "käyttäjille {recipient_mentions}, ja {last_user_mention}."
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 msgid "{fullname} moderation"
 msgstr "moderaatiopyynnöt käyttäjälle {fullname}"
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr "Virheellinen hakuehto: {desc}"
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr "Viallinen suppea operaattorikombo: {desc}"
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr "Duplikaatti with-operaattori."
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr "Viallinen with-operaattori"
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr "Puuttuva 'anchor' argumentti."
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 #, fuzzy
 #| msgid "Missing 'anchor' argument."
 msgid "Missing 'anchor_date' argument."
 msgstr "Puuttuva 'anchor' argumentti."
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr "Virheellinen linkki"
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr "Operaattoria {operator} ei tueta."
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr "Operandia {operand} ei tueta."
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 msgid "Navigation view does not exist."
 msgstr "Navigointinäkymää ei ole"
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr "Viesti käyttäjältä {admin_group_syntax}:"
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6245,7 +5673,7 @@ msgstr ""
 "\n"
 "Lisätietoja [Zulipin käyttöohjeissa luokalle]({getting_started_url})!\n"
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6255,7 +5683,7 @@ msgstr ""
 "\n"
 "Lisätietoja [aloitusoppaassamme]({getting_started_url})! \n"
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6265,7 +5693,7 @@ msgstr ""
 "\n"
 "Meillä on myös ohje [Zulipin käytöstäa luokassa]({organization_setup_url}).\n"
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6276,7 +5704,7 @@ msgstr ""
 "Meillä on myös ohjeita [organisaation siirtämiseen Zulipiin]"
 "({organization_setup_url})\n"
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "\n"
@@ -6298,7 +5726,7 @@ msgstr ""
 "**poistetaan  automaattisesti** 30 päivässä, jolle sitä [muunneta\n"
 "pysyväksi]({convert_demo_organization_help_url}).\n"
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
@@ -6308,7 +5736,7 @@ msgstr ""
 "Aloitin joitakin keskusteluja aluksi. Niitä\n"
 "löytyy [Saapuneista](/#inbox).\n"
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6319,7 +5747,7 @@ msgstr ""
 "Voit aina palata [Tervetuloa Zulipiin -videoon]({navigation_tour_video_url}) "
 "appin yleiskatsaukseksi.\n"
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6344,7 +5772,7 @@ msgstr ""
 "{demo_organization_text}\n"
 "\n"
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
@@ -6354,7 +5782,7 @@ msgstr ""
 "Voit [ladata](/apps) [mobiili- ja työpöytäsovellukset](/apps).\n"
 "Zulip toimii hyvin myös selaimessa.\n"
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -6366,7 +5794,7 @@ msgstr ""
 "help/change-your-profile-picture)\n"
 "ja muokkaa [profiilitietojasi](/help/edit-your-profile).\n"
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -6382,7 +5810,7 @@ msgstr ""
 "kieltä](/help/change-your-language), tai muutoin mukauttaa Zulippiasi\n"
 "[Asetuksistasi](#settings/preferences).\n"
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6399,7 +5827,7 @@ msgstr ""
 "\n"
 "[Etsi ja tilaa kanavia]({settings_link})\n"
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -6427,7 +5855,7 @@ msgstr ""
 "Näytä [Uudet keskustelut](#recent) nähdäksesi aiheet mistä on viimeksi "
 "keskusteltu.\n"
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -6441,7 +5869,7 @@ msgstr ""
 "\n"
 "Painamalla näppäintä `?` saat [ohjesivun](#keyboard-shortcuts).\n"
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -6460,7 +5888,7 @@ msgstr ""
 "ajasta\n"
 "ja niin edelleen.\n"
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6475,7 +5903,7 @@ msgstr ""
 "Lisätietoja [Aloitusohjeessa](/help/getting-started-with-zulip) tai\n"
 "[ohjekeskuksessa](/help).\n"
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6486,7 +5914,7 @@ msgstr ""
 "Voit keskustella kanssani. Jos\n"
 "tarvitset ohjeita, kokeile seuraavia viestejä: {bot_commands}\n"
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6505,7 +5933,7 @@ msgstr ""
 "tai jopa [siirtää aiheen uudelle kanavalle]"
 "({move_content_another_channel_help_url}).\n"
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
@@ -6513,7 +5941,7 @@ msgstr ""
 "\n"
 ":point_right: kokeile siirtää tätä viestiä toiseen aiheeseen ja takaisin.\n"
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6534,12 +5962,11 @@ msgstr ""
 "kanavalla #**{zulip_discussion_channel_name}** joka näkyy\n"
 "sivulistauksessa vasemmassa sivupalkissa ja ylhäällä.\n"
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr "Tervetuloa Zulipiin."
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -6551,7 +5978,7 @@ msgstr ""
 "aiheyhteydessään, \n"
 "riippumatta siitä montako keskustelua on menossa.\n"
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
@@ -6561,7 +5988,7 @@ msgstr ""
 ":point_right: Lisää keskusteluja ja lukemattomia viestejä\n"
 "löytyy [saapuneista](/#inbox).\n"
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -6573,7 +6000,7 @@ msgstr ""
 "klikkaa \n"
 "`+` -nappulaa nimen vierestä.\n"
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -6584,7 +6011,7 @@ msgstr ""
 "Anna keskustelulle aihe. Esimerkiksi: \n"
 "“Hei voimmeko keskustella ...?“ \n"
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
@@ -6592,7 +6019,7 @@ msgstr ""
 "\n"
 ":point_right: Kokeile aloittaa uusi viesti tällä kanavalla.\n"
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6603,7 +6030,7 @@ msgstr ""
 ":point_right:  Käytä tätä aihetta kokeillaksesi [Zulipin viesti-ominaisuutta]"
 "({format_message_help_url}).\n"
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6638,7 +6065,7 @@ msgstr ""
 "\n"
 "```\n"
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
@@ -6647,7 +6074,7 @@ msgstr ""
 "\n"
 "Tämä **Tervehdys**-aihe on hyvä paikka sanoa \"hei\" :wave: tiimille.\n"
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
@@ -6657,102 +6084,102 @@ msgstr ""
 ":point_right: Klikkaa tätä viestiä aloittaaksesi uuden viestin tässä "
 "aiheessa.\n"
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr "viestin siirtäminen"
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr "kokeilut"
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr "aloita keskustelu"
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr "tervehdykset"
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr "Virheellinen JSON vastauksessa"
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr "Virheellinen vastaussanoman muoto"
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr "Tyhjä tai väärän pituinen token"
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr "Virheellinen APNS-token"
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr "Virheelliset GCM-asetukset bouncerille: prioriteetti {priority!r}"
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr "Virheelliset GCM-asetukset bouncerille: {options}"
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr "Token ei ole olemassa"
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr "{full_name} maintisi @{user_group_name}:"
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr "{full_name} mainitsi sinut:"
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr "{full_name} mainitisi kaikki:"
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "Uusi viesti"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr "Testi-ilmoitus"
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr "Tämä on testi-ilmoitus kohteesta {realm_name} ({realm_url})."
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr "Laitetta ei tunnisteta"
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr "Laitetta ei tunnisteta push bouncerin toimesta"
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr "Ei aktiivisia rekisteröityjä push-laitteita"
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr "Verkkovirhe yhdistettäessä Zulipin push-ilmoituspalveluun."
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 "Palvelinvirhe Zulipin push-ilmoituspalvelusssa, yritä uudestaan myöhemmin."
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
@@ -6760,45 +6187,43 @@ msgstr ""
 "Push-ilmoitusasetusvirhe palvelimella, ota yhteys ylläpitoon tai yritä "
 "uudestaan mylhemmin."
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 #, fuzzy
 #| msgid "Invalid API key"
 msgid "Invalid `push_key`"
 msgstr "Virheellinen API-avain"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr "Virheelinen tietotyyppi kanavan tunnukselle"
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr "Käyttäjällä ei ole valtuutusta tähän kyselyyn"
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr "'{email}' ei enää käytä Zulipia."
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr "Et voi lähettää suoria viestejä organisaatiosi ulkopuolelle."
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr "Muistutksen pituusyläraja: {max_length} merkkiä."
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "You requested a reminder for the following direct message. Note:\n"
@@ -6810,13 +6235,13 @@ msgstr ""
 "Pyysit muistutusta yksityisviestistä. Viesti:\n"
 "> {note}"
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 #, fuzzy
 #| msgid "You requested a reminder for the following direct message."
 msgid "You requested a reminder for the following message."
 msgstr "Pyysit muistutusta yksityisviestistsä."
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
@@ -6825,11 +6250,11 @@ msgstr ""
 "Pyysit muistutusta yksityisviestistä. Viesti:\n"
 "> {note}"
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr "Pyysit muistutusta yksityisviestistsä."
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{user_silent_mention} [sent]({conversation_url}) a todo list."
 msgid ""
@@ -6837,14 +6262,14 @@ msgid ""
 "{topic_pretty_link}."
 msgstr "{user_silent_mention} [lähetti]({conversation_url}) todo-listan."
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{user_silent_mention} [said]({conversation_url}):"
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr "{user_silent_mention} [sanoi]({conversation_url}):"
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{user_silent_mention} [sent]({conversation_url}) a todo list."
 msgid ""
@@ -6852,7 +6277,7 @@ msgid ""
 "{list_of_recipient_mentions}."
 msgstr "{user_silent_mention} [lähetti]({conversation_url}) todo-listan."
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{user_silent_mention} [said]({conversation_url}):"
 msgid ""
@@ -6860,707 +6285,691 @@ msgid ""
 "{list_of_recipient_mentions}:"
 msgstr "{user_silent_mention} [sanoi]({conversation_url}):"
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{user_silent_mention} [sent]({conversation_url}) a todo list."
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr "{user_silent_mention} [lähetti]({conversation_url}) todo-listan."
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{user_silent_mention} [sent]({conversation_url}) a todo list."
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr "{user_silent_mention} [lähetti]({conversation_url}) todo-listan."
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 msgid "Reminder does not exist"
 msgstr "Muistutus ei ole olemassa"
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr "Push-ilmoitusten bouncerin virhe: {error}"
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr "Ei voida päätellä argumenttien '{var_name1}' ja '{var_name2}' välillä"
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr "Puuttuva '{var_name}' argumentti"
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr "Sopimaton arvo '{bad_value}' muuttujalle: {var_name}"
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr "Ajastettua viestiä ei ole"
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr "{service_name} tilin turvallisuus"
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr "Oletuskanava ei voi olla yksityinen."
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr "Web-julkiset kanavat eivät ole käytössä."
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr "Sinulla ei ole oikeuksia lähettää viestiä tälle kanavalle."
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr "Ei lupaa lähettää viestiä kanavalle {channel_name}"
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 #, fuzzy
 #| msgid "You don't have permission to resolve topics in this channel."
 msgid "You do not have permission to create new topics in this channel."
 msgstr "Sinulla ei ole oikeuksia ratkaista viestiä tällä kanavalla."
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr "Viallinen kanavan tunnus"
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr "Viallinen kanavan nimi {channel_name}"
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr "Kanavia ({channel_names}) ei ole (hölöpölö)"
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr "Oletuskanavaryhmää tunnuksella {group_id} ei ole olemassa."
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr "Kanavan nimi ei voi olla tyhjä."
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr "Kanavan nimi on liian pitkä (yläraja: {max_length} merkkiä)."
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr "Virheellinen merkki kanavan nimessä kohdassa {position}."
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr "Virheellinen merkki aiheessa kohdassa {position}."
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr "Tilaajatietoja ei ole saatavilla tälle kanavalle"
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr "Ei voida hakea tilaajia yksityiselle kanavalle"
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr "Kuvaa ei pystytty purkamaan; latasitko kuvatiedoston?"
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr "Kuvan koko ylittää rajan."
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr "Kuva on viallinen tai puuttellinen"
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr "{var_name} ei ole totuusarvo"
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} does not have the expected format"
 msgstr "{var_name} ei ole oikeassa muodossa"
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr "{var_name} ei ole päivämäärä"
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr "{var_name} ei ole sanakirja"
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr "Virheellinen {var_name}"
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr "Argumentti {argument} ḱohdassa {var_name} on odottamaton"
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr "{var_name} ei ole liukuluku"
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr "{var_name} on liian lyhyt"
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr "{var_name} ei ole kokonaisluku"
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr "{var_name} ei ole JSONia"
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr "{var_name} on liian pitkä"
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr "{var_name} ei ole lista-tyyppinen"
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr "{var_name} on liian pitkä (rajoitus: {max_length} merkkiä)"
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr "{var_name} on liian lyhyt."
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr "{var_name} ei ole merkkijono"
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr "{var_name} ei ole oikeassa muodossa"
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr "{var_name} pitäisi olla {length} pitkä"
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr "{var_name} on liian pitkä (rajoitus: {max_length} merkkiä)"
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr "{var_name} on liian pitkä (rajoitus: {max_length} merkkiä)"
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr "{var_name} ei voi olla tyhjä"
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr "Virheellinen {var_name}: {msg}"
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr "{var_name} kenttä puuttuu: {msg}"
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr "Virheellisen muotoinen tietosisältö"
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr "Ei mahdolline lista arvoja"
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr "Ei URL"
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr "Ei tunnistettu aikavyöhyke"
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr "{var_name} ei ole oikeanmuotoinen hexa-värikoodi"
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr "Virheellinen {setting_name}"
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr "Lähetys ylittäisi organisaatiosi lähetyskiintiön."
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr "Liian iso kuva"
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr "Käyttäjäryhmä on deaktivoitu."
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr "Virheellinen käyttäjäryhmä"
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid user group ID: {group_id}"
 msgid "Invalid user group ID: {user_group_id}"
 msgstr "Virheellinen ryhmän tunnus: {group_id}"
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr "Viallinen systeemiryhmänimi."
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr "Virheellinen ryhmän tunnus: {group_id}"
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr "{setting_name} ei voi olla role.internet-ryhmä."
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr "{setting_name} ei voi olla role_nobody-ryhmä."
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr "{setting_name} ei voi olla role:everyone-ryhmä."
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr "{setting_name} eo voi olla {group_name}-ryhmä."
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr "Käyttäjäryhmän nimi ei voi olla tyhjä."
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr "Käyttäjäryhmän nimi ei voi olla yli {max_length} merkkiä."
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr "Käyttäjäryhmän nimi ei voi alkaa {prefix}."
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr "Asiakasohjelma ei antanut uusia arvoja."
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 "Asiakkaan on välitettävä emoji_name, jos hän välittää joko emoji_code:n tai "
 "reaction_type:n."
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr "Nimi on liian pitkä!"
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 msgid "Name must not be empty!"
 msgstr "Nimi ei saa olla tyhjä"
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr "Virheellinen merkki nimessä!"
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr "Virheellinen muoto!"
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr "Tässä organisaatiossa nimien on oltava ainutlaatuisia."
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr "Nimi on jo käytössä."
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr "Sopimaton nimi tai käyttäjätunnus"
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr "Virheellinen integraatio {integration_name}."
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr "Puuttuva asetusparametri {keys}"
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr "Virheellinen {key} arvo {value} ({error})"
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr "Virheellinen konfiguraatiotieto!"
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr "Virheellinen bottityyppi"
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr "Virheellinen käyttöliittymätyyppi"
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr "Virheelllinen käyttäjätunnus {user_id}"
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr "Ei kyseistä bottia"
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr "Ei kyseistä käyttäjää"
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr "Käyttäjä on poistettu käytöstä"
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr "{item} ei voi olla tyhjä."
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr ""
 "{var_name} on liian vähän merkkejä {length}; pitäisi olla {target_length}"
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a string"
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr "{var_name} ei ole merkkijono"
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr "{container} pitäisi sisältää tarkalleen {length} alkiota"
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr "{key_name} ei sisällä {var_name} avainta"
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr "Odottamattomia argumentteja {keys}"
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr "{var_name} ei ole allowed_type"
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr "{variable} != {expected_value} ({value} on väärin)"
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr "{var_name} ei ole URL-osoite"
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr "URL-kuvion pitää sisältää %(username)s."
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr "'{item}' ei voi olla tyhjä."
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr "Kentällä ei voi olla samaa valintaa monesti."
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr "'{value}' ei ole kelvollinen vaihtoehto kentälle '{field_name}'."
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr "{var_name} ei ole merkkijono tai kokonaislukulista"
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr "{var_name} ei ole merkkijono tai kokonaisluku"
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr "{var_name} ei ole pituutta"
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr "{var_name} puuttuu"
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr "Tuntematon PresentUrlOption: {config}"
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr "HTTP-tapahtuman otsikko puuttuu '{header}'"
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr "Algoritmia {algorithm} ei tueta."
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr "Webhookin salaisuus puuttuu. Aseta webhook_secret urlia generoidessa."
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr "Webhookin allekirjoituksen varmennus epäonnistui."
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr "Zcommand tulisi aloittaa kauttaviivalla."
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr "Komentoa {command} ei ole olemassa"
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 "`zulip_update_announcements_stream` on odotuksenvastaisesti deaktivoitu."
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr "CSRF virhe: {reason}"
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr "Käänteisvälipalvelimen asetusvirhe: {proxy_reason}"
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr "Viallisia käyttäjien ID:itä: {invalid_ids}"
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr "Käyttäjätunnus {user_id} on deaktivoitu"
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr "Käyttäjätunnus {user_id} on botti"
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr "Päivämäärä"
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr "Ulkoinen tili"
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr "Pronominit"
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr "Ei kukaan"
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr "Täydet jäsenet"
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "Jäsenet"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr "Kaikki internetissä"
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Invalid characters in emoji name"
 msgid "Invalid auto-conversion field: empty field name."
 msgstr "Virheellinen merkki emojin nimessä"
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr "Ryhmä %(name)r URL-mallineessa ei ole linkittimen kuviossa."
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr "Virheellinen säännöllinen ilmaus {regex}"
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr "Tuntematon säännöllisen lauseen virhe"
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr "Virheellinen URL-malline."
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid "Example input does not match the linkifier pattern."
 msgstr "Ryhmä %(name)r URL-mallineessa ei ole linkittimen kuviossa."
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr "Ryhmä %(name)r URL-mallineessa ei ole linkittimen kuviossa."
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr "Ryhmä %(name)r linkittimen kuviosssa ei ole URLin mallineessa."
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid ""
@@ -7568,7 +6977,7 @@ msgid ""
 "pattern."
 msgstr "Ryhmä %(name)r URL-mallineessa ei ole linkittimen kuviossa."
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgid ""
@@ -7576,333 +6985,330 @@ msgid ""
 "template."
 msgstr "Ryhmä %(name)r linkittimen kuviosssa ei ole URLin mallineessa."
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr "Unicode-emoji"
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "Mukautetut emojit"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr "Zulipin ekstraemoji"
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr "Virheellinen merkki emojin nimessä"
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr "Pygments-kielessä on virheellisiä merkkejä"
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr "Puuttuva code URLin mallineessa tarvitaan"
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr "code pitää olla ainoa muuttuja URL-mallineessa"
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr "hiekkalaatikko"
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr "yleinen"
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr "kanavan tapahtumat"
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr "Roskaposti"
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr "Häirintä"
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr "Sopimaton sisältö"
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr "Rikkoo yhteisön sääntöjä"
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr "muu syy"
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr "Zulipin päivitykset"
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr "Saatavilla Zulip Standardilla. Päivitä käyttääksesi."
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr "Saatavilla Zulip Cloud Plussassa. Päivitä käyttääksesi."
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr "Salli GIFfit ikäluokituksella G (yleiset yleisöt)"
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr "Salli GIFfit ikäluokituksella PG (vanhempian valvonnan alaisena)"
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 "Salli GIFfit ikäluokituksella PG-13 (alle 13-vuotiaat vain vanhempian "
 "valvonnan alaisena)"
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr "Salli GIFfit ikäluokituksella R (rajoitettu)"
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr "Julkinen verkko"
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "Julkinen"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr "Yksityinen, jaettu historia"
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr "Yksityinen, suojattu historia"
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr "Järjestelmänvalvojat, moderaattorit ja vieraat"
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr "Järjestelmänvalvojat, moderaattorit ja jäsenet"
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr "Järjestelmänvalvojat ja moderaattorit"
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr "Vain järjestelmänvalvojat"
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr "Tuntematon käyttäjä"
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr "Organisaation omistaja"
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr "Organisaation järjestelmänvalvoja"
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr "Moderaattori"
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "Jäsen"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "Vieras"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr "Tuntematon IP osoite"
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr "tuntematon käyttöjärjestelmä"
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr "Tuntematon selain"
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr "Puuttuva 'queue_id' argumentti"
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr "Puuttuva 'last_event_id' argumentti"
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr "{event_id} uudempi tapahtuma on jo leikattu!"
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr "Tapahtuma {event_id} ei ollut tässä jonossa"
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr "Virheellinen tapahtumajonotunnus: {queue_id}"
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 msgid "Failed to generate challenge"
 msgstr "Haasteen luonti epäonnistui"
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr "JWT-varmennus ei ole käytössä tässä organisaatiossa"
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr "Pyyntö ei sisältänyt JSON web tokenia"
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr "Sopimaton JSON web token"
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr "Sähköpostia ei määritelty JSON web token -vaatimuksissa"
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr "Aliverkkotunnus vaaditaan"
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr "Salasana on väärin."
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr "Tästä kansiosta pitää poistaa kaikki kanavat jotta sen voi arkistoida."
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr "User-Agent-otsikko puuttuu viestistä"
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr "Kentän nimi ei voi olla tyhjä."
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr "Valitse vähintään yksi."
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr "Kentän tyyppiä ei tueta näytettäväksi profiilin yhteenvedossa."
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 #, fuzzy
 #| msgid "Field type not supported for display in profile summary."
 msgid "Field type not supported for use for user matching."
 msgstr "Kentän tyyppiä ei tueta näytettäväksi profiilin yhteenvedossa."
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr "Virheellinen kenttätyyppi."
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr "Vain 2 profiilikenttää voi näyttää profiiliyhteenvedossa."
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr "Samanniminen kenttä on jo olemassa."
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr "Oletusarvoista mukautettua kenttää ei voi päivittää."
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr "Endpoint ei ole käytettävissä tuotannossa."
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr "DevAuthBackend ei ole käytössä."
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr "Virheellinen {key}-parametri anonyymissä pyynnössä"
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr "Tietokanta on tyhjä"
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr "Ei voida lähettää komentoa postgresql:lle"
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr "Ei voida yhdistää rabbitmq:hun"
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr "Ei voida hake rabbitmq:lta"
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr "Ei voida lähettää redisille"
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr "ei voida kirjoittaa memcahched:hen"
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr "Ei voitu hakea memcached:stä"
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr "Ei kyseistä kutsua"
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 #, fuzzy
 #| msgid "Invitation has already been revoked"
 msgid "Invitation already used or deactivated."
 msgstr "kutsu on jo poistettu käytöstä"
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr "kutsu on jo poistettu käytöstä"
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr "Virheellinen kanavan tunnus {channel_id}: ei lähetettyjä kutsuja."
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr "Sinulla ei ole oikeuksia tilata toisien käyttäjien puolesta kanavia."
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr "Sinun täytyy määritellä ainakin yksi sähköpostiosoite."
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
@@ -7910,100 +7316,98 @@ msgstr ""
 "Jotkut osoitteista käyttää jo Zulipia, joten heille ei lähetetty kutsua. "
 "Muille kutsut lähetettiin!"
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr "Viestin muokkaushistoria on poistettu käytöstä tässä organisaatiossa"
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr "Sinulla ei ole oikeuksia poistaa tätä viestiä"
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr "Tämän viestin poistamisen aikaraja on umpeutunut"
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr "Viesti on jo poistettu"
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr "Liian monta viestiä pyydetty (enintään {max_messages})."
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr "Ankkurin voi jättä pois vain alueen lopusta"
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr "Aihetta ei ole {topic}"
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr "Selitys tarvitaan."
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 msgid "Message reporting is not enabled in this organization."
 msgstr "Viestien raportointi on poistettu käytöstä tässä organisaatiossa."
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr "Puuttuva lähettäjä"
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr "Peilaus ei ole sallittu vastaanottajan käyttäjätunnukselle"
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr "Virheellinen toistettu viesti"
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr "Tekoäly on poissa käytöstä tällä palvelimella."
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr "Tekoäly-rahoitus on loppu."
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr "Ei viestejä yhteen vedettäväksi"
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr "Ei voi mykistää itseään"
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr "Käyttäjä on jo mykistetty"
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr "Käyttäjä ei ole mykistetty"
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr "Sisäänrakennetulla näkymällä ei voi olla mukautettua nimeä."
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr "Mukautetulla näkymällä pitää olla hyväksyttävä nimi."
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 msgid "Navigation view already exists."
 msgstr "Navigaationäkymä on jo olemassa."
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr "Tuntematon onboarding_step {onboarding_step}"
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -8014,108 +7418,108 @@ msgstr ""
 "Aioit katsoa [Welcome to Zulip videon]({navigation_tour_video_url}) "
 "myögemmin. Onko nyt hyvin aikaa?\n"
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr "Läsnäolo ei ole tuettu boteille."
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr "Ei läsnäolotietoja käyttäjälle {user_id_or_email}"
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr "Virheellinen tila: {status}"
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 #, fuzzy
 #| msgid "You do not have permission to change default channels."
 msgid "You do not have permission to manage plans and billing."
 msgstr "Sinulla ei ole oikeuksia vaihtaa oletuskanavaa."
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr "Palvelin ei tue push-ilmoituspalvelua"
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr "Vrihe bouncerilta: {result}"
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr "Varmennussalaisuutta ei ole valmistettu"
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr ""
 "Vähintään yksi argumentti seuraavista on oltava: emoji_name, emoji_code"
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr "Vastaanottoilmoitukset on poistettu käytössä tässä organisaatiossa."
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr "Virheellinen kieli {language}"
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr "Vähintään yksi todennusmenetelmä on oltava käytössä."
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr "virheellinen video_chat_provider {video_chat_provider}"
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid giphy_rating {giphy_rating}"
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr "Virheellinen giphy_rating {giphy_rating}"
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr "On oltava demo-organisaatio."
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
@@ -8123,7 +7527,7 @@ msgstr ""
 "Datanpoistoajan pitää olla enintään {max_allowed_days} päivää "
 "tulevaisuudessa."
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
@@ -8131,226 +7535,225 @@ msgstr ""
 "Datanpoistoajan pitää olla vähintään {min_allowed_days} päivää "
 "tulevaisuudessa."
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr "Virheelinen verkkotunnus: {error}"
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr "Verkkotunnus {domain} on jo osa organisaatiotasi."
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr "Verkkotunnukselle {domain} ei löytynyt merkintää."
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr "Sinun täytyy lähettää ainoastaan yksi tiedosto."
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr "Vain järjestelmänvalvojat voivat korvata oletusemojin."
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr "Ladattu tiedosto on suurempi kuin sallittu {max_size} Mt."
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 #, fuzzy
 #| msgid "JWT authentication is not enabled for this organization"
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr "JWT-varmennus ei ole käytössä tässä organisaatiossa"
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr "Raja-arvo ylitetty."
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr "Virheellinen tiedonpoimintatunnus"
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr "Poimintatiedot on jo poistettu"
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr "Vienti epäonnistui, ei poistettavia"
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr "Vienti vielä kesken"
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr "Sinun täytyy lähettää ainoastaan yksi kuvake."
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr "Linkiyttäjää ei löytynyt."
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr "Voit ladata yhden logon."
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid characters in pygments language"
 msgid "Invalid character in language: {character}"
 msgstr "Pygments-kielessä on virheellisiä merkkejä"
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid language '{language}'"
 msgid "Language '{language}' is not allowed."
 msgstr "Virheellinen kieli {language}"
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr "Virheellinen leikkikenttä"
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr "Vientiä ei voi perua aloittamisen jälkeen."
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr "Ei kirjautunut"
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 msgid "Importing messages…"
 msgstr "Tuodaan viestejä…"
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr "Tuodaan liitteitä…"
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr "Tuodaan konvertoitua Slack-dataa…"
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr "Viimeistellään tuontia…"
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr "Valmis."
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr "Yksikään käyttäjä ei vastaa sähköpostiosoitetta."
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "Your full name"
 msgid "Your name"
 msgstr "Koko nimi"
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr "Vastaanottaja tarvitaan kun päivitetään ajastettua viestiä."
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr "Aihe vaaditaan kun päivitetään ajastetun viestin tyyppiä kanavalle."
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr "Virheellinen pyyntöformaatti"
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr "Virheellinen DSN"
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr "Yksityiset kanavat eivät voi olla oletuksia."
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr "Sinun täytyy välittää joko \"new_description\" tai \"new_group_name\"."
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr "Virheellinen \"op\" arvo. Määritä joko \"add\" tai \"remove\"."
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr "Virheelliset parametrit"
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr "Kanavan sisällön saanti on vaadittu."
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr "Kanavalla on jo tämä nimi."
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr "Ei mitään tehtävää. Määritä vähintään joko \"add\" tai \"delete\"."
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr "{user_full_name} tilasi kanavan {channel_name} sinulle."
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr "{user_full_name} tilasi kanavia sinulle:"
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr "Ei pääsyä kanavalle ({channel_name})."
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr "{user_name} loi kanavat: {new_channels}."
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr "{user_name} loi kanavan {new_channels}."
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr "uudet kanavat"
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr "**Web-julkinen** kanava, jonka on luonut {user_name}. **Kuvaus.**"
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr "**Julkinen** kanava, jonka on luonut {user_name}. **Kuvaus.**"
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
@@ -8358,7 +7761,7 @@ msgstr ""
 "**Yksityinen (jaettu historia)** kanava, jonka on luonut {user_name}. "
 "**Kuvaus.**"
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
@@ -8367,26 +7770,26 @@ msgstr ""
 "**Yksityinen (suojattu historia)** kanava, jonka on luonut {user_name}. "
 "**Kuvaus.**"
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr "{property} ei ole boolenarvo"
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr "Tuntematon tilausominaisuus: {property}"
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr "Ei tilattu kanavaa {channel_id}"
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr "Virheellinen json aliviestille"
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
@@ -8395,7 +7798,7 @@ msgstr ""
 "Tiedosto on enimmäiskokoa suurempi ({max_size} MiB), joka sallitaan tälle "
 "organisaatiolle."
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
@@ -8403,59 +7806,58 @@ msgid ""
 msgstr ""
 "Tiedosto on palvelimen asetusten enimmäiskokoa suurempi ({max_size} MiB)."
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr "Tiedosto on viennin enimmäiskokoa suurempi {max_file_size} MiB"
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr "Käyttäjä on poistanut käytöstä ilmoitukset kanavaviesteistä"
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr "Puuttuva to-argumentti"
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr "Tyhjä 'to' lista"
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr "Käyttäjä on poistanut käytöstä kirjoittamisilmoitukste suoraviesteistä"
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr "<p>Tiedostoa ei ole tai se on poistettu.</p>"
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr "<p>Et ole valtuutettu katsomaan tätä tiedostoa.</p>"
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr "Virheellinen token"
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr "Virheellinen tiedostonimi"
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr "Sinun pitää määritellä lähetettävä tiedosto"
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr "Voit lähettää ainoastaan yhden tiedoston kerrallaan"
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr "Uutta tietoa ei ole toimitettu"
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
@@ -8463,111 +7865,111 @@ msgstr ""
 "Ei mitään tehtävää. Ainakin tarvitaan \"add\", \"delete\", \"add_subgroups\" "
 "tai \"delete_subgroups\"."
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr "{user_full_name} lisäsis sinut ryhmään {group_name}."
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr "{user_full_name} poisti sinut ryhmästä {group_name}."
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr "Käyttäjä {user_id} on jo tämän ryhmän jäsen"
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr "Käyttäjää {user_id} ei löydy tästä ryhmästä"
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr "Käyttäjäryhmä {group_id} on jo tämän ryhmän aliryhmä."
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
 "subgroups."
 msgstr "Käyttäjäryhmä {user_group_id} on jo annetun ryhmän aliryhmä."
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr "Käyttäjäryhmä {group_id} ei ole tämän ryhmän aliryhmä."
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr "Tämä organisaatio ei salli avatarmuutoksia."
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr ""
 "Sähköpostinosoitteen muuttaminen on poistettu käytöstä tässä organisaatiossa."
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr "Virheellinen default_language"
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr "Virheellinen ilmoituksen merkkiääni {notification_sound}"
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr "Virheellinen sähköpostin eräjakso: {seconds} sekuntia"
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr "Zulip-salasanaasi hallitaan LDAP:ssa"
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr "Väärä salasana!"
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, fuzzy, python-brace-format
 #| msgid "You're making too many attempts! Try again in {seconds} seconds."
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr "Liian monta yritystä, yritä uudelleen {seconds} sekunnin kuluttua."
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr "Uusi salasana on liian heikko!"
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr "Sinun täytyy lähettää ainoastaan yksi avatar."
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr "Aihe ei ole mykistetty"
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr "Organisaation ainoaa omistajaa ei voi poistaa käytöstä"
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Nobody in this Zulip organization will be able to see this email address."
@@ -8575,26 +7977,26 @@ msgid "User is not allowed to delete other user's messages."
 msgstr ""
 "Kukaan täss Zulip-organisaatiossa ei pusty näkemään tätä sähköpostiosoitetta."
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr "Käyttäjällä ei ole oikeutta muuttaa käyttäjän sähköpostia"
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 "Organisaation ainoalta omistajalta ei voi poistaa omistajan käyttöoikeuksia."
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr "Virheellinen uusi sähköpostiosoite."
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr "Viallinen uusi sähköpostiosoite: {message}"
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
@@ -8606,25 +8008,25 @@ msgstr ""
 "Ei voi luoda botteja ennen kuin FAKE_EMAIL_DOMAIN on määritetty oikein.\n"
 "Ota yhteyttä palvelimesi järjestelmänvalvojaan."
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 #, fuzzy
 #| msgid "Email is already in use."
 msgid "Email address already in use"
 msgstr "Sähköpostiosoite on jo käytössä."
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr "Omistajan vaihto epäonnistui, ei kyseistä käyttäjää"
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr "Omistajan vaihto epäonnistui, käyttäjä on poistettu käytöstä"
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr "Omistajan vaihto epäonnistui, botit eivät voi omistaa toisia botteja"
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
@@ -8632,140 +8034,140 @@ msgstr ""
 "Ei voi luoda botteja ennen kuin FAKE_EMAIL_DOMAIN on määritetty oikein.\n"
 "Ota yhteyttä palvelimesi järjestelmänvalvojaan."
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr "Sulautetut botit eivät ole käytössä."
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr "Virheellinen sulautetun botin nimi."
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr "Käyttäjällä ei ole lupaa tehdä käyttäjiä"
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr "Sähköposti '{email}' ei ole sallittu tässä organisaatiossa"
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr ""
 "Kertakäyttöiset sähköpostiosoitteet eivät ole sallittuja tässä "
 "organisaatiossa"
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom access token"
 msgid "Invalid {provider_name} access token"
 msgstr "Virheellinen Zoom-käyttöoikeustunnus"
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} call"
 msgstr "Zoom-puhelun aloittaminen epäonnistui"
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Zoom credentials have not been configured"
 msgid "{provider_name} credentials have not been configured"
 msgstr "Zoom-tunnuksia ei ole määritetty"
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom credentials"
 msgid "Invalid {provider_name} credentials"
 msgstr "Virheelliset Zoom-tunnukset"
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error connecting to the BigBlueButton server."
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr "Virhe yhteyden muodostamisessa Big Blue Button -palvelimeen."
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error authenticating to the BigBlueButton server."
 msgid "Error authenticating to the {provider_name} server"
 msgstr "Big Blue Button -palvelimen todennusvirhe."
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "BigBlueButton server returned an unexpected error."
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr "Big Blue Button-palvelin palautti tuntemattoman virheen."
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom session identifier"
 msgid "Invalid {provider_name} session identifier"
 msgstr "Virheellinen Zoom-istunnon tunniste"
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr "Tuntematon Zoom käyttäjän sähköposti"
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} public room."
 msgstr "Zoom-puhelun aloittaminen epäonnistui"
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr "Virheellinen allekirjoitus."
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{full_name}'s Zulip room"
 msgstr "{full_name} mainitsi sinut:"
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr "Projekteja jotka käyttävät tätä versionhallintaa ei tueta"
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr "Virheellinen tietosisältö"
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr "Tuntematon webhook pyyntö"
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr "Aihe ei voi olla tyhjä"
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr "Sisältö ei voi olla tyhjä"
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr "Jotform-payloadia ei pystytty käsittelemään"
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr "Virheellinen JSON syöte"
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr "Tapahtuma-avain puuttuu payloadista"
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr "Virhe: channels_map_to_topics parametri on muuta kuin 0 tai 1"
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr "Tuntematon WordPress-webhooktoiminto: {hook}"
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
@@ -8774,76 +8176,76 @@ msgstr ""
 "Datojen vienti on valmis [Katsele ja lataa viedyt datat]"
 "({export_settings_link})."
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr "Varmennesalaisuus on vanhentunut"
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr "Varmennesalaisuus on viallinen"
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr "Varmennesalaisuus on väärän muotoinen"
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr "Varmennesalaisuus on toiselle laitenimelle"
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr "Virheellinen aliverkkotunnus push-ilmoituksen ohjaajalle"
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr "Täytyy vahvistaa oikealla Zulip-palvelimen API-avaimella"
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr "Virheellinen UUID"
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr "Virheellinen token-tyyppi"
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 "{hostname} sisältää viallisia osia (kuten: polku, hakulauseke, fragmentti)."
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr "{hostname} ei ole oikeanmuotoinen palvelinnimi"
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr "{hostname} ei ole vielä rekisteröity"
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr "Virheellinen palvelinylläpidon söhköpostiosoite: {email_reason}"
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr "example.com ei ole sallittu sähköpostiosoite."
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr "{domain} on viallinen koska slille ei ole MX-tietueita"
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr "{domain} ei ole olemassa"
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
@@ -8852,29 +8254,29 @@ msgstr ""
 "Globaalit käyttörajat on käytetty lopppuun. Yritä uudestaan myöhemmin tai "
 "hae apua sähköpostitse osoitteesta {support_email}."
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr "Palvelimen rekisteröintiä ei löytynyt"
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr "Palvelin vastasi ettei sillä ole varmennussalaisuuksia."
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, fuzzy, python-brace-format
 #| msgid "Error response received from the host: {status_code}"
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr "Virheviesti palvelimelta: {status_code}"
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr "Puuttuva ios_app_id"
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr "user_id tai user_uuid puuttuu"
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
@@ -8883,50 +8285,50 @@ msgstr ""
 "Tilaus ei salli push-notifikaatioiden lähettämistä. Palvelin vastasi: "
 "{reason}"
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr "Tilaus ei salli push-ilmoitusten lähettämistä."
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr "Virheellinen ominaisuus {property}"
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr "Virheellinen tapahtumatyyppi."
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr "Tiedot ovat epäkunnossa."
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr "Kaksoiskappale rekisteröinnistä havaittu."
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr "Viallinen auditointilokidata"
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr "Salasanasi on vaihdettava."
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr "id_token parametri puuttuu"
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 #, fuzzy
 #| msgid "Missing id_token parameter"
 msgid "Missing idp param"
 msgstr "id_token parametri puuttuu"
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr "Virheellinen OTP"
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr "Ei voi käyttää yhtäaikaisesti mobile_flow_otp ja desktop_flow_otp."
 

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -34,7 +34,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-04-27 16:30+0000\n"
 "Last-Translator: Raphaël Hertzog <hertzog@debian.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/zulip/django/fr/"
@@ -47,54 +47,54 @@ msgstr ""
 "1000000 == 0 ? 1 : 2;\n"
 "X-Generator: Weblate 5.17.1-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "Non autorisé pour les utilisateurs invités"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "Organisation non valide"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr "Canaux publics"
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr "Canaux privés"
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr "Messages directs"
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr "Messages directs de groupe"
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr "Canal manquant pour graphique : {chart_name}"
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr "Nom du graphique inconnu : {chart_name}"
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr ""
 "L'heure de début est postérieure à l'heure de fin. Début : {start}, Fin : "
 "{end}"
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr ""
 "Aucune donnée d'analyse disponible. Veuillez contacter votre administrateur "
 "système."
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -108,7 +108,7 @@ msgstr ""
 "({deactivate_user_help_page_link}) pour permettre à de nouveaux utilisateurs "
 "de s'inscrire."
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -120,7 +120,7 @@ msgstr ""
 "utilisateurs inactifs]({deactivate_user_help_page_link}) pour permettre plus "
 "qu'une seule inscription."
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -132,7 +132,7 @@ msgstr ""
 "inactifs]({deactivate_user_help_page_link}) pour permettre à plus de deux "
 "utilisateurs de s'inscrire."
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -144,7 +144,7 @@ msgstr ""
 "inactifs]({deactivate_user_help_page_link}) pour permettre à plus de trois "
 "utilisateurs de s'inscrire."
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -158,7 +158,7 @@ msgstr ""
 "de licences pour la période de facturation en cours et la suivante]"
 "({billing_page_link}) est supérieur au nombre actuel d’utilisateurs."
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
@@ -166,7 +166,7 @@ msgstr ""
 "Votre organisation n'as pas assez de licences Zulip. Les invitations n'ont "
 "pas pu être envoyées."
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
@@ -174,16 +174,15 @@ msgstr ""
 "Votre organisation n'a pas assez de licences Zulip pour modifier le rôle "
 "d'un utilisateur invité."
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr "L'enregistrement est désactivé"
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr "Serveur à distance non valide."
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
@@ -192,7 +191,7 @@ msgstr ""
 "Vous devez acheter des licenses pour tous les utilisateurs actifs dans votre "
 "organisation (minimum {min_licenses})."
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
@@ -202,43 +201,43 @@ msgstr ""
 "traitées à partir de cette page. Pour terminer la mise à niveau, veuillez "
 "contacter {email}."
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr "Aucune méthode de paiement n'est enregistrée."
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr "{brand} termine dans {last4}"
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr "Méthode de paiement inconnue. Merci de contacter {email}."
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr "Quelque chose s'est mal passé. Merci de contacter {email}."
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "Quelque chose s'est mal passé. Merci de recharger la page."
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr "Quelque chose s'est mal passé. Merci de patienter quelques secondes."
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 "Veuillez ajouter une carte de crédit avant de commencer votre essai gratuit."
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr "Merci d'ajouter une carte de crédit pour programmer une amélioration."
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
@@ -246,19 +245,19 @@ msgstr ""
 "Impossible de mettre le plan à jour. Le plan a expiré et a été remplacé par "
 "un nouveau plan."
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr ""
 "Impossible de mettre le plan à jour. Ce type de plan n'est plus disponible."
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 "Impossible de mettre à jour les licences dans la période de facturation en "
 "cours pour le plan d’essai."
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
@@ -266,7 +265,7 @@ msgstr ""
 "Impossible de mettre à jour les licences manuellement. Votre plan induit une "
 "gestion automatique des licences."
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
@@ -274,13 +273,13 @@ msgstr ""
 "Votre forfait comprend déjà {licenses} licences pour la période de "
 "facturation en cours."
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr ""
 "Vous ne pouvez pas réduire les licences dans la période de facturation en "
 "cours."
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
@@ -288,7 +287,7 @@ msgstr ""
 "Impossible de changer les licences pour le prochain cycle de facturation "
 "pour un plan en cours de rétrogradation."
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
@@ -297,7 +296,7 @@ msgstr ""
 "Le renouvellement de votre plan est déjà programmé avec "
 "{licenses_at_next_renewal} licences."
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
@@ -306,27 +305,27 @@ msgstr ""
 "Vous avez déjà acheté {licenses_at_next_renewal} licences pour la prochaine "
 "période de facturation."
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr "Rien à changer."
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr "Aucun client pour cette organisation !"
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr "Session introuvable"
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr "Intention de paiement introuvable"
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr "Passez stripe_session_id ou stripe_invoice_id"
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -341,20 +340,19 @@ msgstr ""
 "Si vous pouviez {begin_link} mentionner Zulip comme sponsor sur votre site "
 "web {end_link}, nous vous en serions très reconnaissants !"
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr "Le paramètre 'confirmed' est requis"
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr "Le jeton d'accès à la facturation a expiré."
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr "Jeton d'accès à la facturation non valide."
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
@@ -363,40 +361,39 @@ msgstr ""
 "Impossible de réconcilier les données de facturation entre le serveur et le "
 "domaine. Veuillez contacter {support_email}"
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr "Le compte utilisateur n’existe pas encore."
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr "Vous devez accepter les conditions d’utilisation pour continuer."
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 "Cet identifiant d’organisation Zulip (zulip_org_id) n’est pas enregistré "
 "dans le système de gestion de facturation de Zulip."
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr "zulip_org_key non valide pour ce zulip_org_id."
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr "L'enregistrement de votre serveur a été désactivé."
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "Erreur"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr "Page introuvable (404)"
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
@@ -405,11 +402,11 @@ msgstr ""
 "Si cette erreur est inattendue, vous pouvez <a href=\"mailto:"
 "%(support_email)s\">contacter le support</a>."
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr "Accès refusé (403)"
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
@@ -418,11 +415,11 @@ msgstr ""
 "les identifiants requis pour authentifier votre accès. Pour résoudre ce "
 "problème :"
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr "Assurez-vous que votre navigateur autorise les cookies pour ce site."
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
@@ -430,16 +427,15 @@ msgstr ""
 "Vérifiez si des paramètres de confidentialité ou des extensions de votre "
 "navigateur bloquent les en-têtes “Referer”, et désactivez-les pour ce site."
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr "Méthode non autorisée (405)"
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr "Erreur de serveur interne"
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
@@ -448,7 +444,7 @@ msgstr ""
 "problème et travaillons à le résoudre. Zulip se chargera automatiquement dès "
 "que le service sera rétabli."
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -459,7 +455,7 @@ msgstr ""
 "a> pour plus d’informations, et <a href=\"mailto:"
 "%(support_email)s\">contacter le support Zulip</a> pour toute question."
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
@@ -468,7 +464,7 @@ msgstr ""
 "problème et travaillons à le résoudre. Zulip se chargera automatiquement dès "
 "que le service sera rétabli."
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
@@ -477,7 +473,7 @@ msgstr ""
 "<a href=\"mailto:%(support_email)s\">Contactez les administrateurs de ce "
 "serveur</a> pour obtenir de l’aide."
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
@@ -487,138 +483,136 @@ msgstr ""
 "consulter le <a href=\"%(troubleshooting_url)s\">guide de dépannage d'un "
 "serveur Zulip</a>."
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr "Analytique pour %(target_name)s | Zulip"
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 "Les statistiques sont entièrement disponibles 24 heures après la création de "
 "l'organisation."
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr "Analytique Zulip pour %(target_name)s"
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr "Résumé de l&#39;organisation"
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr "nombre d&#39;utilisateurs"
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr "Utilisateurs actifs au cours des 15 derniers jours"
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr "Nombre d&#39;invités"
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr "Nombre total de messages"
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr "Nombre de messages au cours des 30 derniers jours"
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr "Stockage de fichiers en cours d&#39;utilisation"
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "Utilisateurs actifs"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr "Actifs quotidiennement"
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr "Actifs lors des 15 derniers jours"
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr "Total des utilisateurs"
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "Utilisateurs"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr "Messages envoyés par type de destinataire"
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "Moi"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "Tout le monde"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "La semaine dernière"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "Le mois dernier"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "L'année dernière"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "Tout le temps"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr "Messages envoyés au fil du temps"
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "Quotidien"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "Hebdomadaire"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr "Cumulatif"
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "Humains"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "Robots"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr "Messages lus au fil du temps"
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr "Messages envoyés par le client"
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr "Dernière mise à jour"
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
@@ -627,15 +621,15 @@ msgstr ""
 "graphique des “Messages envoyés au cours du temps” est mis à jour une fois "
 "par heure."
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr "Adresse électronique changée"
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr "Adresse électronique changée !"
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
@@ -644,22 +638,22 @@ msgstr ""
 "Cela confirme que le courriel de votre compte Zulip est passé de "
 "%(old_email_html_tag)s à %(new_email_html_tag)s"
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr "Confirmation de votre adresse électronique"
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr "Le lien de confirmation n'existe pas"
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr ""
 "Oups. Nous n'avons pas pu trouver votre lien de confirmation dans le système."
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
@@ -668,29 +662,29 @@ msgstr ""
 "Dans tous les cas, écrivez-nous à %(support_email_html_tag)s et nous "
 "réglerons cela rapidement."
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr "Lien de confirmation expiré ou désactivé"
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr "Oups. Le lien de confirmation a expiré ou a été désactivé."
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr ""
 "Veuillez contacter l'administrateur de votre organisation pour un nouveau "
 "lien."
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr "Lien de confirmation malformé"
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr "Oups. Le lien de confirmation est mal formé."
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
@@ -699,72 +693,55 @@ msgstr ""
 "vous obtenez toujours cette page, c'est probablement notre faute. Nous "
 "sommes désolés."
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr "Facturation"
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr "Fermer le modal"
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr "Peu importe"
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr "Rétrograder"
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "Annuler"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr "Confirmer"
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr "Annuler la mise à niveau"
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr "Statut de facturation"
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr "Désactiver l'enregistrement du serveur ?"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr "La gestion des offres n'est pas disponible"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -781,7 +758,7 @@ msgstr ""
 "self-hosted-billing#log-in-to-billing-management\">instructions de "
 "connexion</a> pour gérer le forfait de votre serveur Zulip."
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
@@ -790,7 +767,7 @@ msgstr ""
 "autre question, <a href=\"mailto :{{ support_email }}\">contactez le "
 "support</a>."
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
@@ -798,7 +775,7 @@ msgstr ""
 "La gestion des forfaits pour ce serveur n'est pas disponible car au moins "
 "une organisation hébergée sur ce serveur dispose déjà d'un forfait actif."
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -809,730 +786,240 @@ msgstr ""
 "connecter</a> pour gérer le forfait de votre organisation, ou <a "
 "href='mailto:%(support_email)s'>contacter le support</a> pour toute question."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr "Limite de débit dépassée"
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr "Limite de débit dépassée."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 "Votre serveur a dépassé le nombre maximal d'exécution pour cette action."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, python-format
 msgid "You can try again in %(retry_after_string)s."
 msgstr "Vous pouvez réessayer dans %(retry_after_string)s."
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr "Mise à niveau"
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr "Envoyer la facture et débuter l'essai gratuit"
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr "Envoyer la facture"
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr "Ouvrir le répertoire des communautés"
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr "Filtrer par catégorie"
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "Tous"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr "Catégories"
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr "10,000 messages"
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr "Illimité"
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr "Fichiers jusqu'à 10 Mo"
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr "Fichiers jusqu'à 1 Go"
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr "Pris en charge"
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr "Auto-géré"
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr "Pour les organisations comptant jusqu'à 10 utilisateurs"
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr "25 utilisateurs minimum"
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr "Non disponible"
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr "La communauté de développement Zulip"
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr "Rejoindre en tant qu'utilisateur"
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr "Inscrivez-vous en tant qu'auto-hébergeur"
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr "Rejoindre en tant que contributeur"
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "Créer une organisation"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr "Demander une démonstration"
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr "Auto-héberger Zulip"
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr "Demande de parrainage"
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr "Tarifs éducation"
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr "Voir les prix"
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr "Zulip pour les entreprises"
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 msgid "Zulip for open source"
 msgstr "Zulip pour le logiciel libre"
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr "Chien avec des lunettes et un ordinateur portable"
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation"
 msgstr "Capture d'écran d'une conversation Zulip"
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr "Capture d'écran d'une conversation Zulip avec le robot sentry"
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr "Capture d'écran de la boîte de réception Zulip"
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr "Ordinateur portable ouvert avec un livre à l'intérieur"
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr "Deux mains assemblant un puzzle"
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 msgid "Message with code"
 msgstr "Message avec du code"
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr "Éclair"
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr "Lien"
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr "Gouvernail"
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr "Contacter le support"
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr "De"
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr "Organisation"
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr "Sujet"
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr "Message"
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr "Soumettre"
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr "Merci de nous avoir contactés"
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr "Merci de nous avoir contactés !"
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr "Nous vous contacterons bientôt."
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
@@ -1540,11 +1027,11 @@ msgstr ""
 "pouvez trouver des réponses aux questions fréquemment posées dans le <a "
 "href=\"/help/\">centre d&#39;aide de Zulip</a> ."
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 msgid "Get started"
 msgstr "Commencer"
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
@@ -1554,51 +1041,50 @@ msgstr ""
 "accepter les <a href=\"https://zulip.com/policies/terms\">Conditions d&#39;"
 "Ctilisation de Zulip</a> pour continuer."
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr "Ou utilisez l’un de vos téléphones de secours :"
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr "En dernier recours, vous pouvez utiliser un jeton de secours :"
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr "Utiliser un jeton de secours"
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr "Acceptez les Conditions d&#39;Utilisation"
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr "Bienvenue sur Zulip"
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "Adresse électronique"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr ""
 "Abonnez-moi à la lettre d'information occasionnelle de Zulip (quelques e-"
 "mails par an)."
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr "Continuer"
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr "Confirmez votre adresse électronique"
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1609,7 +1095,7 @@ msgstr ""
 "class=\"user_email semi-bold\">%(email)s</span>) pour recevoir un courriel "
 "de confirmation de Zulip."
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
@@ -1618,12 +1104,12 @@ msgstr ""
 "réception ou dans votre dossier Spam, nous pouvons vous <a href=\"#\" "
 "id=\"resend_email_link\">le renvoyer</a>."
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr "Vue publique de {org_name} | Discussion d'équipe Zulip"
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
@@ -1631,14 +1117,14 @@ msgstr ""
 "Naviguez les canaux accessibles publiquement dans {org_name} sans vous "
 "connectez."
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 "Puisque vous utilisez un navigateur très vieux ou non supporté, il se peut "
 "que Zulip ne fonctionne pas."
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
@@ -1649,7 +1135,7 @@ msgstr ""
 "target=\"_blank\" rel=\"noopener noreferrer\">Téléchargez la dernière "
 "version.</a>"
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
@@ -1657,39 +1143,38 @@ msgstr ""
 "Si ce message ne disparaît pas, essayez de <a class=\"reload-"
 "lnk\">recharger</a> la page."
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 "Erreur de chargement de Zulip. Essayez de <a class=\"reload-lnk\">recharger</"
 "a> la page."
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr "Aucune conversation ne correspond à vos filtres."
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr "Cette vue charge encore des messages."
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr "Charger plus"
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr "Appel vidéo terminé"
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr "Vous pouvez maintenant fermer cette fenêtre."
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr "Erreur de configuration"
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
@@ -1698,7 +1183,7 @@ msgstr ""
 "d'organisation. Veuillez utiliser EmailAuthBackend pour créer votre "
 "organisation, puis réessayez."
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1709,33 +1194,32 @@ msgstr ""
 "savoir comment les configurer, veuillez consulter la <a "
 "href=\"%(doc_url)s\">documentation</a>."
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr "Compte non trouvé"
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr "Compte Zulip non trouvé."
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, python-format
 msgid "No account found for %(email)s."
 msgstr "Aucun compte trouvé pour %(email)s."
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr "Se connecter avec un autre compte"
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr "Continuer vers l'inscription"
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 msgid "Try Zulip in a demo organization"
 msgstr "Essayez Zulip dans une organisation de démonstration"
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
@@ -1745,19 +1229,19 @@ msgstr ""
 "subtitle-link\" href=\"%(root_domain_url)s/new/\">créez une organisation "
 "permanente</a>."
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 msgid "Try Zulip"
 msgstr "Essayer Zulip"
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "Créer une nouvelle organisation"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr "Créer une nouvelle organisation Zulip"
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
@@ -1767,16 +1251,15 @@ msgstr ""
 "new/demo/\">créez une organisation de démonstration</a> — aucune adresse "
 "électronique requise !"
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr "Entrer votre adresse électronique"
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr "Votre adresse e-mail"
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
@@ -1786,11 +1269,11 @@ msgstr ""
 "help/import-from-mattermost\">Mattermost</a> ou <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr "Comment avez-vous entendu parler de Zulip pour la première fois ?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
@@ -1798,42 +1281,41 @@ msgstr ""
 "Cette valeur n'est utilisée que si vous souscrivez à une offre, auquel cas "
 "elle sera transmise à l'équipe Zulip."
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr "Choisissez une option"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr "Merci de décrire"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr "Ou avez vous vu la publicité ?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr "Quelle organisation ?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr "Lequel ?"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr "Choisissez en un"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr "Type d'Organisation"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr "Langue de l'organisation"
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
@@ -1843,72 +1325,68 @@ msgstr ""
 "mattermost\">Mattermost</a> ou <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid "Import chat history?"
 msgstr "Importer l’historique des discussions ?"
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr "Nom de l'organisation"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "URL de l'organisation"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr "Utiliser %(external_host)s"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "OU"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "S'inscrire"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "S'inscrire à Zulip"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr "Vous avez besoin d'une invitation pour rejoindre cette organisation."
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr "S'inscrire avec %(identity_provider)s"
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr "Vous possédez déjà un compte ?"
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "Se connecter"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr "Configurer la confidentialité de l’adresse email"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
@@ -1916,7 +1394,7 @@ msgstr ""
 "Zulip vous permet de contrôler quels rôles dans l'organisation peuvent voir "
 "votre adresse e-mail."
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
@@ -1925,11 +1403,11 @@ msgstr ""
 "électronique par rapport à la configuration par défaut de cette "
 "organisation ?"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr "Qui peut accéder à votre adresse e-mail"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1940,7 +1418,7 @@ msgstr ""
 "help/configure-email-visibility\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">après votre inscription</a>."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
@@ -1948,7 +1426,7 @@ msgstr ""
 "Les administrateurs de cette organisation Zulip pourront voir cette adresse "
 "électronique."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
@@ -1956,14 +1434,14 @@ msgstr ""
 "Les administrateurs et les modérateurs de cette organisation Zulip pourront "
 "voir cette adresse électronique."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 "Personne au sein de l'organisation Zulip ne pourra voir cette adresse "
 "électronique."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
@@ -1971,81 +1449,80 @@ msgstr ""
 "D'autres utilisateurs de cette organisation Zulip pourront voir cette "
 "adresse électronique."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "Changer"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr "Inscription"
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr "Créer votre organisation"
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr "Créer votre compte"
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr ""
 "<p>Saisissez les détails de votre compte pour terminer l'enregistrement.</p>"
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr "Ton organisation"
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr "Votre compte"
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr "Ne pas importer les paramètres"
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr "Importer les paramètres à partir d'un compte Zulip existant"
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr "Votre nom complet"
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "Nom"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr "Votre compte est affiché de la façon suivante dans Zulip."
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "Mot de passe"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr "Entrez votre mot de passe LDAP/Active Directory."
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 "Ceci est utilisé pour les applications mobiles et autres outils qui "
 "requièrent un mot de passe."
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr "Force du mot de passe"
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr "Qu'est-ce qui vous intéresse ?"
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
@@ -2054,15 +1531,15 @@ msgstr ""
 "J'accepte les <a href=\"%(root_domain_url)s/policies/terms\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">Conditions d'utilisation</a>."
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr "Organisation désactivée"
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr "Organisation déplacée"
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
@@ -2071,7 +1548,7 @@ msgstr ""
 "Cette organisation a été déplacée vers <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -2083,14 +1560,14 @@ msgstr ""
 "URL</a> dans <span id=\"deactivated-org-auto-redirect-countdown\">5</span> "
 "secondes."
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 msgid ""
 "This organization has been deactivated, and all organization data has been "
 "deleted."
 msgstr ""
 "L'organisation a été désactivée, et toutes ses données ont été supprimées."
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
@@ -2099,7 +1576,7 @@ msgstr ""
 "Vous pouvez <a href=\"mailto:%(support_email)s\">contacter l'assistance "
 "Zulip</a> pour demander à réutiliser cet URL pour une nouvelle organisation."
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
@@ -2109,11 +1586,11 @@ msgstr ""
 "administrateurs de ce serveur Zulip</a> pour savoir s'il est possible de "
 "réutiliser cette URL pour une nouvelle organisation."
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 msgid "This organization has been deactivated."
 msgstr "L'organisation a été désactivée."
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -2123,7 +1600,7 @@ msgstr ""
 "href=\"mailto:%(support_email)s\">contacter l'assistance Zulip</a> pour la "
 "réactiver."
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
@@ -2133,7 +1610,7 @@ msgstr ""
 "informations sur les raisons de sa désactivation, merci de contacter "
 "directement les administrateurs de l'organisation."
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -2144,15 +1621,15 @@ msgstr ""
 "href=\"mailto:%(support_email)s\">contacter les administrateurs de ce "
 "serveur Zulip</a> pour le réactiver."
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr "Terminer la connexion à l&#39;application de bureau"
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr "Terminer la connexion de bureau"
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
@@ -2160,93 +1637,92 @@ msgstr ""
 "Utilisez votre navigateur pour compléter la connexion, puis revenez ici pour "
 "coller votre jeton de connexion."
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr "Coller le jeton ici"
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr "Terminer"
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr "Jeton incorrect."
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr "Jeton accepté. Connexion en cours…"
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr "Connectez-vous à l&#39;application de bureau"
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 "Copiez de jeton de connexion puis retournez sur l'application Zulip pour "
 "compléter la connexion :"
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "Copier"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr "Vous pouvez ensuite fermer cette fenêtre."
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr "Ou bien, continuez avez votre navigateur."
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr "Utilisateur anonyme"
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr "Propriétaires"
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "Administrateurs"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr "Modérateurs"
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr "Utilisateurs invités"
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "Utilisateurs normaux"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr "Transférer des courriels vers un compte de courriels"
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "Fermer"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "Mettre à jour"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr "Zulip"
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr "Résumé"
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
@@ -2255,17 +1731,17 @@ msgstr ""
 "Félicitations, vous avez créé une nouvelle organisation Zulip : "
 "<b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr "Bienvenue sur Zulip !"
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr "Vous avez rejoint l'organisation Zulip <b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
@@ -2275,36 +1751,36 @@ msgstr ""
 "application web, <a href=\"%(apps_page_link)s\">mobile et de bureau</a> de "
 "Zulip :"
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr "URL de l'organisation : %(organization_url)s"
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr "Votre nom d'utilisateur : %(ldap_username)s"
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr "Utiliser votre compte LDAP pour vous connecter"
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr "Adresse électronique de votre compte : %(email)s"
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr "Aller à l'organisation"
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
@@ -2313,7 +1789,7 @@ msgstr ""
 "Si vous êtes nouveau sur Zulip, consultez notre <a "
 "href=\"%(getting_user_started_link)s\">guide de démarrage</a> !"
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2324,7 +1800,7 @@ msgstr ""
 "href=\"%(getting_organization_started_link)s\">migrer votre organisation "
 "vers Zulip</a>."
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
@@ -2333,17 +1809,17 @@ msgstr ""
 "Des questions ? <a href=\"mailto:%(support_email)s\">Contactez-nous</a> — "
 "nous serions ravis de vous aider !"
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr "%(realm_name)s sur Zulip : Votre nouvelle organisation"
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr "%(realm_name)s sur Zulip : Votre nouveau compte"
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
@@ -2351,12 +1827,12 @@ msgstr ""
 "Félicitations, vous avez créé une nouvelle organisation Zulip : "
 "%(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr "Vous avez rejoint l'organisation Zulip %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
@@ -2365,7 +1841,7 @@ msgstr ""
 "Vous utiliserez les informations suivantes pour vous connecter aux "
 "applications web, mobile et de bureau de Zulip (%(apps_page_link)s) :"
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
@@ -2374,7 +1850,7 @@ msgstr ""
 "Si vous êtes nouveau sur Zulip, consultez notre guide de démarrage "
 "(%(getting_user_started_link)s) !"
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
@@ -2383,19 +1859,19 @@ msgstr ""
 "Nous avons également un guide pour migrer votre organisation vers Zulip "
 "(%(getting_organization_started_link)s)."
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 "Vous avez des questions ? Contactez-nous à %(support_email)s — nous serons "
 "ravis de vous aider !"
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2404,17 +1880,17 @@ msgstr ""
 "Si vous avez des questions, s'il vous plait contactez cet administrateur "
 "serveur Zulip à l'adresse %(support_email)s."
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr "Salut,"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2426,12 +1902,12 @@ msgstr ""
 "%(realm_url)s. Pour confirmer cette mise à jour et définir un mot de passe "
 "pour ce compte, veuillez cliquer ci-dessous :"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr "Confirmer et définir le mot de passe"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2440,14 +1916,14 @@ msgstr ""
 "Si vous n'avez pas demandé ce changement, veuillez nous contacter "
 "immédiatement à %(support_email)s."
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 msgid "Verify your email address for your Zulip demo organization"
 msgstr ""
 "Vérifiez votre adresse électronique pour votre organisation de démonstration "
 "Zulip"
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2456,8 +1932,8 @@ msgstr ""
 "Si vous n'avez pas demandé cette modification, veuillez nous contacter "
 "immédiatement à <%(support_email)s>."
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2468,34 +1944,34 @@ msgstr ""
 "associée au compte Zulip sur %(realm_url)s, pour passer de %(old_email)s à "
 "%(new_email)s. Pour confirmer ce changement, veuillez cliquer ci-dessous :"
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr "Confirmer la modification de l'adresse email"
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr ""
 "Vérifiez votre nouvelle adresse électronique pour %(organization_host)s"
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr "Vous avez demandé une nouvelle organisation Zulip :"
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr "Type d’organisation : %(organization_type)s"
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr "Vous vous êtes enregistré récemment sur Zulip. Incroyable !"
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
@@ -2504,34 +1980,34 @@ msgstr ""
 "votre compte. Vous pourrez modifier les informations ci-dessus si vous le "
 "souhaitez."
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr ""
 "Veuillez cliquer sur le bouton ci-dessous pour terminer votre inscription."
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr "Compléter votre inscription"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr "Créer votre organisation Zulip"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr "Activer votre compte Zulip"
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr "Cliquer sur le bouton ci-dessous pour terminer votre inscription."
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
@@ -2540,20 +2016,20 @@ msgstr ""
 "Avez-vous des questions ou un feedback à partager ? Contactez nous à "
 "l'adresse %(support_email)s - Nous sommes heureux de vous aider !"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr "Gérer les préférences courriel"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr "Se désinscrire des courriels promotionnels"
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
@@ -2562,17 +2038,17 @@ msgstr ""
 "Votre compte Zulip sur <a href=\"%(realm_url)s\">%(realm_url)s</a> a été "
 "désactivé, et vous ne pourrez plus vous connecter."
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr "Les administrateurs ont fourni le commentaire suivant :"
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr "Notification de désactivation de compte sur %(realm_name)s"
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
@@ -2581,11 +2057,11 @@ msgstr ""
 "Votre compte Zulip sur %(realm_url)s a été désactivé, et vous ne pourrez "
 "plus vous connecter."
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr "Nouveaux canaux"
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2596,7 +2072,7 @@ msgstr ""
 "%(new_streams_count)s nouveaux canaux dans <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
@@ -2605,7 +2081,7 @@ msgstr ""
 "Vous avez %(new_messages_count)s nouveaux messages dans <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
@@ -2614,8 +2090,8 @@ msgstr ""
 "Il y a %(new_streams_count)s nouveaux canaux dans <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because your organization <a "
@@ -2627,8 +2103,8 @@ msgstr ""
 "href=\"%(help_url)s\">masque le contenu des messages</a> dans les "
 "notifications par courriel."
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to <a "
@@ -2639,22 +2115,22 @@ msgstr ""
 "class=\"content_disabled_help_link\" href=\"%(help_url)s\">masquer le "
 "contenu du message</a> dans les notifications par courriel."
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr ""
 "<a href=\"%(realm_url)s\">Connectez-vous</a> à Zulip pour vous mettre à jour."
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr "Se désinscrire des résumés par courriel"
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr "Résumé Zulip pour %(realm_name)s"
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2663,19 +2139,19 @@ msgstr ""
 "Vous avez %(new_messages_count)s nouveaux messages, et il y a "
 "%(new_streams_count)s nouveaux canaux dans %(realm_name)s."
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 "Vous avez %(new_messages_count)s nouveaux messages dans %(realm_name)s."
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr "Il y a %(new_streams_count)s nouveaux canaux dans %(realm_name)s."
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because your organization hides "
@@ -2686,8 +2162,8 @@ msgstr ""
 "masque le contenu des messages dans les notifications par courriel. "
 "Consultez %(hide_content_url)s pour plus de détails."
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to hide "
@@ -2697,32 +2173,30 @@ msgstr ""
 "masquer le contenu des messages dans les notifications par courriel. "
 "Consultez %(help_url)s pour plus de détails."
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr "Connectez à Zulip pour ne rien manquer : %(organization_url)s."
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr "Gérer les préférences courriel :"
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr "Se désinscrire des résumés par courriel :"
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr "Poissons qui nagent"
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr "Merci pour votre demande !"
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
@@ -2731,8 +2205,7 @@ msgstr ""
 "Votre adresse électronique %(email)s est associée à des comptes sur les "
 "organisations Zulip Cloud suivantes :"
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
@@ -2741,7 +2214,7 @@ msgstr ""
 "Votre courriel %(email)s est enregistré avec les organisations Zulip "
 "suivantes hébergées par %(external_host)s :"
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
@@ -2750,20 +2223,16 @@ msgstr ""
 "Si vous rencontrez des difficultés pour vous connecter, vous pouvez <a "
 "href=\"%(help_reset_password_link)s\">réinitialiser votre mot de passe</a>."
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 "Vous avez demandé une liste de comptes Zulip pour cette adresse électronique."
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr "Malheureusement, aucun compte Zulip Cloud n'a été trouvé."
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
@@ -2772,7 +2241,7 @@ msgstr ""
 "Malheureusement, aucun compte n'a été trouvé dans les organisations Zulip "
 "hébergées par %(external_host)s."
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2784,30 +2253,27 @@ msgstr ""
 "href=\"%(help_logging_in_link)s\">essayer une autre méthode</a> pour trouver "
 "votre compte."
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 "Si vous n'êtes pas à l'origine de cette demande, vous pouvez ignorer ce "
 "courriel sans crainte."
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr "Vos comptes Zulip"
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr "Aucun compte Zulip n'a été trouvé"
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 "Si vous avez des problèmes pour vous connecter, vous pouvez réinitialiser "
 "votre mot de passe."
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
@@ -2817,12 +2283,12 @@ msgstr ""
 "(%(find_accounts_link)s), ou essayer un autre moyen de retrouver votre "
 "compte (%(help_logging_in_link)s)."
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr "Salut les gens,"
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
@@ -2831,17 +2297,17 @@ msgstr ""
 "%(referrer_name)s vous invite à rejoindre Zulip &mdash; l'outil de "
 "communication d'équipe conçu pour la productivité."
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr "Pour commencer, cliquez sur le bouton ci-dessous."
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr "%(referrer_full_name)s vous invite à rejoindre %(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
@@ -2851,17 +2317,17 @@ msgstr ""
 "rejoignez sur Zulip -- l'outil de communication d'équipe pour gagner en "
 "productivité."
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr "Pour commencer, cliquez sur le lien ci-dessous."
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr "Rebonjour,"
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
@@ -2871,13 +2337,13 @@ msgstr ""
 "rejoindre Zulip &mdash; l'outil de communication d'équipe conçu pour la "
 "productivité."
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr "C'est le dernier rappel que vous recevrez pour cette invitation."
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
@@ -2886,12 +2352,12 @@ msgstr ""
 "Cette invitation expire dans deux jours. Une fois expirée, vous devrez en "
 "demander une nouvelle à %(referrer_name)s."
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr "Rappel : Rejoignez %(referrer_name)s sur %(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2902,7 +2368,7 @@ msgstr ""
 "souhaite vous inviter sur Zulip -- l'outil de communication d'équipe conçu "
 "pour la productivité."
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2911,7 +2377,7 @@ msgstr ""
 "Si vous avez la moindre question, merci de contacter les administrateurs de "
 "ce serveur Zulip via l'adresse <a href=\"mailto:%(email)s\">%(email)s</a>."
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
@@ -2920,23 +2386,21 @@ msgstr ""
 "Vous avez des questions ou des commentaires à partager ? <a href=\"mailto:"
 "%(email)s\">Contactez-nous</a> — nous serions ravis de vous aider !"
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr "Vous recevez ceci parce que vous avez été personnellement mentionné."
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr ""
 "Vous recevez ceci parce que @%(mentioned_user_group_name)s a été mentionné."
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
@@ -2945,8 +2409,8 @@ msgstr ""
 "Vous recevez ceci parce que tous les participants à la conversation ont été "
 "mentionnés dans %(channel_name)s > %(topic_name)s."
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
@@ -2954,16 +2418,16 @@ msgstr ""
 "Vous recevez ce message car vous avez activé les notifications pour les "
 "mentions génériques sur les sujets que vous suivez."
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 "Vous recevez ceci car tout le monde a été mentionné dans #%(channel_name)s."
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
@@ -2971,8 +2435,8 @@ msgstr ""
 "Vous recevez ceci car vous avez activé les notifications par courriel pour "
 "les conversations que vous suivez."
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
@@ -2981,7 +2445,7 @@ msgstr ""
 "Vous recevez ceci car vous avez activé les notifications par courriel pour "
 "#%(channel_name)s."
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2993,7 +2457,7 @@ msgstr ""
 "href=\"%(notif_url)s\">gérez les préférences de notifications par courriel</"
 "a>."
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
@@ -3003,7 +2467,7 @@ msgstr ""
 "%(realm_name)s</a>, ou <a href=\"%(notif_url)s\">gérer les préférences de "
 "notification par courriel</a>."
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
@@ -3013,7 +2477,7 @@ msgstr ""
 "a>, ou <a href=\"%(notif_url)s\">gérez les préférences de notification par "
 "courriel</a>."
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
@@ -3022,43 +2486,43 @@ msgstr ""
 "Ne répondez pas à ce courriel. Le serveur Zulip n'est pas configuré pour "
 "accepter les courriels entrants (<a href=\"%(url)s\">aide</a>)."
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr "Messages directs de groupe avec %(direct_message_group_display_name)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr "Messages directs avec %(sender_str)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr "[résolu] #%(channel_name)s > %(topic_name)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr "Nouveaux messages"
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 "Répondez directement à cet e-mail ou affichez-le dans le Zulip de "
 "%(realm_name)s :"
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr "Afficher ou répondre dans le Zulip de %(realm_name)s :"
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr "Répondre dans le Zulip de %(realm_name)s :"
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
@@ -3066,7 +2530,7 @@ msgstr ""
 "Ne répondez pas à ce courriel. Le serveur Zulip n'est pas configuré pour "
 "accepter les courriels entrants. Aide :"
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -3077,22 +2541,22 @@ msgstr ""
 "remplacée par %(new_email)s. Si vous n'avez pas demandé ce changement, "
 "veuillez nous contacter immédiatement à %(support_email)s."
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr "Cher,"
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr "L'équipe Zulip"
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr "Adresse électronique Zulip changée à %(realm_name)s"
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -3103,7 +2567,7 @@ msgstr ""
 "à celle-ci : %(new_email)s. Si vous n'avez pas demandé cette modification, "
 "veuillez nous contacter immédiatement à <%(support_email)s>."
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
@@ -3111,46 +2575,46 @@ msgstr ""
 "Organisation : %(organization_url)s Date/heure : %(login_time)s Courriel : "
 "%(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr "Nous avons remarqué une connexion récente au compte Zulip suivant."
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr "Organisation : %(organization_link)s"
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr "Courriel : %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr "Heure : %(login_time)s"
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr "Appareil : %(device_browser)s sur %(device_os)s."
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr "Adresse IP : %(device_ip)s"
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr "S'il s'agissait de vous, parfait ! Il n'y a rien d'autre à faire."
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3161,31 +2625,31 @@ msgstr ""
 "dans votre compte, veuillez <a href=\"%(reset_link)s\">réinitialiser votre "
 "mot de passe</a> ou nous contacter immédiatement à %(support_email)s."
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr "Merci,"
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr "Sécurité de Zulip"
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr "Se désabonner des notifications de connexion"
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr "Nouvelle connexion à partir de %(device_browser)s sur %(device_os)s"
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr "Organisation : %(organization_url)s"
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3196,7 +2660,7 @@ msgstr ""
 "dans votre compte, veuillez changer votre mot de passe à %(reset_link)s ou "
 "nous contacter immédiatement à %(support_email)s."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -3208,7 +2672,7 @@ msgstr ""
 "href=\"%(get_organization_started)s\">guide pour migrer vers Zulip</a> pour "
 "commencer."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
@@ -3216,7 +2680,7 @@ msgstr ""
 "Sinon, voici quelques conseils que nous entendons souvent de la part de nos "
 "clients pour évaluer <i>n’importe quel</i> outil de discussion d’équipe :"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
@@ -3225,12 +2689,12 @@ msgstr ""
 "<a href=\"%(invite_users)s\"><b>Invitez vos coéquipiers</b></a> à explorer "
 "avec vous et à partager leurs points de vue."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr "Utilisez l'application elle-même pour discuter de vos impressions."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -3242,7 +2706,7 @@ msgstr ""
 "seule façon de découvrir comment une nouvelle application de discussion "
 "améliorera la communication de votre équipe."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -3253,21 +2717,21 @@ msgstr ""
 "efficace</a>, et nous espérons que ces conseils aideront votre équipe à en "
 "faire l’expérience concrètement."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr "Se désabonner des mails de bienvenue pour %(realm_name)s"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr "Choisir l'application de chat pour votre équipe"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
@@ -3276,7 +2740,7 @@ msgstr ""
 "bienvenue ! Vous pouvez suivre notre guide pour migrer vers Zulip pour "
 "commencer."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
@@ -3284,7 +2748,7 @@ msgstr ""
 "Sinon, voici quelques conseils que les clients nous donnent souvent pour "
 "évaluer un produit de chat d'équipe :"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
@@ -3292,7 +2756,7 @@ msgstr ""
 "Inviter vos coéquipiers à explorer avec vous et à partager leurs points de "
 "vue."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
@@ -3302,7 +2766,7 @@ msgstr ""
 "outils de chat en ligne. C'est le seul moyen d'expérimenter réellement "
 "comment une nouvelle application de chat aidera votre équipe à communiquer."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
@@ -3310,8 +2774,8 @@ msgstr ""
 "Zulip est conçu pour permettre une communication efficace, et nous espérons "
 "que ces conseils aideront votre équipe à en faire l'expérience."
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
@@ -3322,71 +2786,71 @@ msgstr ""
 "guide des principales fonctionnalités de Zulip pour des organisations comme "
 "la vôtre !"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr "Voir le guide Zulip pour les entreprises"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr "Voir le guide Zulip pour les projets open-source"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr "Voir le guide Zulip pour l'éducation"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr "Voir le guide Zulip pour la recherche"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr "Voir le guide Zulip pour les événements et les conférences"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr "Voir le guide Zulip pour les organisations à but non lucratif"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr "Voir le guide Zulip pour les communautés"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr "Guide Zulip pour les entreprises"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr "Guide Zulip pour les projets open-source"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr "Guide Zulip pour l'éducation"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr "Guide Zulip pour la recherche"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr "Guide Zulip pour les événements et les conférences"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr "Guide Zulip pour les organisations à but non lucratif"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr "Guide Zulip pour les communautés"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
@@ -3394,7 +2858,7 @@ msgstr ""
 "Voici quelques conseils pour organiser vos conversations Zulip en fonction "
 "des sujets."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
@@ -3402,8 +2866,8 @@ msgstr ""
 "Dans Zulip, les <b>canaux</b> déterminent qui reçoit un message. Les "
 "<b>conversations</b> indiquent de quoi il s’agit."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
@@ -3412,12 +2876,12 @@ msgstr ""
 "Vous verrez chaque message dans son contexte, quel que soit le nombre de "
 "discussions en cours."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr "Canaux et conversations dans l’application Zulip"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3429,11 +2893,11 @@ msgstr ""
 "n’interrompra pas les échanges en cours. Pour bien nommer une conversation, "
 "imaginez terminer la phrase : « Hé, on peut discuter de… ? »"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr "Exemples de sujets courts"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3448,17 +2912,17 @@ msgstr ""
 "<a href=\"%(move_channels_link)s\">déplacer une conversation vers un autre "
 "canal</a>."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr "Aller sur Zulip"
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr "Organisez vos conversations à l'aide de sujets"
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
@@ -3466,7 +2930,7 @@ msgstr ""
 "Dans Zulip, les canaux déterminent qui reçoit un message. Les conversations "
 "indiquent de quoi il s’agit."
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3480,8 +2944,8 @@ msgstr ""
 "(%(rename_topics_link)s), ou même déplacer une conversation vers un autre "
 "canal (%(move_channels_link)s)."
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
@@ -3490,16 +2954,16 @@ msgstr ""
 "Quelqu’un (peut-être vous) a demandé un nouveau mot de passe pour le compte "
 "Zulip %(email)s sur %(realm_url)s."
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr ""
 "Cliquer sur le bouton ci-dessous pour réinitialiser votre mot de passe."
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr "Réinitialiser le mot de passe"
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3510,18 +2974,18 @@ msgstr ""
 "désactivé. Vous pouvez contacter un administrateur de l'organisation pour <a "
 "href=\"%(help_link)s\">réactiver votre compte</a>."
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr "Vous n'avez pas de compte dans cette organisation Zulip."
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr "Vous n'avez pas de compte actif dans les organisations suivantes."
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
@@ -3529,26 +2993,26 @@ msgstr ""
 "Vous pouvez essayer de vous connecter ou de réinitialiser votre mot de passe "
 "dans les organisme(s) ci-dessus."
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 "Si vous ne reconnaissez pas cette activité, vous pouvez ignorer ce courriel "
 "en toute sécurité."
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr "Demande de réinitialisation de mot de passe pour %(realm_name)s"
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr ""
 "Veuillez cliquer sur le lien ci-dessous pour réinitialiser votre mot de "
 "passe."
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
@@ -3557,7 +3021,7 @@ msgstr ""
 "Vous aviez précédemment un compte sur %(realm_url)s, mais il a été "
 "désactivé. Vous pouvez contacter un administrateur pour le réactiver."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3568,7 +3032,7 @@ msgstr ""
 "plan Zulip hébergé gratuit, en raison de factures impayées. Les factures "
 "impayées ont été annulées."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
@@ -3577,7 +3041,7 @@ msgstr ""
 "Pour continuer sur le plan Zulip Cloud Standard, veuillez mettre à niveau à "
 "nouveau en allant sur %(upgrade_url)s."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
@@ -3586,8 +3050,8 @@ msgstr ""
 "Si vous pensez qu'il s'agit d'une erreur ou si vous avez besoin de plus de "
 "détails, veuillez nous contacter à %(support_email)s."
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip demo organization, %(realm_name)s, on "
@@ -3596,8 +3060,8 @@ msgstr ""
 "Vous avez désactivé votre organisation de démonstration Zulip, "
 "%(realm_name)s, le %(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
@@ -3606,8 +3070,8 @@ msgstr ""
 "Votre organisation de démonstration Zulip, %(realm_name)s, a été désactivée "
 "par %(deactivating_owner)s le %(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
@@ -3616,8 +3080,8 @@ msgstr ""
 "Votre organisation de démonstration Zulip, %(realm_name)s, a été désactivée "
 "le %(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
@@ -3626,8 +3090,8 @@ msgstr ""
 "Vous avez désactivé votre organisation Zulip, %(realm_name)s, le "
 "%(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
@@ -3636,8 +3100,8 @@ msgstr ""
 "Votre organisation Zulip, %(realm_name)s, a été désactivée par "
 "%(deactivating_owner)s le %(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
@@ -3646,16 +3110,16 @@ msgstr ""
 "Votre organisation Zulip, %(realm_name)s, a été désactivée le "
 "%(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 "Toutes les données associées à cette organisation ont été définitivement "
 "supprimées."
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
@@ -3664,8 +3128,8 @@ msgstr ""
 "Toutes les données associées à cette organisation seront définitivement "
 "supprimées le %(deletion_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
@@ -3673,19 +3137,19 @@ msgstr ""
 "Si vous avez des questions ou des préoccupations, veuillez répondre à cet e-"
 "mail dès que possible."
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr "Votre organisation Zulip %(realm_name)s a été désactivée"
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr "Chers anciens administrateurs de %(realm_name)s,"
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
@@ -3694,8 +3158,8 @@ msgstr ""
 "Un de vos administrateurs a demandé la réactivation de l’organisation de "
 "démonstration Zulip, précédemment désactivée, hébergée sur %(realm_url)s."
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
@@ -3704,16 +3168,16 @@ msgstr ""
 "Un de vos administrateur a demandé la réactivation de l’organisation Zulip "
 "précédemment désactivée hébergée sur %(realm_url)s."
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr "Cliquez sur le bouton ci-dessous pour réactiver votre organisation."
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr "Réactiver l'organisation"
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
@@ -3721,19 +3185,19 @@ msgstr ""
 "Si la demande a été faite par erreur, il n'y a rien à faire et ce lien "
 "expirera dans 24 heures."
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip demo organization"
 msgstr "Réactivez votre organisation de démonstration Zulip"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr "Réactivez votre organization Zulip"
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr "Cliquez sur le lien ci-dessous pour réactiver votre organisation."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3742,18 +3206,18 @@ msgstr ""
 "Vous ou une personne agissant en votre nom avez demandé un lien de connexion "
 "pour gérer le plan Zulip de <b>%(remote_server_hostname)s</b>."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 msgid "Click the button below to log in."
 msgstr "Cliquez sur le bouton ci-dessous pour vous connecter."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr "Ce lien expirera dans %(validity_in_hours)s heures."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
@@ -3762,11 +3226,11 @@ msgstr ""
 "Des questions ? <a href=\"%(billing_help_link)s\">En savoir plus</a> ou "
 "contacter %(billing_contact_email)s."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr "Connexion à la gestion du plan Zulip"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3775,12 +3239,12 @@ msgstr ""
 "Vous ou une personne agissant en votre nom avez demandé un lien de connexion "
 "pour gérer le plan Zulip de %(remote_server_hostname)s."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr "Cliquez surle lien ci-dessous pour vous connecter."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
@@ -3789,7 +3253,7 @@ msgstr ""
 "Des questions ? En savoir plus : %(billing_help_link)s ou contacter "
 "%(billing_contact_email)s."
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
@@ -3798,16 +3262,16 @@ msgstr ""
 "Cliquez sur le bouton ci-dessous pour confirmer votre adresse électronique "
 "et accéder à la gestion du plan Zulip de <b>%(remote_realm_host)s</b>."
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr "Confirmer et se connecter"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr "Confirmation de l’adresse électronique pour la gestion du plan Zulip"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
@@ -3816,7 +3280,7 @@ msgstr ""
 "Cliquez sur le lien ci-dessous pour confirmer votre adresse électronique et "
 "accéder à la gestion du plan Zulip de %(remote_realm_host)s."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
@@ -3825,7 +3289,7 @@ msgstr ""
 "Votre demande de parrainage Zulip a été approuvée ! Votre organisation a été "
 "mise à niveau vers <a href=\"%(plans_link)s\">l'offre Zulip Communauté</a>."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
@@ -3834,12 +3298,12 @@ msgstr ""
 "Si vous pouviez <a href=\"%(link_to_zulip)s\">mentionner Zulip comme sponsor "
 "sur votre site web</a>, nous vous en serions très reconnaissants !"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr "Parrainage de l'offre Communauté approuvé pour %(billing_entity)s !"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
@@ -3847,7 +3311,7 @@ msgstr ""
 "Votre demande de parrainage Zulip a été approuvée ! Votre organisation a été "
 "mise à niveau vers l'offre Zulip Communauté."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
@@ -3855,22 +3319,22 @@ msgstr ""
 "Si vous pouviez mentionner Zulip comme sponsor sur votre site web, nous vous "
 "en serions très reconnaissants !"
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr "Trouvez vos comptes"
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr "Trouver votre compte Zulip"
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 "Courriels envoyés ! Les adresses saisies sur la page précédente sont listées "
 "ci-dessous :"
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
@@ -3880,7 +3344,7 @@ msgstr ""
 "href=\"%(current_url)s\">identifier des comptes pour une autre adresse "
 "électronique</a>."
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
@@ -3889,7 +3353,7 @@ msgstr ""
 "de toutes les organisations Zulip Cloud dans lesquelles vous avez des "
 "comptes actifs."
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
@@ -3898,7 +3362,7 @@ msgstr ""
 "de toutes les organisations Zulip de ce serveur dans lesquelles vous avez "
 "des comptes actifs."
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
@@ -3906,214 +3370,214 @@ msgstr ""
 "Si vous avez aussi oublié votre mot de passe, vous pouvez <a href=\"/help/"
 "change-your-password\">le réinitialiser</a>."
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr "Adresse électronique"
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "Trouver des comptes"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr "Produit"
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr "Pourquoi Zulip"
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr "Fonctionnalités"
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr "Tarifs"
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 msgid "Zulip Cloud"
 msgstr "Zulip Cloud"
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr "Auto-hébergement"
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr "Sécurité"
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "Intégrations"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr "Applications de bureau et mobile"
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr "Nouvelle organisation"
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr "Solutions"
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr "Entreprise"
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr "Éducation"
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr "Recherche"
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr "Événements et conférences"
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr "Projets open source"
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr "Communautés"
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr "Ingénieurs"
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr "Témoignages clients"
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr "Communautés ouvertes"
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr "Ressources"
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr "Commencer"
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr "Centre d'aide"
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr "Chat de la communauté"
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr "Partenaires"
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr "Statut de Zulip Cloud"
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr "Migration vers Zulip"
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr "Installer un serveur Zulip"
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr "Mettre à niveau un serveur Zulip"
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr "Contribuer"
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr "Guide de contribution"
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr "Communauté de développement"
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr "Traduction"
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr "GitHub"
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr "À propos de nous"
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr "Equipe"
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "Historique"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr "Valeurs"
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr "Emplois"
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr "Blog"
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr "Supporter Zulip"
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr "Mastodon"
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Bluesky handle"
 msgid "Bluesky"
 msgstr "Identifiant Bluesky"
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr "Propulsé par <a href=\"https://zulip.com\">Zulip</a>"
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr "Conditions d'utilisation"
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr "Politique de confidentialité"
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr "Attributions"
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr "Plus de %(integrations_count_display)s intégrations natives."
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 msgid ""
 "And hundreds more through <a href=\"/integrations/zapier\">Zapier</a> and <a "
 "href=\"/integrations/ifttt\">IFTTT</a>."
@@ -4121,53 +3585,49 @@ msgstr ""
 "Et des centaines d'autres via <a href=\"/integrations/zapier\">Zapier</a> et "
 "<a href=\"/integrations/ifttt\">IFTTT</a>."
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr "Recherche d'intégrations"
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr "Intégrations personnalisées"
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr "Webhooks entrants"
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr "Robots interactifs"
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr "API REST"
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr "Adresse électronique non valide"
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr "Email non autorisé"
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr ""
 "L'adresse électronique avec laquelle vous essayez de vous inscrire n'est pas "
 "valide."
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4178,7 +3638,7 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>, n'autorise pas les inscriptions "
 "avec des adresses électroniques de votre domaine."
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4189,7 +3649,7 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>, n'autorise pas les inscriptions "
 "avec des adresses électroniques jetables."
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4200,24 +3660,24 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>, n'autorise pas les inscriptions "
 "avec des adresses électroniques contenant \"+\"."
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr "Veuillez vous inscrire en utilisant une adresse électronique valide."
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr "Veuillez vous inscrire en utilisant une adresse e-mail autorisée."
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr "Aucune organisation trouvée"
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr "Il n'y a pas d'organisation Zulip à l'adresse <b>%(current_url)s</b>."
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -4228,7 +3688,7 @@ msgstr ""
 "accounts/find/\">obtenez une liste de vos comptes Zulip Cloud</a>, ou encore "
 "<a href=\"mailto:%(support_email)s\">contactez le support Zulip</a>."
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -4240,7 +3700,7 @@ msgstr ""
 "encore <a href=\"mailto:%(support_email)s\">contactez les administrateurs de "
 "ce serveur Zulip</a>."
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
@@ -4249,61 +3709,61 @@ msgstr ""
 "<a href=\"%(current_url)s/serverlogin/\">Cliquez ici</a> pour accéder à la "
 "gestion de l'offre tarifaire pour votre serveur Zulip."
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr "Session de connexion invalide ou expirée"
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr "Session de connextion non valide ou expirée."
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr "Se connecter à Zulip"
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 "Vous êtes déjà enregistré avec cette adresse électronique. Veuillez vous "
 "connecter ci-dessous."
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr "Adresse électronique ou nom d'utilisateur"
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "Nom d'utilisateur"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr "Mot de passe oublié ?"
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr "Se connecter avec %(identity_provider)s"
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr "Voir sans compte"
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 "Vous n'avez pas encore de compte ? Vous avez besoin d'une invitation pour "
 "rejoindre cette organisation."
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr "Aucune licence disponible"
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr "L'organisation ne peut pas accepter de nouveaux membres pour le moment"
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
@@ -4313,7 +3773,7 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a> pour le moment car toutes les "
 "licences Zulip Cloud sont utilisées."
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
@@ -4321,19 +3781,19 @@ msgstr ""
 "Contactez la personne qui vous a invité et demandez-lui d'augmenter le "
 "nombre de licences, puis réessayez."
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr "Avancer jusqu'au contenu principal"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr "Erreur d'authentification de sous-domaine"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr "Sous-domaine d&#39;authentification"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -4348,16 +3808,15 @@ msgstr ""
 "vous connecter, il s'agit très probablement d'un bug du serveur ou d'une "
 "erreur de configuration."
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 msgid "Demo organizations disabled"
 msgstr "Les organisations de démonstration sont désactivées"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr "Mise à jour requise"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
@@ -4365,7 +3824,7 @@ msgstr ""
 "Vous utilisez une ancienne version de l'application de bureau Zulip qui "
 "n'est plus supportée."
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
@@ -4373,23 +3832,22 @@ msgstr ""
 "La fonctionnalité de mise à jour automatique ne fonctionne plus dans cette "
 "vieille version de l'application de bureau Zulip."
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr "Téléchargez la dernière version."
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 "Vous avez dépassé la limite du nombre d'exécution de cette action pour votre "
 "utilisateur."
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr "Lien de création d&#39;organisation requis"
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -4402,12 +3860,11 @@ msgstr ""
 "html\">documentation</a> sur la création d'une nouvelle organisation pour "
 "plus d'informations."
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr "Lien de création d&#39;organisation expiré ou invalide"
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
@@ -4415,11 +3872,11 @@ msgstr ""
 "Malheureusement, ce lien n'est pas valide pour créer une organisation. "
 "Veuillez <a href=\"/new/\">obtenir un nouveau lien</a> et réessayer."
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr "Enregistrement inattendu du serveur Zulip"
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -4431,17 +3888,16 @@ msgstr ""
 "%(support_email)s\">contacter le support Zulip</a> pour obtenir de l’aide "
 "afin de résoudre ce problème."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr "Navigateur non compatible"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr "%(browser_name)s n’est pas pris en charge par Zulip."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
@@ -4451,7 +3907,7 @@ msgstr ""
 "href=\"%(supported_browsers_page_link)s\">navigateurs modernes</a> tels que "
 "Firefox, Chrome et Edge."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
@@ -4459,21 +3915,20 @@ msgstr ""
 "Vous pouvez également utiliser <a href=\"%(apps_page_link)s\">l’application "
 "de bureau Zulip</a>."
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr "Le compte est désactivé"
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 msgid "Finalize organization import"
 msgstr "Finaliser l'importation de l'organisation"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 msgid "Organization import completed!"
 msgstr "Importation de l’organisation terminée !"
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -4484,55 +3939,54 @@ msgstr ""
 "électronique que vous avez vérifiée avec Zulip (<strong>%(verified_email)s</"
 "strong>). Sélectionnez un compte auquel associer votre adresse électronique."
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 msgid "Select your account"
 msgstr "Sélectionnez votre compte"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 msgid "Create new account"
 msgstr "Créer un nouveau compte"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr "Organisation réactivée avec succès"
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr "Votre organisation a été réactivée avec succès."
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr ""
 "Le lien de réactivation de l&#39;organisation a expiré ou n&#39;est pas "
 "valide"
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr ""
 "Le lien de réactivation de l'organisation est expiré ou n'est pas valide."
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr "Se connecter à votre organisation"
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr "votre-organisation"
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr "Vous ne connaissez pas l'URL de votre organisation ?"
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr "Trouvez votre organisation."
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr "Suivant"
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4543,11 +3997,11 @@ msgstr ""
 "href=\"%(org_creation_link)s\">Créez une nouvelle organisation</a> si vous "
 "n’en avez pas encore."
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 msgid "Self-hosting Zulip?"
 msgstr "Héberger Zulip vous-même ?"
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4557,11 +4011,11 @@ msgstr ""
 "href=\"%(self_hosted_login_help)s\">vous connecter pour gérer les "
 "abonnements et la facturation.</a>"
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr "Réinitialiser votre mot de passe"
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
@@ -4570,64 +4024,64 @@ msgstr ""
 "un lien pour réinitialiser votre mot de passe à l'adresse e-mail avec "
 "laquelle vous vous êtes inscrit."
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr "Envoyer un lien de réinitialisation"
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr "Définir un nouveau mot de passe"
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "Confirmer le mot de passe"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr ""
 "Désolé, le lien que vous avez fourni est invalide ou a déjà été utilisé."
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr "Nouveau mot de passe correctement créé"
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr "Vous avez créé un nouveau mot de passe !"
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr ""
 "Veuillez vous <a href=\"%(login_url)s\">connecter</a> avec votre nouveau mot "
 "de passe."
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr "Courriel de réinitialisation du mot de passe envoyé"
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr "Mot de passe réinitialisé envoyé !"
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr ""
 "Vérifiez votre courriel dans quelques minutes pour finaliser le processus."
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr "Importer depuis Slack"
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr "Progression de l'importation"
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr "Vérification du statut de l’importation…"
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4639,7 +4093,7 @@ msgstr ""
 "slack#import-your-data-into-zulip\"> processus d'importation Zulip Cloud "
 "(via le support) </a> pour finaliser votre importation."
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4652,15 +4106,15 @@ msgstr ""
 "rel=\"noopener noreferrer\" target=\"_blank\">ces instructions</a> pour "
 "obtenir un <strong>jeton OAuth d’utilisateur bot</strong>."
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr "Jeton OAuth d’utilisateur bot Slack"
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr "Téléversez votre fichier d’exportation Slack"
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
@@ -4670,20 +4124,20 @@ msgstr ""
 "data \" target=\"_blank\" rel=\"noopener noreferrer\">ces instructions</a> "
 "pour obtenir votre exportation de l’historique des messages Slack."
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr "Démarrer le téléversement"
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr "Fichier d’exportation téléversé"
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr ""
 "Qui sera autorisé à voir les adresses électroniques des autres utilisateurs ?"
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
@@ -4693,11 +4147,11 @@ msgstr ""
 "visibility \" target=\"_blank\">modifier</a> leur configuration de "
 "visibilité de l’adresse électronique lorsqu’ils se connectent."
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr "Démarrer l’importation"
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
@@ -4706,7 +4160,7 @@ msgstr ""
 "<br /> en cliquant sur le bouton <b>Terminer l’inscription</b> dans votre "
 "courriel."
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
@@ -4714,7 +4168,7 @@ msgstr ""
 "Ou <span id=\"cancel-slack-import\" tabindex=\"0\">créer une organisation</"
 "span> sans importer de données."
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4726,7 +4180,7 @@ msgstr ""
 "into-zulip\" rel=\"noopener noreferrer\" target=\"_blank\">procédure</a> "
 "d’importation via le support."
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4738,22 +4192,22 @@ msgstr ""
 "into-zulip\" rel=\"noopener noreferrer\" target=\"_blank\">procédure</a> "
 "d’importation auto-hébergée."
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr "Sélectionnez le compte pour l&#39;authentification"
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr "<h1 class=\"get-started\">Choisissez un compte</h1>"
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 "Votre compte GitHub a aussi des adresses électroniques non vérifiées qui lui "
 "sont associées."
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
@@ -4762,15 +4216,15 @@ msgstr ""
 "devez d'abord <a href=\"https://github.com/settings/emails\">le vérifier "
 "auprès de GitHub.</a>"
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr "Erreur lors de la désinscription du courriel"
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr "Requête de désabonnement d'une adresse électronique inconnue"
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
@@ -4778,7 +4232,7 @@ msgstr ""
 "Hey ! Il semble que vous avez essayé de vous désabonner de quelque chose, "
 "mais nous ne reconnaissons pas l'URL."
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4788,12 +4242,11 @@ msgstr ""
 "Vérifiez que vous avez bien l'URL complète et réessayez, ou <a href=\"mailto:"
 "%(support_email)s\">envoyez-nous un courriel</a> et nous nous en occuperons !"
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr "Paramètres courriel mis à jour"
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
@@ -4802,7 +4255,7 @@ msgstr ""
 "Vous vous êtes désabonnés des courriels Zulip de type "
 "« %(subscription_type)s » pour <a href=\"%(realm_url)s\">%(realm_name)s</a>."
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
@@ -4812,49 +4265,48 @@ msgstr ""
 "href=\"%(realm_url)s/#settings/notifications\">paramètres de notification</"
 "a>."
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr "Ordre de mappage non valide."
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr "Questions et discussions concernant l'utilisation de Zulip."
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr "Expérimentez Zulip ici. :test_tube:"
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr "Pour des discussions au sein d'une équipe"
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr "inscriptions"
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr "{user} a rejoint cette organisation."
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr "{user} a accepté votre invitation à rejoindre Zulip !"
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 "Impossible d'activer un compte provisoire ; demandez à l'utilisateur de "
 "s'inscrire à la place."
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 msgid "Cannot reactivate a deleted user"
 msgstr "Impossible de réactiver un utilisateur supprimé"
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
@@ -4862,26 +4314,25 @@ msgstr ""
 "Vous n'êtes pas autorisé à modifier ce champ. Contactez un administrateur "
 "pour le mettre à jour."
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr "Champ id {id} introuvable."
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr "Nom du groupe de canaux par défaut invalide : « {group_name} »"
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 "Nom du groupe de canaux par défaut trop long (limite : {max_length} "
 "caractères)"
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
@@ -4889,12 +4340,12 @@ msgstr ""
 "Le nom du groupe de canaux par défaut « {group_name} » contient des "
 "caractères NULL (0x00)."
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr "Groupe de canaux par défaut invalide : « {group_name} »"
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
@@ -4902,12 +4353,12 @@ msgstr ""
 "« {channel_name} » est un canal par défaut et ne peut pas être ajouté à "
 "« {group_name} »"
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr "Le groupe de canaux par défaut « {group_name} » existe déjà"
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
@@ -4916,7 +4367,7 @@ msgstr ""
 "Le canal « {channel_name} » est déjà présent dans le groupe de canaux par "
 "défaut « {group_name} »"
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
@@ -4925,12 +4376,12 @@ msgstr ""
 "Le canal « {channel_name} » n'est pas présent dans le groupe de canaux par "
 "défaut « {group_name} »"
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr "Ce groupe de canaux par défaut est déjà nommé « {group_name} »"
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
@@ -4939,7 +4390,7 @@ msgstr ""
 "vous pouvez envoyer en une journée. Étant donné que vous avez atteint la "
 "limite, aucune invitation n'a été envoyée."
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
@@ -4948,78 +4399,78 @@ msgstr ""
 "personnes à rejoindre cette organisation. Merci de demander à un "
 "administrateur de cette organisation, ou à un utilisateur plus ancien."
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 "Certaines adresses électroniques ne sont pas valides, nous n'avons donc "
 "envoyé aucune invitation."
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr "Nous n'avons pas été capable d'inviter quelqu’un."
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr "Rien à changer"
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr "Les messages directs ne peuvent pas être déplacés dans des canaux."
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr "Les messages directes ne peuvent pas avoir de sujet."
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr "propagate_mode non valide sans modification de sujet"
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr ""
 "La conversation « general chat » ne peut pas être marquée comme résolue"
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr "Ne peut pas changer le contenu du message et le canal en même temps"
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr "Le widgets ne peuvent être modifiés."
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr "Votre organisation a désactivé la modification des messages"
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr "Vous n'avez pas la permission de modifier ce message"
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr "La limite de temps pour modifier ce message est dépassée"
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr "{user} a marqué ce sujet comme résolu."
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr "{user} a marqué ce sujet comme non résolu."
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr "Ce sujet a été déplacé vers {new_location} par {user}."
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr "Un message a été déplacé de ce sujet vers {new_location} par {user}."
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
@@ -5028,12 +4479,12 @@ msgstr ""
 "{changed_messages_count} messages ont été déplacés de ce sujet vers "
 "{new_location} par {user}."
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr "Ce sujet a été déplacé ici de {old_location} par {user}."
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
@@ -5041,7 +4492,7 @@ msgstr ""
 "[Un message]({message_link}) a été déplacé ici depuis {old_location} par "
 "{user}."
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
@@ -5050,69 +4501,66 @@ msgstr ""
 "{changed_messages_count} messages ont été déplacés ici de {old_location} par "
 "{user}."
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to resolve topics in this channel."
 msgstr ""
 "Vous n'êtes pas autorisé à marquer les conversations comme résolues sur ce "
 "canal."
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr "Le temps limite pour modifier ce sujet de message est dépassé."
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr "Vous n'avez pas la permission de déplacer ce message"
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr "Le délai autorisé pour modifier le canal de ce message est écoulé"
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr "Marqueur invalide : « {flag} »"
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr "Marqueur non modifiable : « {flag} »"
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr "Opération de marqueur de message invalide : « {operation} »"
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr "Message(s) invalide(s)"
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr "Impossible d'afficher le message"
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr "Exactement un canal attendu"
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr "Type de données invalide pour le canal"
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr "Type de données non valide pour un destinataire"
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 "Les listes de destinataires peuvent intégrer des adresses électronique ou ID "
 "d'utilisateurs, mais pas les deux."
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
@@ -5121,7 +4569,7 @@ msgstr ""
 "Votre bot {bot_identity} a tenté d’envoyer un message au canal d’ID "
 "{channel_id}, mais aucun canal n’existe avec cet identifiant."
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -5132,7 +4580,7 @@ msgstr ""
 "{channel_name}, mais ce canal n’existe pas. Cliquez [ici]"
 "({new_channel_link}) pour le créer."
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
@@ -5141,29 +4589,29 @@ msgstr ""
 "Votre bot {bot_identity} a tenté d’envoyer un message au canal "
 "{channel_name}. Le canal existe, mais il n’a aucun abonné."
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr "Vous n’avez pas la permission d’accéder à certains destinataires."
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr "Widgets : Contenu JSON non valide reçu du programmeur de l'API"
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr "Widgets : {error_msg}"
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr "Les modifications suivantes ont été apportées à votre compte."
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr "{user} a apporté les modifications suivantes à votre compte."
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5174,27 +4622,25 @@ msgstr ""
 "- **Ancien {field_name} :** {old_value}\n"
 "- **Nouveau {field_name} :** {new_value}\n"
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr "Un emoji personnalisé avec le même nom existe déjà."
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr "Format d’image invalide"
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr "La liste ordonnée ne doit pas contenir de lien automatique en double"
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 "La liste ordonnée doit énumérer tous les liens automatiques existants une "
 "seule fois"
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
@@ -5203,42 +4649,42 @@ msgstr ""
 "Vous devez passer à l’offre {required_upgrade_plan_name} pour utiliser cette "
 "méthode d’authentification."
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 "Méthode d’authentification invalide : {name}. Méthodes valides : {methods}"
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 "La méthode d’authentification {name} n’est pas disponible dans votre offre "
 "actuelle."
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr "Le canal de demande de modération doit être privé."
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr "L’extrait enregistré n’existe pas."
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr "Le message programmé a déjà été envoyé"
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 #, fuzzy
 #| msgid "Reminder does not exist"
 msgid "Reminder could not be sent."
 msgstr "Le rappel n'existe pas"
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr "Le message ne peut pas être envoyé à l'heure programmée."
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
@@ -5247,38 +4693,38 @@ msgstr ""
 "Ce message que vous avez programmé pour {delivery_datetime} n'a pas été "
 "envoyé à cause de cette erreur :"
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr "[Voir les messages programmés](#scheduled)"
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr "Le canal est déjà désactivé"
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr "Le canal #**{channel_name}** a été archivé."
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr "Le canal n’est actuellement pas désactivé"
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr "Un canal nommé {channel_name} existe déjà"
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr "Le canal est privé et n’a aucun abonné"
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr "Le canal #**{channel_name}** a été désarchivé."
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
@@ -5287,7 +4733,7 @@ msgstr ""
 "{user} a modifié les [permissions d’accès]({help_link}) de ce canal, passant "
 "de **{old_policy}** à **{new_policy}**."
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -5300,41 +4746,39 @@ msgstr ""
 "* **Ancien** : {old_setting_description}\n"
 "* **Nouveau** : {new_setting_description}\n"
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 "{user_name} a renommé le canal {old_channel_name} en {new_channel_name}."
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr "Aucune description."
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr "{user} a modifié la description de ce canal."
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr "Ancienne description"
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr "Nouvelle description"
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr "Pour toujours"
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr "{number_of_days} jours"
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
@@ -5343,11 +4787,11 @@ msgstr ""
 "Les messages de ce canal seront désormais supprimés automatiquement "
 "{number_of_days} jours après leur envoi."
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr "Les messages de ce canal seront désormais conservés indéfiniment."
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -5364,26 +4808,26 @@ msgstr ""
 "\n"
 "{summary_line}"
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr "Automatique"
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr "Conversation *{empty_topic_display_name}* autorisée"
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr "Aucune conversation *{empty_topic_display_name}*"
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr "Seule la conversation *{empty_topic_display_name}* est autorisée"
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
@@ -5393,73 +4837,63 @@ msgstr ""
 "*discussion générale* ? », passant de {old_topics_policy} à "
 "{new_topics_policy}."
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr "Vous ne pouvez pas joindre un sous-message à ce message."
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr "Identifiant utilisateur invalide : {user_id}"
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr "Le groupe d’utilisateurs « {group_name} » existe déjà."
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr "Permission insuffisante"
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr "Cette API n'est pas disponible pour les robots de webhook entrants."
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr "Le compte n'est pas associé avec ce sous-domaine"
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr "Ce paramètre n'accepte pas les requêtes de robots."
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr "Doit être un administrateur du serveur"
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr "Ce paramètre requière une authentification HTTP basique."
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr "En-tête d'autorisation invalide pour l'authentification basique"
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr "En-tête d'autorisation manquant pour l'authentification basique"
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr "Les robots de webhook n'ont accès qu'aux webhooks"
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr "Adresse électronique ou mot de passe incorrect."
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
@@ -5468,44 +4902,43 @@ msgstr ""
 "Votre compte {username} a été désactivé. Veuillez contacter l&#39;"
 "administrateur de votre organisation pour le réactiver."
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr "Le mot de passe est trop faible."
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr "Le sous-domaine a besoin d'une taille de 3 ou plus."
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr "Le sous-domaine ne peut pas démarrer ou se terminer avec un '-'."
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr ""
 "Le sous-domaine ne peut contenir que des lettres minuscules, des nombres et "
 "des '-'."
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr "Ce sous-domaine est déjà utilisé. Veuillez en choisir un autre."
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr "Ce sous-domaine est réservé. Veuillez en choisir un autre."
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr "Merci d'utiliser votre véritable adresse électronique."
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr ""
 "L'organisation que vous essayez de rejoindre avec {email} n'existe pas."
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
@@ -5513,13 +4946,13 @@ msgstr ""
 "Veuillez demander une invitation pour {email} de la part de l'administrateur "
 "de l'organisation."
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 "Impossible de rejoindre l’organisation : l’authentification par mot de passe "
 "n’est pas activée."
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
@@ -5528,13 +4961,13 @@ msgstr ""
 "Votre adresse électronique, {email}, n'est pas dans un des domaines "
 "autorisés à s'inscrire pour les comptes de cette organisation."
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr ""
 "Les adresses électronique contenant un + ne sont pas autorisées dans cette "
 "organisation."
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
@@ -5545,32 +4978,31 @@ msgstr ""
 "contacter la personne qui vous a invité et lui demander d'augmenter le "
 "nombre de licences, puis réessayez."
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr "Nous avons vérifié que vous êtes un humain !"
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr "Vérification que vous n’êtes pas un bot…"
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 msgid "Challenges are not enabled."
 msgstr "Les défis ne sont pas activés."
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr "La validation a échoué, veuillez réessayer."
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "Nouveau mot de passe"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr "Confirmation du nouveau mot de passe"
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "You're making too many attempts to sign in. Try again in "
@@ -5579,7 +5011,7 @@ msgstr ""
 "Vous effectuez trop de tentatives de connexion. Réessayez dans "
 "{retry_after_string} ou contactez un administrateur pour obtenir de l’aide."
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
@@ -5587,90 +5019,88 @@ msgstr ""
 "Votre mot de passe a été désactivé car il est trop faible. Réinitialisez "
 "votre mot de passe pour en créer un nouveau."
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr "Jeton"
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 "Conseil : vous pouvez saisir plusieurs adresses électroniques en les "
 "séparant par une virgule."
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr "Merci d'entrer au maximum 10 adresses électroniques."
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr "Nous n'avons pas pu trouver cette organisation Zulip."
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr "Courriel invalide '{email}'"
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr "Sujet manquant"
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr "Impossible d’envoyer vers plusieurs canaux"
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr "Canal manquant"
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr "Le message doit avoir un destinataire"
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr "Type de message invalide"
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr "Pièce jointe invalide"
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr ""
 "Une erreur est survenue pendant la suppression de la pièce-jointe. Merci de "
 "réessayer plus tard."
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr "Le message doit avoir un destinataire !"
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name can't be empty."
 msgstr "Le nom du dossier de canaux ne peut pas être vide."
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr ""
 "Caractère invalide dans le nom du dossier de canaux, à la position "
 "{position}."
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr "Le nom du dossier de canaux est déjà utilisé"
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 msgid "Invalid channel folder ID"
 msgstr "ID de dossier de canaux non valide"
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 msgid "Configure owner account email address."
 msgstr "Configurer l’adresse électronique du compte propriétaire."
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5683,72 +5113,72 @@ msgstr ""
 "automatiquement supprimée le {deletion_time}, à moins qu'elle ne soit "
 "[convertie en organisation permanente]({convert_demo}).\n"
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, python-brace-format
 msgid "{var_name} is not Base64 encoded"
 msgstr "{var_name} n'est pas encodé au format Base64"
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 msgid "Invalid `device_id`"
 msgstr "`device_id` non valide"
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr "Résumé {service_name}"
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr "Le domaine ne peut pas être vide."
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr "Le domaine doit contenir au moins un point (.)"
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr "Le nom de domaine est trop long"
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr "Le domaine ne peut pas démarrer ou se terminer avec un point (.)"
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr "Les '.' consécutifs ne sont pas permis."
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr "Les sous-domaines ne peuvent pas démarrer ou se terminer avec un '-'."
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr ""
 "Le domaine ne peut contenir que des lettres, des nombres, des '.' et des '-'."
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr "L'horodatage ne doit pas être négatif."
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr "Le sujet ne doit pas contenir d'octets nuls"
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 "Vous devez spécifier exactement 1 identifiant de canal pour les messages de "
 "canal"
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr "Cet utilisateur a désactivé la synchronisation des brouillons."
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr "Le brouillon n'existe pas"
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5759,87 +5189,87 @@ msgstr ""
 "courriel de notification :\n"
 "{error_message}"
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr "Courriel sans objet"
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr "Ouvrez Zulip pour afficher le contenu masqué"
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr "Notifications {service_name}"
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr "Adresse électronique non valide."
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr "En-dehors de votre domaine."
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr "Les adresses électroniques contenant un + ne sont pas autorisées."
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr "Réservé aux robots système."
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr "{email} possède déjà un compte"
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr "Possède déjà un compte."
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr "Le compte a été désactivé."
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr "L’émoji « {emoji_name} » n’existe pas"
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr "Emoji personnalisé non valide."
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr "Nom d'emoji personnalisé non valide."
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr "L'emoji personnalisé a été désactivé."
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr "Code d'emoji non valide."
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr "Nom d'emoji invalide."
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr "Type d'emoji invalide."
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr ""
 "Doit être un administrateur de l'organisation ou le créateur de l'emoji"
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr "Les noms des emoji doivent se terminer par une lettre ou un chiffre."
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
@@ -5847,62 +5277,62 @@ msgstr ""
 "Les noms d'emoji ne doivent contenir que des lettres minuscules anglaises, "
 "des chiffres, des espaces, des tirets et des traits de soulignement."
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr "Le nom de l'emoji est manquant"
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr "Impossible d'allouer la file d'attente d'événements"
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr "Non connecté : Authentification API ou session utilisateur requise"
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr "Le canal « {channel_name} » existe déjà"
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr "Le canal « {stream} » n’existe pas"
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr "Aucun canal n’existe avec l’identifiant « {stream_id} »"
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr "Combinaison de paramètres non prise en charge : {parameters}"
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr "{required_parameter} est requis lorsque {set_parameter} est défini."
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr "propriétaire de l'organisation"
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr "utilisateur"
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr "Impossible de désactiver le seul {entity}."
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr "Instruction d'inclusion Markdown non valide : {include_statement}"
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
@@ -5910,35 +5340,34 @@ msgstr ""
 "Utilisation de l’API au-delà de la limite de débit ; consultez https://zulip."
 "com/api/http-headers#rate-limiting-response-headers"
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr "JSON malformé"
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr "Doit être un administrateur de l'organisation"
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr "Doit être un propriétaire de l'organisation"
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Must be an organization owner"
 msgid "Must be a bot user"
 msgstr "Doit être un propriétaire de l'organisation"
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr "Votre nom d'utilisateur ou votre mot de passe est incorrect"
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr "L'organisation a été désactivée"
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
@@ -5946,24 +5375,24 @@ msgstr ""
 "L&#39;inscription au service de notification push mobile pour votre serveur "
 "a été désactivée"
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr ""
 "L'authentification par mot de passe est désactivée dans cette organisation"
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr "Votre mot de passe a été désactivé et doit être réinitialisé"
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr "Clé API invalide"
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr "Clé API mal formée"
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
@@ -5972,29 +5401,28 @@ msgstr ""
 "L’événement « {event_type} » n’est actuellement pas pris en charge par le "
 "webhook {webhook_name} ; ignoré"
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 "Impossible d&#39;analyser la demande : {webhook_name} a-t-il généré cet "
 "événement ?"
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr "Utilisateur non-authentifié"
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr "Sous-domaine invalide"
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 "Vous n’avez pas la permission de démarrer des conversations en messages "
 "directs."
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
@@ -6003,13 +5431,13 @@ msgstr ""
 "L’envoi de messages vers la conversation « {empty_topic_display_name} » "
 "n’est pas autorisé dans ce canal."
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 "Seule la conversation {empty_topic_display_name} est autorisée dans ce canal."
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
@@ -6019,20 +5447,20 @@ msgstr ""
 "trouver dans la conversation {empty_topic_display_name}. Envisagez de "
 "renommer ou de supprimer les autres conversations."
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr "Les messages directs sont désactivés dans cette organisation."
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr ""
 "Cette conversation ne contient aucun utilisateur autorisé à la valider."
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr "Accès refusé"
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
@@ -6042,15 +5470,15 @@ msgstr ""
 "{total_messages_allowed_to_move}/{total_messages_in_topic} messages les plus "
 "récents de ce sujet."
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr "Cette réaction existe déjà."
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr "Cette réaction n'existe pas."
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
@@ -6059,246 +5487,246 @@ msgstr ""
 "contacter le support Zulip pour obtenir de l’aide afin de résoudre ce "
 "problème."
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr "Organisation non enregistrée"
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 "Vous n’avez pas la permission d’utiliser les mentions génériques de canal "
 "dans ce canal."
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 "Vous n’avez pas la permission d’utiliser les mentions génériques de "
 "conversation dans cette conversation."
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr "La valeur de « {field_name} » ne correspond pas à la valeur attendue."
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr "« {setting_name} » doit être un groupe d’utilisateurs système."
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 "Impossible de désactiver un groupe d'utilisateurs en cours d'utilisation."
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr "Vous n'avez pas la permission d'administrer ce canal."
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr "Vous n'avez pas la permission de modifier les canaux par défaut."
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr "L'adresse électronique est déjà utilisée."
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr "La date de livraison prévue doit se situer dans le futur."
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr "Valeur non valide de bouncer_public_key"
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr "Requête expirée"
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr "Valeur non valide de encrypted_push_registration"
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 "Le serveur n'est pas configuré pour utiliser le service de notifications "
 "push."
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Already has an account."
 msgid "Atlassian account ID"
 msgstr "Possède déjà un compte."
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 msgid "Behance username"
 msgstr "Identifiant Behance"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 msgid "Bitbucket username"
 msgstr "Identifiant Bitbucket"
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr "Identifiant Bluesky"
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 msgid "Codeberg username"
 msgstr "Identifiant Codeberg"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr "Identifiant Discord"
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 msgid "Dribbble username"
 msgstr "Identifiant Dribbble"
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 msgid "Facebook username"
 msgstr "Identifiant Facebook"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr "Nom d&#39;utilisateur GitHub"
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 msgid "GitLab username"
 msgstr "Identifiant GitLab"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 msgid "Instagram username"
 msgstr "Identifiant Instagram"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr "Identifiant LinkedIn"
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 msgid "Mastodon profile"
 msgstr "Profil Mastodon"
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 msgid "Medium username"
 msgstr "Identifiant Medium"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 msgid "Pinterest username"
 msgstr "Identifiant Pinterest"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 msgid "Reddit username"
 msgstr "Identifiant Reddit"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 msgid "Snapchat username"
 msgstr "Identifiant Snapchat"
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 msgid "Threads username"
 msgstr "Identifiant Threads"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 msgid "TikTok username"
 msgstr "Identifiant TikTok"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 msgid "Twitch username"
 msgstr "Identifiant Twitch"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 msgid "X username"
 msgstr "Identifiant X"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr "Identifiant YouTube"
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr "Type de compte externe non valide"
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr "Frameworks d'intégration"
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 msgid "Video calling"
 msgstr "Appel vidéo"
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr "Intégration continue"
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr "Support client"
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr "Déploiement"
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr "Divertissement"
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr "Communication"
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr "Financier"
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr "Ressources humaines"
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr "Marketing"
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr "Divers"
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr "Suivi"
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr "Gestion de projet"
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr "Productivité"
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr "Contrôle de version"
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr "Le message ne doit pas être vide"
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr "Le message ne doit pas contenir d'octets nuls"
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr "Vous n'êtes pas autorisé à mentionner le groupe '{user_group_name}'."
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr "{other_users} et {last_user}"
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
@@ -6307,7 +5735,7 @@ msgstr ""
 "{reporting_user_mention} a signalé un message envoyé par "
 "{reported_user_mention} le {reported_message_date_sent}."
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
@@ -6316,7 +5744,7 @@ msgstr ""
 "{reporting_user_mention} a signalé un message envoyé par "
 "{reported_user_mention} à {recipient_user} le {reported_message_date_sent}."
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
@@ -6326,71 +5754,71 @@ msgstr ""
 "{reported_user_mention} à {list_of_direct_message_recipients} le "
 "{reported_message_date_sent}."
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr "Message original : {channel_message_link}"
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr "[Message original]({direct_message_link})"
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "{fullname} moderation"
 msgstr "Modération de {fullname}"
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr "Opérateur de restriction non valide : {desc}"
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr "Combinaison de restrictions invalide : {desc}"
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr "Opérateur 'with' en doublon."
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr "Opérateur 'with' non valide"
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr "Argument 'anchor' manquant."
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor_date' argument."
 msgstr "Argument 'anchor_date' manquant."
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr "Ancre invalide"
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr "Opérateur {operator} non supporté."
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr "Opérande {operand} non supporté."
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 msgid "Navigation view does not exist."
 msgstr "La vue de navigation n’existe pas."
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr "Une note de {admin_group_syntax} :"
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6401,7 +5829,7 @@ msgstr ""
 "Pour en savoir plus, consultez notre [guide d’utilisation de Zulip pour un "
 "cours]({getting_started_url})!\n"
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6412,7 +5840,7 @@ msgstr ""
 "Pour en savoir plus, consultez notre [guide de prise en main]"
 "({getting_started_url})!\n"
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6423,7 +5851,7 @@ msgstr ""
 "Nous proposons aussi un guide pour [configurer Zulip pour un cours]"
 "({organization_setup_url}).\n"
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6434,7 +5862,7 @@ msgstr ""
 "Nous proposons aussi un guide pour [migrer votre organisation vers Zulip]"
 "({organization_setup_url}).\n"
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6450,7 +5878,7 @@ msgstr ""
 "[convertie en organisation permanente]"
 "({convert_demo_organization_help_url}).\n"
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
@@ -6461,7 +5889,7 @@ msgstr ""
 "les retrouver\n"
 "dans votre [Boîte de réception](/#inbox).\n"
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6473,7 +5901,7 @@ msgstr ""
 "({navigation_tour_video_url}) pour une rapide présentation de "
 "l’application.\n"
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6498,7 +5926,7 @@ msgstr ""
 "{demo_organization_text}\n"
 "\n"
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
@@ -6509,7 +5937,7 @@ msgstr ""
 "apps/).\n"
 "Zulip fonctionne également très bien dans un navigateur.\n"
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -6521,7 +5949,7 @@ msgstr ""
 "[une image de profil](/help/change-your-profile-picture)\n"
 "et modifier [vos informations de profil](/help/edit-your-profile).\n"
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -6540,7 +5968,7 @@ msgstr ""
 "Zulip\n"
 "dans vos [Préférences](#settings/preferences).\n"
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6558,7 +5986,7 @@ msgstr ""
 "\n"
 "[Parcourir et s'abonner aux canaux]({settings_link}).\n"
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -6588,7 +6016,7 @@ msgstr ""
 "Consultez les [Conversations récentes](#recent) pour voir la liste \n"
 "des sujets en cours.\n"
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -6604,7 +6032,7 @@ msgstr ""
 "Appuyez sur `?` à tout moment pour afficher la [liste des raccourcis]"
 "(#keyboard-shortcuts).\n"
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -6624,7 +6052,7 @@ msgstr ""
 "spoilers, les heures globales\n"
 "et plus encore.\n"
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6639,7 +6067,7 @@ msgstr ""
 "Consultez notre [guide de démarrage](/help/getting-started-with-zulip),\n"
 "ou parcourez le [centre d'aide](/help/) pour en savoir plus !\n"
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6650,7 +6078,7 @@ msgstr ""
 "Vous pouvez discuter avec moi autant que vous le souhaitez !\n"
 "Pour obtenir de l'aide, essayez l'un des messages suivants : {bot_commands}\n"
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6669,7 +6097,7 @@ msgstr ""
 "ou même de déplacer une conversation [vers un autre canal]"
 "({move_content_another_channel_help_url}).\n"
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
@@ -6678,7 +6106,7 @@ msgstr ""
 ":point_right : Essayez de déplacer ce message vers une autre conversation, "
 "puis de le remettre en place.\n"
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6701,12 +6129,11 @@ msgstr ""
 "dans la barre\n"
 "latérale gauche et en haut de la page.\n"
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr "bienvenue sur Zulip !"
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -6718,7 +6145,7 @@ msgstr ""
 "dans son contexte, \n"
 "quelle que soit l’activité des autres discussions.\n"
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
@@ -6729,7 +6156,7 @@ msgstr ""
 "#inbox) \n"
 "pour voir les autres conversations contenant des messages non lus.\n"
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -6741,7 +6168,7 @@ msgstr ""
 "latérale gauche,\n"
 "puis cliquez sur le bouton `+` à côté de son nom.\n"
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -6753,7 +6180,7 @@ msgstr ""
 "« Salut,\n"
 "on pourrait parler de… ? »\n"
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
@@ -6761,7 +6188,7 @@ msgstr ""
 "\n"
 ":point_right : Essayez de démarrer une nouvelle conversation sur ce canal.\n"
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6772,7 +6199,7 @@ msgstr ""
 ":point_right :  Utilisez cette conversation pour essayer les "
 "[fonctionnalités de messagerie de Zulip]({format_message_help_url}).\n"
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6808,7 +6235,7 @@ msgstr ""
 "\n"
 "```\n"
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
@@ -6818,7 +6245,7 @@ msgstr ""
 "Cette conversation **accueil** est l'endroit idéal pour dire « salut » : "
 "wave : à vos collègues.\n"
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
@@ -6828,105 +6255,105 @@ msgstr ""
 ":point_right : Cliquez sur ce message pour rédiger une nouvelle réponse dans "
 "la même conversation.\n"
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr "déplacer des messages"
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr "expérimentations"
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr "démarrer une conversation"
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr "accueil"
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr "JSON non valide dans la réponse"
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr "Format de réponse non valide"
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr "Jeton vide ou de taille non valide"
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr "Jeton APNS non valide"
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr "Option GCM invalide envoyée au relais : priorité {priority!r}"
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr "Options GCM invalides envoyées au relais : {options}"
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr "Le jeton n'existe pas"
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr "{full_name} a mentionné @{user_group_name} :"
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr "{full_name} vous a mentionné :"
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr "{full_name} a mentionné tout le monde :"
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "Nouveau message"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr "Notification de test"
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr ""
 "Ceci est une notification de test envoyée par {realm_name} ({realm_url})."
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr "Appareil non reconnu"
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr "Appareil non reconnu par le relais de notifications push"
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr "Aucun appareil push actif enregistré"
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 "Erreur réseau lors de la connexion au service de notifications push de Zulip."
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 "Erreur interne du serveur du service de notifications push de Zulip. "
 "Veuillez réessayer ultérieurement."
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
@@ -6934,11 +6361,11 @@ msgstr ""
 "Problème de configuration des notifications push sur le serveur. Contactez "
 "l’administrateur système ou réessayez plus tard."
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 msgid "Invalid `push_key`"
 msgstr "Valeur non valide de `push_key`"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
@@ -6946,34 +6373,32 @@ msgstr[0] "{secs}{nbsp}seconde"
 msgstr[1] "{secs}{nbsp}secondes"
 msgstr[2] "{secs}{nbsp}secondes"
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr "Type de données invalide pour l’identifiant de canal"
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr "L'utilisateur n'est pas autorisé pour cette requête"
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr "'{email}' n'utilise plus Zulip."
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr ""
 "Vous ne pouvez pas envoyer de messages directs en dehors de votre "
 "organisation."
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr "Longueur maximale des notes de rappel : {max_length} caractères"
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
@@ -6982,11 +6407,11 @@ msgstr ""
 "Vous avez demandé un rappel pour le message suivant. Note :\n"
 "> {note}"
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr "Vous avez demandé un rappel pour le message suivant."
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
@@ -6995,11 +6420,11 @@ msgstr ""
 "Vous avez demandé un rappel pour le message direct suivant. Note :\n"
 "> {note}"
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr "Vous avez demandé un rappel pour le message direct suivant."
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
@@ -7008,14 +6433,14 @@ msgstr ""
 "{user_silent_mention} [a envoyé]({conversation_url}) un {widget} dans "
 "{topic_pretty_link}."
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 "{user_silent_mention} [a dit]({conversation_url}) dans {topic_pretty_link} :"
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
@@ -7024,7 +6449,7 @@ msgstr ""
 "{user_silent_mention} [a envoyé]({conversation_url}) un{widget} à "
 "{list_of_recipient_mentions}."
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
@@ -7033,362 +6458,349 @@ msgstr ""
 "{user_silent_mention} [a dit]({conversation_url}) à "
 "{list_of_recipient_mentions} :"
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr "Vous vous [êtes envoyé]({conversation_url}) un {widget}."
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr "Vous vous [êtes envoyé]({conversation_url}) une note :"
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 msgid "Reminder does not exist"
 msgstr "Le rappel n'existe pas"
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr "Erreur du relais de notifications push : {error}"
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr ""
 "Impossible de trancher entre les arguments '{var_name1}' et '{var_name2}'"
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr "Argument '{var_name}' manquant"
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr "Valeur incorrecte pour '{var_name}' : {bad_value}"
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr "Le message programmé n'existe pas"
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr "Sécurité du compte {service_name}"
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr "Un canal par défaut ne peut pas être privé."
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr "Les canaux publics web ne sont pas activés."
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr "Vous n’avez pas la permission de publier dans ce canal."
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr "Non autorisé à envoyer vers le canal « {channel_name} »"
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 msgid "You do not have permission to create new topics in this channel."
 msgstr ""
 "Vous n'êtes pas autorisé à démarrer de nouvelles conversations dans ce canal."
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr "Identifiant de canal invalide"
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr "Nom de canal invalide : « {channel_name} »"
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr "Le(s) canal(aux) ({channel_names}) n’existe(nt) pas"
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 "Le groupe de canaux par défaut d’identifiant « {group_id} » n’existe pas."
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr "Le nom du canal ne peut pas être vide."
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr "Le nom du canal est trop long (limite : {max_length} caractères)."
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr "Caractère invalide dans le nom du canal, à la position {position}."
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr "Caractère invalide dans la conversation, à la position {position} !"
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr "Les données des abonnés ne sont pas disponibles pour ce canal"
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr "Impossible de récupérer les abonnés du canal privé"
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr "Impossible de décoder l'image ; avez vous envoyé un fichier d'image ?"
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr "La taille de l'image dépasse la limite."
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr "L’image est corrompue ou tronquée"
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr "{var_name} n'est pas un booléen"
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} does not have the expected format"
 msgstr "{var_name} n'a pas le format attendu"
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr "{var_name} n'est pas une date"
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr "{var_name} n'est pas un dict"
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr "{var_name} non valide"
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr "L’argument « {argument} » dans {var_name} est inattendu"
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr "{var_name} n'est pas un nombre réel"
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr "{var_name} est trop petit"
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr "{var_name} n'est pas un entier"
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr "{var_name} n’est pas un JSON valide"
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr "{var_name} est trop grand"
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr "{var_name} n'est pas une liste"
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr "{var_name} est trop long (limite : {max_length} caractères)"
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr "{var_name} est trop court."
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr "{var_name} n'est pas une chaîne"
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr "{var_name} a un format invalide"
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr "{var_name} n’a pas une longueur de {length}"
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr "{var_name} est trop long (limite : {max_length} éléments)"
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr "{var_name} est trop court (minimum {min_length} éléments)"
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr "{var_name} ne peut pas être vide"
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr "{var_name} invalide : {msg}"
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr "Champ {var_name} manquant : {msg}"
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr "Charge utile malformée"
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr "N’est pas dans la liste des valeurs possibles"
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr "N’est pas une URL"
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr "Fuseau horaire non reconnu"
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr "{var_name} n'est pas un code de couleur hexadécimal valide"
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr "{setting_name} non valide"
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr "Nombre invalide pour un entier non-signé de 32 bits"
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr ""
 "L'envoi de ce fichier provoquerait le dépassement du quota de votre "
 "organisation."
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr "La taille de l’image dépasse la limite"
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr "Le groupe d’utilisateurs est désactivé."
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr "Nom de groupe d'utilisateurs non valide"
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {user_group_id}"
 msgstr "ID de groupe d'utilisateurs non valide : {user_group_id}"
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr "Nom de groupe système invalide."
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr "Identifiant de groupe d’utilisateurs invalide : {group_id}"
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 "Le paramètre « {setting_name} » ne peut pas être défini sur le groupe « role:"
 "internet »."
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 "Le paramètre « {setting_name} » ne peut pas être défini sur le groupe « role:"
 "nobody »."
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 "Le paramètre « {setting_name} » ne peut pas être défini sur le groupe « role:"
 "everyone »."
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 "Le paramètre « {setting_name} » ne peut pas être défini sur le groupe "
 "« {group_name} »."
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr "Le nom du groupe d’utilisateurs ne peut pas être vide !"
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr ""
 "Le nom du groupe d’utilisateurs ne peut pas dépasser {max_length} caractères."
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr ""
 "Le nom du groupe d’utilisateurs ne peut pas commencer par « {prefix} »."
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
@@ -7397,7 +6809,7 @@ msgstr ""
 "'{setting_name}' doit être réservé aux administrateurs de l'organisation "
 "pour les groupes utilisés dans 'workplace_users_group'."
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
@@ -7406,194 +6818,191 @@ msgstr ""
 "l'organisation lorsque 'workplace_users_group' inclut des groupes définis "
 "par l'utilisateur."
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr "Le client n'a envoyé aucune nouvelle valeur."
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 "Le client doit transmettre emoji_name s'il transmet emoji_code ou "
 "reaction_type."
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr "Nom trop long !"
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 msgid "Name must not be empty!"
 msgstr "Le nom ne doit pas être vide !"
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr "Caractères invalides dans le nom !"
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr "Format invalide !"
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr "Des noms uniques sont requis dans cette organisation."
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr "Ce nom est déjà utilisé."
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr "Mauvais nom ou nom d'utilisateur"
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr "Intégration « {integration_name} » invalide."
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr "Paramètre de configuration manquant : {keys}"
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr "Valeur {value} invalide pour {key} ({error})"
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr "Données de configuration non valides !"
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr "Type de robot non valide"
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr "Type d'interface non valide"
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr "ID d'utilisateur non valide : {user_id}"
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr "Aucun robot"
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr "Aucun utilisateur"
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr "L'utilisateur est désactivé"
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr "{item} ne peut pas être vide."
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr ""
 "{var_name} a une longueur incorrecte {length} ; elle doit être de "
 "{target_length}"
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr "{var_name} n'est pas un horodatage respectant le format ISO 8601"
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr "{container} devrait avoir exactement {length} éléments"
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr "La clé {key_name} est manquante dans {var_name}"
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr "Arguments inattendus : {keys}"
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr "{var_name} n'est pas un allowed_type"
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr "{variable} != {expected_value} ({value} est faux)"
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr "{var_name} n'est pas une URL"
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr "Le modèle d&#39;URL doit contenir &quot;%(username)s&quot;."
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr "'{item}' ne peut pas être vide."
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr "Le champ ne doit pas avoir de choix en double."
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr "'{value}' n'est pas une option valide pour '{field_name}'."
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr "{var_name} n'est ni une chaîne ni une liste d'entiers"
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr "{var_name} n'est ni une chaîne ni un entier"
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr "{var_name} n&#39;a pas de longueur"
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr "{var_name} est manquant"
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr "Valeur inconnue pour 'PresetUrlOption' : {config}"
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr "En-tête d'événement HTTP manquant '{header}'"
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr "L'algorithme '{algorithm}' n'est pas supporté."
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
@@ -7601,11 +7010,11 @@ msgstr ""
 "La valeur secrète du webhook est manquant. Merci de positionner "
 "webhook_secret lorsque vous générez l'URL."
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr "La vérification de la signature du webhook a échouée."
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
@@ -7613,94 +7022,94 @@ msgstr ""
 "'workplace_users_group' doit être un groupe dont les membres ne peuvent être "
 "gérés que par les administrateurs de l'organisation."
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr "La zcommand devrait commencer par une barre oblique."
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr "Commande inexistante : {command}"
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 "De manière inattendue, `zulip_update_announcements_stream` est désactivé."
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr "Erreur CSRF : {reason}"
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr "Mauvaise configuration du proxy inversé : {proxy_reason}"
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr "IDs d'utilisateurs non valides : {invalid_ids}"
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr "L'utilisateur avec l'ID {user_id} est désactivé"
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr "L'utilisateur avec l'ID {user_id} est un robot"
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr "Liste déroulante"
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr "Texte court"
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr "Paragraphe"
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr "Date"
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr "Compte externe"
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr "Pronoms"
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr "Personne"
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr "Membres confirmés"
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "Membres"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr "Tout le monde sur Internet"
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr "Champ d'auto-conversion invalide : caractère '}' manquant."
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: empty field name."
 msgstr "Champ d'auto-conversion invalide : nom de champ vide."
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
@@ -7708,52 +7117,52 @@ msgstr ""
 "Le groupe %(name)r dans le champ d'auto-conversion n'est pas présent dans le "
 "motif de l'identificateur de lien."
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr "Expression rationnelle incorrecte : {regex}"
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr "Erreur d'expression régulière inconnue"
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr "Format d'URL invalide."
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 msgid "Example input does not match the linkifier pattern."
 msgstr ""
 "L'entrée d'exemple ne contient pas de texte correspondant au modèle du lien "
 "automatique."
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr "Le texte d'exemple ne correspond pas au champ d'auto-conversion."
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 "Le groupe %(name)r dans le modèle d'URL n'est pas présent dans le motif de "
 "l'identificateur de lien."
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 "Le groupe %(name)r dans le modèle de lien n'est pas présent dans le modèle "
 "d'URL."
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr "Un modèle d'URL alternatif ne peut pas être identique au modèle d'URL."
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr "Les modèles d'URL alternatifs doivent être unique."
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in alternative URL template is not present in linkifier "
@@ -7762,7 +7171,7 @@ msgstr ""
 "Le groupe %(name)r dans le modèle d'URL alternatif n'est pas présent dans le "
 "motif de l'identificateur de lien."
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in linkifier pattern is not present in alternative URL "
@@ -7771,334 +7180,331 @@ msgstr ""
 "Le groupe %(name)r dans le modèle de lien n'est pas présent dans le modèle "
 "d'URL alternatif."
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr "Emoji unicode"
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "Emoji personnalisé"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr "Emoji spécial Zulip"
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr "Caractères invalides dans le nom de l'emoji"
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr "Caractères invalides dans la langue des pygments"
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr "La variable requise \"code\" est manquante dans le modèle d'URL"
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr "\"code\" devrait être la seule variable présente dans le modèle d'URL"
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr "bac à sable"
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr "général"
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr "événements du canal"
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr "Spam"
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr "Harcèlement"
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr "Contenu inapproprié"
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr "Enfreint les normes de la communauté"
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr "Autre raison"
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr "Mises à jour de Zulip"
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr "Disponible sur Zulip Cloud Standard. Mettre à niveau pour accéder."
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr ""
 "Disponible sur Zulip Cloud Plus. Passez à une offre supérieure pour y "
 "accéder."
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr "Désactivé"
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr "Autoriser les GIF classés G (Public général)"
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr "Autoriser les GIF classés PG (Conseil parental)"
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr "Autoriser les GIF classés PG-13 (Conseil parental - moins de 13 ans)"
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr "Autoriser les GIF classés R (Restreint)"
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr "Public sur le Web"
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "Publique"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr "Privé, historique partagé"
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr "Privé, historique protégé"
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr "Administrateurs, modérateurs, membres et invités"
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr "Administrateurs, modérateurs et membres"
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr "Administrateurs et modérateurs"
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr "Seulement les administrateurs"
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr "Utilisateur inconnu"
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr "Administrateur de l'organisation"
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr "Administrateur de l'organisation"
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr "Modérateur"
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "Membre"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "Invité"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr "Adresse IP inconnue"
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr "un système d'exploitation inconnu"
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr "Un navigateur inconnu"
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr "Argument 'queue_id' manquant"
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr "Argument 'last_event_id' manquant"
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr "Un événement plus récent que {event_id} a déjà été nettoyé !"
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr "L'événement {event_id} introuvable dans cette file d'attente"
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr "Mauvais identifiant de file d'attente d'événements : {queue_id}"
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 msgid "Failed to generate challenge"
 msgstr "Échec de génération d'un défi"
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr "L'authentification JWT n'est pas activée pour cette organisation"
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr "Jeton web JSON absent de la requête"
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr "Jeton web JSON non valide"
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr "Pas d'email spécifié dans les réclamations du jeton web JSON"
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr "Sous-domaine requis"
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr "Le mot de passe est incorrect."
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr "Vous devez supprimer tous les canaux de ce dossier pour l'archiver."
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr "En-tête User-Agent absent de la requête"
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr "L'étiquette ne peut pas être vide."
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr "Les champs doivent avoir au moins un choix disponible."
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr ""
 "Type de champ non pris en charge pour l&#39;affichage dans le résumé du "
 "profil."
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for use for user matching."
 msgstr "Type de champ non pris en charge pour identifier des utilisateurs."
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr "Type de champ invalide."
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 "Seuls 2 champs de profil personnalisés peuvent être affichés dans le résumé "
 "du profil."
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr "Un champ avec cette étiquette existe déjà."
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr "Le champ personnalisé par défaut ne peut être modifié."
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr "Point final non disponible en production."
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr "DevAuthBackend n'est pas activé."
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr "Paramètre '{key}' non valide pour une requête anonyme"
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr "La base de données est vide"
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr "Ne peut pas interroger postgresql"
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr "Ne peut pas se connecter à rabbitmq"
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr "Ne peut pas interroger rabbitmq"
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr "Ne peut pas interroger redis"
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr "Ne peut pas écrire dans memcached"
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr "Ne peut pas interroger memcached"
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr "Aucune invitation"
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 msgid "Invitation already used or deactivated."
 msgstr "L'invitation a déjà été utilisée ou a été désactivée."
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr "L'invitation a déjà été révoquée"
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 "ID de canal {channel_id} non valide. Aucune invitation n'a été envoyée."
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr "Vous n'êtes pas autorisé à abonner d'autres utilisateurs aux canaux."
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr "Vous devez spécifier au moins une adresse électronique."
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
@@ -8107,104 +7513,102 @@ msgstr ""
 "envoyé d'invitation. Nous avons bien sûr envoyé des invitations à toutes les "
 "autres personnes !"
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr ""
 "L'historique de modification des messages est désactivé dans cette "
 "organisation"
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr "Vous n'avez pas la permission de supprimer ce message"
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr "La limite de temps pour supprimer ce message est dépassée"
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr "Message déjà supprimé"
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr "Trop de messages demandés (maximum {max_messages})."
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr "L'ancre ne peut être exclue qu'à une extrémité de la plage"
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr "Aucun sujet tel que '{topic}'"
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr "Une explication est requise."
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 msgid "Message reporting is not enabled in this organization."
 msgstr ""
 "La fonction de signalement des messages n'est pas activée dans cette "
 "organisation."
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr "Expéditeur manquant"
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr "Mise en mirror non autorisée avec un ID utilisateur de destinataire"
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr "Message mirroir non valide"
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr "Les fonctionnalités d'IA ne sont pas activées sur ce serveur."
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr "Limite mensuelle de crédits IA atteinte."
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr "Pas de messages à résumer dans la conversation"
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr "On ne peut pas se rendre muet soi-même"
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr "Cet utilisateur est déjà muet"
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr "Cet utilisateur n'est pas muet"
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr "Les vues standards ne peuvent pas avoir de nom personnalisé."
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr "Les vues personnalisées doivent avoir un nom valide."
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 msgid "Navigation view already exists."
 msgstr "La vue de navigation existe déjà."
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr "Valeur inconnue pour onboarding_step : {onboarding_step}"
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -8215,38 +7619,38 @@ msgstr ""
 "Vous avez demandé à regarder la vidéo [Bienvenue sur Zulip]"
 "({navigation_tour_video_url}) plus tard. Est-ce le bon moment ?\n"
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr "La présence n'est pas supportée pour les utilisateurs robots."
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr "Pas de données de présence pour {user_id_or_email}"
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr "Statut non valide : {status}"
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 msgid "You do not have permission to manage plans and billing."
 msgstr "Vous n'avez pas la permission de gérer les forfaits et la facturation."
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr "Le serveur n'utilise pas le service de notification push"
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr "Erreur retournée par le bouncer : {result}"
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr "Vérification du secret non préparé"
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
@@ -8254,60 +7658,60 @@ msgstr ""
 "Paramètres manquants : vous devez fournir tous les champs \"push key\", ou "
 "tous les champs \"token\", ou les deux."
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 "Aucun enregistrement de notification push n'existe pour la rotation de la "
 "clé."
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr "Un enregistrement est déjà en cours pour ce périphérique."
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 "Aucun enregistrement de notification push n'existe pour la rotation du jeton "
 "(\"token\")."
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr ""
 "Au moins un des arguments suivants doit être présent : emoji_nam, emoji_code"
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr "Les confirmations de lecture sont désactivées dans cette organisation."
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr "Langage non valide '{language}'"
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr "Au moins une méthode d'authentification doit être activée."
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr "video_chat_provider non valide {video_chat_provider}"
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr "Valeur incorrecte pour gif_rating_policy : {gif_rating_policy}"
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 "L'organisation n'est pas éligible au tarif réduit pour les utilisateurs non-"
 "professionnels."
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
@@ -8315,17 +7719,17 @@ msgstr ""
 "Le tarif réduit pour les utilisateurs professionnels ne peut pas être activé "
 "avec le forfait à tarif réduit actuel."
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr "Doit être une organisation de démonstration."
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 "Valeur non valide pour la durée avant la suppression des données d'une "
 "organisation de démonstration."
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
@@ -8333,7 +7737,7 @@ msgstr ""
 "La durée avant la suppression des données doit être au maximum de "
 "{max_allowed_days} jours."
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
@@ -8341,49 +7745,49 @@ msgstr ""
 "La durée avant la suppression des données doit être d'au moins "
 "{min_allowed_days} jours."
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr "Domaine non valide : {error}"
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr "Le domaine {domain} fait déjà partie de votre organisation."
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr "Aucune entrée trouvée pour le domaine {domain}."
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr "Vous devez envoyer exactement un fichier."
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr "Seulement les administrateurs peuvent surpasser les emojis par défaut."
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr ""
 "La taille du fichier envoyé est plus grande que la limite autorisée de "
 "{max_size} MiB"
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr ""
 "Les exports de toutes les données publiques et privées ne sont pas autorisés "
 "dans cette organisation."
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr "Taux limite dépassé."
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
@@ -8392,57 +7796,57 @@ msgstr ""
 "L'export que vous avez demandé est trop volumineux pour un traitement "
 "automatique. Merci de demander un export manuel en contactant {email}."
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr "ID d'exportation non valide"
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr "Exportation déjà supprimée"
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr "L'export a échoué, rien à supprimer"
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr "Export toujours en cours"
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr "Vous devez envoyer exactement une icône."
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr "Transformation en lien introuvable."
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr "Vous devez envoyer exactement un logo."
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Invalid character in language: {character}"
 msgstr "Caractère invalide dans le langage : {character}"
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Language '{language}' is not allowed."
 msgstr "Le langage '{language}' n'est pas autorisé."
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr "Bac à sable non valide"
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr "Impossible d’annuler l’importation une fois qu’elle a commencé."
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr "Non authentifié"
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
@@ -8451,129 +7855,128 @@ msgstr ""
 "fermez cet onglet, vous pouvez revenir ici via le lien « Terminer "
 "l’inscription » dans votre courriel."
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 msgid "Importing messages…"
 msgstr "Importation des messages en cours…"
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr "Importation des pièces jointes…"
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr "Importation des données Slack converties…"
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr "Finalisation de l’importation…"
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr "Terminé !"
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr "Aucun utilisateur ne correspond à l’adresse électronique fournie."
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 msgid "Your name"
 msgstr "Votre nom"
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr ""
 "Destinataire requis lors de la mise à jour du type de message programmé."
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 "Un sujet est requis lors de la mise à jour du type de message planifié vers "
 "un canal."
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr "Format de requête non valide"
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr "DSN non valide"
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr "Les canaux privés ne peuvent pas être définis par défaut."
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr "Vous devez fournir \"new_description\" ou \"new_group_name\"."
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr "Valeur non valide pour \"op\". Spécifier soit \"add\" ou \"remove\"."
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr "Paramètres invalides"
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr "L’accès au contenu du canal est requis."
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr "Le canal porte déjà ce nom."
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr "Rien à faire. Spécifiez au moins un \"ajouter\" ou \"supprimer\"."
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr "{user_full_name} vous a ajouté au groupe {channel_name}."
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr "{user_full_name} vous a abonné aux canaux suivants :"
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr "Impossible d’accéder au canal ({channel_name})."
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr "{user_name} a créé les canaux suivants : {new_channels}."
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr "{user_name} a créé un nouveau canal : {new_channels}."
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr "nouveaux canaux"
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr "Canal **public web** créé par {user_name}. **Description :**"
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr "Canal **public** créé par {user_name}. **Description :**"
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 "Canal **privé, historique partagé** créé par {user_name}. **Description :**"
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
@@ -8581,26 +7984,26 @@ msgid ""
 msgstr ""
 "Canal **privé, historique protégé** créé par {user_name}. **Description :**"
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr "{property} n’est pas une valeur booléenne"
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr "Propriété d'abonnement inconnue : {property}"
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr "Non abonné au canal d’identifiant {channel_id}"
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr "JSON du sous-message non valide"
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
@@ -8609,7 +8012,7 @@ msgstr ""
 "Le fichier est plus volumineux que la taille maximale de téléversement "
 "({max_size} Mio) autorisée par l’offre de votre organisation."
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
@@ -8618,7 +8021,7 @@ msgstr ""
 "Le fichier est plus volumineux que la taille maximale de téléversement "
 "configurée sur ce serveur ({max_size} Mio)."
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
@@ -8627,56 +8030,55 @@ msgstr ""
 "Le fichier téléversé dépasse la taille maximale autorisée pour les "
 "importations ({max_file_size} Mio)."
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 "L’utilisateur a désactivé les notifications de saisie pour les messages de "
 "canal"
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr "Argument 'to' manquant"
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr "Liste 'to' est vide"
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr ""
 "L'utilisateur a désactivé les notifications de frappe pour les messages "
 "directs"
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr "<p>Ce fichier n’existe pas ou a été supprimé.</p>"
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr "<p>Vous n'êtes pas autorisé à visualiser ce fichier.</p>"
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr "Jeton non valide"
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr "Nom de fichier non valide"
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr "Vous devez spécifier un fichier à envoyer"
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr "Vous ne pouvez envoyer qu'un seul fichier à la fois"
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr "Aucune nouvelle donnée fournie"
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
@@ -8684,33 +8086,33 @@ msgstr ""
 "Aucune action à effectuer. Spécifiez au moins l’une des options suivantes : "
 "« add », « delete », « add_subgroups » ou « delete_subgroups »."
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr "{user_full_name} vous a ajouté au groupe {group_name}."
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr "{user_full_name} vous a retiré du groupe {group_name}."
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr "L'utilisateur {user_id} est déjà membre de ce groupe"
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr "Il n'y a aucun membre '{user_id}' dans ce groupe d'utilisateurs"
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr ""
 "Le groupe d&#39;utilisateurs {group_id} est déjà un sous-groupe de ce groupe."
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
@@ -8719,7 +8121,7 @@ msgstr ""
 "Le groupe d'utilisateurs {user_group_id} est déjà un sous-groupe de l'un des "
 "sous-groupes transmis."
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
@@ -8727,103 +8129,103 @@ msgstr ""
 "Les sous-groupes d'un groupe utilisé pour 'workplace_users_group' ne doivent "
 "autoriser que les administrateurs de l'organisation à gérer leurs membres."
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr ""
 "Le groupe d&#39;utilisateurs {group_id} n&#39;est pas un sous-groupe de ce "
 "groupe."
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr "Cette organisation ne permet pas de modifier son avatar."
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr ""
 "Le changement d'adresse électronique est désactivé dans votre organisation."
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr "default_language non valide"
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr "Son de notification non valide '{notification_sound}'"
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr "Période d'envoi par courriel non valide : {seconds} secondes"
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr "Vous devez fournir soit des user_ids, soit des group_ids."
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr "Impossible de modifier ce paramètre pour d’autres utilisateurs."
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr "Votre mot de passe Zulip est géré dans l'annuaire LDAP"
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr "Mot de passe incorrect !"
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr ""
 "Vous avez fait trop de tentatives ! Réessayez dans {retry_after_string}."
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr "Le nouveau mot de passe est trop faible !"
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr "Vous devez envoyer exactement un avatar."
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr "Ce sujet n'est pas muet"
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr "Impossible de désactiver le seul propriétaire de l'organisation"
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 msgid "User is not allowed to delete other user's messages."
 msgstr ""
 "L'utilisateur n'est pas autorisé à supprimer les messages d'autres "
 "utilisateurs."
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 "L’utilisateur n’est pas autorisé à modifier les adresses électroniques des "
 "utilisateurs"
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 "La permission de propriétaire ne peut être retirée du seul propriétaire de "
 "l'organisation."
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr "Nouvelle adresse électronique invalide."
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr "Erreur dans la nouvelle adresse électronique : {message}"
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 msgid ""
 "Can't change bot email until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
@@ -8832,25 +8234,25 @@ msgstr ""
 "FAKE_EMAIL_DOMAIN n’est pas correctement configuré.\n"
 "Veuillez contacter votre administrateur système."
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 msgid "Email address already in use"
 msgstr "Adresse électronique déjà utilisée"
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr "Échec du changement de propriétaire, utilisateur introuvable"
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr "Échec du changement de propriétaire, l'utilisateur est désactivé"
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr ""
 "Échec du changement de propriétaire, les robots ne peuvent pas détenir "
 "d'autres bots"
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
@@ -8859,133 +8261,133 @@ msgstr ""
 "configuré correctement.\n"
 "Veuillez contacter votre administrateur."
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr "Les robots intégrés ne sont pas activés."
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr "Nom de robot intégré non valide."
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr "Utilisateur non autorisé à créer des utilisateurs"
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr ""
 "L'adresse électronique '{email}' n'est pas autorisée dans cette organisation"
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr ""
 "Les adresses électroniques jetables ne sont pas autorisées dans cette "
 "organisation"
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} access token"
 msgstr "Jeton d’accès {provider_name} non valide"
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} call"
 msgstr "Échec de la création de l’appel {provider_name}"
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} credentials have not been configured"
 msgstr "Les identifiants {provider_name} n’ont pas été configurés"
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} credentials"
 msgstr "Identifiants {provider_name} non valides"
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr "Erreur de connexion au serveur {provider_name} : {reason}"
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error authenticating to the {provider_name} server"
 msgstr "Erreur d'authentification sur le serveur {provider_name}"
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr "Le serveur {provider_name} a renvoyé une erreur inattendue : {status}"
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} session identifier"
 msgstr "Identifiant de session {provider_name} non valide"
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr "Adresse électronique Zoom inconnue"
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} public room."
 msgstr "Échec de la création de la salle publique {provider_name}."
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr "Signature non valide."
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{full_name}'s Zulip room"
 msgstr "La salle Zulip de {full_name}"
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 "Les projets utilisant ce fournisseur de système de contrôle de version ne "
 "sont pas pris en charge"
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr "Charge utile non valide"
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr "Requête webhook inconnue"
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr "Le sujet ne peut pas être vide"
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr "Le contenu ne peut être vide"
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr "Impossible de traiter la charge utile de Jotform"
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr "Entrée JSON malformée"
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr "La clé d'événements est absente de la charge utile"
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr "Erreur : channels_map_to_topics paramètre autre que 0 ou 1"
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr "Action de webhook WordPress inconnue : {hook}"
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
@@ -8994,79 +8396,79 @@ msgstr ""
 "Votre exportation de données est terminée. [Voir et télécharger les "
 "exportations]({export_settings_link})."
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr "Le secret de vérification a expiré"
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr "Le secret de vérification est invalide"
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr "Le secret de vérification est mal formé"
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr "Le secret de vérification est destiné à un autre nom d’hôte"
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr ""
 "Sous-domaine non valide pour le serveur de relai des notifications push"
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr "À valider avec une clé API valide de serveur Zulip"
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr "UUID non valide"
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr "Type de jeton invalide"
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 "{hostname} contient des composants non valides (ex. : chemin, requête, "
 "fragment)."
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr "{hostname} n'est pas un nom d'hôte valide"
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr "{hostname} n’est pas encore enregistré"
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 "Adresse électronique de l’administrateur du serveur invalide : {email_reason}"
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr "example.com n’est pas un domaine adresse électronique valide."
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr "{domain} est invalide car il ne possède aucun enregistrement MX"
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr "{domain} n’existe pas"
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
@@ -9076,28 +8478,28 @@ msgstr ""
 "été atteintes. Veuillez réessayer ultérieurement ou contacter "
 "{support_email} pour obtenir de l’aide."
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr "Aucune inscription trouvée pour ce nom d’hôte"
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr "L’hôte a signalé qu’il ne possède aucun secret de vérification."
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr "Reçu un code de statut inattendu de l’hôte : {status_code}"
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr "ios_app_id manquant"
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr "User_id ou user_uuid manquant"
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
@@ -9106,48 +8508,48 @@ msgstr ""
 "Votre offre ne permet pas l’envoi de notifications push. Raison fournie par "
 "le serveur : {reason}"
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr "Votre offre ne permet pas l’envoi de notifications push."
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr "Propriété non valide {property}"
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr "Type d’événement invalide."
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr "Les données sont hors d'ordre."
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr "Double enregistrement détecté."
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr "Données de journal d'audit malformées"
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr "Vous devez réinitialiser votre mot de passe."
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr "Paramètre id_token manquant"
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 msgid "Missing idp param"
 msgstr "Paramètre idp manquant"
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr "OTP non valide"
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr ""
 "Impossible d'utiliser mobile_flow_otp et desktop_flow_otp en même temps."

--- a/locale/gl/LC_MESSAGES/django.po
+++ b/locale/gl/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 19:12+0000\n"
 "Last-Translator: Alex Vandiver <alexmv@zulip.com>\n"
 "Language-Team: Galician <https://hosted.weblate.org/projects/zulip/django/gl/"
@@ -19,50 +19,50 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr ""
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr ""
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr ""
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr ""
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr ""
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr ""
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -71,7 +71,7 @@ msgid ""
 "users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -79,7 +79,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than one user to join."
 msgstr ""
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -87,7 +87,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than two users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -95,7 +95,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than three users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -104,148 +104,147 @@ msgid ""
 "({billing_page_link}) is greater than the current number of users."
 msgstr ""
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr ""
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr ""
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
 "(minimum {min_licenses})."
 msgstr ""
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
 "page. To complete the upgrade, please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr ""
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr ""
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr ""
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr ""
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr ""
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr ""
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
 msgstr ""
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
 msgstr ""
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
 "licenses."
 msgstr ""
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
 "billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr ""
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr ""
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr ""
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -255,100 +254,97 @@ msgid ""
 "we would really appreciate it!"
 msgstr ""
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
 "{support_email}"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr ""
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr ""
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr ""
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
 "%(support_email)s\">contact support</a>."
 msgstr ""
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr ""
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
 msgstr ""
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr ""
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
 msgstr ""
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr ""
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr ""
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
 msgstr ""
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -356,289 +352,270 @@ msgid ""
 "a> with any questions."
 msgstr ""
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
 "a> for support."
 msgstr ""
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
 "href=\"%(troubleshooting_url)s\">Zulip server troubleshooting guide</a>."
 msgstr ""
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr ""
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr ""
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr ""
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr ""
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr ""
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr ""
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr ""
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr ""
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr ""
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr ""
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr ""
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr ""
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr ""
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr ""
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr ""
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr ""
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr ""
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr ""
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr ""
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr ""
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr ""
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr ""
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr ""
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr ""
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr ""
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr ""
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr ""
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr ""
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr ""
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr ""
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
 "%(old_email_html_tag)s to %(new_email_html_tag)s"
 msgstr ""
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr ""
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
 msgstr ""
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr ""
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr ""
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -649,19 +626,19 @@ msgid ""
 "server."
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -669,788 +646,297 @@ msgid ""
 "%(support_email)s'>contact support</a> with any questions."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, python-format
 msgid "You can try again in %(retry_after_string)s."
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr ""
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr ""
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr ""
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr ""
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr ""
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr ""
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr ""
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr ""
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr ""
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr ""
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr ""
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr ""
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr ""
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr ""
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 msgid "Zulip for open source"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 msgid "Message with code"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
 msgstr ""
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 msgid "Get started"
 msgstr ""
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
 "continue."
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "Correo"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1458,78 +944,77 @@ msgid ""
 "from Zulip."
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
 msgstr ""
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr ""
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr ""
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr ""
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr ""
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr ""
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr ""
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr ""
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
 msgstr ""
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1537,210 +1022,203 @@ msgid ""
 "href=\"%(doc_url)s\">documentation</a>."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, python-format
 msgid "No account found for %(email)s."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Create a new organization"
 msgid "Try Zulip in a demo organization"
 msgstr "Create a new organization"
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 msgid "Try Zulip"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "Create a new organization"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid "Import chat history?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "Organization URL"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "OR"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "Entrar"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1748,123 +1226,122 @@ msgid ""
 "noreferrer\">after you join</a>."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "Change"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "Nome"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "Contrasinal"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr ""
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">Terms of Service</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr ""
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr ""
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -1872,45 +1349,45 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 msgid ""
 "This organization has been deactivated, and all organization data has been "
 "deleted."
 msgstr ""
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
 "inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
 "administrators</a> to inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 msgid "This organization has been deactivated."
 msgstr ""
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
 "%(support_email)s\">contact Zulip support</a> to reactivate it."
 msgstr ""
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -1918,165 +1395,164 @@ msgid ""
 "reactivate it."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "Copy"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "Administradores"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "Usuarios normais"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "Close"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "Actualizar"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr ""
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
 "<b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
 "href=\"%(apps_page_link)s\">mobile and desktop</a> apps:"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
 "href=\"%(getting_user_started_link)s\">getting started guide</a>!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2084,83 +1560,83 @@ msgid ""
 "Zulip</a>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
 "to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
 "desktop apps (%(apps_page_link)s):"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
 "(%(getting_user_started_link)s)!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
 "(%(getting_organization_started_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2168,32 +1644,32 @@ msgid ""
 "password for this account, please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "%(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 msgid "Verify your email address for your Zulip demo organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "<%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2201,113 +1677,113 @@ msgid ""
 "please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
 "— we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
 "deactivated, and you will no longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr ""
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2315,22 +1791,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because your organization <a "
@@ -2338,8 +1814,8 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to <a "
@@ -2347,39 +1823,39 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr ""
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because your organization hides "
@@ -2387,81 +1863,74 @@ msgid ""
 "details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to hide "
 "message content in email notifications. See %(help_url)s for more details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr ""
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
 "organizations:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
 "organizations hosted by %(external_host)s:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
 "href=\"%(help_reset_password_link)s\">reset your password</a>."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
 "%(external_host)s."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2469,97 +1938,94 @@ msgid ""
 "to find your account."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
 "try another way to find your account (%(help_logging_in_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
 "communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr ""
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
 "-- the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
 "Zulip &mdash; the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
 "to ask %(referrer_name)s for another one."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2567,72 +2033,70 @@ msgid ""
 "productivity."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at <a href=\"mailto:%(email)s\">%(email)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
 "%(email)s\">Contact us</a> — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
 "#%(channel_name)s > %(topic_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2640,68 +2104,68 @@ msgid ""
 "preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails (<a href=\"%(url)s\">help</a>)."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2709,22 +2173,22 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2732,52 +2196,52 @@ msgid ""
 "immediately at <%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2785,31 +2249,31 @@ msgid ""
 "contact us immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2817,7 +2281,7 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -2825,25 +2289,25 @@ msgid ""
 "Zulip</a> to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
 "with you and share their unique perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -2851,7 +2315,7 @@ msgid ""
 "experience how a new chat app will help your team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -2859,148 +2323,148 @@ msgid ""
 "action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
 "team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
 "organizations like yours!"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3008,11 +2472,11 @@ msgid ""
 "about…?”"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3021,23 +2485,23 @@ msgid ""
 "href=\"%(move_channels_link)s\">move a topic to a different channel</a>."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3046,23 +2510,23 @@ msgid ""
 "(%(move_channels_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
 "%(email)s on %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3070,46 +2534,46 @@ msgid ""
 "href=\"%(help_link)s\">reactivate your account</a>."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
 "You can contact an organization administrator to reactivate your account."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3117,541 +2581,537 @@ msgid ""
 "have been voided."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
 "to %(upgrade_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip demo organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip demo organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Create a new organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "Create a new organization"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for <b>%(remote_server_hostname)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 msgid "Click the button below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for %(remote_server_hostname)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
 "management for <b>%(remote_realm_host)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
 "management for %(remote_realm_host)s."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the <a href=\"%(plans_link)s\">Zulip Community plan</a>."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
 "website</a>, we would really appreciate it!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
 msgstr ""
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
 "accounts for another email address</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr ""
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "Find accounts"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr ""
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr ""
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr ""
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 msgid "Zulip Cloud"
 msgstr ""
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr ""
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr ""
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr ""
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr ""
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr ""
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr ""
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr ""
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr ""
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr ""
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr ""
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr ""
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr ""
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr ""
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr ""
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr ""
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr ""
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr ""
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr ""
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr ""
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr ""
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr ""
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr ""
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr ""
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr ""
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr ""
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr ""
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "History"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr ""
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr ""
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr ""
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr ""
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr ""
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 msgid "Bluesky"
 msgstr ""
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr ""
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr ""
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr "Política de privacidade"
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 msgid ""
 "And hundreds more through <a href=\"/integrations/zapier\">Zapier</a> and <a "
 "href=\"/integrations/ifttt\">IFTTT</a>."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3659,7 +3119,7 @@ msgid ""
 "emails with your email domain."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3667,7 +3127,7 @@ msgid ""
 "disposable email addresses."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3675,24 +3135,24 @@ msgid ""
 "emails that contain \"+\"."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3700,7 +3160,7 @@ msgid ""
 "%(support_email)s\">contact Zulip support</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3708,89 +3168,89 @@ msgid ""
 "%(support_email)s\">contact this Zulip server's administrators</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
 "management for your Zulip server."
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr ""
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr ""
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr ""
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "Nome de usuario"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr ""
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr ""
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr ""
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> because all Zulip Cloud licenses are in use."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -3799,42 +3259,40 @@ msgid ""
 "or misconfiguration."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 msgid "Demo organizations disabled"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -3842,22 +3300,21 @@ msgid ""
 "organization for more information."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -3865,44 +3322,42 @@ msgid ""
 "Zulip support</a> for assistance in resolving this issue."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
 "a> like Firefox, Chrome, and Edge."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 msgid "Finalize organization import"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 msgid "Organization import completed!"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -3910,54 +3365,53 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 msgid "Select your account"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create a new organization"
 msgid "Create new account"
 msgstr "Create a new organization"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr ""
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -3965,81 +3419,81 @@ msgid ""
 "have one yet."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 msgid "Self-hosting Zulip?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">log in to manage plans and billing.</a>"
 msgstr ""
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr ""
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
 msgstr ""
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr ""
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr ""
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr ""
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr ""
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr ""
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4047,7 +3501,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4056,57 +3510,57 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr ""
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4114,7 +3568,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4122,40 +3576,40 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4163,300 +3617,294 @@ msgid ""
 "away!"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
 "href=\"%(realm_url)s/#settings/notifications\">notification settings</a>."
 msgstr ""
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr ""
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr ""
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr ""
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr ""
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr ""
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr ""
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr ""
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 msgid "Cannot reactivate a deleted user"
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr ""
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr ""
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr ""
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr ""
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
 msgstr ""
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
 msgstr ""
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr ""
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr ""
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr ""
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr ""
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr ""
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr ""
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr ""
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr ""
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr ""
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr ""
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
 "{new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
 "{user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to resolve topics in this channel."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr ""
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr ""
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr ""
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr ""
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr ""
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
 "but there is no channel with that ID."
 msgstr ""
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4464,36 +3912,36 @@ msgid ""
 "it."
 msgstr ""
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
 "The channel exists but does not have any subscribers."
 msgstr ""
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr ""
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr ""
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr ""
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4501,107 +3949,105 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
 "authentication method."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr ""
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 msgid "Reminder could not be sent."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
 "the following error:"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr ""
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr ""
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr ""
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr ""
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr ""
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
 "**{old_policy}** to **{new_policy}**."
 msgstr ""
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -4610,51 +4056,49 @@ msgid ""
 "* **New**: {new_setting_description}\n"
 msgstr ""
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr ""
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr ""
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr ""
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr ""
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr ""
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr ""
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 msgstr ""
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr ""
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -4665,283 +4109,269 @@ msgid ""
 "{summary_line}"
 msgstr ""
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr ""
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr ""
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr ""
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr ""
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr ""
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr ""
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr ""
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr ""
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr ""
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr ""
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr ""
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
 "organization administrator to reactivate it."
 msgstr ""
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr ""
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr ""
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr ""
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr ""
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr ""
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr ""
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr ""
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
 "to register for accounts in this organization."
 msgstr ""
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr ""
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 msgid "Challenges are not enabled."
 msgstr ""
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr ""
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr ""
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "You're making too many attempts to sign in. Try again in "
 "{retry_after_string} or contact your organization administrator for help."
 msgstr ""
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
 msgstr ""
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr ""
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr ""
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr ""
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr ""
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr ""
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr ""
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr ""
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr ""
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr ""
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr ""
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr ""
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name can't be empty."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 msgid "Invalid channel folder ID"
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 msgid "Configure owner account email address."
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4950,69 +4380,69 @@ msgid ""
 "organization]({convert_demo}).\n"
 msgstr ""
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, python-brace-format
 msgid "{var_name} is not Base64 encoded"
 msgstr ""
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 msgid "Invalid `device_id`"
 msgstr ""
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr ""
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr ""
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr ""
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr ""
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr ""
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr ""
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr ""
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr ""
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr ""
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr ""
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5020,607 +4450,605 @@ msgid ""
 "{error_message}"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr ""
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr ""
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr ""
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr ""
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr ""
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr ""
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr ""
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr ""
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr ""
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr ""
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr ""
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr ""
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr ""
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
 msgstr ""
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr ""
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr ""
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr ""
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr ""
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr ""
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr ""
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr ""
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr ""
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 msgid "Must be a bot user"
 msgstr ""
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr ""
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr ""
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr ""
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
 "webhook; ignoring"
 msgstr ""
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr ""
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr ""
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr ""
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr ""
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} most recent messages in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr ""
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr ""
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
 msgstr ""
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr ""
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr ""
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr ""
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr ""
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr ""
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Find accounts"
 msgid "Atlassian account ID"
 msgstr "Find accounts"
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 msgid "Behance username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 msgid "Bitbucket username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 msgid "Codeberg username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 msgid "Dribbble username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 msgid "Facebook username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "GitLab username"
 msgstr "Nome de usuario"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 msgid "Instagram username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 msgid "Mastodon profile"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "Medium username"
 msgstr "Nome de usuario"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 msgid "Pinterest username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "Reddit username"
 msgstr "Nome de usuario"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 msgid "Snapchat username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 msgid "Threads username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "TikTok username"
 msgstr "Nome de usuario"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "Twitch username"
 msgstr "Nome de usuario"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "Nome de usuario"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr ""
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr ""
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 msgid "Video calling"
 msgstr ""
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr ""
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr ""
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr ""
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr ""
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr ""
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr ""
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr ""
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr ""
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr ""
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr ""
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr ""
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr ""
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr ""
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr ""
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "{fullname} moderation"
 msgstr ""
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr ""
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr ""
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor_date' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr ""
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 msgid "Navigation view does not exist."
 msgstr ""
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5628,7 +5056,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5636,7 +5064,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5644,7 +5072,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5652,7 +5080,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5662,14 +5090,14 @@ msgid ""
 "a permanent organization]({convert_demo_organization_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
 "them in your [Inbox](/#inbox).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5677,7 +5105,7 @@ msgid ""
 "({navigation_tour_video_url}) for a quick app overview.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5692,14 +5120,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -5707,7 +5135,7 @@ msgid ""
 "and edit your [profile information](/help/edit-your-profile).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -5718,7 +5146,7 @@ msgid ""
 "experience in your [Preferences](#settings/preferences).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5729,7 +5157,7 @@ msgid ""
 "[Browse and subscribe to channels]({settings_link}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -5746,7 +5174,7 @@ msgid ""
 "discussed.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -5755,7 +5183,7 @@ msgid ""
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -5767,7 +5195,7 @@ msgid ""
 "times, and more.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5777,7 +5205,7 @@ msgid ""
 "or browse the [help center](/help/) to learn more!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5785,7 +5213,7 @@ msgid ""
 "get help, try one of the following messages: {bot_commands}\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5797,13 +5225,13 @@ msgid ""
 "({move_content_another_channel_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5817,12 +5245,11 @@ msgid ""
 "and above.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr ""
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -5830,14 +5257,14 @@ msgid ""
 "no matter how many other conversations are going on.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
 "conversations with unread messages.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -5845,7 +5272,7 @@ msgid ""
 "the `+` button next to its name.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -5853,13 +5280,13 @@ msgid ""
 "can we chat about…?”\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5867,7 +5294,7 @@ msgid ""
 "({format_message_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5887,1322 +5314,1299 @@ msgid ""
 "```\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
 "teammates.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
 "conversation.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr ""
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr ""
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr ""
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr ""
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 msgid "Invalid `push_key`"
 msgstr ""
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr ""
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr ""
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr ""
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 msgid "Reminder does not exist"
 msgstr ""
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr ""
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr ""
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr ""
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr ""
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr ""
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr ""
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr ""
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr ""
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 msgid "You do not have permission to create new topics in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr ""
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr ""
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr ""
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr ""
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr ""
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr ""
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} does not have the expected format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr ""
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr ""
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr ""
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {user_group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr ""
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr ""
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr ""
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr ""
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr ""
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 msgid "Name must not be empty!"
 msgstr ""
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr ""
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr ""
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr ""
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr ""
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr ""
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr ""
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr ""
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr ""
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr ""
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr ""
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr ""
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr ""
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr ""
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr ""
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr ""
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr ""
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr ""
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr ""
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr ""
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr ""
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr ""
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr ""
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr ""
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr ""
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr ""
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr ""
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr ""
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr ""
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr ""
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr ""
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr ""
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr ""
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr ""
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr ""
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr ""
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "Membros"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr ""
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: empty field name."
 msgstr ""
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr ""
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr ""
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 msgid "Example input does not match the linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in alternative URL template is not present in linkifier "
 "pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in linkifier pattern is not present in alternative URL "
 "template."
 msgstr ""
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr ""
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr ""
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr ""
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr ""
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr ""
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr ""
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr ""
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr ""
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr ""
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr ""
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr ""
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr ""
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "Público"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr ""
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr ""
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr ""
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr ""
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr ""
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr ""
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr ""
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr ""
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr ""
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr ""
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr ""
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr ""
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr ""
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr ""
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr ""
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr ""
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 msgid "Failed to generate challenge"
 msgstr ""
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr ""
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr ""
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr ""
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr ""
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr ""
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr ""
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for use for user matching."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr ""
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr ""
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr ""
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr ""
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr ""
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr ""
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr ""
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr ""
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 msgid "Invitation already used or deactivated."
 msgstr ""
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr ""
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr ""
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr ""
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
 msgstr ""
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr ""
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr ""
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr ""
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr ""
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr ""
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr ""
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr ""
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr ""
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 msgid "Message reporting is not enabled in this organization."
 msgstr ""
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr ""
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr ""
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr ""
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr ""
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr ""
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr ""
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr ""
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr ""
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr ""
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 msgid "Navigation view already exists."
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7210,856 +6614,854 @@ msgid ""
 "later. Is this a good time?\n"
 msgstr ""
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr ""
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr ""
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 msgid "You do not have permission to manage plans and billing."
 msgstr ""
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr ""
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr ""
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr ""
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr ""
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr ""
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr ""
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr ""
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr ""
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr ""
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr ""
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr ""
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr ""
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr ""
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr ""
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr ""
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr ""
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr ""
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr ""
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr ""
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Invalid character in language: {character}"
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Language '{language}' is not allowed."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr ""
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr ""
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 msgid "Importing messages…"
 msgstr ""
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 msgid "Your name"
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr ""
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr ""
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr ""
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr ""
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr ""
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr ""
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr ""
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr ""
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr ""
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr ""
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr ""
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr ""
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr ""
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
 "**"
 msgstr ""
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr ""
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr ""
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr ""
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr ""
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr ""
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr ""
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr ""
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr ""
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr ""
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr ""
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr ""
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr ""
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr ""
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 msgstr ""
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr ""
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr ""
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
 "subgroups."
 msgstr ""
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr ""
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr ""
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr ""
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr ""
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr ""
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr ""
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr ""
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr ""
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr ""
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr ""
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 msgid "User is not allowed to delete other user's messages."
 msgstr ""
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr ""
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr ""
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 msgid ""
 "Can't change bot email until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 msgstr ""
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 msgid "Email address already in use"
 msgstr ""
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr ""
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr ""
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr ""
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 msgstr ""
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr ""
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr ""
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr ""
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr ""
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr ""
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} access token"
 msgstr ""
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} call"
 msgstr ""
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} credentials have not been configured"
 msgstr ""
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} credentials"
 msgstr ""
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr ""
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error authenticating to the {provider_name} server"
 msgstr ""
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr ""
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} session identifier"
 msgstr ""
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr ""
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} public room."
 msgstr ""
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr ""
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{full_name}'s Zulip room"
 msgstr ""
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr ""
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr ""
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr ""
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr ""
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr ""
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr ""
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr ""
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr ""
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr ""
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
 "({export_settings_link})."
 msgstr ""
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr ""
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr ""
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr ""
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr ""
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr ""
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr ""
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr ""
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr ""
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr ""
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr ""
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr ""
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr ""
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
 "try again later or reach out to {support_email} for assistance."
 msgstr ""
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr ""
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr ""
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr ""
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr ""
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
 "server: {reason}"
 msgstr ""
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr ""
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr ""
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr ""
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr ""
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr ""
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr ""
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr ""
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr ""
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 msgid "Missing idp param"
 msgstr ""
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr ""
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr ""

--- a/locale/gu/LC_MESSAGES/django.po
+++ b/locale/gu/LC_MESSAGES/django.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 19:16+0000\n"
 "Last-Translator: Alex Vandiver <alexmv@zulip.com>\n"
 "Language-Team: Gujarati <https://hosted.weblate.org/projects/zulip/django/gu/"
@@ -22,51 +22,51 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "મહેમાન વપરાશકર્તાઓ માટે મંજૂર નથી"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "અયોગ્ય સંસ્થા"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr "જાહેર ચેનલો"
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr "ખાનગી ચેનલો"
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr "સીધા સંદેશો"
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr "ગ્રૂપ ડાયરેક્ટ સંદેશો"
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr "ચાર્ટ માટે ચેનલ ઉપલબ્ધ નથી: {chart_name}"
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr "અજ્ઞાત ચાર્ટ નામ: {chart_name}"
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr "શરૂ સમય અંત સમયથી પછી છે. શરૂ: {start}, અંત: {end}"
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr ""
 "કોઈ વિશ્લેષણાત્મક માહિતી ઉપલબ્ધ નથી. કૃપા કરીને તમારા સર્વર વ્યવસ્થાપકનો સંપર્ક કરો."
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -79,7 +79,7 @@ msgstr ""
 "વપરાશકર્તાઓને નિષ્ક્રિય કરો]({deactivate_user_help_page_link}) નવા વપરાશકર્તાઓને "
 "જોડાવવાની મંજૂરી આપો."
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -90,7 +90,7 @@ msgstr ""
 "({billing_page_link}) અથવા [નિષ્ક્રિય વપરાશકર્તાઓને નિષ્ક્રિય કરી શકો છો]"
 "({deactivate_user_help_page_link}) જેથી એકથી વધુ વપરાશકર્તા જોડાઈ શકે."
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -101,7 +101,7 @@ msgstr ""
 "({billing_page_link}) અથવા [નિષ્ક્રિય વપરાશકર્તાઓને નિષ્ક્રિય કરી શકો છો]"
 "({deactivate_user_help_page_link}) જેથી બેથી વધુ વપરાશકર્તા જોડાઈ શકે."
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -112,7 +112,7 @@ msgstr ""
 "({billing_page_link}) અથવા [નિષ્ક્રિય વપરાશકર્તાઓને નિષ્ક્રિય કરી શકો છો]"
 "({deactivate_user_help_page_link}) જેથી ત્રણથી વધુ વપરાશકર્તા જોડાઈ શકે."
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -125,28 +125,27 @@ msgstr ""
 "આગામી બિલિંગ અવધિ માટેની લાયસન્સ સંખ્યા]({billing_page_link}) હમણાં હાજર "
 "વપરાશકર્તાઓની સંખ્યાથી વધુ હોય."
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr "તમારી સંસ્થા પાસે પૂરતું Zulip લાઇસન્સ નથી. આમંત્રણો મોકલેલા નથી."
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
 msgstr "તમારા સંસ્થામાં મહેમાન યુઝરની ભૂમિકા બદલવા માટે પૂરતું Zulip લાઇસન્સ નથી."
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr "નોંધણી નિષ્ક્રિય કરવામાં આવી છે"
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr "અયોગ્ય રિમોટ સર્વર."
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
@@ -155,7 +154,7 @@ msgstr ""
 "તમારી સંસ્થાના સક્રિય ઉપયોગકર્તાઓ માટે તમે લાયસન્સો ખરીદવા જ જોઈએ (ન્યૂનતમ "
 "{min_licenses})."
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
@@ -164,58 +163,58 @@ msgstr ""
 "આ પેજથી {max_licenses} લાયસન્સ વાળી ચલણ ની ચલાઈ શકાય નહીં. અપગ્રેડ પૂર્ણ કરવા માટે, "
 "કૃપા કરીને {email} સંપર્ક કરો."
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr "ફાઇલ પર કોઈ ચૂકવણી પદ્ધતિ નથી."
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr "{brand} અંતમાં સમાપ્ત થાય છે {last4}"
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr "અજ્ઞાત ચુકવણી પદ્ધતિ. કૃપા કરીને {email} સંપર્ક કરો."
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr "કંઈ ખોટું થયું. કૃપા કરીને સંપર્ક કરો {email}."
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "કંઈ ખોટું થયું. કૃપા કરીને પૃષ્ઠને રીલોડ કરો."
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr "કંઈક ખોટું થયું. થોડા સેકન્ડ રાહ જુઓ અને ફરી પ્રયાસ કરો."
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr "કૃપા કરીને તમારા મુક્ત ટ્રાયલ શરૂ કરવા પહેલાં કૃપયા કરીને એક ક્રેડિટ કાર્ડ ઉમેરો."
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr "અપગ્રેડ શેડ્યૂલ માટે કૃપયા કરીને એક ક્રેડિટ કાર્ડ ઉમેરો."
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
 msgstr ""
 "યોજનાને અપડેટ કરવામાં અસમર્થ. યોજના સમાપ્ત થઈ ગઈ છે અને નવી યોજનાથી બદલાઈ ગઈ છે."
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr "યોજનાને અપડેટ કરવામાં અસમર્થ. યોજના સમાપ્ત થઈ ગઈ છે."
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr "મુકત પરીક્ષા યોજના માટે વર્તમાન બિલિંગ અવધિમાં લાયસન્સને અપડેટ કરી શકાય નહીં."
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
@@ -223,24 +222,24 @@ msgstr ""
 "માન્ય નથી કે લાયસન્સો હાથથી અપડેટ કરી શકાય છે. તમારી યોજના આપોઆપ લાયસન્સ વ્યવસ્થાપન "
 "પર છે."
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr "તમારી યોજના વર્તમાન બિલિંગ અવધિમાં પહેલાથી પર છે {licenses} લાયસન્સો પર."
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr "તમે વર્તમાન બિલિંગ અવધિમાં લાયસન્સને ઘટાડી શકતા નથી."
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
 msgstr ""
 "જે યોજના ડાઉનગ્રેડ થઈ રહી છે માટે આવતી બિલિંગ ચક્રના લાયસન્સોને બદલી શકાય તેવી નથી."
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
@@ -249,7 +248,7 @@ msgstr ""
 "તમારી યોજના પહેલેથી નિયત કરવામાં આવી છે કે {licenses_at_next_renewal} લાયસન્સથી "
 "નવીનીકરણ કરવામાં આવશે."
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
@@ -257,27 +256,27 @@ msgid ""
 msgstr ""
 "તમે આગલી બિલિંગ અવધિ માટે પહેલેથી જ {licenses_at_next_renewal} લાઇસન્સ ખરીદ્યા છે."
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr "કંઈ બદલવાનું નથી."
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr "આ સંસ્થા માટે કોઈ ગ્રાહક નથી!"
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr "સત્ર મળ્યું નથી"
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr "ચુકવેલ ચૂક આપત્તિ મળી નથી"
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr "Pass stripe_session_id or stripe_invoice_id"
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -292,20 +291,19 @@ msgstr ""
 "જો તમે {begin_link} તમારી વેબસાઇટ{end_link} પર સ્પોન્સર તરીકે Zulipને લિસ્ટ કરી શકો "
 "તો, અમે ખૂબ આભારી હશીએ!"
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr "પેરામીટર 'કન્ફર્મ્ડ' જરૂરી છે"
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr "બિલિંગ ઍક્સેસ ટોકન સમાપ્ત થયું."
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr "અમાન્ય બિલિંગ ઍક્સેસ ટોકન."
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
@@ -314,38 +312,37 @@ msgstr ""
 "સર્વર અને ખેતી વચ્ચે બિલિંગ ડેટાને સમન્વય કરી શક્યો નહિ. કૃપા કરીને સંપર્ક કરો "
 "{support_email}"
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr "વપરાશકર્તા એકાઉન્ટ હજી સરખું અસ્તિત્વમાં નથી."
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr "આગળ વધવા માટે તમે સેવાની શરતો સ્વીકાર કરવી આવશ્યક છે."
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr "આ ઝુલિપ_ઓર્ગ_આઈડી ઝુલિપના બિલિંગ વ્યવસ્થાની સાથે નોંધાયેલ નથી."
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr "આ જુલિપ ઓર્ગ આઈડી માટે અમાન્ય જુલિપ ઓર્ગ કી."
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr "તમારી સર્વર નોંધણી નિષ્ક્રિય થઈ ગઈ છે."
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "ભૂલ"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr "પેજ મળ્યું નથી (404)"
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, fuzzy, python-format
 #| msgid ""
 #| "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd "
@@ -357,42 +354,41 @@ msgstr ""
 "પ્રશ્નો? અમને મદદ કરવા માટે <a href=\"mailto:%(support_email)s\">અમારો સંપર્ક કરો</"
 "a> —અમે તમને મદદ કરવા માટે ખુશ છીએ!"
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr "પહોંચ નિષેધિત (403)"
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
 msgstr ""
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr ""
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
 msgstr ""
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr "પદ્ધતિ મંજૂર નથી (405)"
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr "આંતરિક સર્વર ત્રુટિ"
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
 msgstr ""
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -400,13 +396,13 @@ msgid ""
 "a> with any questions."
 msgstr ""
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, fuzzy, python-format
 #| msgid ""
 #| "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd "
@@ -418,143 +414,141 @@ msgstr ""
 "પ્રશ્નો? અમને મદદ કરવા માટે <a href=\"mailto:%(support_email)s\">અમારો સંપર્ક કરો</"
 "a> —અમે તમને મદદ કરવા માટે ખુશ છીએ!"
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
 "href=\"%(troubleshooting_url)s\">Zulip server troubleshooting guide</a>."
 msgstr ""
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr "એનાલિટિક્સ માટે %(target_name)s | Zulip"
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr "સંગઠન સૃષ્ટિ પછી 24 કલાક પછી એનાલિટિક્સ પૂરી રીતે ઉપલબ્ધ છે."
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr "Zulip વિશ્લેષણ માટે %(target_name)s"
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr "સંગઠનની સારાંશ"
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr "વપરાશકર્તાઓની સંખ્યા"
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr "છેલ્લા 15 દિવસોમાં સક્રિય વપરાશકર્તાઓ"
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr "મુસાફરોની સંખ્યા"
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr "સંદેશોની કુલ સંખ્યા"
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr "છેલ્લા 30 દિવસમાં સંદેશોની સંખ્યા"
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr "ફાઇલ સંગ્રહણ વપરાય છે"
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "સક્રિય વપરાશકર્તાઓ"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr "દૈનિક સક્રિયો"
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr "15 દિવસ સક્રિય"
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr "કુલ વપરાશકર્તાઓ"
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "વપરાશકર્તાઓ"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr "પ્રાપ્તિ પ્રકાર દ્વારા મોકલેલા સંદેશો"
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "હું"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "દરેકને"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "ગત અઠવાડિયામાં"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "પાછલા મહિને"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "પાછલા વર્ષ"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "સર્વસમય"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr "સમયની સાથે મોકલાયેલા સંદેશો"
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "દૈનિક"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "સાપ્તાહિક"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr "કુમુલેટિવ"
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "માણવો"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "બોટ્સ"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr "સમયની સાથે વાંચવામાં આવેલા સંદેશો"
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr "ગ્રાહક દ્વારા મોકલેલા સંદેશો"
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr "છેલ્લો અપડેટ"
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
@@ -562,15 +556,15 @@ msgstr ""
 "દિવસભર બધા ગ્રાફની પૂર્ણ અપડેટ એક વખત થાય છે. \"સમય પર મેસેજ મોકલેલ\" ગ્રાફ એક કલાક "
 "થી અપડેટ થાય છે."
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr "ઇમેઇલ બદલી ગઈ"
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr "ઇમેઇલ બદલી ગઈ!"
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
@@ -579,48 +573,48 @@ msgstr ""
 "આ પુષ્ટિ કરે છે કે તમારા Zulip એકાઉન્ટનો ઇમેઇલ સરનામું %(old_email_html_tag)s થી "
 "%(new_email_html_tag)s પર બદલાઈ ગયો છે"
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr "તમારું ઇમેઇલ સરનામું પુષ્ટિ કરવું"
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr "પુષ્ટિકરણ લિંક અસ્તિત્વમાં નથી"
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr "ઓહ! અમે સિસ્ટમમાં તમારી પુષ્ટિકરણ લિંક શોધી શક્યાત્ર નથી."
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr "પુષ્ટિકરણ લિંક સમાપ્ત થઈ ગયું છે અથવા નિષ્ક્રિય થયેલ છે"
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr "ઓહો. પુષ્ટિકરણ લિંક સમાપ્ત થઈ ગયો છે અથવા નિષ્ક્રિય થયો છે."
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr "કૃપા કરીને નવી લિંક માટે તમારી સંસ્થા પ્રશાસકનો સંપર્ક કરો."
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr "પુષ્ટિકરણ લિંક અયોગ્ય રૂપરેખાંકિત"
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr "ઓહો. પુષ્ટિકરણ લિંક અયોગ્ય છે."
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
@@ -628,72 +622,55 @@ msgstr ""
 "ખાતરી કરો કે તમે તમારા બ્રાઉઝરમાં લિંકને યોગ્યરીતે કૉપિ કર્યું છે. જો તમે હજી પણ આ પૃષ્ઠનો "
 "સામનો કરાવી રહ્યા છો, તો તે અમારી ભૂલ હોઈ શકે છે. અમે ખેડૂં છીએ."
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr "બિલિંગ"
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr "બંધ મોડલ"
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr "ચિંતા નહીં"
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr "ડાઉનગ્રેડ"
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "રદ કરો"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr "પુષ્ટિ કરો"
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr "અપગ્રેડ રદ કરો"
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr "બિલિંગ સ્થિતિ"
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr "સર્વર નોંધણી નિષ્ક્રિય કરો?"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr "પ્લાન વ્યવસ્થાપન ઉપલબ્ધ નથી"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -704,19 +681,19 @@ msgid ""
 "server."
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -724,736 +701,246 @@ msgid ""
 "%(support_email)s'>contact support</a> with any questions."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr "રેટ લિમિટ પાર થઈ ગઈ"
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr "રેટ લિમિટ પાર થઈ ગઈ."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, fuzzy, python-format
 #| msgid "You can try again in %(retry_after)s seconds."
 msgid "You can try again in %(retry_after_string)s."
 msgstr "તમે %(retry_after)s સેકંડ પછી ફરીથી પ્રયાસ કરી શકો છો."
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr "અપગ્રેડ"
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr ""
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr "ખુલ્લી સમુદાય નિર્દેશિકા"
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr "વર્ગ દ્વારા ફિલ્ટર કરો"
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "બધા"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr "શ્રેણીઓ"
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr "10,000 સંદેશ"
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr "અમર્યાદિત"
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr "આધારિત"
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr "સ્વયં વ્યવસ્થિત"
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr "10 વપરાશકર્તાઓ માટે સંસ્થાઓ માટે"
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr "ઉપલબ્ધ નથી"
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr "ઝુલિપ વિકાસ સમુદાય"
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr "વપરાશકર્તા તરીકે જોડાઓ"
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr "સ્વયં-હોસ્ટર તરીકે જોડાઓ"
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr "સંયોજક તરીકે જોડાઓ"
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "સંસ્થા બનાવો"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr ""
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr "સ્વ-હોસ્ટ ઝુલિપ"
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr "સંવેદનાત્મક સંરચના માટે વિનંતી કરો"
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr "શિક્ષણ ભાવની કિંમત"
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr "કિંમત જુઓ"
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr "Zulip વ્યાપાર માટે"
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Zulip guide for open-source projects"
 msgid "Zulip for open source"
 msgstr "ઓપન-સોર્સ પ્રોજેક્ટ્સ માટે Zulip ગાઈડ જુઓ"
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Create your Zulip organization"
 msgid "Screenshot of Zulip conversation"
 msgstr "નવી Zulip સંસ્થા બનાવો"
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Messages sent over time"
 msgid "Message with code"
 msgstr "સમયની સાથે મોકલાયેલા સંદેશો"
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr "લિંક"
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr "સંપર્ક સપોર્ટ"
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr "માંથી"
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr "સંસ્થાઓ"
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr "વિષય"
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr "સંદેશ"
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr "સબમિટ"
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr "અમારો સંપર્ક કરવા માટે આભાર"
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr "અમારો સંપર્ક કરવા માટે આભાર!"
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr "અમે તમારી સાથે તેમજ તમારી સાથે જલદીથી સં."
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
@@ -1463,13 +950,13 @@ msgstr ""
 "href=\"/help/\">જુલિપ મદદ કેન્દ્રમાં</a> આપત્તિજનક કાર્યકર્તાઓ અથવા ખરાબ કાર્યકર્તાઓ "
 "સમાવિષ્ટ થઈ શકે છે."
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 #, fuzzy
 #| msgid "Getting started"
 msgid "Get started"
 msgstr "શરૂ થવું"
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
@@ -1478,49 +965,48 @@ msgstr ""
 "આ ટીમ ચેટ હવે Zulip Cloud પર હોસ્ટ થઈ રહ્યું છે. આગળ વધવા માટે, કૃપા કરીને <a "
 "href=\"https://zulip.com/policies/terms\">Zulip સેવાની શરતો</a> સ્વીકારો."
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr "અથવા, વૈકઅપ ફોનમાંથી એકનો ઉપયોગ કરો:"
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr "છેલ્લી આશાનું ઉપયોગ કરીને, તમે બેકઅપ ટોકનનો ઉપયોગ કરી શકો છો:"
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr "બેકઅપ ટોકન ઉપયોગ કરો"
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr "સેવાની શરતો સ્વીકારો"
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr "જુલિપમાં આપનું સ્વાગત છે"
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "ઇમેઇલ"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr "મને Zulip ની ઓછી ટ્રેફિક ન્યુઝલેટર (વર્ષમાં થોડી ઇમેઇલ્સ) સબ્સ્ક્રાઇબ કરો."
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr "ચાલો"
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr "તમારું ઇમેઇલ સરનામું પુષ્ટિ કરો"
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1530,7 +1016,7 @@ msgstr ""
 "તમારી નોંધણી પૂરી કરવા માટે, તમારા ઇમેઇલ એકાઉન્ટ (<span class=\"user_email semi-"
 "bold\">%(email)s</span>) પર Zulip ના કન્ફર્મેશન ઇમેઇલ માટે ચેક કરો."
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
@@ -1538,30 +1024,30 @@ msgstr ""
 "જો તમને તમારા ઇનબોક્સ અથવા સ્પામ ફોલ્ડરમાં કોઈ પુષ્ટિકરણ ઇમેઇલ જોઈતી નથી, તો અમે તેને "
 "<a href=\"#\" id=\"resend_email_link\">ફરીથી મોકલી શકીએ</a>."
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr ""
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
@@ -1569,38 +1055,37 @@ msgstr ""
 "જો આ સંદેશ ચલે ન જાય, તો પૃષ્ઠને <a class=\"reload-lnk\">રીલોડ</a> કરવાની પ્રયાસ "
 "કરો."
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 "ઝુલિપ લોડ કરતાં ભૂલ. પૃષ્ઠને<a class=\"reload-lnk\">રીલોડ</a> કરવાનો પ્રયાસ કરો."
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr "તમારા ફિલ્ટરો સાથે કોઈ ચર્ચાઓ મેળ ખાયા નથી."
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr "આ દ્રશ્ય હજી સુધી સંદેશોને લોડ કરી રહ્યું છે."
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr "વધુ લોડ કરો"
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr "વિડિયો કૉલ સમાપ્ત થઈ ગઈ"
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr "આપ આવી વિન્ડો બંધ કરી શકો છો."
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr "રૂપરેખાંકન ભૂલ"
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
@@ -1608,7 +1093,7 @@ msgstr ""
 "તમે પ્રથમ સંસ્થા બનાવીને LDAP વાપરીને લોગ ઇન કરવાનો પ્રયાસ કરી રહ્યા છો. કૃપા કરીને "
 "EmailAuthBackend વાપરીને તમારી સંસ્થા બનાવો અને પછી ફરીથી પ્રયાસ કરો."
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1616,206 +1101,199 @@ msgid ""
 "href=\"%(doc_url)s\">documentation</a>."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr "ખાતું મળ્યું નથી"
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr "Zulip એકાઉન્ટ મળ્યું નથી."
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, fuzzy, python-format
 #| msgid "Your account email: %(email)s"
 msgid "No account found for %(email)s."
 msgstr "તમારું એકાઉન્ટ ઇમેઇલ: %(email)s"
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr "બીજા એક એકાઉન્ટ સાથે લોગ ઇન કરો"
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr "નોંધઃ કેવલ રજીસ્ટ્રેશન જારી રાખો"
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Must be a demo organization."
 msgid "Try Zulip in a demo organization"
 msgstr "ડેમો સંસ્થા હોવી જોઈએ."
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Try Zulip now"
 msgid "Try Zulip"
 msgstr "હવે ઝુલિપ પ્રયાસ કરો"
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "નવી સંસ્થા બનાવો"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr "નવી Zulip સંસ્થા બનાવો"
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr "તમારું ઇમેઇલ સરનામું દાખલ કરો"
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr "તમારો ઇમેઇલ"
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr "સંસ્થા પ્રકાર"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr "સંસ્થા ભાષા"
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 #, fuzzy
 #| msgid "Private, shared history"
 msgid "Import chat history?"
 msgstr "ખાનગી, ભાગીદાર ઇતિહાસ"
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr "સંગઠન નામ"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "સંસ્થા URL"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr "ઉપયોગ કરો %(external_host)s"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "અથવા"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "સાઇન અપ"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "ઝુલિપ માટે સાઇન અપ કરો"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr "આ સંસ્થામાં જોડાઈ માટે તમને એક આમંત્રણ જરૂરી છે."
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr "સાઇન અપ કરો %(identity_provider)s સાથે"
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr "પહેલેથી એક ખાતું છે?"
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "લોગ ઇન કરો"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr "ઇમેઇલ સરનામુંની ગોપનીયતા રૂપરેખાંકિત કરો"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
 msgstr ""
 "Zulip તમને આપની ઇમેઇલ સરનામું જોવા માટે સંસ્થાની ભૂમિકાઓને નિયંત્રિત કરવાની મંજૂરી આપે છે."
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
@@ -1823,11 +1301,11 @@ msgstr ""
 "શું તમે આ સંસ્થા માટેની મૂળભૂત રૂપરેખાંકના માટે તમારા ઇમેઇલની ગોપનીયતા સેટિંગને બદલવા માંગો "
 "છો?"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr "તમારું ઇમેઇલ સરનામું કોણ ઍક્સેસ કરી શકે છે"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1837,101 +1315,100 @@ msgstr ""
 "તમે જોઈન થવા પછી આ સેટિંગ પણ <a href=\"%(root_domain_url)s/help/configure-email-"
 "visibility\" target=\"_blank\" rel=\"noopener noreferrer\">બદલી શકો છો</a>."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr "આ ઝુલિપ સંગઠનના પ્રશાસકો આ ઈમેઇલ સરનામું જોઈ શકશે."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
 msgstr "આ ઝુલિપ સંગઠનના પ્રશાસકો અને મોડરેટરો આ ઈમેઇલ સરનામું જોઈ શકશે."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr "આ ઝુલિપ સંગઠનમાં કોઈપણ આ ઈમેઇલ સરનામું જોઈ શકશે નહીં."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr "આ ઝુલિપ સંગઠનમાં અન્ય વપરાશકર્તાઓ આ ઈમેઇલ સરનામું જોઈ શકશે."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "બદલો"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr "નોંધણી"
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr "તમારી સંસ્થા બનાવો"
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr "તમારું ખાતું બનાવો"
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr "<p>નોંધઃ નોંધઃ તમારી ખાતાની વિગતો દાખલ કરો રજીસ્ટ્રેશન પૂર્ણ કરવા માટે.</p>"
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr "તમારી સંસ્થા"
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr "તમારું ખાતું"
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr "સેટિંગ્સ ઇમ્પોર્ટ નહીં કરવી"
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr "અસ્તિત્વમાં રહેલા Zulip એકાઉન્ટમાંથી સેટિંગ્સ ઇમ્પોર્ટ કરો"
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "નામ"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "પાસવર્ડ"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr "તમારો LDAP/એક્ટિવ ડિરેક્ટરી પાસવર્ડ દાખલ કરો."
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr "આ મોબાઇલ એપ્લિકેશન્સ અને અન્ય સાધનો માટે વાપરાય છે જે પાસવર્ડ જરૂરી છે."
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr "પાસવર્ડ શક્તિ"
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr "તમને શું વર્તન છે?"
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
@@ -1940,22 +1417,22 @@ msgstr ""
 "હું <a href=\"%(root_domain_url)s/policies/terms\" target=\"_blank\" "
 "rel=\"noopener noreferrer\">સેવાની શરતોને </a>સ્વીકારું છું."
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr "નિષ્ક્રિય સંસ્થા"
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr ""
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -1963,7 +1440,7 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid ""
@@ -1971,41 +1448,41 @@ msgid ""
 "deleted."
 msgstr "આ સંગઠન નિષ્ક્રિય કરવામાં આવ્યું છે"
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
 "inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
 "administrators</a> to inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid "This organization has been deactivated."
 msgstr "આ સંગઠન નિષ્ક્રિય કરવામાં આવ્યું છે"
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
 "%(support_email)s\">contact Zulip support</a> to reactivate it."
 msgstr ""
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, fuzzy, python-format
 #| msgid ""
 #| "If you have any questions, please contact this Zulip server's "
@@ -2018,15 +1495,15 @@ msgstr ""
 "જો તમારી કોઈ પ્રશ્નો હોય, તો %(support_email)s પર આ ઝુલિપ સર્વરના વ્યવસ્થાપકોનો "
 "સંપર્ક કરો."
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr "ડેસ્કટોપ એપ લોગિન પૂર્ણ કરો"
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr "ડેસ્કટોપ એપ લોગિન પૂર્ણ કરો"
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
@@ -2034,109 +1511,108 @@ msgstr ""
 "તમારી લોગિન પૂર્ણ કરવા માટે તમારા વેબ બ્રાઉઝરનો ઉપયોગ કરો, પછી તમારી લોગિન ટોકન "
 "પેસ્ટ કરવા માટે અહીં આવો."
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr "અહીં ટોકન પેસ્ટ કરો"
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr "સમાપ્ત કરો"
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr "ખોટો ટોકન."
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr "ટોકન સ્વીકાર્ય છે. તમને લોગિન કરવામાં આવી રહ્યું છે…"
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr "ડેસ્કટોપ એપમાં લોગ ઇન કરો"
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 "આપને આ લોગિન ટોકન કૉપિ કરીને તેને આપના Zulip એપ પર પુર્ણ લોગઇન કરવા માટે પાછા આવો:"
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "કૉપી"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr "આપ પછી આ વિન્ડો બંધ કરી શકો છો."
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr "અથવા, તમારા બ્રાઉઝરમાં ચાલો."
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr "અનામિક વપરાશકર્તા"
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr "માલિકો"
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "સંચાલકો"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr "મોડરેટર્સ"
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr "મુખ્ય વપરાશકર્તાઓ"
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "સામાન્ય વપરાશકર્તાઓ"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr "ઇમેઇલ્સને ઇમેઇલ એકાઉન્ટમાં ફોરવર્ડ કરો"
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "બંધ"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "અપડેટ"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr "Zulip"
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr "ડાઇજેસ્ટ"
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
 "<b>%(realm_name)s</b>."
 msgstr "અભિનંદન, તમે નવી ઝુલિપ સંગઠન બનાવ્યું છે: <b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr "જુલિપમાં આપનું સ્વાગત છે!"
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr "તમે Zulip સંસ્થાને જોડાયેલ છો <b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
@@ -2145,43 +1621,43 @@ msgstr ""
 "આપ જુલિપ વેબ, <a href=\"%(apps_page_link)s\">મોબાઇલ અને ડેસ્કટોપ </a>એપ્સમાં લૉગ ઇન "
 "કરવા માટે નીચેની માહિતીનો ઉપયોગ કરશો:"
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr "Organization URL: %(organization_url)s"
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr "તમારું વપરાશકર્તા નામ: %(ldap_username)s"
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr "તમારા LDAP એકાઉન્ટનો ઉપયોગ કરીને લોગ ઇન કરો"
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr "તમારું એકાઉન્ટ ઇમેઇલ: %(email)s"
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr "સંસ્થાને જાઓ"
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
 "href=\"%(getting_user_started_link)s\">getting started guide</a>!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2189,7 +1665,7 @@ msgid ""
 "Zulip</a>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
@@ -2198,28 +1674,28 @@ msgstr ""
 "પ્રશ્નો? અમને મદદ કરવા માટે <a href=\"mailto:%(support_email)s\">અમારો સંપર્ક કરો</"
 "a> —અમે તમને મદદ કરવા માટે ખુશ છીએ!"
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr "%(realm_name)s પર Zulip: તમારી નવી સંગઠન વિગતો"
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr "%(realm_name)s પર Zulip: તમારી નવી ખાતાની વિગતો"
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr "અભિનંદન, તમે નવી ઝુલિપ સંગઠન બનાવ્યું છે: %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr "તમે Zulip સંસ્થાને જોડાયેલ છો %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
@@ -2228,32 +1704,32 @@ msgstr ""
 "આપ જુલિપ વેબ, મોબાઇલ અને ડેસ્કટોપ એપ્સમાં લૉગ ઇન કરવા માટે નીચેની માહિતીનો ઉપયોગ કરશો "
 "(%(apps_page_link)s):"
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
 "(%(getting_user_started_link)s)!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
 "(%(getting_organization_started_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 "પ્રશ્નો? અમારો સંપર્ક કરો %(support_email)s — અમે તમને મદદ કરવા માટે ખૂબ આવડીશું!"
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2262,17 +1738,17 @@ msgstr ""
 "જો તમારી કોઈ પ્રશ્નો હોય, તો %(support_email)s પર આ ઝુલિપ સર્વરના વ્યવસ્થાપકોનો "
 "સંપર્ક કરો."
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr "હાય,"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2280,12 +1756,12 @@ msgid ""
 "password for this account, please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr "પાસવર્ડની પુષ્ટિ કરો અને સેટ કરો"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2294,14 +1770,14 @@ msgstr ""
 "જો તમે આ બદલાવની વિનંતી કરી નથી, તો કૃપા કરીને તમે તત્કાલ અમારાથી સંપર્ક કરો "
 "%(support_email)s."
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 #, fuzzy
 #| msgid "Verify your new email address for your demo Zulip organization"
 msgid "Verify your email address for your Zulip demo organization"
 msgstr "તમારા ડેમો Zulip સંગઠન માટે તમારું નવું ઇમેઇલ સરનામું ચકાસો"
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2310,8 +1786,8 @@ msgstr ""
 "જો તમે આ બદલાવની વિનંતી કરી નથી, તો કૃપા કરીને તમે તત્કાલ અમારાથી સંપર્ક કરો "
 "%(support_email)s."
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2319,66 +1795,66 @@ msgid ""
 "please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr "ઇમેઇલ બદલાવવાની પુષ્ટિ કરો"
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr "તમારું નવું ઇમેઇલ સરનામું પરીક્ષણ કરો %(organization_host)s"
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr "તમે નવી ઝુલિપ સંગઠનની વિનંતી કરી છે:"
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr "સંગઠન પ્રકાર: %(organization_type)s"
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr "તમે હાલમાં Zulip માટે સાઇન અપ કર્યું છે. આશ્ચર્યજનક!"
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, fuzzy
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
 msgstr "નીચેની બટન પર ક્લિક ક"
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr "પૂર્ણ નોંધણી"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr "નવી Zulip સંસ્થા બનાવો"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr "તમારું Zulip એકાઉન્ટ સક્રિય કરો"
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr "નીચેની લિંક પર ક્લિક કરો અને નોંધણી પૂર્ણ કરો."
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
@@ -2387,48 +1863,48 @@ msgstr ""
 "શું તમને પ્રશ્નો અથવા પ્રતિસાદ આપવાની જરૂર છે? અમારો સંપર્ક કરો %(support_email)s — અમે "
 "તમારી મદદ કરવા માટે ખૂબ આવેશ છીએ!"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr "ઇમેઇલ પસંદગીઓ સંચાલિત કરો"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr "માર્કેટિંગ ઇમેઇલથી અનસબ્સ્ક્રાઇબ કરો"
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
 "deactivated, and you will no longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr "વ્યવસ્થાપકો ને નીચેની ટિપ્પણી આપી છે:"
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr "પરિમાર્જન નોટિફિકેશન %(realm_name)s પર ખાતા નિષ્ક્રિય કરવામાં આવ્યું છે"
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr ""
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2436,22 +1912,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because your organization has "
@@ -2467,8 +1943,8 @@ msgstr ""
 "class=\"content_disabled_help_link\" href=\"%(help_url)s\">ઇમેઇલ નોટિફિકેશનમાં "
 "સંદેશની વિષયવસ્તુ દર્શાવવાની સક્ષમતા આપી છે</a>."
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because you have disabled <a "
@@ -2483,40 +1959,40 @@ msgstr ""
 "class=\"content_disabled_help_link\" href=\"%(alert_notif_url)s\">ઇમેઇલ "
 "નોટિફિકેશનમાં સંદેશની વિષયવસ્તુ દર્શાવવાની સક્ષમતા આપી છે</a>"
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, fuzzy, python-format
 #| msgid "Click here to log in to Zulip and catch up."
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr "અપડેટ કરવા માટે અહીં ક્લિક કરો Zulip માં લૉગ ઇન કરો અને સુધારો કરો."
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr "ડાઇજેસ્ટ ઇમેઇલથી અનસબ્સ્ક્રાઇબ કરો"
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr "Zulip ડાઇજેસ્ટ %(realm_name)s માટે"
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2533,8 +2009,8 @@ msgstr ""
 "વિગતો દર્શાવવાની સક્ષમતા આપી છે.\n"
 "વધુ વિગતો માટે %(hide_content_url)s જુઓ.\n"
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2550,7 +2026,7 @@ msgstr ""
 "દર્શાવવાની સક્ષમતા આપી છે.\n"
 "વધુ વિગતો માટે %(alert_notif_url)s જુઓ.\n"
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, fuzzy, python-format
 #| msgid "Click here to log in to Zulip and catch up: %(organization_url)s."
 msgid "Log in to Zulip to catch up: %(organization_url)s."
@@ -2558,35 +2034,32 @@ msgstr ""
 "યુઝરને ગુજરાતીમાં અનુવાદ કરવામાં આવેલ ટેક્સટ છે: \"યુલિપ પર લૉગ ઇન કરવા અને અપડેટ કરવા "
 "માટે અહીં ક્લિક કરો: %(organization_url)s.\""
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr "ઇમેઇલ પસંદગીઓ સંચાલિત કરો"
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr "ડાઇજેસ્ટ ઇમેઇલથી અનસબ્સ્ક્રાઇબ કરો"
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr "સવારી માછલી"
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr "તમારી વિનંતી માટે આભાર!"
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
 "organizations:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
@@ -2595,33 +2068,29 @@ msgstr ""
 "તમારું ઇમેઇલ સરનામું %(email)s ને નીચેના જુલીપ સંગઠનોથી હોસ્ટ કરવામાં આવેલ છે "
 "%(external_host)s:"
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
 "href=\"%(help_reset_password_link)s\">reset your password</a>."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
 "%(external_host)s."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2629,38 +2098,35 @@ msgid ""
 "to find your account."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr "તમારા Zulip એકાઉન્ટ્સ"
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
 "try another way to find your account (%(help_logging_in_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr "હાય અહીં,"
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
@@ -2669,18 +2135,18 @@ msgstr ""
 "%(referrer_name)s તમને Zulip પર જોડાવવાની મંજૂરી આપે છે &mdash; એન્ટરપ્રાઇઝ માટે "
 "ડિઝાઇન કરવામાં આવેલ ટીમ સંચાર સાધન."
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr "શરૂ કરવા માટે, નીચેની બટન પર ક્લિક કરો."
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 "%(referrer_full_name)s ને તમને %(referrer_realm_name)s માં જોડાવવાની આમંત્રણ આપ્યું છે"
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
@@ -2689,17 +2155,17 @@ msgstr ""
 "%(referrer_full_name)s (%(referrer_email)s) તમને Zulip પર જોડાવવા માંગે છે - એને "
 "ટીમ સંચાલન સાધન જેમાં ઉત્પાદકતા માટે રચાયેલ છે."
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr "શરૂ કરવા માટે, નીચેની લિંક પર ક્લિક કરો."
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr "ફરીથી હાય,"
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
@@ -2708,13 +2174,13 @@ msgstr ""
 "આ એક મિત્રતાપૂર્ણ યાદી છે કે %(referrer_name)s તમને Zulip પર તેમની સાથે જોડાવવા માંગે "
 "છે &mdash; ઉત્પાદકતા માટે ડિઝાઇન કરવામાં આવેલ ટીમ સંચાલન સાધન."
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr "આ આમંત્રણ માટે તમે મેળવશો તેની છેલ્લ."
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
@@ -2723,13 +2189,13 @@ msgstr ""
 "આ નિમંત્રણ બે દિવસમાં સમાપ્ત થાય છે. જો નિમંત્રણ સમાપ્ત થાય તો, તમને બીજો માંગવું પડશે "
 "%(referrer_name)s થી."
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr ""
 "યાદદાશ્ત: જોડાવા માટે %(referrer_name)s સાથે %(referrer_realm_name)s પર જોડાઓ"
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2739,7 +2205,7 @@ msgstr ""
 "આ એક મિત્રતાપૂર્ણ યાદી છે કે %(referrer_name)s (%(referrer_email)s) તમને Zulip પર "
 "તેમની સાથે જોડાવવા માંગે છે -- ઉત્પાદકતા માટે ડિઝાઇન કરવામાં આવેલ ટીમ સંચાલન સાધન."
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2748,7 +2214,7 @@ msgstr ""
 "જો તમારી કોઈ પ્રશ્નો હોય, તો આ ઝુલિપ સર્વરના પ્રશાસકોનો સંપર્ક કરો <a href=\"mailto:"
 "%(email)s\">%(email)s</a>."
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
@@ -2757,13 +2223,13 @@ msgstr ""
 "શું તમને પ્રશ્નો અથવા પ્રતિસાદ આપવાની જરૂર છે? <a href=\"mailto:%(email)s\">અમારો "
 "સંપર્ક કરો</a> —અમે તમારી સહાય કરવા માટે ખૂબ આવીશ છીએ!"
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr "તમને આ મોકલવામાં આવ્યો છે કારણ કે તમને વ્યક્તિગતરીત ઉલ્લેખ કરવામાં આવ્યો છે."
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
@@ -2771,18 +2237,16 @@ msgstr ""
 "તમને આ મેળવવામાં આવી છે કારણ કે @%(mentioned_user_group_name)s ને ઉલ્લેખ કરવામાં આવ્યો "
 "હતો."
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
 "#%(channel_name)s > %(topic_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
@@ -2790,15 +2254,15 @@ msgstr ""
 "તમે આ પ્રાપ્ત કરી રહ્યા છો કારણ કે તમે તમારા અનુસરવામાં આવતા વિષયો માટે વાઇલ્ડકાર્ડ "
 "ઉલ્લેખ સૂચનાઓને સક્ષમ કર્યા છે."
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
@@ -2806,15 +2270,15 @@ msgstr ""
 "તમે આ પ્રાપ્ત કરી રહ્યા છો કારણ કે તમે તમારા અનુસરવામાં આવતા વિષયો માટે ઇમેઇલ સૂચનાઓને "
 "સક્ષમ કર્યા છે."
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2825,7 +2289,7 @@ msgstr ""
 "%(realm_name)s Zulip</a>, or <a href=\"%(notif_url)s\">manage email "
 "preferences</a>."
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
@@ -2834,7 +2298,7 @@ msgstr ""
 "<a href=\"%(narrow_url)s\">જુલિપમાં જુઓ અથવા જવાબ આપો %(realm_name)s</a>, અથવા "
 "<a href=\"%(notif_url)s\">ઇમેઇલ પસંદગીઓ વ્યવસ્થાપિત કરો</a>."
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
@@ -2843,7 +2307,7 @@ msgstr ""
 "<a href=\"%(narrow_url)s\">જુલિપમાં %(realm_name)s જુઓ </a>અથવા જવાબ આપો , <a "
 "href=\"%(notif_url)s\">અથવા ઇમેઇલ પસંદગીઓ વ્યવસ્થાપિત કરો</a>."
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
@@ -2852,41 +2316,41 @@ msgstr ""
 "આ ઇમેઇલને જવાબ આપતા ન રહેવું. આ ઝુલિપ સર્વર પ્રવેશિત થવા માટે રૂપરેખાંકિત નથી (<a "
 "href=\"%(url)s\">મદદ</a>)."
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr "સાથે %(direct_message_group_display_name)s સાથે સમૂહ DMs"
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr "DMs with %(sender_str)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr "નવા સંદેશ"
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr "આ ઇમેઇલને સીધા જવાબ આપો અથવા તેને %(realm_name)s Zulip માં જુઓ:"
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr "View or reply in %(realm_name)s Zulip:"
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr "જવાબ આપો %(realm_name)s Zulip માં:"
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
@@ -2894,7 +2358,7 @@ msgstr ""
 "આ ઇમેઇલને જવાબ આપતા નહીં કરવું. આ ઝુલિપ સર્વર આવતા ઇમેઇલો સ્વીકારવા માટે રૂપરેખિત નથી. "
 "મદદ:"
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2905,22 +2369,22 @@ msgstr ""
 "બદલાવની વિનંતી તમે કરી નથી, તો કૃપા કરીને તમે તમારી સાથે તકનીકી સહાય માટે તમારો "
 "સંપર્ક તક જરૂરી છે %(support_email)s."
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr "શ્રેષ્ઠ,"
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr "ટીમ Zulip"
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr "Zulip ઈમેઇલ %(realm_name)s માટ"
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2931,52 +2395,52 @@ msgstr ""
 "બદલાવની વિનંતી તમે કરી નથી, તો કૃપા કરીને તમે તમારી સાથે તકનીકી સહાય માટે તમારો "
 "સંપર્ક તક જરૂરી છે %(support_email)s."
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 msgstr "સંસ્થાનું: %(organization_url)s સમય: %(login_time)s ઇમેઇલ: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr "અમે નીચેના જુલિપ એકાઉન્ટ માટેની હાલમાંથી લોગઇનની નોંધ લીધી છે."
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr "સંસ્થા: %(organization_link)s"
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr "ઇમેઇલ: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr "સમય: %(login_time)s"
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr "ઉપકરણ: %(device_browser)s પર %(device_os)s."
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr "IP સરનામું: %(device_ip)s"
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr "જો આ તમારી કરતાં હતી, સરસ! તમારે કંઈ બીજું કરવું નથી."
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2987,31 +2451,31 @@ msgstr ""
 "કરીને તમારો પાસવર્ડ રીસેટ કરો <a href=\"%(reset_link)s\">અહીંથી</a> અથવા તમારી "
 "સાથે તત્કાલ સંપર્ક કરો %(support_email)s."
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr "આભાર,"
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr "Zulip સુરક્ષા"
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr "લોગિન સૂચનાઓથી અનસબ્સ્ક્રાઈબ કરો"
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr "નવી લોગઇન %(device_browser)s પર %(device_os)s પરથી"
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr "સંસ્થા: %(organization_url)s"
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3022,7 +2486,7 @@ msgstr ""
 "કરીને તમારો પાસવર્ડ રીસેટ કરો %(reset_link)s પર અથવા તમારી સાથે તત્કાલ સંપર્ક કરો "
 "%(support_email)s પર."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -3030,7 +2494,7 @@ msgid ""
 "Zulip</a> to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
@@ -3038,7 +2502,7 @@ msgstr ""
 "અન્યથા, અહીં કેટલાક સલાહો છે જે અમે સામાન્યતઃ ગ્રાહકોને <i>સામાન્ય</i> ટીમ ચેટ ઉત્પાદની "
 "મૂલ્યાંકન માટે સાંભળીએ છીએ:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
@@ -3047,12 +2511,12 @@ msgstr ""
 "<a href=\"%(invite_users)s\"><b>તમારા ટીમમેટ્સને આમંત્રિત</b></a> કરો અને તમારી "
 "સાથે અનુભવો અને તેમની વિશેષ દૃષ્ટિકોણો વહેંચો."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr "તમારા છાપામાં તમારી છાપાની વિશેષાંક વિશે ચેટ કરવા માટે એપનો ઉપયોગ કરો."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -3063,7 +2527,7 @@ msgstr ""
 "b></a>, કોઈપણ અન્ય ચેટ સાધનોનો ઉપયોગ કરતાં નહીં. આ નવી ચેટ એપ તમારી ટીમને કેવી રીતે "
 "સંવાદ કરવામાં મદદ કરશે તે અનુભવવાની એકમાત્ર રીત છે."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -3074,27 +2538,27 @@ msgstr ""
 "સંપર્ક કરવાની માટે, અને અમે આશા કરીએ છીએ કે આ ટીપ્સ તમારા ટીમને તેને અમલમાં લાવવામાં મદદ "
 "કરે."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr "આપને %(realm_name)s માટેના સ્વાગત ઇમેઇલોથી અનસબ્સ્ક્રાઈબ થવું"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr "તમારા ટીમ માટે ચેટ એપ પસંદ કરવું છે"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
@@ -3102,7 +2566,7 @@ msgstr ""
 "અન્યથા, અહીં કેટલાક સલાહો છે જે અમે સામાન્યતઃ ગ્રાહકોને સામાન્ય ટીમ ચેટ ઉત્પાદની મૂલ્યાંકન "
 "માટે સાંભળીએ છીએ:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
@@ -3110,7 +2574,7 @@ msgstr ""
 "તમારા ટીમમેટ્સને તમારી સાથે અન્વેષણ કરવા અને તેમની વિશિષ્ટ દૃષ્ટિકોણો વહેંચવા માટે આમંત્રિત "
 "કરો."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
@@ -3119,7 +2583,7 @@ msgstr ""
 "તમારા ટીમની સાથે એક સપ્તાહની ટ્રાયલ ચલાવો, કોઈપણ અન્ય ચેટ સાધનોનો ઉપયોગ કરતાં નહીં. "
 "આ એકમાત્ર રીત છે કે નવી ચેટ એપ તમારી ટીમને કેવી રીતે સંવાદ કરવામાં મદદ કરશે તે અનુભવવાની."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
@@ -3127,8 +2591,8 @@ msgstr ""
 "Zulip ડિઝાઇન કરેલ છે કે પ્રભાવશાળી સંવાદ સાધની સાથે સંપર્ક કરવાની માટે, અને અમે આશા "
 "કરીએ છીએ કે આ ટીપ્સ તમારા ટીમને તેને અમલમાં લાવવામાં મદદ કરે."
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
@@ -3138,84 +2602,84 @@ msgstr ""
 "કામ કરી શકે છે તે શોધવામાં તમારી મદદ કરવા માટે આ ગાઇડને ચેક કરો. તેમના જેવા સંગઠનો માટે "
 "મુખ્ય Zulip વ્યાપારના વૈશિષ્ટ્યો માટે આ ગાઇડ જોઈને આવો!"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr "વ્યાપારો માટે Zulip ગાઈડ જુઓ"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr "ઓપન-સોર્સ પ્રોજેક્ટ્સ માટે Zulip ગાઈડ જુઓ"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr "શિક્ષણ માટે Zulip ગાઇડ જુઓ"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr "શોધ માટે Zulip ગાઈડ જુઓ"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr "ઈવેન્ટ્સ અને કોન્ફરન્સો માટે ઝુલિપ ગાઈડ જુઓ"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr "નોન-પ્રોફિટ્સ માટે ઝુલિપ ગાઈડ જુઓ"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr "સમુદાયો માટે Zulip ગાઇડ જુઓ"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr "વ્યાપારો માટે Zulip ગાઈડ જુઓ"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr "ઓપન-સોર્સ પ્રોજેક્ટ્સ માટે Zulip ગાઈડ જુઓ"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr "શિક્ષણ માટે Zulip ગાઇડ જુઓ"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr "શોધ માટે Zulip ગાઈડ જુઓ"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr "ઈવેન્ટ્સ અને કોન્ફરન્સો માટે ઝુલિપ ગાઈડ જુઓ"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr "નોન-પ્રોફિટ્સ માટે ઝુલિપ ગાઈડ જુઓ"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr "સમુદાયો માટે Zulip ગાઇડ જુઓ"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
 msgstr "ટોપિસ સાથે તમારા Zulip વાર્તાઓને સંગઠિત રાખવા માટે કેટલાક ટીપ્સ છે."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
@@ -3223,12 +2687,12 @@ msgstr ""
 "વિષયોનો ઉપયોગ કરીને, તમે એક સમયે એક સંવાદ વાંચી શકો છો. તમે જો કોઈ પણ વિવિધ ચર્ચાઓ "
 "ચાલી રહી હોય, તો તમે પ્રત્યેક સંદેશને સંદર્ભમાં જોઈ શકશો."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3236,11 +2700,11 @@ msgid ""
 "about…?”"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr "ટ્રાન્સલેશન કરવામાં આવેલ ટેક્સટ: ટૂંકા વિષયોના ઉદાહરણો"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3249,23 +2713,23 @@ msgid ""
 "href=\"%(move_channels_link)s\">move a topic to a different channel</a>."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr "જુલિપ પર જાઓ"
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr "વિષયો સાથે તમારી વાર્તાઓને સંગઠિત રાખો"
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3274,23 +2738,23 @@ msgid ""
 "(%(move_channels_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
 "%(email)s on %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr "તમારો પાસવર્ડ રીસેટ કરવા માટે નીચેની બટન પર ક્લિક કરો."
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr "પાસવર્ડ રીસેટ કરો"
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3301,18 +2765,18 @@ msgstr ""
 "એક સંસ્થા પ્રશાસકનો સંપર્ક કરી શકો છો જેથી તમારું <a href=\"%(help_link)s\">એકાઉન્ટ "
 "પુનઃસક્રિય થાય</a>."
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr "તમારી આ જુલીપ સંસ્થામાં ખાતું નથી."
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr "તમારી પાસે નીચેની સંસ્થા(ઓ)માં સક્રિય ખાતાઓ છે."
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
@@ -3320,29 +2784,29 @@ msgstr ""
 "તમે ઉપરાંત સંસ્થા(ઓ)માં લૉગિન કરવા અથવા તમારો પાસવર્ડ રીસેટ કરવા માટે પ્રયાસ કરી શકો "
 "છો."
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr "જો તમે આ પ્રવૃત્તિને ઓળખતા નથી, તો તમે આ ઇમેઇલને સાવધાન."
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr "%(realm_name)s માટે પાસવર્ડ રીસેટ વિનંતી"
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr "તમારો પાસવર્ડ રીસેટ કરવા માટે નીચેની લિંક પર ક્લિક કરો."
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
 "You can contact an organization administrator to reactivate your account."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3352,7 +2816,7 @@ msgstr ""
 "તમારી સંસ્થા, %(organization_name_with_link)s, વિનામૂલ્ય ચૂકવણીઓ કારણે Zulip Cloud "
 "મફત યોજનામાં ડાઉનગ્રેડ થઈ ગઈ છે. વિનામૂલ્ય ચૂકવણીઓ નિષ્ફળ થઈ ગઈ છે."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
@@ -3361,7 +2825,7 @@ msgstr ""
 "જુલિપ ક્લાઉડ માનક પ્લાન પર ચાલી રહ્યા માટે, કૃપા કરીને %(upgrade_url)s પર જઈને ફરીથી "
 "અપગ્રેડ કરો."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
@@ -3370,8 +2834,8 @@ msgstr ""
 "જો તમને લાગે કે આ ભૂલ હતી અથવા વધુ વિગતો જોઈએ, તો કૃપા કરીને અમારી સાથે સંપર્ક કરો "
 "%(support_email)s."
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid "You've joined the Zulip organization %(realm_name)s."
 msgid ""
@@ -3379,104 +2843,104 @@ msgid ""
 "%(localized_date)s."
 msgstr "તમે Zulip સંસ્થાને જોડાયેલ છો %(realm_name)s."
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr "પ્રિય %(realm_name)s ના પૂર્વ વ્યવસ્થાપકો,"
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip demo organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr "તમારી સંસ્થાને પુનઃસક્રિયાત કરવા માટે નીચેની બટન પર ક્લિક કરો."
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr "નિષ્ક્રિય સંસ્થા પુનઃસક્રિય કરો"
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
@@ -3484,21 +2948,21 @@ msgstr ""
 "જો વિનંતી ભૂલથી થઈ હતી, તો તમે કોઈ પણ ક્રિયા કરી શકતા નથી અને આ લિંક 24 કલાકમાં "
 "સમાપ્ત થશે."
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Reactivate your Zulip organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "તમારી Zulip સંગઠનને ફરીથી સક્રિય કરો"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr "તમારી Zulip સંગઠનને ફરીથી સક્રિય કરો"
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr "તમારી સંસ્થાને પુનઃસક્રિયાત કરવા માટે નીચેની લિંક પર ક્લિક કરો."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3507,20 +2971,20 @@ msgstr ""
 "તમે, અથવા તમારી પ્રતિનિધિત્વમાં કોઈએ જુલીપ પ્લાન મેનેજ કરવા માટે લોગ ઇન લિંકની વિનંતી "
 "કરી છે <b>%(remote_server_hostname)s</b>."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, fuzzy
 #| msgid "Click the link below to log in."
 msgid "Click the button below to log in."
 msgstr "લૉગ ઈન કરવા માટે નીચેની લિંક પર ક્લિક કરો."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr "આ લિંક %(validity_in_hours)s કલાકમાં સમાપ્ત થશે."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
@@ -3529,11 +2993,11 @@ msgstr ""
 "પ્રશ્નો? <a href=\"%(billing_help_link)s\">વધુ જાણો</a> અથવા સંપર્ક કરો "
 "%(billing_contact_email)s."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr "ઝુલિપ પ્લાન મેનેજમેન્ટમાં લોગ ઇન કરો"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3542,12 +3006,12 @@ msgstr ""
 "તમે, અથવા તમારી પ્રતિનિધિત્વમાં કોઈએ જુલીપ પ્લાન મેનેજ કરવા માટે લોગ ઇન લિંકની વિનંતી "
 "કરી છે %(remote_server_hostname)s."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr "લૉગ ઈન કરવા માટે નીચેની લિંક પર ક્લિક કરો."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
@@ -3556,7 +3020,7 @@ msgstr ""
 "પ્રશ્નો? વધુ માહિતી મેળવો %(billing_help_link)s પર અથવા સંપર્ક કરો "
 "%(billing_contact_email)s."
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
@@ -3565,16 +3029,16 @@ msgstr ""
 "તમારી ઇમેઇલ ખાતરી કરવા અને Zulip પ્લાન મેનેજમેન્ટમાં લૉગ ઇન કરવા માટે નીચેની બટન પર "
 "ક્લિક કરો: <b>%(remote_realm_host)s</b>."
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr "પુષ્ટિ કરો અને લોગ ઇન કરો"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr "ઝુલિપ યોજના વ્યવસ્થાપન માટે ઇમેઇલ ની પુષ્ટિ કરો"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
@@ -3583,7 +3047,7 @@ msgstr ""
 "તમારી ઇમેઇલ ખાતરી કરવા અને Zulip પ્લાન મેનેજમેન્ટમાં લૉગ ઇન કરવા માટે નીચેની લિંક પર "
 "ક્લિક કરો: %(remote_realm_host)s."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
@@ -3592,7 +3056,7 @@ msgstr ""
 "તમારી Zulip સ્પોન્સરશિપનું અરજીનું મંજૂર થયું છે! તમારા સંસ્થાને <a "
 "href=\"%(plans_link)s\">Zulip સમુદાય યોજના</a> પર અપગ્રેડ કરવામાં આવી છે."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
@@ -3601,12 +3065,12 @@ msgstr ""
 "જો તમે તમારા <a href=\"%(link_to_zulip)s\">વેબસાઇટ પર સ્પોન્સર તરીકે Zulip નું નમુનું "
 "બનાવી શકતા હો</a>, તો અમે તેનો ખૂબ આભારી થીશું!"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr "કમ્યુનિટી પ્લાન સ્પોન્સરશિપ %(billing_entity)s માટે મંજૂર કરાઈ છે!"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
@@ -3614,27 +3078,27 @@ msgstr ""
 "તમારો Zulip સ્પોન્સરશિપનો અરજી મંજૂર થઈ ગયો છે! તમારી સંસ્થા Zulip કમ્યુનિટી પ્લાન પર "
 "ઉપગ્રાડ થઇ ગઈ છે."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
 msgstr ""
 "જો તમે તમારી વેબસાઇટ પર Zulip ને એક સ્પોન્સર તરીકે યાદ કરી શકો, તો અમે ખૂબ આભારી થીશું!"
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr "તમારા એકાઉન્ટ્સ શોધો"
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr "તમારા Zulip એકાઉન્ટ્સ શોધો"
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
@@ -3643,234 +3107,234 @@ msgstr ""
 "જો તમને ઇમેઇલ મેળવવું નાંભતું હોય,<a href=\"%(current_url)s\"> તો તમે બીજી ઇમેઇલ "
 "સરનામાને માટે એકાઉન્ટ્સ શોધી શકો છો</a>."
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr "ઇમેઇલ સરનામું"
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "એકાઉન્ટ્સ શોધો"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr "ઉત્પાદન"
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr "કેટલાક Zulip"
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr "લક્ષણો"
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr "યોજનાઓ અને ભાવનીયતા"
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Zulip Cloud status"
 msgid "Zulip Cloud"
 msgstr "Zulip ક્લાઉડ સ્થિતિ"
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr "સ્વ-હોસ્ટિંગ"
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr "સુરક્ષા"
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "એક્સથાન"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr "ડેસ્કટોપ અને મોબાઇલ એપ્લિકેશન્સ"
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr "નવી સંસ્થા"
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr "સમાધાનો"
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr "વ્યાપાર"
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr "શિક્ષણ"
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr "શોધ"
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr "ઘટનાઓ અને સમારોહો"
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr "ખુલ્લી સોર્સ પ્રોજેક્ટ્સ"
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr "સમુદાયો"
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr "ગ્રાહક વૃત્તાંતો"
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr "ખુલ્લી સમુદાયો"
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr "સ્ત્રોતો"
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr "શરૂ થવું"
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr "મદદ કેન્દ્ર"
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr "સમુદાય ચેટ"
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr "Zulip ક્લાઉડ સ્થિતિ"
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr "Zulip સર્વર સ્થાપિત કરી રહ્યા છો"
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr "Zulip સર્વર અપગ્રેડ કરી રહ્યા છો"
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr "યોગદાન"
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr "યોગદાન ગાઈડ"
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr "ડેવલપમેન્ટ સમુદાય"
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr "ભાષાંતર"
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr "GitHub"
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr "અમારા વિશે"
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr "ટીમ"
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "ઇતિહાસ"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr "મૂલ્યો"
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr "નોકરીઓ"
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr "બ્લોગ"
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr "Zulip સપોર્ટ"
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr "માસ્ટોડોન"
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr "લિંકેડઇન"
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Values"
 msgid "Bluesky"
 msgstr "મૂલ્યો"
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr "પાવર્ડ બાય <a href=\"https://zulip.com\">Zulip</a>"
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr "સેવાની શરતો"
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr "ગોપનીયતા નીતિ"
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr "વેબસાઇટ પ્રમાણિકતાઓ"
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr "ઓવર %(integrations_count_display)s નેટિવ એન્ટિગ્રેશન્સ."
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 #, fuzzy
 #| msgid ""
 #| "And hundreds more through <a href=\"/integrations/doc/zapier\">Zapier</a> "
@@ -3882,51 +3346,47 @@ msgstr ""
 "અને હજારો વધારે માધ્યમિક <a href=\"/integrations/doc/zapier\">Zapier</a> અને <a "
 "href=\"/integrations/doc/ifttt\">IFTTT</a> દ્વારા."
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr "એન્ટિગ્રેશન્સ શોધો"
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr "કસ્ટમ એન્ટિગ્રેશન્સ"
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr "ઇનકમિંગ વેબહુક્સ"
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr "ઇન્ટરએક્ટિવ બોટ્સ"
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr "REST API"
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr "અમાન્ય ઇમેઇલ"
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr "ઇમેઇલ અનુમત નથી"
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr "તમે સાઇન અપ કરવા માટે જોઈ રહ્યા ઇમેઇલ સરનામું માન્ય નથી."
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3934,7 +3394,7 @@ msgid ""
 "emails with your email domain."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3942,7 +3402,7 @@ msgid ""
 "disposable email addresses."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3950,24 +3410,24 @@ msgid ""
 "emails that contain \"+\"."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr "કૃપા કરીને માન્ય ઇમેઇલ સરનામું વપરાશી સાઇન અપ કરો."
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr "કૃપા કરીને મંજૂર ઇમેઇલ સરનામું વપરાશી સાઇન અપ કરો."
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3975,7 +3435,7 @@ msgid ""
 "%(support_email)s\">contact Zulip support</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3983,71 +3443,71 @@ msgid ""
 "%(support_email)s\">contact this Zulip server's administrators</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
 "management for your Zulip server."
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr "અયોગ્ય અથવા અવધારણ લોગિન સત્ર"
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr "અયોગ્ય અથવા અવધારણ લોગિન સત્ર."
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr "ઝુલિપમાં લોગ ઇન કરો"
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr "આ ઈમેઇલ સરનામાથી તમે પહેલાંથી રજીસ્ટર કર્યું છે. નીચે લોગ ઇન કરો."
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr "ઈમેઇલ અથવા યુઝરનેમ"
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "યુઝરનેમ"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr "તમારો પાસવર્ડ ભૂલ્યો છે?"
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr "%(identity_provider)s સાથે લોગ ઇન કરો"
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr "એક એકાઉન્ટ વિનાનું જોવો"
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr "હજી સુધી એક એકાઉન્ટ નથી? તમારે આ સંગઠનમાં શામેલ થવા માટે આમંત્રણ મળવું જોઈએ."
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr "કોઈ લાયસન્સ ઉપલબ્ધ નથી"
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr "સંગઠન હવે નવા સભ્યોને સ્વીકારી શકતું નથી"
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> because all Zulip Cloud licenses are in use."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
@@ -4055,19 +3515,19 @@ msgstr ""
 "કૃપા કરીને તમને આમંત્રિત કરેલા વ્યક્તિથી સંપર્ક કરો અને તેમને લાયસન્સોની સંખ્યા વધારવા માટે "
 "વિનંતી કરો, પછી ફરીથી પ્રયત્ન કરો."
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr "મુખ્ય વિષયને પર્યાય કરો"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr "પ્રમાણીકરણ સબડોમેન ત્રુટિ"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr "પ્રમાણીકરણ સબડોમેન ત્રુટિ"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -4076,44 +3536,42 @@ msgid ""
 "or misconfiguration."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 #, fuzzy
 #| msgid "New organization"
 msgid "Demo organizations disabled"
 msgstr "નવી સંસ્થા"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr "અપડેટ જરૂરી છે"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr "નવીનતમ વેર્શન ડાઉનલોડ કરો."
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr "સંગઠન સૃષ્ટિની લિંક જરૂરી છે"
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -4121,22 +3579,21 @@ msgid ""
 "organization for more information."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr "સંસ્થા સૃષ્ટિનું લિંક સમાપ્ત થયું અથવા અમાન્ય છે"
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr "અનપેક્ષિત Zulip સર્વર નો નોંધણી"
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, fuzzy, python-format
 #| msgid ""
 #| "Your organization is registered to a different Zulip server. Please "
@@ -4149,49 +3606,47 @@ msgstr ""
 "તમારું સંગઠન એક વિવિધ Zulip સર્વરમાં નોંધવામાં આવ્યું છે. આ સમસ્યા સુધારવા માટે કૃપા કરીને "
 "Zulip સપોર્ટ સંપર્ક કરો."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr "અસમર્થિત બ્રાઉઝર"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, fuzzy, python-format
 #| msgid "Presence is not supported for bot users."
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr "બોટ વપરાશકર્તા માટે હાજરી આધારિત સેવાઓ સપોર્ટ કરતું નથી."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
 "a> like Firefox, Chrome, and Edge."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr "ખાતું નિષ્ક્રિય કરવામાં આવ્યું છે"
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Invalid organization"
 msgid "Finalize organization import"
 msgstr "અયોગ્ય સંસ્થા"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Organization not registered"
 msgid "Organization import completed!"
 msgstr "સંગઠન નોંધાયું નથી"
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -4199,56 +3654,55 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Select your account"
 msgstr "તમારું ખાતું બનાવો"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Create new account"
 msgstr "તમારું ખાતું બનાવો"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr "સંસ્થા સફળતાથી પુનઃસક્રિય થઈ ગઈ"
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr "તમારી સંસ્થા સફળતાથી પુનઃસક્રિય થઈ ગઈ છે."
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr "સંસ્થા પુનઃસક્રિય લિંક સમાપ્ત થઈ ગઈ અથવા અમાન્ય છે"
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr "સંસ્થા પુનઃસક્રિય લિંક સમાપ્ત થઈ ગઈ છે અથવા અમાન્ય છે."
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr "તમારી સંસ્થામાં લૉગ ઇન કરો"
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr "તમારું સંસ્થા URL જાણતા નથી?"
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr "તમારી સંસ્થા શોધો."
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr "આગળ"
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4256,24 +3710,24 @@ msgid ""
 "have one yet."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 #, fuzzy
 #| msgid "Self-host Zulip"
 msgid "Self-hosting Zulip?"
 msgstr "સ્વ-હોસ્ટ ઝુલિપ"
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">log in to manage plans and billing.</a>"
 msgstr ""
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr "તમારો પાસવર્ડ રીસેટ કરો"
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
@@ -4281,62 +3735,62 @@ msgstr ""
 "તમારો પાસવર્ડ ભૂલી ગયો છે? કોઈ સમસ્યા નથી, અમે તમારો પાસવર્ડ રીસેટ કરવાની લિંક તમારે "
 "તમારી સાઇન અપ કરેલી ઇમેઇલ પર મોકલીશું."
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr "રીસેટ લિંક મોકલો"
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr "નવો પાસવર્ડ સેટ કરો"
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "પાસવર્ડ ખાતરી કરો"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr "ખેડૂત, તમે આપેલી લિંક અમાન્ય છે અથવા પહેલાથી વપરાયેલ છે."
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr "નવો પાસવર્ડ સફળતાથી સેટ કરવામાં આવ્યો"
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr "તમે નવો પાસવર્ડ સેટ કર્યો છે!"
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr "કૃપા કરીને તમારો નવો પાસવર્ડથી <a href=\"%(login_url)s\">લૉગ ઇન</a> કરો."
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr "પાસવર્ડ રીસેટ ઇમેઇલ મોકલી છે"
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr "પાસવર્ડ રીસેટ મોકલે છે!"
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr "પ્રક્રિયાને પૂર્ણ કરવા માટે થોડા મિનિટ્સ માં તમારી ઇમેઇલ ચેક કરો."
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 #, fuzzy
 #| msgid "Export still in progress"
 msgid "Import progress"
 msgstr "એક્સપોર્ટ હજુ પણ પ્રગતિ માં છે"
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4344,7 +3798,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4353,60 +3807,60 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 #, fuzzy
 #| msgid ""
 #| "Nobody in this Zulip organization will be able to see this email address."
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr "આ ઝુલિપ સંગઠનમાં કોઈપણ આ ઈમેઇલ સરનામું જોઈ શકશે નહીં."
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4414,7 +3868,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4422,20 +3876,20 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr "પ્રમાણીકરણ માટે ખાતું પસંદ કરો"
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr "<h1 class=\"get-started\">ખાતા પસંદ કરો</h1>"
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr "તમારા GitHub એકાઉન્ટમાં અપ્રમાણિત ઇમેઇલ સરનામાઓ પણ જોડાયેલા છે."
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
@@ -4444,21 +3898,21 @@ msgstr ""
 "href=\"https://github.com/settings/emails\">ગીથબ સાથે ચકાસો </a>આપીને માન્ય "
 "કરવો જોઈએ."
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr "ઈમેઇલ થાય છે ત્રુટિ રદ કરવામાં આવી છે"
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr "અજ્ઞાત ઇમેઇલ અનસબ્સ્ક્રાઇબ વિનંતી"
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
 msgstr "હાય અહીં! તમે શુંબન્ધ થવા માટે પ્રયત્ન કર્યું છે, પરંતુ અમે URL ને ઓળખતા નથી."
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4469,134 +3923,131 @@ msgstr ""
 "href=\"mailto:%(support_email)s\">અમને ઇમેઇલ</a> કરો અને અમે આ સમસ્યાને સમાધાન "
 "કરીશું!"
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr "ઇમેઇલ સેટિંગ્સ અપડેટ થઈ ગયાં છે"
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
 "href=\"%(realm_url)s/#settings/notifications\">notification settings</a>."
 msgstr ""
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr "અમાન્ય ક્રમ મેપિંગ."
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr ""
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr ""
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr ""
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr "સાઇન અપ્સ"
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr "{user} આ સંસ્થાની સાથે જોડાઈ ગયા છે."
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr "{user} તમારો આમંત્રણ Zulipમાં જોડાવા સ્વીકાર કર્યો છે!"
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 "એક ટાળાટ એકાઉન્ટને સક્રિય કરી શકાતો નથી; વપરાશકર્તાને સાઇન અપ કરવા વિનંતી કરો માટે."
 "બદલાઈ તરીકે."
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 #, fuzzy
 #| msgid "Cannot deactivate the only {entity}."
 msgid "Cannot reactivate a deleted user"
 msgstr "એકમાત્ર {entity} ને નિષ્ક્રિય કરી શકાતું નથી."
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr "ક્ષેત્ર id {id} મળ્યું નથી."
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr ""
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr ""
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr ""
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
@@ -4604,7 +4055,7 @@ msgstr ""
 "વપરાશકર્તાઓને સુરક્ષિત રાખવા માટે, Zulip તમે એક દિવસમાં કેટલાક નિમંત્રણો મોકલી શકો છો, "
 "પરંતુ તમે મર્યાદા પર પહોંચ્યા છો, તેથી કોઈ નિમંત્રણો મોકલાઈ નથી."
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
@@ -4612,75 +4063,75 @@ msgstr ""
 "આ સંસ્થા માટે નિમંત્રણો મોકલવા માટે તમારું એકાઉન્ટ ખૂબ નવું છે. સંસ્થા પ્રશાસક, અથવા એક વધુ "
 "અનુભવી વપરાશકર્તાને વિનંતી કરો."
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr "કેટલાક ઇમેઇલ માન્ય ન થયા, તેથી અમે કોઈ નિમંત્રણો મોકલ્યા નથી."
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr "અમે કોઈને નિમંત્રણો મોકલી શક્યા નથી."
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr "કંઈપણ બદલવા નથી"
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr ""
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr "ડાયરેક્ટ સંદેશોમાં વિષયો ન હોઈ શકે."
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr "વિષય સંપાદન વિનાનું અમાન્ય propagate_mode"
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr ""
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr "વિજેટ્સ સંપાદિત નથી."
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr "તમારી સંસ્થાને સંદેશ સંપાદન બંધ કરી દીધું છે"
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr "તમારી આ સંદેશને સંપાદિત કરવાની પરવાનગી નથી"
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr "આ સંદેશને સંપાદિત કરવાની સમયસર પસાર થઇ ગયો છે"
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr "{user} ને આ વિષયને સ્થિર તરીકે ચિહ્નિત કર્યો છે."
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr "{user} ને આ વિષયને અસ્થિર તરીકે ચિહ્નિત કર્યો છે."
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr "આ વિષય {user} દ્વારા {new_location} માં ખસેડાયો હતો."
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr "આ વિષયમાંથી એક સંદેશ {user} દ્વારા {new_location} માં ખસેડાયો હતો."
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
@@ -4689,18 +4140,18 @@ msgstr ""
 "{changed_messages_count} સંદેશો આ વિષયમાંથી {user} દ્વારા {new_location} માં "
 "ખસેડાયા હતા."
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr "આ વિષય {user} દ્વારા {old_location} માંથી આવ્યો હતો."
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 msgstr "[એક સંદેશ]({message_link}) {user} દ્વારા {old_location} માંથી આવ્યો હતો."
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
@@ -4709,74 +4160,71 @@ msgstr ""
 "{changed_messages_count} સંદેશો {old_location} થી {user} દ્વારા અહીં ખસેડવામાં "
 "આવ્યા છે."
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 #, fuzzy
 #| msgid "You don't have permission to delete this message"
 msgid "You don't have permission to resolve topics in this channel."
 msgstr "તમારી પાસે આ સંદેશ માટે મિટાવવાની મંજૂરી નથી"
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr "આ સંદેશનું વિષય એડિટ કરવાનો સમય સમાપ્ત થયો છે."
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr "આ સંદેશને ખસેડવાની પરવાનગી નથી"
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr ""
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr "અમાન્ય ધ્વજ: '{flag}'"
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr "ધ્વજ એડિટ કરી શકાય તે નથી: '{flag}'"
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr "અમાન્ય સંદેશ ધ્વજ કાર્યવાહી: '{operation}'"
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr "અમાન્ય સંદેશ(ઓ)"
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr "સંદેશનું રીંડર કરી શકાતું નથી"
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr "પ્રાપ્તિગૃહીતાઓ માટે અમાન્ય ડેટા પ્રકાર"
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr "પ્રાપ્તિગૃહીત યાદીમાં ઇમેઇલ અથવા વપરાશકર્તા ID હોઈ શકે છે, પરંતુ બેમાં નથી."
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
 "but there is no channel with that ID."
 msgstr ""
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4784,36 +4232,36 @@ msgid ""
 "it."
 msgstr ""
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
 "The channel exists but does not have any subscribers."
 msgstr ""
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr "તમને પ્રાપ્તિગૃહીતો માંથી કેટલાક પરવાનગી નથી."
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr "વિજેટ્સ: API પ્રોગ્રામર અમાન્ય JSON માહિતી મોકલી"
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr "વિજેટ્સ: {error_msg}"
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4821,66 +4269,64 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr "આ નામવાળો ખાસ ઇમોજી પહેલેથી અસ્તિત્વમાં છે."
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr "ક્રમબદ્ધ યાદીમાં સંદર્ભાત્મક પ્રકારકર્તાઓ નથી હોવી"
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 "ક્રમબદ્ધ યાદીમાં બધા અસ્તિત્વમાં હોય તેવા સંદર્ભાત્મક પ્રકારકર્તાઓનું નિર્દ્ધારણ એકવાર થવું "
 "જોઈએ"
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
 "authentication method."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr "અમાન્ય પ્રમાણીકરણ પદ્ધતિ: {name}. માન્ય પદ્ધતિઓ છે: {methods}"
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr ""
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr "શેડ્યુલ્ડ સંદેશ પહેલેથી મોકલાયો હતો"
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder could not be sent."
 msgstr "ટોકન અસ્તિત્વ નથી"
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr "સંદેશ શેડ્યુલ્ડ સમયમાં મોકવું નથી."
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
@@ -4888,45 +4334,45 @@ msgid ""
 msgstr ""
 "{delivery_datetime} માટે તમે શેડ્યુલ્ડ કર્યો સંદેશ નીચેની ભૂલ માટે મોકવામાં આવ્યો નથી:"
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr "[શેડ્યુલ્ડ સંદેશો જુઓ](#scheduled)"
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr ""
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr ""
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr ""
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr ""
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
 "**{old_policy}** to **{new_policy}**."
 msgstr ""
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -4935,51 +4381,49 @@ msgid ""
 "* **New**: {new_setting_description}\n"
 msgstr ""
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr "વર્ણન નથી."
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr ""
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr "જૂનો વર્ણન"
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr "નવો વર્ણન"
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr "સદા"
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr ""
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 msgstr ""
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr ""
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -4990,99 +4434,89 @@ msgid ""
 "{summary_line}"
 msgstr ""
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr "તમે આ સંદેશ પર એક સબસંદેશ જોડી શકતા નથી."
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr "અમાન્ય વપરાશકર્તા આઈડી {user_id}"
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr "વપરાશકર્તા ગ્રુપ '{group_name}' પહેલેથી અસ્તિત્વમાં છે."
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr "અપૂર્ણ પરવાનગી"
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr "આ API આવર્તન વેબહુક બોટ્સ માટે ઉપલબ્ધ નથી."
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr "એકાઉન્ટ આ ઉપનામ સાથે જોડાયેલ નથી"
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr "આ ઇન્ડપોઇન્ટ બોટ વિનંતીઓને સ્વીકારતું નથી."
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr "સર્વર પ્રશાસક હોવું જોઈએ"
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr "આ ઇન્ડપોઇન્ટ HTTP મૂળભૂત પ્રમાણિકરણની જરૂર છે."
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr "મૂળભૂત પ્રમાણિકરણ માટે અમાન્ય અધિકૃત શીર્ષક"
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr "મૂળભૂત પ્રમાણિકરણ માટે ગુનતાસૂચક હેડર અનુપસ્થિત છે"
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr "વેબહૂક બોટ્સ ફક્ત વેબહૂક એક્સેસ કરી શકે છે"
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr ""
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
@@ -5091,62 +4525,61 @@ msgstr ""
 "તમારું ખાતું {username} નિષ્ક્રિય કરવામાં આવ્યું છે. કૃપા કરીને તમારો સંગઠન પ્રબંધકનો સંપર્ક "
 "કરો તેને પુનઃસક્રિય કરવા માટે."
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr "પાસવર્ડ ખૂબ કમજોર છે."
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr "સબડોમેનને લાંબાઈ 3 અથવા તેથી વધુ હોવી જરૂરી છે."
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr "સબડોમેન '-' દ્વારા શરૂ કરી શકે છે અથવા સમાપ્ત થવું જરૂરી નથી."
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr "સબડોમેનમાં ફક્ત લોઅરકેસ અક્ષરો, અંક અને '-' હોવું જરૂરી છે."
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr "સબડોમેન આરક્ષિત છે. કૃપા કરીને અલગ એક પસંદ કરો."
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr "કૃપા કરીને તમારો વાસ્તવિક ઇમેઇલ સરનામું ઉપયોગ કરો."
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr "તમે {email} વાપરીને જોઈન થવાનો પ્રયાસ કરી રહ્યાં છો તે સંગઠન અસ્તિત્વમાં નથી."
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr "કૃપા કરીને સંગઠન પ્રબંધકનીથી {email} માટે એક આમંત્રણનો વિનંતી કરો."
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
 "to register for accounts in this organization."
 msgstr "તમારું ઇમેઇલ સરનામું, {email}, આ સંગઠનમાં ખાતા નોંધાવવા માટે માન્ય ડોમેન્સમાં નથી."
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr "આ સંગઠનમાં + સાથે સમાવિષ્ટ ઇમેઇલ સરનામું માન્ય નથી."
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
@@ -5156,34 +4589,33 @@ msgstr ""
 "કરીને તમને આમંત્રિત કરેલ વ્યક્તિનો સંપર્ક કરો અને તેમને લાયસન્સીની સંખ્યાને વધારવાની વિનંતી "
 "કરો, પછી ફરીથી પ્રયાસ કરો."
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 #, fuzzy
 #| msgid "Embedded bots are not enabled."
 msgid "Challenges are not enabled."
 msgstr "એમ્બેડેડ બોટ્સ સક્રિય નથી."
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "નવો પાસવર્ડ"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr "નવો પાસવર્ડ પુષ્ટિકરણ"
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "You're making too many attempts to sign in. Try again in {seconds} "
@@ -5195,7 +4627,7 @@ msgstr ""
 "તમે પ્રવેશ કરવા માટે ખૂબ વધારે પ્રયાસો કરી રહ્યાં છો. {seconds} સેકન્ડમાં ફરીથી પ્રયાસ "
 "કરો અથવા તમારા સંગઠનના પ્રબંધકનો સંપર્ક કરો."
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
@@ -5203,91 +4635,89 @@ msgstr ""
 "તમારો પાસવર્ડ ખૂબ કમજોર છે તેથી તમારો પાસવર્ડ નિષ્ક્રિય કરવામાં આવ્યો છે. તમારો પાસવર્ડ "
 "રીસેટ કરો અને નવો બનાવો."
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr "ટોકન"
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr "સૂચના: તમે તેમના વચ્ચે કોમા સાથે ઘણાં ઇમેઇલ સરનામો દાખલ કરી શકો છો."
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr "કૃપા કરીને સૌથી જૂનું 10 ઇમેઇલ સરનામો દાખલ કરો."
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr "અમે ઓળખી નથી કે તે ઝુલિપ સંગઠન."
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr "અયોગ્ય ઇમેઇલ '{email}'"
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr "વિષય ગુમ છે"
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr ""
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr ""
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr "સંદેશમાં પ્રાપ્તિકર્તાઓ હોવી જોઈએ"
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr "અયોગ્ય સંદેશ પ્રકાર"
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr "અયોગ્ય અટેચમેન્ટ"
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr "અટેચમેન્ટ ડિલીટ કરતી વખતે એક ભૂલ આવી. કૃપા કરીને પછી ફરીથી પ્રયાસ કરો."
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr "સંદેશ પ્રાપ્તિકર્તાઓ ધરાવો જ જરૂરી છે!"
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "User group name can't be empty!"
 msgid "Channel folder name can't be empty."
 msgstr "વપરાશકર્તા ગ્રુપ નામ ખાલી ન હોઈ શકે!"
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid character in topic, at position {position}!"
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr "વિષયમાં અમાન્ય અક્ષર, સ્થાન {position} પર!"
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Invalid data export ID"
 msgid "Invalid channel folder ID"
 msgstr "અમાન્ય ડેટા એક્સપોર્ટ આઈડી"
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 #, fuzzy
 #| msgid "Confirm your email address"
 msgid "Configure owner account email address."
 msgstr "તમારું ઇમેઇલ સરનામું પુષ્ટિ કરો"
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| " Congratulations, you have created a new demo Zulip organization. Note "
@@ -5303,72 +4733,72 @@ msgstr ""
 "દ્વારા આપોઆપ કાઢવામાં આવશે. ડેમો સંસ્થાઓ વિશે વધુ માહિતી માટે અહીં ક્લિક કરો "
 "%(demo_organizations_help_link)s!"
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a date"
 msgid "{var_name} is not Base64 encoded"
 msgstr "{var_name} તારીખ નથી"
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 #, fuzzy
 #| msgid "Invalid emoji code."
 msgid "Invalid `device_id`"
 msgstr "અયોગ્ય ઇમોજી કોડ."
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr "{service_name} ડાઈજેસ્ટ"
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr "ડોમેન ખાલી ન હોઈ."
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr "ડોમેનમાં ઓછામાં ઓછું એક ડોટ (.) હોવું જરૂરી છે"
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr "ડોમેન ખૂબ લાંબુ છે"
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr "ડોમેન ડોટ (.) સાથે શરૂ અથવા સમાપ્ત ન થઈ શકે"
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr "એક પછીના '.' નામાં નિષ્ક્રિય છે."
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr "સબડોમેન ડેશમાં શરૂ અથવા સમાપ્ત થવું જ નહીં."
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr "ડોમેનમાં ફક્ત અક્ષરો, અંક, '.' અને '-' હોવું જ જરૂરી છે."
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr "ટાઇમસ્ટેમ્પ નકારાત્મક ન હોઈ."
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr "વિષયમાં નલ બાઇટ્સ ન હોવું જોઈએ"
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr "વપરાશકર્તાને ડ્રાફ્ટ્સ સમન્વય અનિષ્ક્રિય કર્યો છે."
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr "ડ્રાફ્ટ અસ્તિત્વમાં નથી"
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5376,261 +4806,259 @@ msgid ""
 "{error_message}"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr "સ્પોઇલર સામગ્રી જોવા માટે ઝુલીપ ખોલો"
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr "{service_name} સૂચનાઓ"
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr "અયોગ્ય સરનામું."
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr "તમારા ડોમેન બહાર."
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr "+ સાથે સમાવિષ્ટ ઇમેઇલ સરનામું માન્ય નથી."
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr "સિસ્ટમ બોટ્સ માટે આપાતવારી છે."
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr "{email} પહેલેથી ખાતું છે"
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr "પહેલેથી ખાતું છે."
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr "ખાતું નિષ્ક્રિય કરવામાં આવ્યું છે."
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr "ઇમોજી '{emoji_name}' અસ્તિત્વમાં નથી"
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr "અયોગ્ય કસ્ટમ ઇમોજી."
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr "અયોગ્ય કસ્ટમ ઇમોજી નામ."
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr "આ કસ્ટમ ઇમોજી નિષ્ક્રિય કરવામાં આવ્યું છે."
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr "અયોગ્ય ઇમોજી કોડ."
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr "અયોગ્ય ઇમોજી નામ."
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr "અયોગ્ય ઇમોજી પ્રકાર."
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr "એક સંગઠન પ્રબંધક અથવા ઇમોજી લેખક હોવું જરૂરી છે"
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr "ઇમોજી નામો બીજું લેખન અથવા અંક સાથે પૂર્ણ થવો જોઈએ."
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
 msgstr ""
 "ઇમોજી નામોમાં ફક્ત લોઅરકેસ અંગ્રેજી અક્ષરો, અંક, જગ્યાઓ, ડેશ, અને અન્ડરસ્કોર હોવું જોઈએ."
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr "ઇમોજી નામ ગુમ છે"
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr "ઈવેન્ટ યૂનિવર્સ આવાજો આવંટા નથી"
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr "લોગ ઇન નથી: API પ્રમાણિકરણ અથવા વપરાશકર્તા સેશન જરૂરી છે"
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, fuzzy, python-brace-format
 #| msgid "User group '{group_name}' already exists."
 msgid "Channel '{channel_name}' already exists"
 msgstr "વપરાશકર્તા ગ્રુપ '{group_name}' પહેલેથી અસ્તિત્વમાં છે."
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr "સંગઠન માલિક"
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr "વપરાશકર્તા"
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr "એકમાત્ર {entity} ને નિષ્ક્રિય કરી શકાતું નથી."
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr "અયોગ્ય માર્કડાઉન સામેલ કરો સ્ટેટમેન્ટ: {include_statement}"
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr "અયોગ્ય JSON"
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr "એક સંગઠન પ્રબંધક હોવું જોઈએ"
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr "એક સંગઠન માલિક હોવું જોઈએ"
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Must be an organization owner"
 msgid "Must be a bot user"
 msgstr "એક સંગઠન માલિક હોવું જોઈએ"
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr "તમારું વપરાશકર્તાનામ અથવા પાસવર્ડ અમાન્ય છે"
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr "આ સંગઠન નિષ્ક્રિય કરવામાં આવ્યું છે"
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr "તમારા સર્વર માટે મોબાઇલ પુશ સૂચના સેવા નોંધણી નિષ્ક્રિય કરવામાં આવ્યું છે"
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr "આ સંગઠનમાં પાસવર્ડ પ્રમાણિકરણ નિષ્ક્રિય કરેલું છે"
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr "તમારું પાસવર્ડ નિષ્ક્રિય કરવામાં આવ્યું છે અને રીસેટ કરવાની જરૂર છે"
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr "અયોગ્ય API કી"
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr "અયોગ્ય API કી"
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
 "webhook; ignoring"
 msgstr "'{event_type}' ઇવેન્ટ હાલમાં {webhook_name} વેબહૂક દ્વારા સપોર્ટેડ નથી; અવગણવું"
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr "વિનંતી પાર્સ કરી શકાતી નથી: ક્યારેય {webhook_name} આ ઇવેન્ટ બનાવ્યો હતો?"
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr "વપરાશકર્તા પ્રમાણિત નથી"
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr "અયોગ્ય સબડોમેન"
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr "આ સંસ્થામાં ડાયરેક્ટ સંદેશો અક્ષમ કરાયા છે."
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr ""
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr "પ્રવેશ નિષ્કર્ષિત"
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
@@ -5639,15 +5067,15 @@ msgstr ""
 "તમે ફક્ત આ વિષયમાં સૌથી હાલના સંદેશો {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} માત્ર ખસાના સંદેશો નક્કી કરવા માટે પરવાનગી છે."
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr "પ્રતિક્રિયા પહેલેથી અસ્તિત્વમાં છે."
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr "પ્રતિક્રિયા અસ્તિત્વમાં નથી."
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
@@ -5655,365 +5083,365 @@ msgstr ""
 "તમારું સંગઠન એક વિવિધ Zulip સર્વરમાં નોંધવામાં આવ્યું છે. આ સમસ્યા સુધારવા માટે કૃપા કરીને "
 "Zulip સપોર્ટ સંપર્ક કરો."
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr "સંગઠન નોંધાયું નથી"
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr "આ વિષયમાં વિષય વાઈલ્ડકાર્ડ ઉલ્લેખ કરવાની પરવાનગી નથી."
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr ""
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr "'{setting_name}' એ સિસ્ટમ વપરાશકર્તા ગ્રુપ હોવું જોઈએ."
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr ""
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr "શેડ્યુલ્ડ વિતરણ સમય ભવિષ્યમાં હોવો જોઈએ."
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Server doesn't use the push notification service"
 msgid "Server is not configured to use push notification service."
 msgstr "સર્વર પુશ નોટિફિકેશન સેવાનો ઉપયોગ નથી કરે"
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Already has an account."
 msgid "Atlassian account ID"
 msgstr "પહેલેથી ખાતું છે."
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Behance username"
 msgstr "ખરાબ નામ અથવા વપરાશકર્તા નામ"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Bitbucket username"
 msgstr "GitHub વપરાશકર્તાનામ"
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Codeberg username"
 msgstr "ટ્વિટર વપરાશકર્તાનામ"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Dribbble username"
 msgstr "GitHub વપરાશકર્તાનામ"
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Facebook username"
 msgstr "ખરાબ નામ અથવા વપરાશકર્તા નામ"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr "GitHub વપરાશકર્તાનામ"
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "GitLab username"
 msgstr "GitHub વપરાશકર્તાનામ"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Instagram username"
 msgstr "ટ્વિટર વપરાશકર્તાનામ"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Mastodon"
 msgid "Mastodon profile"
 msgstr "માસ્ટોડોન"
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Medium username"
 msgstr "GitHub વપરાશકર્તાનામ"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Pinterest username"
 msgstr "ટ્વિટર વપરાશકર્તાનામ"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Reddit username"
 msgstr "GitHub વપરાશકર્તાનામ"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Snapchat username"
 msgstr "GitHub વપરાશકર્તાનામ"
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Threads username"
 msgstr "ટ્વિટર વપરાશકર્તાનામ"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "TikTok username"
 msgstr "ટ્વિટર વપરાશકર્તાનામ"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Twitch username"
 msgstr "ટ્વિટર વપરાશકર્તાનામ"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "યુઝરનેમ"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr "અયોગ્ય બાહ્ય એકાઉન્ટ પ્રકાર"
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr "એક્સટેગ્રેશન ફ્રેમવર્ક્સ"
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 #, fuzzy
 #| msgid "Video call ended"
 msgid "Video calling"
 msgstr "વિડિયો કૉલ સમાપ્ત થઈ ગઈ"
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr "ચિલંતિત એક્સટ્રાક્ટિવ"
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr "ગ્રાહક સપોર્ટ"
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr "ડિપ્લોયમેન્ટ"
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr "મનોરંજન"
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr "સંચાર"
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr "આર્થિક"
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr "માનવ સંસાધનો"
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr "માર્કેટિંગ"
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr "વિવિધ"
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr "નિગરાણ"
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr "પ્રોજેક્ટ વ્યવસ્થાપન"
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr "ઉત્પાદકતા"
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr "આવૃત્તિ નિયંત્રણ"
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr "સંદેશ ખાલી ન હોવો"
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr "સંદેશ નલ બાઈટ્સ સમાવી નહીં શકે"
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{fullname} moderation"
 msgstr "{full_name} ને તમને ઉલ્લેખ કર્યો:"
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr "અયોગ્ય સંક્ષિપ્ત ઓપરેટર: {desc}"
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr ""
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr ""
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr "ગુમ થયેલ 'એંકર' તરફથી માહિતી નથી."
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 #, fuzzy
 #| msgid "Missing 'anchor' argument."
 msgid "Missing 'anchor_date' argument."
 msgstr "ગુમ થયેલ 'એંકર' તરફથી માહિતી નથી."
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr "અયોગ્ય એન્કર"
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr "ઓપરેટર {operator} આધારિત નથી."
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr ""
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 #, fuzzy
 #| msgid "Confirmation link does not exist"
 msgid "Navigation view does not exist."
 msgstr "પુષ્ટિકરણ લિંક અસ્તિત્વમાં નથી"
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6021,7 +5449,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6029,7 +5457,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6037,7 +5465,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6045,7 +5473,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| " Congratulations, you have created a new demo Zulip organization. Note "
@@ -6062,14 +5490,14 @@ msgstr ""
 "દ્વારા આપોઆપ કાઢવામાં આવશે. ડેમો સંસ્થાઓ વિશે વધુ માહિતી માટે અહીં ક્લિક કરો "
 "%(demo_organizations_help_link)s!"
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
 "them in your [Inbox](/#inbox).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6077,7 +5505,7 @@ msgid ""
 "({navigation_tour_video_url}) for a quick app overview.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6092,14 +5520,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -6107,7 +5535,7 @@ msgid ""
 "and edit your [profile information](/help/edit-your-profile).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -6118,7 +5546,7 @@ msgid ""
 "experience in your [Preferences](#settings/preferences).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6129,7 +5557,7 @@ msgid ""
 "[Browse and subscribe to channels]({settings_link}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -6146,7 +5574,7 @@ msgid ""
 "discussed.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -6155,7 +5583,7 @@ msgid ""
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -6167,7 +5595,7 @@ msgid ""
 "times, and more.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6177,7 +5605,7 @@ msgid ""
 "or browse the [help center](/help/) to learn more!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6185,7 +5613,7 @@ msgid ""
 "get help, try one of the following messages: {bot_commands}\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6197,13 +5625,13 @@ msgid ""
 "({move_content_another_channel_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6217,12 +5645,11 @@ msgid ""
 "and above.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr ""
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -6230,14 +5657,14 @@ msgid ""
 "no matter how many other conversations are going on.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
 "conversations with unread messages.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -6245,7 +5672,7 @@ msgid ""
 "the `+` button next to its name.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -6253,13 +5680,13 @@ msgid ""
 "can we chat about…?”\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6267,7 +5694,7 @@ msgid ""
 "({format_message_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6287,914 +5714,896 @@ msgid ""
 "```\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
 "teammates.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
 "conversation.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr ""
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr ""
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr ""
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr "પ્રતિસાદમાં અમાન્ય JSON"
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr "અમાન્ય પ્રતિસાદ ફોર્મેટ"
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr "ખાલી અથવા અમાન્ય લંબાઈ ટોકન"
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr "અમાન્ય APNS ટોકન"
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr "બૌન્સર માટે અમાન્ય GCM વિકલ્પ: પ્રાથમિકતા {priority!r}"
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr "બૌન્સર માટે અમાન્ય GCM વિકલ્પો: {options}"
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr "ટોકન અસ્તિત્વ નથી"
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr "{full_name} ને @{user_group_name} ઉલ્લેખ કર્યો:"
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr "{full_name} ને તમને ઉલ્લેખ કર્યો:"
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr "{full_name} ને તમામને ઉલ્લેખ કર્યો:"
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "નવો સંદેશ"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr "ટેસ્ટ સૂચના"
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr "ડિવાઇસ ઓળખવામાં નહીં આવ્યું"
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr "પુશ બાઉન્સર દ્વારા ડિવાઇસ ઓળખવામાં નહીં આવ્યું"
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 #, fuzzy
 #| msgid "Server doesn't use the push notification service"
 msgid "Network error while connecting to Zulip push notification service."
 msgstr "સર્વર પુશ નોટિફિકેશન સેવાનો ઉપયોગ નથી કરે"
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 #, fuzzy
 #| msgid "Server doesn't use the push notification service"
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr "સર્વર પુશ નોટિફિકેશન સેવાનો ઉપયોગ નથી કરે"
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 #, fuzzy
 #| msgid "Invalid API key"
 msgid "Invalid `push_key`"
 msgstr "અયોગ્ય API કી"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr "આ પ્રશ્ન માટે વપરાશકર્તાને અધિકૃત નથી"
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr "'{email}' આવાસ થઇ રહ્યા છે Zulip."
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr "તમે આપની સંસ્થાની બહાર સીધા સંદેશો મોકલી શકતા નથી."
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr "{var_name} ખૂબ લાંબું છે (લિમિટ: {max_length} અક્ષરો)"
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder does not exist"
 msgstr "ટોકન અસ્તિત્વ નથી"
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr "પુશ સૂચનાઓ બાઉન્સર ભૂલ: {error}"
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr "'{var_name1}' અને '{var_name2}' તરફનો વિચાર ન કરી શકાય"
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr "'{var_name}' વિચાર ગુમ છે"
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr "'{var_name}' માટે ખરાબ મૂલ્ય: {bad_value}"
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr "નિર્ધારિત સંદેશ અસ્તિત્વમાં નથી"
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr "{service_name} એકાઉન્ટ સુરક્ષા"
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr ""
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr ""
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 #, fuzzy
 #| msgid "You don't have permission to delete this message"
 msgid "You do not have permission to create new topics in this channel."
 msgstr "તમારી પાસે આ સંદેશ માટે મિટાવવાની મંજૂરી નથી"
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr ""
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr ""
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr ""
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr ""
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr ""
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr "વિષયમાં અમાન્ય અક્ષર, સ્થાન {position} પર!"
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr "છબી ડીકોડ કરી શકતા નથી; શું તમે છબી ફાઈલ અપલોડ કર્યું છે?"
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr "ચિત્ર આકાર મર્યાદા પાર કરે છે."
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr "{var_name} બૂલિયન નથી"
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} does not have a length"
 msgid "{var_name} does not have the expected format"
 msgstr "{var_name} ની લંબાઈ નથી"
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr "{var_name} તારીખ નથી"
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr "{var_name} ડિક્શનરી નથી"
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr "અમાન્ય {var_name}"
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr "{var_name} પર વિનામૂલ્યની વાત \"{argument}\""
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr "{var_name} ફ્લોટ નથી"
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr "{var_name} ખૂબ ઓછું છે"
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr "{var_name} પૂર્ણાંક નથી"
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr "{var_name} માન્ય JSON નથી"
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr "{var_name} ખૂબ મોટું છે"
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr "{var_name} લીસ્ટ નથી"
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr "{var_name} ખૂબ લાંબું છે (લિમિટ: {max_length} અક્ષરો)"
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr "{var_name} ખૂબ છોટું છે."
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr "{var_name} સ્ટ્રિંગ નથી"
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr "{var_name} ખૂબ લાંબું છે (લિમિટ: {max_length} અક્ષરો)"
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr "{var_name} ખૂબ લાંબું છે (લિમિટ: {max_length} અક્ષરો)"
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr "{var_name} ખાલી નથી"
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr "અમાન્ય {var_name}: {msg}"
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr "વ્યર્થરૂપે નામું પાયલો"
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr "{var_name} માન્ય હેક્સ કલર કોડ નથી"
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr "અમાન્ય {setting_name}"
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr "અપલોડ તમારી સંગઠનની અપલોડ કોટા પાર થઈ જશે."
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr ""
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr ""
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr "અમાન્ય વપરાશકર્તા ગ્રુપ"
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid user group ID: {group_id}"
 msgid "Invalid user group ID: {user_group_id}"
 msgstr "અમાન્ય વપરાશકર્તા ગ્રુપ ID: {group_id}"
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr ""
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr "અમાન્ય વપરાશકર્તા ગ્રુપ ID: {group_id}"
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr "'{setting_name}' સેટિંગ 'role:internet' ગ્રુપમાં સેટ કરવામાં આવશે નહીં."
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr "'{setting_name}' સેટિંગ 'role:nobody' ગ્રુપમાં સેટ કરવામાં આવશે નહીં."
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr "'{setting_name}' સેટિંગ 'role:everyone' ગ્રુપમાં સેટ કરવામાં આવશે નહીં."
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr "'{setting_name}' સેટિંગ '{group_name}' ગ્રુપમાં સેટ કરવામાં આવશે નહીં."
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr "વપરાશકર્તા ગ્રુપ નામ ખાલી ન હોઈ શકે!"
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr "વપરાશકર્તા ગ્રુપ નામ {max_length} અક્ષરોથી વધારે હોઈ શકતું નથી."
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr "વપરાશકર્તા ગ્રુપ નામ '{prefix}' સાથે શરૂ નથી થતું."
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr "ક્લાયન્ટ કોઈ પણ નવી મૂલ્યો પાસ કરી નથી."
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 "ક્લાયન્ટ ને પાસ કરવું જરૂરી છે કે તેઓ કોઈ પણ એમોજી કોડ અથવા પ્રતિક્રિયા_પ્રકાર પાસ કરે છે."
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr "નામ ખૂબ લાંબું છે!"
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 #, fuzzy
 #| msgid "Message must not be empty"
 msgid "Name must not be empty!"
 msgstr "સંદેશ ખાલી ન હોવો"
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr "નામમાં અમાન્ય અક્ષરો!"
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr "અમાન્ય ફોર્મેટ!"
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr ""
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr ""
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr "ખરાબ નામ અથવા વપરાશકર્તા નામ"
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr "અમાન્ય એકત્રિત '{integration_name}'."
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr "અમાન્ય સંરચના પેરામીટર્સ: {keys}"
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr "અમાન્ય {key} મૂલ્ય {value} ({error})"
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr "અમાન્ય રૂપરેખાંકન ડેટા!"
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr "અમાન્ય બોટ પ્રકાર"
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr "અમાન્ય ઇન્ટરફેસ પ્રકાર"
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr "અમાન્ય વપરાશકર્તા ID: {user_id}"
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr "આ રીતેનો બોટ નથી"
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr "આ રીતેનો વપરાશકર્તા નથી"
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr "વપરાશકર્તા નિષ્ક્રિય કરેલો છે"
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr "{item} ખાલી ન હોઈ શકે."
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr "{var_name} ગલત લંબાઈ {length}; {target_length} હોવી જોઈએ"
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a string"
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr "{var_name} સ્ટ્રિંગ નથી"
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr "{container} પર exactly {length} આઇટમ્સ હોવી જોઈએ"
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr "{key_name} કી {var_name}માં ગુમ છે"
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr "અનપેક્ત વાતો: {keys}"
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr "{var_name} માન્ય પ્રકાર નથી"
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr "{variable} != {expected_value} ({value} ખોટું છે)"
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr "{var_name} એ URL નથી"
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr "URL પેટર્ન %(username)s માં હોવું જોઈએ."
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr "'{item}' ખાલી ન હોઈ શકે."
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr "ક્ષેત્ર ડ્યુપ્લિકેટ પસંદગીઓ ધરાવી શકતું નથી."
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr "'{value}' '{field_name}' માટે માન્ય પસંદગી નથી."
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr "{var_name} સ્ટ્રિંગ અથવા એક પૂર્ણાંક લિસ્ટ નથી"
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr "{var_name} સ્ટ્રિંગ અથવા પૂર્ણાંક નથી"
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr "{var_name} ની લંબાઈ નથી"
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr "{var_name} ગુમ છે"
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr "HTTP ઇવેન્ટ હેડર '{header}' ગુમ છે"
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, fuzzy, python-brace-format
 #| msgid "Operator {operator} not supported."
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr "ઓપરેટર {operator} આધારિત નથી."
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr "zકમાંડમાં અગર સ્લેશ હોવો જોઈએ."
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr "આવા કમાન્ડ નથી: {command}"
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr "CSRF ત્રુટિ: {reason}"
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr "રિવર્સ પ્રૉક્સી ગલત રૂપરેખાંકન: {proxy_reason}"
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr "ID {user_id} સાથે વપરાશકર્તા નિષ્ક્રિય કર્યો છે"
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr "ID {user_id} સાથે વપરાશકર્તા બોટ છે"
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr "તારીખ"
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr "બહારી એકાઉન્ટ"
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr "પ્રોનાઉન્સ"
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr "કોઈ નહીં"
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr ""
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "સભ્યો"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr ""
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Invalid characters in emoji name"
 msgid "Invalid auto-conversion field: empty field name."
 msgstr "ઇમોજી નામમાં અમાન્ય અક્ષરો"
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr "URL ટેમ્પ્લેટમાં %(name)r ગ્રૂપ લિંકિફાયર પેટર્નમાં હાજર નથી."
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr "ખરાબ નિયમિત અભિવ્યક્તિ: {regex}"
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr "અજ્ઞાત નિયમિત અભિવ્યક્તિ ત્રુટિ"
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr "અમાન્ય URL ટેમ્પ્લેટ."
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid "Example input does not match the linkifier pattern."
 msgstr "URL ટેમ્પ્લેટમાં %(name)r ગ્રૂપ લિંકિફાયર પેટર્નમાં હાજર નથી."
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr "URL ટેમ્પ્લેટમાં %(name)r ગ્રૂપ લિંકિફાયર પેટર્નમાં હાજર નથી."
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr "લિંકિફાયર પેટર્નમાં %(name)r ગ્રૂપ URL ટેમ્પ્લેટમાં હાજર નથી."
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid ""
@@ -7202,7 +6611,7 @@ msgid ""
 "pattern."
 msgstr "URL ટેમ્પ્લેટમાં %(name)r ગ્રૂપ લિંકિફાયર પેટર્નમાં હાજર નથી."
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgid ""
@@ -7210,333 +6619,330 @@ msgid ""
 "template."
 msgstr "લિંકિફાયર પેટર્નમાં %(name)r ગ્રૂપ URL ટેમ્પ્લેટમાં હાજર નથી."
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr "યુનિકોડ ઇમોજી"
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "કસ્ટમ ઇમોજી"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr "Zulip અતિરિક્ત ઇમોજી"
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr "ઇમોજી નામમાં અમાન્ય અક્ષરો"
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr "પાયમેંટ ભાષામાં અમાન્ય અક્ષરો"
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr "URL ટેમ્પ્લેટમાં જરૂરી વેરિએબલ \"કોડ\" ગુમ છે"
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr "\"કોડ\" URL ટેમ્પ્લેટમાં એકમાત્ર વેરિએબલ હોવી જોઈએ"
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr ""
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr ""
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr ""
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr ""
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr "Zulip Cloud Standard પર ઉપલબ્ધ છે. પહોંચ માટે અપગ્રેડ કરો."
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr "Zulip Cloud Plus પર ઉપલબ્ધ છે. પહોંચ માટે અપગ્રેડ કરો."
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr "GIFs રેટેડ G (સામાન્ય સાક્ષાત્કાર) મંજૂર છે"
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr "GIFs રેટેડ PG (માતા-પિતાઓની માર્ગદર્શન) મંજૂર છે"
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr "GIFs રેટેડ PG-13 (માતા-પિતાઓની માર્ગદર્શન - 13 થી ઓછા) મંજૂર છે"
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr "GIFs રેટેડ R (પાબંધિત) મંજૂર છે"
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr "વેબ-પબ્લિક"
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "સાર્વજનિક"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr "ખાનગી, ભાગીદાર ઇતિહાસ"
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr "ખાનગી, સુરક્ષિત ઇતિહાસ"
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr "એડમિન્સ, મોડરેટર્સ, સભ્યો અને મહેમાનો"
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr "એડમિન્સ, મોડરેટર્સ અને સભ્યો"
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr "એડમિન્સ અને મોડરેટર્સ"
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr "ફક્ત એડમિન્સ"
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr "અજ્ઞાત વપરાશકર્તા"
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr "સંસ્થા માલિક"
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr "સંસ્થા પ્રશાસક"
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr "મોડરેટર"
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "સભ્ય"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "મહેમાન"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr "અજ્ઞાત IP સરનામું"
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr "અજ્ઞાત ઓપરેટિંગ સિસ્ટમ"
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr "અજ્ઞાત બ્રાઉઝર"
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr "ગુમ થતી 'queue_id' વાદળું"
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr "ગુમ થતી 'last_event_id' વાદળું"
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr "{event_id} કરતાં નવો ઇવેન્ટ પહેલાથીજ પ્રૂન થઇ ગયો છે!"
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr "ઇવેન્ટ {event_id} આ ક્યુનમાં નથી"
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr "ખરાબ ઇવેન્ટ ક્યૂ આઈડી: {queue_id}"
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 #, fuzzy
 #| msgid "Failed to create Zoom call"
 msgid "Failed to generate challenge"
 msgstr "ઝૂમ કૉલ બનાવવામાં નિષ્ફળ થયું"
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr "આ સંસ્થા માટે JWT પ્રમાણીકરણ સક્રિય કરવામાં આવ્યું નથી"
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr "કોઈ JSON વેબ ટોકન વિનંતીમાં પાસ કરાયો નથી"
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr "ખરાબ JSON વેબ ટોકન"
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr "JSON વેબ ટોકન દાવોમાં કોઈ ઇમેઇલ નિર્દિષ્ટ કર્યો નથી"
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr "ઉપ-ડોમેન જરૂરી છે"
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr "પાસવર્ડ અમાન્ય છે."
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr "વિનંતીમાં યુઝર-એજેન્ટ શીર્ષક ગુમ છે"
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr "લેબલ ખાલી હોઈ શકે નહિં."
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr "ફિલ્ડમાં ઓળખ કમિપને એક હોવું જોઈએ."
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr "પ્રોફાઇલ સારાંશમાં પ્રદર્શન માટે ક્ષેત્ર પ્રકાર સપોર્ટ નથી."
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 #, fuzzy
 #| msgid "Field type not supported for display in profile summary."
 msgid "Field type not supported for use for user matching."
 msgstr "પ્રોફાઇલ સારાંશમાં પ્રદર્શન માટે ક્ષેત્ર પ્રકાર સપોર્ટ નથી."
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr "અમાન્ય ક્ષેત્ર પ્રકાર."
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr "માત્ર 2 કસ્ટમ પ્રોફાઇલ ફિલ્ડ્સ પ્રોફાઇલ સારાંશમાં દર્શાવવામાં આવી શકે છે."
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr "તે લેબલ સાથે એક ક્ષેત્ર પહેલાથીજ અસ્તિત્વમાં છે."
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr "મૂલભૂત કસ્ટમ ક્ષેત્ર અપડેટ."
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr "એન્ડપોઇન્ટ ઉત્પાદન પ્રક્રિયામાં ઉપલબ્ધ નથી."
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr "DevAuthBackend સક્રિય નથી."
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr "અજ્ઞાત વિનંતી માટે અમાન્ય '{key}' પેરામીટર"
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr "ડેટાબેસ ખાલી છે"
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr "પોસ્ટગ્રેસક્યુએલ ક્યુરી કરી શકાતી નથી"
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr "રેબિટએમ્યુએ કનેક્ટ કરી શકાતું નથી"
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr "રેબિટએમ્યુએ ક્યુરી કરી શકાતી નથી"
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr "રેડીસ ક્યુરી કરી શકાતું નથી"
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr "મેમકેશ્ડમાં લખી શકાતું નથી"
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr "મેમકેશ્ડ ક્યુરી કરી શકાતું નથી"
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr "આ જેમ આમંત્રણ નથી"
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 #, fuzzy
 #| msgid "Invitation has already been revoked"
 msgid "Invitation already used or deactivated."
 msgstr "આમંત્રણ પહેલાથીજ પ્રત્યાહ્ય કરવામાં આવ્યું છે"
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr "આમંત્રણ પહેલાથીજ પ્રત્યાહ્ય કરવામાં આવ્યું છે"
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr ""
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr "તમે ઓળખવામાં કમિપને એક ઇમેઇલ સરનામું નક્કી કરવું જોઈએ."
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
@@ -7544,108 +6950,106 @@ msgstr ""
 "તે સરનામાઓમાંથી કેટલાક પહેલેથીજ Zulip વાપરાય છે, તેથી અમે તેમને કોઈ નિમંત્રણો મોકલ્યા "
 "નથી. અમે બાકી બધાને નિમંત્રણો મોકલ્યા!"
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr "આ સંસ્થામાં સંદેશ સંપાદન ઇતિહાસ અક્ષમ કર્યો છે"
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr "તમારી પાસે આ સંદેશ માટે મિટાવવાની મંજૂરી નથી"
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr "આ સંદેશને મિટાવવાની સમયમર્યાદા પાર થઇ ગઈ છે"
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr "સંદેશ પહેલાથીજ રદ કરાયો છે"
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr "ઘણું વધુ સંદેશોની વિનંતી કરી છે (મહત્તમ {max_messages})."
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr "એંકર ફક્ત દાયરાના અંતમાં બહાર કરાયો શકાય છે"
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr "આ પ્રકાર '{topic}' નથી"
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Organization creation link required"
 msgid "An explanation is required."
 msgstr "સંગઠન સૃષ્ટિની લિંક જરૂરી છે"
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Zephyr mirroring is not allowed in this organization"
 msgid "Message reporting is not enabled in this organization."
 msgstr "આ સંસ્થામાં ઝેફાર આઇનોરિંગ મંજૂર નથી"
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr "ગુમ થતો પ્રેષક"
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr "સ્વીકૃત વપરાશકર્તા આઈડીસાથે મિરરિંગ મંજૂર નથી"
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr "અમાન્ય મિરર સંદેશ"
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr ""
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr ""
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr ""
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr "સ્વયંને મ્યુટ કરી શકાતું નથી"
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr "વપરાશકર્તા પહેલેથી મ્યુટ કરવામાં આવ્યો છે"
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr "વપરાશકર્તા મ્યુટ નથી"
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 #, fuzzy
 #| msgid "{hostname} is not a valid hostname"
 msgid "Custom views must have a valid name."
 msgstr "{hostname} માન્ય હોસ્ટનેમ નથી"
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 #, fuzzy
 #| msgid "Reaction already exists."
 msgid "Navigation view already exists."
 msgstr "પ્રતિક્રિયા પહેલેથી અસ્તિત્વમાં છે."
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr "અજ્ઞાત onboarding_step: {onboarding_step}"
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7653,575 +7057,573 @@ msgid ""
 "later. Is this a good time?\n"
 msgstr ""
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr "બોટ વપરાશકર્તા માટે હાજરી આધારિત સેવાઓ સપોર્ટ કરતું નથી."
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr "{user_id_or_email} માટે હાજરી ડેટા નથી"
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr "અમાન્ય સ્થિતિ: {status}"
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 #, fuzzy
 #| msgid "You don't have permission to delete this message"
 msgid "You do not have permission to manage plans and billing."
 msgstr "તમારી પાસે આ સંદેશ માટે મિટાવવાની મંજૂરી નથી"
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr "સર્વર પુશ નોટિફિકેશન સેવાનો ઉપયોગ નથી કરે"
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr "બાઉન્સર દ્વારા એરર: {result}"
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr ""
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr "નીચેના માંથી કમાંડો માંથી નોકરી કરવું જરૂરી છે: એમોજી_નામ, એમોજી_કોડ"
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr "આ સંસ્થામાં રીડ રસીપ્ટ્સ ડિસેબલ કરવામાં આવી છે."
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr "અમાન્ય ભાષા '{language}'"
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr "ઓળખપ્રદ પરિક્રિયાઓ માટે ઓળખપ્રદ પ્રકાર એક અથવા વધુ સક્રિય હોવું જોઈએ."
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr "અમાન્ય વીડિયો ચેટ પ્રોવાઇડર {video_chat_provider}"
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid giphy_rating {giphy_rating}"
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr "અમાન્ય giphy_rating {giphy_rating}"
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr "ડેમો સંસ્થા હોવી જોઈએ."
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr "અમાન્ય ડોમેન: {error}"
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr "ડોમેન {domain} પહેલેથી તમારી સંસ્થાનો ભાગ છે."
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr "ડોમેન {domain} માટે કોઈ એન્ટ્રી મળી નથી."
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr "તમે બધીક એક ફાઇલ અપલોડ કરવી જોઈએ."
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr "ફક્ત વ્યવસ્થાપકો મૂલભૂત ઇમોજી ઓવરરાઇડ કરી શકે છે."
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr "અપલોડ કરેલ ફાઈલ મંજૂર કરેલ {max_size} MiB ના મર્યાદાથી વધારે મોટી છે"
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 #, fuzzy
 #| msgid "JWT authentication is not enabled for this organization"
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr "આ સંસ્થા માટે JWT પ્રમાણીકરણ સક્રિય કરવામાં આવ્યું નથી"
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr "રેટ મર્યાદાને ઓછું કર્યું."
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr "અમાન્ય ડેટા એક્સપોર્ટ આઈડી"
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr "એક્સપોર્ટ પહેલાથીથી ડિલીટ થઇ ગયું છે"
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr "એક્સપોર્ટ અસફળ થયું, ડિલીટ કરવા માટે કંઈ નથી"
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr "એક્સપોર્ટ હજુ પણ પ્રગતિ માં છે"
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr "તમે બધીક એક આઈકોન અપલોડ કરવો જરૂરી છે."
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr "લિંકફાયર મળ્યું નથી."
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr "તમે બધીક એક લોગો અપલોડ કરવો જરૂરી છે."
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid characters in pygments language"
 msgid "Invalid character in language: {character}"
 msgstr "પાયમેંટ ભાષામાં અમાન્ય અક્ષરો"
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid language '{language}'"
 msgid "Language '{language}' is not allowed."
 msgstr "અમાન્ય ભાષા '{language}'"
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr "અમાન્ય ખેળાયાળા"
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "User not authenticated"
 msgid "Unauthenticated"
 msgstr "વપરાશકર્તા પ્રમાણિત નથી"
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "Direct messages"
 msgid "Importing messages…"
 msgstr "સીધા સંદેશો"
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "Your email"
 msgid "Your name"
 msgstr "તમારો ઇમેઇલ"
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr "સ્થિતિ અપડેટ કરવામાં પ્રાપ્તિ જરૂરી છે જ્યારે યોજનાબદ્ધ સંદેશનો પ્રકાર અપડેટ થાય છે."
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr "અમાન્ય અરેજી ફોર્મેટ"
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr "અમાન્ય DSN"
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr ""
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr "\"નવું_વર્ણન\" અથવા \"નવું_ગ્રુપ_નામ\" પાસ કરવું જરૂરી છે."
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr "\"ઓપ\" માટે અમાન્ય મૂલ્ય. \"ઉમેરો\" અથવા \"દૂર કરો\" માંથી એક નિર્દિષ્ટ કરો."
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr "અયોગ્ય પેરામીટર્સ"
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr ""
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr ""
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr "કંઈ કરવાનું નથી. \"ઉમેરો\" અથવા \"ડિલીટ\" માંથી ઓળખો નીચેની એક નિર્દિષ્ટ કરો."
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, fuzzy, python-brace-format
 #| msgid "{user_full_name} added you to the group {group_name}."
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr "{user_full_name} તમને ગ્રુપ {group_name} માં ઉમેર્યું છે."
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr ""
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr ""
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr ""
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
 "**"
 msgstr ""
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr ""
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr "અજ્ઞાત સબ્સ્ક્રિપ્શન ગુણધર્મ: {property}"
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr ""
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr "સબમેસેજ માટે અમાન્ય json"
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr ""
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr "'તો' સારવાર ગુમ થયું"
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr "'તો' ની ખાલી યાદી"
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr "વપરાશકર્તા સિધ્ધા સંદેશો માટે ટાઈપિંગ સૂચનાઓ અક્રિય કર્યા છે"
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr "<p>આ ફાઇલ અસ્તિત્વમાં નથી અથવા તે ડિલીટ કરવામાં આવી છે.</p>"
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr "<p>આ ફાઇલ જોવા માટે તમારી પરવાહકર્તાની પુનરુત્સર્ગ નથી.</p>"
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr "અમાન્ય ટોકન"
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr "અમાન્ય ફાઈલ નામ"
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr "અપલોડ કરવા માટે તમે ફાઈલ નિર્દિષ્ટ કરવી જોઈએ"
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr "તમે ફક્ત એક ફાઈલ અપલોડ કરી શકો છો"
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr "કોઈ નવી ડેટા પૂર્ણ નથી"
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 msgstr ""
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr "{user_full_name} તમને ગ્રુપ {group_name} માં ઉમેર્યું છે."
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr "{user_full_name} તમને ગ્રુપ {group_name} માંથી દૂર કર્યું છે."
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr "વપરાશકર્તા {user_id} આ ગ્રુપનો પહેલો સભ્ય છે"
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr "આ વપરાશકર્તા ગ્રુપમાં '{user_id}' કોઈ સભ્ય નથી"
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr "વપરાશકર્તા ગ્રુપ {group_id} આ ગ્રુપનો એક સબગ્રુપ છે."
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
 "subgroups."
 msgstr "વપરાશકર્તા ગ્રુપ {user_group_id} પાસ કરેલા સબગ્રુપમાંથી પહેલેથી સબગ્રુપ છે."
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr "વપરાશકર્તા ગ્રુપ {group_id} આ ગ્રુપનો સબગ્રુપ નથી."
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr "આ સંસ્થામાં અવતાર બદલાવો બંધ છે."
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr "આ સંસ્થામાં ઇમેઇલ સરનામાના બદલાવો બંધ છે."
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr "અમાન્ય ડિફોલ્ટ ભાષા"
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr "અમાન્ય નોટિફિકેશન આવાજ '{notification_sound}'"
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr "અમાન્ય ઇમેઇલ બેચિંગ અવધિ: {seconds} સેકન્ડ"
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr "તમારો Zulip પાસવર્ડ LDAP માં મેનેજ કરાયો છે"
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr "ખોટો પાસવર્ડ!"
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, fuzzy, python-brace-format
 #| msgid "You're making too many attempts! Try again in {seconds} seconds."
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr "તમે ખૂબ વધુ પ્રયાસ કરી રહ્યા છો! {seconds} સેકન્ડ પછી ફરીથી પ્રયાસ કરો."
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr "નવો પાસવર્ડ ખૂબ દબાણ છે!"
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr "તમે સાચાં એક અવતાર અપલોડ કરવું જ જોઈએ."
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr "વિષય મ્યુટ નથી"
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr "ફક્ત સંસ્થા માલિકને નિષ્ક્રિય કરી શકાતું નથી"
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Nobody in this Zulip organization will be able to see this email address."
 msgid "User is not allowed to delete other user's messages."
 msgstr "આ ઝુલિપ સંગઠનમાં કોઈપણ આ ઈમેઇલ સરનામું જોઈ શકશે નહીં."
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr "ફક્ત સંસ્થા માલિકની માલિકી પરવાનગી કેવી રીતે દૂર કરવામાં આવી શકે તે નથી."
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr ""
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr ""
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
@@ -8234,25 +7636,25 @@ msgstr ""
 "નથી.\n"
 "કૃપા કરીને તમારા સર્વર પ્રશાસકનો સંપર્ક કરો."
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 #, fuzzy
 #| msgid "Email address"
 msgid "Email address already in use"
 msgstr "ઇમેઇલ સરનામું"
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr "માલિક બદલવામાં નિષ્ફળ થયું, આવા વપરાશકર્તા નથી"
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr "માલિક બદલવામાં નિષ્ફળ થયું, વપરાશકર્તા નિષ્ક્રિય છે"
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr "માલિક બદલવામાં નિષ્ફળ થયું, બોટ્સ અન્ય બોટ્સનું માલિક ન બની શકે"
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
@@ -8261,138 +7663,138 @@ msgstr ""
 "નથી.\n"
 "કૃપા કરીને તમારા સર્વર પ્રશાસકનો સંપર્ક કરો."
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr "એમ્બેડેડ બોટ્સ સક્રિય નથી."
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr "અમાન્ય એમ્બેડેડ બોટ્સ નામ."
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr "વપરાશકર્તા વપરાશકર્તા બનાવવા માટે પરવાનગીધારી નથી"
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr "આ સંસ્થામાં '{email}' ઇમેઇલ માન્ય નથી"
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr "એ સંસ્થામાં ડિસ્પોઝબલ ઇમેઇલ સરનામાઓની મંજૂરી નથી"
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom access token"
 msgid "Invalid {provider_name} access token"
 msgstr "અમાન્ય ઝૂમ ઍક્સેસ ટોકન"
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} call"
 msgstr "ઝૂમ કૉલ બનાવવામાં નિષ્ફળ થયું"
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Zoom credentials have not been configured"
 msgid "{provider_name} credentials have not been configured"
 msgstr "ઝૂમ ક્રેડેન્શીયલ્સ રૂપરેખિત થઈ નથી"
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom credentials"
 msgid "Invalid {provider_name} credentials"
 msgstr "અમાન્ય ઝૂમ ક્રેડેન્શીયલ્સ"
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error connecting to the BigBlueButton server."
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr "BigBlueButton સર્વર સાથે કનેક્ટ કરવામાં ભૂલ."
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error authenticating to the BigBlueButton server."
 msgid "Error authenticating to the {provider_name} server"
 msgstr "BigBlueButton સર્વર પ્રમાણીકરણ માટે ભૂલ."
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "BigBlueButton server returned an unexpected error."
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr "BigBlueButton સર્વરે અનપેક્ષિત ભૂલ આપી."
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom session identifier"
 msgid "Invalid {provider_name} session identifier"
 msgstr "અમાન્ય ઝૂમ સેશન ઓળખાણ"
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr ""
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} public room."
 msgstr "ઝૂમ કૉલ બનાવવામાં નિષ્ફળ થયું"
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr "અમાન્ય સહીગારી."
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{full_name}'s Zulip room"
 msgstr "{full_name} ને તમને ઉલ્લેખ કર્યો:"
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr "આ વર્ઝન કંટ્રોલ સિસ્ટમ પ્રોવાઇડરનો ઉપયોગ કરીને પ્રોજેક્ટ્સ સપોર્ટેડ નથી"
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr "અમાન્ય પેયલોડ"
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr "અજ્ઞાત વેબહુક રિક્વેસ્ટ"
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr "વિષય ખાલી ન હોઈ શકે"
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr "કન્ટેન્ટ ખાલી ન હોઈ શકે"
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr ""
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr "અવૈધ JSON ઇનપુટ"
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr "પેયલોડમાં ઈવેન્ટ્સ કી ગુમ છે"
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr "ભૂલ: channels_map_to_topics પેરામીટર 0 અથવા 1 થી બેહર અન્ય છે"
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr "અજ્ઞાત વર્ડપ્રેસ વેબહુક ક્રિયા: {hook}"
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
@@ -8401,153 +7803,153 @@ msgstr ""
 "તમારી માહિતી નિર્યાત પૂર્ણ થઈ ગઈ છે. [નિર્યાતો જુઓ અને ડાઉનલોડ કરો]"
 "({export_settings_link})."
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr ""
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr ""
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr ""
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr ""
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr "પુશ સૂચનાઓ બાઉન્સર માટે અમાન્ય સબડોમેઇન"
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr "માન્ય ઝુલિપ સર્વર API કી સાથે માન્યતા પ્રમાણિત કરવું જોઈએ"
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr "અમાન્ય UUID"
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr "અમાન્ય ટોકન પ્રકાર"
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr "{hostname} માન્ય હોસ્ટનેમ નથી"
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr ""
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr ""
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr ""
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
 "try again later or reach out to {support_email} for assistance."
 msgstr ""
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr ""
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr ""
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr "ગુમ થયેલ ios_app_id"
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr "વપરાશકર્તા ID અથવા વપરાશકર્તા UUID ગુમ થયું છે"
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
 "server: {reason}"
 msgstr "તમારો યોજના પુષ સૂચનાઓ મોકલવાની મંજૂરી નથી. સર્વર દ્વારા આપેલો કારણ: {reason}"
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr "તમારો યોજના પુષ સૂચનાઓ મોકલવાની મંજૂરી નથી."
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr "અમાન્ય ગુણવત્તા {property}"
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr "અમાન્ય ઘટના પ્રકાર."
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr "ડેટા વ્યવસ્થિત નથી."
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr "રિપીટ નોંધણી શોધાયી."
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr "અવૈધ અનુસંધાન લોગ ડેટા"
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr "તમારે તમારો પાસવર્ડ રીસેટ કરવો જોઈએ."
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr "ગુમ થયેલ id_token પેરામીટર"
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 #, fuzzy
 #| msgid "Missing id_token parameter"
 msgid "Missing idp param"
 msgstr "ગુમ થયેલ id_token પેરામીટર"
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr "અમાન્ય OTP"
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr "મોબાઇલ_flow_otp અને ડેસ્કટોપ_flow_otp ને એકસાથે ઉપયોગ કરી શકાય નહિં."
 

--- a/locale/hi/LC_MESSAGES/django.po
+++ b/locale/hi/LC_MESSAGES/django.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 19:22+0000\n"
 "Last-Translator: Alex Vandiver <alexmv@zulip.com>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/zulip/django/hi/>\n"
@@ -26,50 +26,50 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "अतिथि उपयोगकर्ताओं के लिए अनुमति नहीं है"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "अमान्य संगठन"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr "सार्वजनिक चैनल"
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr ""
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr ""
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr "कोई विश्लेषण डेटा उपलब्ध नहीं है। कृपया अपने सर्वर व्यवस्थापक से संपर्क करें।"
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -78,7 +78,7 @@ msgid ""
 "users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -86,7 +86,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than one user to join."
 msgstr ""
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -94,7 +94,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than two users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -102,7 +102,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than three users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -111,148 +111,147 @@ msgid ""
 "({billing_page_link}) is greater than the current number of users."
 msgstr ""
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr ""
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr ""
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
 "(minimum {min_licenses})."
 msgstr ""
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
 "page. To complete the upgrade, please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr ""
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr ""
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr "अज्ञात भुगतान विधि। कृपया {email} से संपर्क करें।"
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "कुछ गलत हो गया। कृपया पृष्ठ को फिर से लोड करें।"
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr "कुछ गलत हो गया। कृपया कुछ सेकंड प्रतीक्षा करें और पुनः प्रयास करें।"
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr ""
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr ""
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
 msgstr ""
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
 msgstr ""
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
 "licenses."
 msgstr ""
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
 "billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr ""
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr ""
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr ""
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -262,100 +261,97 @@ msgid ""
 "we would really appreciate it!"
 msgstr ""
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
 "{support_email}"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr ""
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr ""
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr ""
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
 "%(support_email)s\">contact support</a>."
 msgstr ""
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr ""
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
 msgstr ""
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr ""
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
 msgstr ""
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr ""
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr ""
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
 msgstr ""
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -363,290 +359,271 @@ msgid ""
 "a> with any questions."
 msgstr ""
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
 "a> for support."
 msgstr ""
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
 "href=\"%(troubleshooting_url)s\">Zulip server troubleshooting guide</a>."
 msgstr ""
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, fuzzy, python-format
 #| msgid "Zulip analytics for %(target_name)s"
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr "के लिए जूलिप एनालिटिक्स %(target_name)s"
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr "के लिए जूलिप एनालिटिक्स %(target_name)s"
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr ""
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr ""
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr ""
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr ""
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr ""
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr ""
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr ""
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "सक्रिय उपयोगकर्ता"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr "दैनिक क्रिया"
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr "15 दिन की गतिविधियाँ"
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr "कुल उपयोगकर्ता"
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "उपयोगकर्ता"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr "प्राप्तकर्ता प्रकार द्वारा भेजे गए संदेश"
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "मुझे"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "हर कोई"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "पिछले सप्ताह"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "पिछले महीने"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "पिछले साल"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "पूरा समय"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr "समय के साथ भेजे गए संदेश"
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "रोज"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "साप्ताहिक"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr "संचयी"
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "मनुष्य"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "बॉट"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr "समय के साथ संदेश पढ़े गए"
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr "क्लाइंट द्वारा भेजे गए संदेश"
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr "आखिरी अपडेट"
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr "ईमेल बदल गया!"
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
 "%(old_email_html_tag)s to %(new_email_html_tag)s"
 msgstr ""
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr ""
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
 msgstr ""
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr "बिलिंग"
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "रद्द करना"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr ""
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr ""
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -657,19 +634,19 @@ msgid ""
 "server."
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -677,790 +654,299 @@ msgid ""
 "%(support_email)s'>contact support</a> with any questions."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, python-format
 msgid "You can try again in %(retry_after_string)s."
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr ""
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr ""
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr ""
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr ""
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr ""
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr ""
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr ""
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr ""
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr ""
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr ""
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr ""
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr ""
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr ""
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr ""
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 msgid "Zulip for open source"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Messages sent over time"
 msgid "Message with code"
 msgstr "समय के साथ भेजे गए संदेश"
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
 msgstr ""
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 msgid "Get started"
 msgstr ""
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
 "continue."
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr "या, वैकल्पिक रूप से, अपने बैकअप फोन में से एक का उपयोग करें:"
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr "अंतिम उपाय के रूप में, आप एक बैकअप टोकन का उपयोग कर सकते हैं:"
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr "बैकअप टोकन का उपयोग करें"
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "ईमेल"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1468,78 +954,77 @@ msgid ""
 "from Zulip."
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
 msgstr ""
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr ""
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr ""
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr ""
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr ""
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr ""
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr ""
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr ""
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
 msgstr ""
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1547,210 +1032,203 @@ msgid ""
 "href=\"%(doc_url)s\">documentation</a>."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, python-format
 msgid "No account found for %(email)s."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Create a new organization"
 msgid "Try Zulip in a demo organization"
 msgstr "एक नया संगठन बनाएं"
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 msgid "Try Zulip"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "एक नया संगठन बनाएं"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid "Import chat history?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "संगठन का URL"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "या"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "साइन अप करें"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "Zulip के लिए साइन अप करें"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr "आपको इस संगठन में शामिल होने के लिए आमंत्रण की आवश्यकता है।"
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr "इसके साथ साइन अप करें %(identity_provider)s"
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "लॉग इन करें"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1758,123 +1236,122 @@ msgid ""
 "noreferrer\">after you join</a>."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "परिवर्तन"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "नाम"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "पासवर्ड"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr ""
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">Terms of Service</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr ""
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr ""
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -1882,45 +1359,45 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 msgid ""
 "This organization has been deactivated, and all organization data has been "
 "deleted."
 msgstr ""
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
 "inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
 "administrators</a> to inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 msgid "This organization has been deactivated."
 msgstr ""
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
 "%(support_email)s\">contact Zulip support</a> to reactivate it."
 msgstr ""
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -1928,165 +1405,164 @@ msgid ""
 "reactivate it."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "प्रतिलिपि"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "व्यवस्थापकों"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "सामान्य उपयोगकर्ता"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "बंद करे"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "अद्यतन करें"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr ""
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
 "<b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
 "href=\"%(apps_page_link)s\">mobile and desktop</a> apps:"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
 "href=\"%(getting_user_started_link)s\">getting started guide</a>!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2094,83 +1570,83 @@ msgid ""
 "Zulip</a>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
 "to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
 "desktop apps (%(apps_page_link)s):"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
 "(%(getting_user_started_link)s)!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
 "(%(getting_organization_started_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr "नमस्ते,"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2178,32 +1654,32 @@ msgid ""
 "password for this account, please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "%(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 msgid "Verify your email address for your Zulip demo organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "<%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2211,113 +1687,113 @@ msgid ""
 "please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
 "— we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
 "deactivated, and you will no longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr ""
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2325,22 +1801,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because your organization <a "
@@ -2348,8 +1824,8 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to <a "
@@ -2357,39 +1833,39 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr ""
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because your organization hides "
@@ -2397,81 +1873,74 @@ msgid ""
 "details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to hide "
 "message content in email notifications. See %(help_url)s for more details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr ""
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
 "organizations:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
 "organizations hosted by %(external_host)s:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
 "href=\"%(help_reset_password_link)s\">reset your password</a>."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
 "%(external_host)s."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2479,97 +1948,94 @@ msgid ""
 "to find your account."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
 "try another way to find your account (%(help_logging_in_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
 "communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr ""
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
 "-- the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
 "Zulip &mdash; the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
 "to ask %(referrer_name)s for another one."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2577,72 +2043,70 @@ msgid ""
 "productivity."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at <a href=\"mailto:%(email)s\">%(email)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
 "%(email)s\">Contact us</a> — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
 "#%(channel_name)s > %(topic_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2650,68 +2114,68 @@ msgid ""
 "preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails (<a href=\"%(url)s\">help</a>)."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2719,22 +2183,22 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2742,52 +2206,52 @@ msgid ""
 "immediately at <%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2795,31 +2259,31 @@ msgid ""
 "contact us immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2827,7 +2291,7 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -2835,25 +2299,25 @@ msgid ""
 "Zulip</a> to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
 "with you and share their unique perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -2861,7 +2325,7 @@ msgid ""
 "experience how a new chat app will help your team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -2869,148 +2333,148 @@ msgid ""
 "action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
 "team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
 "organizations like yours!"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3018,11 +2482,11 @@ msgid ""
 "about…?”"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3031,23 +2495,23 @@ msgid ""
 "href=\"%(move_channels_link)s\">move a topic to a different channel</a>."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3056,23 +2520,23 @@ msgid ""
 "(%(move_channels_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
 "%(email)s on %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3080,46 +2544,46 @@ msgid ""
 "href=\"%(help_link)s\">reactivate your account</a>."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
 "You can contact an organization administrator to reactivate your account."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3127,541 +2591,537 @@ msgid ""
 "have been voided."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
 "to %(upgrade_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip demo organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip demo organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Create a new organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "एक नया संगठन बनाएं"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for <b>%(remote_server_hostname)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 msgid "Click the button below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for %(remote_server_hostname)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
 "management for <b>%(remote_realm_host)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
 "management for %(remote_realm_host)s."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the <a href=\"%(plans_link)s\">Zulip Community plan</a>."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
 "website</a>, we would really appreciate it!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
 msgstr ""
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
 "accounts for another email address</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr ""
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "खाते ढूंढे"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr ""
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr ""
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr ""
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 msgid "Zulip Cloud"
 msgstr ""
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr ""
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr ""
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr ""
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr ""
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr ""
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr ""
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr ""
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr ""
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr ""
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr ""
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr ""
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr ""
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr ""
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr ""
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr ""
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr ""
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr ""
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr ""
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr ""
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr ""
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr ""
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr ""
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr ""
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr ""
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr ""
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr ""
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "इतिहास"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr ""
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr ""
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr ""
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr ""
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr ""
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 msgid "Bluesky"
 msgstr ""
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr ""
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr ""
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr "गोपनीयता नीति"
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 msgid ""
 "And hundreds more through <a href=\"/integrations/zapier\">Zapier</a> and <a "
 "href=\"/integrations/ifttt\">IFTTT</a>."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3669,7 +3129,7 @@ msgid ""
 "emails with your email domain."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3677,7 +3137,7 @@ msgid ""
 "disposable email addresses."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3685,24 +3145,24 @@ msgid ""
 "emails that contain \"+\"."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3710,7 +3170,7 @@ msgid ""
 "%(support_email)s\">contact Zulip support</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3718,89 +3178,89 @@ msgid ""
 "%(support_email)s\">contact this Zulip server's administrators</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
 "management for your Zulip server."
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr ""
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr ""
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr ""
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "उपयोगकर्ता नाम"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr ""
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr ""
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr ""
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> because all Zulip Cloud licenses are in use."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -3809,42 +3269,40 @@ msgid ""
 "or misconfiguration."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 msgid "Demo organizations disabled"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -3852,22 +3310,21 @@ msgid ""
 "organization for more information."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -3875,46 +3332,44 @@ msgid ""
 "Zulip support</a> for assistance in resolving this issue."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
 "a> like Firefox, Chrome, and Edge."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Invalid organization"
 msgid "Finalize organization import"
 msgstr "अमान्य संगठन"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 msgid "Organization import completed!"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -3922,54 +3377,53 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 msgid "Select your account"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create a new organization"
 msgid "Create new account"
 msgstr "एक नया संगठन बनाएं"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr ""
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -3977,81 +3431,81 @@ msgid ""
 "have one yet."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 msgid "Self-hosting Zulip?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">log in to manage plans and billing.</a>"
 msgstr ""
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr ""
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
 msgstr ""
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr ""
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr ""
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr ""
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr ""
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr ""
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4059,7 +3513,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4068,57 +3522,57 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr ""
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4126,7 +3580,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4134,40 +3588,40 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr "अज्ञात ईमेल अनुरोध को रद्द करता है"
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4175,136 +3629,133 @@ msgid ""
 "away!"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
 "href=\"%(realm_url)s/#settings/notifications\">notification settings</a>."
 msgstr ""
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr "अमान्य ऑर्डर मैपिंग।"
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr ""
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr ""
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr ""
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr ""
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr ""
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr ""
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 msgid "Cannot reactivate a deleted user"
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr ""
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr ""
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr ""
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr ""
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
 msgstr ""
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
@@ -4312,165 +3763,162 @@ msgstr ""
 "इस संगठन के लिए आमंत्रण भेजने के लिए आपका खाता बहुत नया है। एक संगठन व्यवस्थापक, या एक "
 "अधिक अनुभवी उपयोगकर्ता से पूछें।"
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr "कुछ ईमेल मान्य नहीं हुए, इसलिए हमने कोई निमंत्रण नहीं भेजा।"
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr "हम किसी को भी आमंत्रित करने में सक्षम नहीं थे।"
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr ""
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr ""
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr ""
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr ""
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr ""
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr ""
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr ""
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr ""
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr ""
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
 "{new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
 "{user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to resolve topics in this channel."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr ""
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr ""
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr ""
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr ""
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr ""
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
 "but there is no channel with that ID."
 msgstr ""
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4478,36 +3926,36 @@ msgid ""
 "it."
 msgstr ""
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
 "The channel exists but does not have any subscribers."
 msgstr ""
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr ""
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr ""
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr ""
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4515,107 +3963,105 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
 "authentication method."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr ""
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 msgid "Reminder could not be sent."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
 "the following error:"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr ""
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr ""
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr ""
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr ""
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr ""
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
 "**{old_policy}** to **{new_policy}**."
 msgstr ""
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -4624,51 +4070,49 @@ msgid ""
 "* **New**: {new_setting_description}\n"
 msgstr ""
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr ""
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr ""
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr ""
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr ""
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr ""
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr ""
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 msgstr ""
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr ""
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -4679,150 +4123,139 @@ msgid ""
 "{summary_line}"
 msgstr ""
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr ""
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr ""
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr ""
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr ""
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr ""
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr ""
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr ""
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr ""
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr ""
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr ""
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr ""
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
 "organization administrator to reactivate it."
 msgstr ""
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr ""
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr ""
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr ""
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr ""
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr ""
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr "जिस संगठन को आप {email} के उपयोग से जोड़ने का प्रयास कर रहे हैं वह मौजूद नहीं है।"
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr "कृपया संगठन व्यवस्थापक से {email} के लिए निमंत्रण का अनुरोध करें।"
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
@@ -4831,133 +4264,130 @@ msgstr ""
 "आपका ईमेल पता, {email}, उन डोमेन में से एक नहीं है, जिन्हें इस संगठन में खातों के लिए "
 "पंजीकरण करने की अनुमति है।"
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr ""
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 msgid "Challenges are not enabled."
 msgstr ""
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr ""
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr ""
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "You're making too many attempts to sign in. Try again in "
 "{retry_after_string} or contact your organization administrator for help."
 msgstr ""
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
 msgstr ""
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr ""
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr ""
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr ""
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr ""
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr ""
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr ""
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr ""
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr ""
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr ""
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr ""
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr "कुर्की हटाते समय एक त्रुटि हुई। बाद में पुन: प्रयास करें।"
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name can't be empty."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 msgid "Invalid channel folder ID"
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 msgid "Configure owner account email address."
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4966,69 +4396,69 @@ msgid ""
 "organization]({convert_demo}).\n"
 msgstr ""
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, python-brace-format
 msgid "{var_name} is not Base64 encoded"
 msgstr ""
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 msgid "Invalid `device_id`"
 msgstr ""
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr ""
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr ""
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr ""
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr ""
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr ""
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr ""
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr ""
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr ""
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr ""
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr ""
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5036,609 +4466,607 @@ msgid ""
 "{error_message}"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr ""
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr ""
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr ""
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr ""
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr ""
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr ""
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr ""
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr ""
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr ""
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr ""
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr ""
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr ""
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr ""
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
 msgstr ""
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr ""
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr ""
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr ""
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr ""
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr ""
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr ""
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr ""
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr ""
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 msgid "Must be a bot user"
 msgstr ""
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr ""
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr ""
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr ""
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
 "webhook; ignoring"
 msgstr ""
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr ""
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr ""
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr ""
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr ""
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} most recent messages in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr ""
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr ""
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
 msgstr ""
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr ""
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr ""
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr ""
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr ""
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr ""
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Find accounts"
 msgid "Atlassian account ID"
 msgstr "खाते ढूंढे"
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 msgid "Behance username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 msgid "Bitbucket username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 msgid "Codeberg username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 msgid "Dribbble username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 msgid "Facebook username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "GitLab username"
 msgstr "उपयोगकर्ता नाम"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 msgid "Instagram username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 msgid "Mastodon profile"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "Medium username"
 msgstr "उपयोगकर्ता नाम"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 msgid "Pinterest username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "Reddit username"
 msgstr "उपयोगकर्ता नाम"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 msgid "Snapchat username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 msgid "Threads username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "TikTok username"
 msgstr "उपयोगकर्ता नाम"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "Twitch username"
 msgstr "उपयोगकर्ता नाम"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "उपयोगकर्ता नाम"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr ""
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr ""
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 #, fuzzy
 #| msgid "Billing"
 msgid "Video calling"
 msgstr "बिलिंग"
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr ""
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr ""
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr ""
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr ""
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr ""
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr ""
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr ""
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr ""
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr ""
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr ""
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr ""
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr ""
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr ""
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr ""
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "{fullname} moderation"
 msgstr ""
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr ""
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr ""
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor_date' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr ""
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 msgid "Navigation view does not exist."
 msgstr ""
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5646,7 +5074,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5654,7 +5082,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5662,7 +5090,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5670,7 +5098,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5680,14 +5108,14 @@ msgid ""
 "a permanent organization]({convert_demo_organization_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
 "them in your [Inbox](/#inbox).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5695,7 +5123,7 @@ msgid ""
 "({navigation_tour_video_url}) for a quick app overview.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5710,14 +5138,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -5725,7 +5153,7 @@ msgid ""
 "and edit your [profile information](/help/edit-your-profile).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -5736,7 +5164,7 @@ msgid ""
 "experience in your [Preferences](#settings/preferences).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5747,7 +5175,7 @@ msgid ""
 "[Browse and subscribe to channels]({settings_link}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -5764,7 +5192,7 @@ msgid ""
 "discussed.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -5773,7 +5201,7 @@ msgid ""
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -5785,7 +5213,7 @@ msgid ""
 "times, and more.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5795,7 +5223,7 @@ msgid ""
 "or browse the [help center](/help/) to learn more!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5803,7 +5231,7 @@ msgid ""
 "get help, try one of the following messages: {bot_commands}\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5815,13 +5243,13 @@ msgid ""
 "({move_content_another_channel_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5835,12 +5263,11 @@ msgid ""
 "and above.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr ""
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -5848,14 +5275,14 @@ msgid ""
 "no matter how many other conversations are going on.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
 "conversations with unread messages.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -5863,7 +5290,7 @@ msgid ""
 "the `+` button next to its name.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -5871,13 +5298,13 @@ msgid ""
 "can we chat about…?”\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5885,7 +5312,7 @@ msgid ""
 "({format_message_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5905,1223 +5332,1202 @@ msgid ""
 "```\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
 "teammates.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
 "conversation.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr ""
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr ""
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr ""
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr ""
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "नया संदेश"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 msgid "Invalid `push_key`"
 msgstr ""
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr ""
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr ""
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr ""
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 msgid "Reminder does not exist"
 msgstr ""
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr ""
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr ""
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr ""
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr ""
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr ""
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr ""
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr ""
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr ""
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 msgid "You do not have permission to create new topics in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr ""
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr ""
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr ""
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr ""
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr ""
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr ""
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} does not have the expected format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr ""
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr ""
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr ""
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {user_group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr ""
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr ""
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr ""
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr ""
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr ""
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 msgid "Name must not be empty!"
 msgstr ""
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr ""
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr ""
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr ""
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr ""
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr ""
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr ""
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr ""
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr ""
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr ""
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr ""
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr ""
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr ""
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr ""
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr ""
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr ""
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr ""
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr ""
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr ""
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr ""
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr ""
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr ""
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr ""
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr ""
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr ""
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr ""
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr ""
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr ""
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr ""
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr ""
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr ""
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr ""
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr ""
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr ""
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr ""
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr ""
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "सदस्य"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr ""
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: empty field name."
 msgstr ""
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr ""
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr ""
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 msgid "Example input does not match the linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in alternative URL template is not present in linkifier "
 "pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in linkifier pattern is not present in alternative URL "
 "template."
 msgstr ""
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr ""
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr ""
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr ""
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr ""
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr ""
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr ""
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr ""
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr ""
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr ""
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr ""
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr ""
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr ""
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "सार्वजनिक"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr ""
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr ""
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr ""
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr ""
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr ""
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr ""
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr ""
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr ""
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr ""
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr ""
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr ""
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr ""
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr ""
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr ""
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr ""
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr ""
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 msgid "Failed to generate challenge"
 msgstr ""
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr ""
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr ""
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr ""
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr ""
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr ""
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr ""
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for use for user matching."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr ""
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr ""
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr ""
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr ""
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr ""
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr ""
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr ""
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr ""
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 msgid "Invitation already used or deactivated."
 msgstr ""
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr ""
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr ""
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr ""
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
@@ -7129,102 +6535,100 @@ msgstr ""
 "उनमें से कुछ पते पहले से ही ज़ूलिप का उपयोग कर रहे हैं, इसलिए हमने उन्हें निमंत्रण नहीं भेजा। "
 "हमने सभी को निमंत्रण भेजा!"
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr ""
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr ""
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr ""
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr ""
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr ""
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr ""
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr ""
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr ""
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Email address changes are disabled in this organization."
 msgid "Message reporting is not enabled in this organization."
 msgstr "इस संगठन में ईमेल पता परिवर्तन अक्षम हैं।"
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr ""
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr ""
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr ""
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr ""
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr ""
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr ""
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr ""
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr ""
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr ""
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 msgid "Navigation view already exists."
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7232,559 +6636,557 @@ msgid ""
 "later. Is this a good time?\n"
 msgstr ""
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr ""
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr ""
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 msgid "You do not have permission to manage plans and billing."
 msgstr ""
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr ""
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr ""
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr ""
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr ""
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr ""
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr ""
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr ""
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr ""
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr ""
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr ""
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr ""
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 #, fuzzy
 #| msgid "Email address changes are disabled in this organization."
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr "इस संगठन में ईमेल पता परिवर्तन अक्षम हैं।"
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr ""
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr ""
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr ""
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr ""
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr ""
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr ""
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr ""
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Invalid character in language: {character}"
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Language '{language}' is not allowed."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr ""
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr ""
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 msgid "Importing messages…"
 msgstr ""
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 msgid "Your name"
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr ""
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr ""
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr ""
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr ""
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr ""
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr "अमान्य मापदण्ड"
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr ""
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr ""
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr ""
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr ""
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr ""
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr ""
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr ""
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
 "**"
 msgstr ""
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr ""
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr ""
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr ""
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr ""
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr ""
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr ""
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr ""
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr ""
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr ""
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr ""
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr ""
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr ""
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr ""
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 msgstr ""
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr ""
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr ""
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
 "subgroups."
 msgstr ""
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr "इस संगठन में ईमेल पता परिवर्तन अक्षम हैं।"
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr ""
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr ""
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr ""
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr "आपका Zulip पासवर्ड LDAP में प्रबंधित है"
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr ""
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr ""
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr ""
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr ""
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr ""
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr ""
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 msgid "User is not allowed to delete other user's messages."
 msgstr ""
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr ""
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr ""
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "No analytics data available. Please contact your server administrator."
@@ -7793,300 +7195,300 @@ msgid ""
 "Please contact your server administrator."
 msgstr "कोई विश्लेषण डेटा उपलब्ध नहीं है। कृपया अपने सर्वर व्यवस्थापक से संपर्क करें।"
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 msgid "Email address already in use"
 msgstr ""
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr ""
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr ""
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr ""
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 msgstr ""
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr ""
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr ""
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr ""
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr ""
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr ""
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} access token"
 msgstr ""
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} call"
 msgstr ""
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} credentials have not been configured"
 msgstr ""
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} credentials"
 msgstr ""
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr ""
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error authenticating to the {provider_name} server"
 msgstr ""
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr ""
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} session identifier"
 msgstr ""
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr ""
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} public room."
 msgstr ""
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr ""
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{full_name}'s Zulip room"
 msgstr ""
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr ""
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr ""
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr ""
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr ""
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr ""
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr ""
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr ""
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr ""
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr ""
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
 "({export_settings_link})."
 msgstr ""
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr ""
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr ""
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr ""
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr ""
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr ""
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr ""
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr ""
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr ""
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr ""
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr ""
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr ""
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr ""
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
 "try again later or reach out to {support_email} for assistance."
 msgstr ""
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr ""
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr ""
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr ""
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr ""
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
 "server: {reason}"
 msgstr ""
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr ""
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr ""
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr ""
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr ""
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr ""
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr ""
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr ""
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr ""
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 msgid "Missing idp param"
 msgstr ""
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr "अमान्य OTP"
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr ""

--- a/locale/hu/LC_MESSAGES/django.po
+++ b/locale/hu/LC_MESSAGES/django.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 19:30+0000\n"
 "Last-Translator: Buzási Róbert <drbuzasi@gmail.com>\n"
 "Language-Team: Hungarian <https://hosted.weblate.org/projects/zulip/django/"
@@ -28,52 +28,52 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "Vendég felhasználóknak nem engedélyezett"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "Hibás szervezet"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr ""
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr ""
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr ""
 "A kezdés ideje a befejezési idő utánra esik. Kezdés: {start}, befejezés: "
 "{end}"
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr "Nincs elemzési adat. Lépj kapcsolatba a szerver adminisztrátorával."
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -86,7 +86,7 @@ msgstr ""
 "felhasználókat]({deactivate_user_help_page_link}), hogy tudjatok új tagokat "
 "hívni."
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -98,7 +98,7 @@ msgstr ""
 "felhasználókat]({deactivate_user_help_page_link}), hogy egynél több tagot is "
 "meghívhassatok."
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -110,7 +110,7 @@ msgstr ""
 "felhasználókat]({deactivate_user_help_page_link}), hogy kettőnél több tagot "
 "is meghívhassatok."
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -122,7 +122,7 @@ msgstr ""
 "felhasználókat]({deactivate_user_help_page_link}), hogy háromnál több tagot "
 "is meghívhassatok."
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -131,78 +131,77 @@ msgid ""
 "({billing_page_link}) is greater than the current number of users."
 msgstr ""
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr ""
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr ""
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
 "(minimum {min_licenses})."
 msgstr ""
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
 "page. To complete the upgrade, please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr ""
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr "{brand} végződése {last4}"
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr ""
 "Ismeretlen fizetési mód. Kérjük, lépjen kapcsolatba a következővel: {email}."
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr "Valami elromlott. Kérjük, lépjen kapcsolatba a következővel: {email}."
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "Valami gond van. Töltsd újra az oldalt."
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr "Valami gond van. Várj pár másodpercet és próbáld újra."
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr ""
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
@@ -210,16 +209,16 @@ msgstr ""
 "Szerződésmódosítás nem lehetséges. A szerződés lejárt, vagy új szerződés "
 "köttetett."
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr "Szerződésmódosítás nem lehetséges. A szerződés lejárt."
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
@@ -227,7 +226,7 @@ msgstr ""
 "Nem tudsz manuálisan változtatni a lincenszek számán. A szerződésed "
 "automatikus licensz-osztásra szól."
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
@@ -235,17 +234,17 @@ msgstr ""
 "A szerződésed szerint már {licenses} licensz érhető el a jelen számlázási "
 "időszakban."
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr "Ebben a számlázási időszakban már nem csökkentheted licenszeid számát."
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
 msgstr ""
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
@@ -253,34 +252,34 @@ msgid ""
 msgstr ""
 "A szerződésed már ütemezetten átáll {licenses_at_next_renewal} licenszre."
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
 "billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr "Nincs változtatnivaló."
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr "Ennél a szervezetnél nincs felhasználó!"
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr "Böngészési folyamat nem található"
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr "Fizetési szándék nem található"
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr ""
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -290,100 +289,97 @@ msgid ""
 "we would really appreciate it!"
 msgstr ""
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
 "{support_email}"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr ""
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "Hiba"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr ""
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
 "%(support_email)s\">contact support</a>."
 msgstr ""
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr ""
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
 msgstr ""
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr ""
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
 msgstr ""
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr ""
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr "Belső kiszolgáló hiba"
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
 msgstr ""
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -391,158 +387,156 @@ msgid ""
 "a> with any questions."
 msgstr ""
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
 "a> for support."
 msgstr ""
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
 "href=\"%(troubleshooting_url)s\">Zulip server troubleshooting guide</a>."
 msgstr ""
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr "Analitika %(target_name)s számára | Zulip"
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 "Az analitikák a szervezet létrehozása után 24 órával válnak teljes mértékben "
 "elérhetővé."
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr "Zulip analitika %(target_name)s számára"
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr ""
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr ""
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr ""
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr ""
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr ""
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr ""
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr ""
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "Aktív felhasználók"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr "Napi aktivitás"
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr "15 napi aktivitás"
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr "Összes felhasználó"
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "Felhasználók"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr "Elküldött üzenetek a címzett típusa szerint"
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "Én"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "Mindenki"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "Előző hét"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "Előző hónap"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "Előző év"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "Összes"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr "Elküldött üzenetek idő szerint"
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "Napi"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "Heti"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr "Halmozott"
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "Emberek"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "Robotok"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr "Elolvasott üzenetek idő szerint"
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr "Elküldött üzenetek a használt kliens alapján"
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr "Utolsó frissítés"
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
@@ -550,15 +544,15 @@ msgstr ""
 "A grafikonok teljes frissítése naponta egyszer történik. Az „idővel "
 "elküldött üzenetek” grafikon óránként egyszer frissül."
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr "Email cím megváltoztatva!"
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
@@ -567,49 +561,49 @@ msgstr ""
 "Megerősítjük, hogy a Zulip-fiókja e-mail címe megváltozott a régi "
 "%(old_email_html_tag)s helyett erre: %(new_email_html_tag)s"
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr "Hoppá. Nem találtuk meg a megerősítő linket a rendszerben."
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr ""
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr ""
 "Hopp! A megerősítésre szolgáló hivatkozás már lejárt vagy letiltásra került."
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr "Új linkért fordulj a szervezet adminisztrátorához."
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr "Hoppá. A megerősítő link hibás."
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
@@ -617,72 +611,55 @@ msgstr ""
 "Győződj meg róla, hogy helyesen másoltad be a linket a böngészőbe. Ha újra "
 "ez az oldal jelenik meg, valószínűleg a mi hibánk. Sajnáljuk."
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr "Számlázás"
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr "Felhatalmazások bezárása"
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "Mégse"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr "Megerősít"
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr ""
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr ""
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -693,19 +670,19 @@ msgid ""
 "server."
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -713,797 +690,306 @@ msgid ""
 "%(support_email)s'>contact support</a> with any questions."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr "A díjkorlát túllépve."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, fuzzy, python-format
 #| msgid "You can try again in %(retry_after)s seconds."
 msgid "You can try again in %(retry_after_string)s."
 msgstr "Próbálkozz újra %(retry_after)s másodperccel később."
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr ""
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr ""
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr "Szűrés kategória szerint"
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "Mindenki"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr "Kategóriák"
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr ""
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr "A Zulip fejlesztési közösség"
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr "Csatlakozz, mint felhasználó"
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr "Csatlakozz, mint szerver-gazda"
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr "Csatlakozz, mint támogató"
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "Szervezet létrehozása"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr ""
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr "Légy Zulip szerver-gazda"
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr "Támogatást igényelni"
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr "Oktatási áraink"
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr "Áraink"
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr "Zulip üzleti használatra"
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Zulip for business"
 msgid "Zulip for open source"
 msgstr "Zulip üzleti használatra"
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Create your Zulip organization"
 msgid "Screenshot of Zulip conversation"
 msgstr "Kezd el saját Zulip szerveződésed"
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Messages sent over time"
 msgid "Message with code"
 msgstr "Elküldött üzenetek idő szerint"
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr "Link"
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr "Kapcsolatfelvétel az ügyfélszolgálattal"
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr "Küldő"
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr "Szervezet"
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr "Tárgy"
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr "Üzenet"
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr "Küld"
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
 msgstr ""
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 #, fuzzy
 #| msgid "Getting started"
 msgid "Get started"
 msgstr "Kezdőlépések"
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
 "continue."
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr "Vagy használhatsz egy tartalék telefont:"
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr "Utolsó esélyként használhatsz tartalék tokent:"
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr "Tartalék token használata"
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr "Felhasználási feltételek elfogadása"
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "E-mail"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr "Feliratkoznék a Zulip ritkásan érkező hírlevelére (évente pár e-mail)."
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1511,78 +997,77 @@ msgid ""
 "from Zulip."
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
 msgstr ""
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr ""
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr ""
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr ""
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr ""
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr ""
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr ""
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr ""
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
 msgstr ""
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1590,215 +1075,208 @@ msgid ""
 "href=\"%(doc_url)s\">documentation</a>."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr "Zulip fiók nem található."
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, fuzzy, python-format
 #| msgid "No entry found for domain {domain}."
 msgid "No account found for %(email)s."
 msgstr "Nem találtunk a {domain} domain-re példát."
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr "Lépj be másik fiókkal"
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr "Tovább a regisztrációhoz"
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Must be a demo organization."
 msgid "Try Zulip in a demo organization"
 msgstr "Csak bemutató szerveződés lehet."
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Why Zulip"
 msgid "Try Zulip"
 msgstr "Miért a Zulip"
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "Új szervezet létrehozása"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr "Új Zulip szervezet létrehozása"
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr "Add meg az e-mail címed"
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr "Szerveződés típusa"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 #, fuzzy
 #| msgid "Private, shared history"
 msgid "Import chat history?"
 msgstr "Privát, közös korábbi üzenetek"
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr "Szervezet neve"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "Szervezet URL-je"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr "%(external_host)shasználata"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "VAGY"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "Feliratkozás"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "Zulip regisztráció"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr "E szervezethez való csatlakozáshoz meghívó szükséges."
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr "Regisztráció %(identity_provider)s segítségével"
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "Bejelentkezés"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1806,126 +1284,125 @@ msgid ""
 "noreferrer\">after you join</a>."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "Változtatás"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr "Hozd létre a szervezetedet"
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr "Hozd létre fiókodat"
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 #, fuzzy
 #| msgid "Click the button below to complete registration."
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr "Kattints az alábbi gombra a regisztráció befejezéséhez."
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr "Saját fiókod"
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr "Ne importálja a beállításokat"
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr "Beállítások importálása meglévő Zulip fiókból"
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "Név"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "Jelszó"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr "Add meg az LDAP/Active Directory jelszavadat."
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 "Ezt mobilalkalmazásokhoz és egyéb, jelszót igénylő eszközökhöz használják."
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr "Jelszó erőssége"
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr "Mi iránt érdeklődsz?"
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">Terms of Service</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr "Letiltott szervezet"
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr ""
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -1933,7 +1410,7 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid ""
@@ -1941,41 +1418,41 @@ msgid ""
 "deleted."
 msgstr "Ez a szervezet letiltásra került."
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
 "inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
 "administrators</a> to inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid "This organization has been deactivated."
 msgstr "Ez a szervezet letiltásra került."
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
 "%(support_email)s\">contact Zulip support</a> to reactivate it."
 msgstr ""
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -1983,15 +1460,15 @@ msgid ""
 "reactivate it."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr "Asztali belépés befejezése"
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
@@ -1999,93 +1476,92 @@ msgstr ""
 "Használd böngésződet a bejelentkezés befejezéséhez, majd térj vissza ide, és "
 "illeszd be a bejelentkezési tokent."
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr "Ide illeszd be a tokent"
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr "Befejezés"
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr "Érvénytelen token."
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr "Token elfogadva. Beléptetünk…"
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 "Másold ezt a tokent vágólapra és térj vissza a Zulip alkalmazásodhoz a "
 "belépés befejezéséhez:"
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "Másolás"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr "Ekkor bezárhatod ezt az ablakot."
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr "Vagy folytathatod a böngészőben is."
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr "Névtelen felhasználó"
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr "Tulajdonosok"
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "Adminisztrátorok"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr "Moderátorok"
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr "Vendég felhasználók"
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "Normál felhasználók"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "Bezár"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "Frissítés"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr "Zulip"
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, fuzzy, python-format
 #| msgid "You've joined the Zulip organization %(realm_name)s."
 msgid ""
@@ -2093,61 +1569,61 @@ msgid ""
 "<b>%(realm_name)s</b>."
 msgstr "Beléptél a(z) %(realm_name)s nevű Zulip szervezetbe."
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr "Üdvözlünk a Zulipban!"
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, fuzzy, python-format
 #| msgid "You've joined the Zulip organization %(realm_name)s."
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr "Beléptél a(z) %(realm_name)s nevű Zulip szervezetbe."
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
 "href=\"%(apps_page_link)s\">mobile and desktop</a> apps:"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr "Szervezet URL-je: %(organization_url)s"
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr "Használd LDAP-fiókod a bejelentkezéshez"
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
 "href=\"%(getting_user_started_link)s\">getting started guide</a>!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2155,83 +1631,83 @@ msgid ""
 "Zulip</a>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
 "to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr "%(realm_name)s a Zulipon: az új szervezeted részletei"
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr "%(realm_name)sa Zulipon: az új fiókod részletei"
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr "Beléptél a(z) %(realm_name)s nevű Zulip szervezetbe."
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
 "desktop apps (%(apps_page_link)s):"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
 "(%(getting_user_started_link)s)!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
 "(%(getting_organization_started_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr "Szia,"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2239,12 +1715,12 @@ msgid ""
 "password for this account, please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2253,14 +1729,14 @@ msgstr ""
 "Ha nem Ön kérte ezt a módosítást, kérjük, azonnal lépjen kapcsolatba velünk "
 "a %(support_email)s telefonszámon."
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 #, fuzzy
 #| msgid "Create your Zulip organization"
 msgid "Verify your email address for your Zulip demo organization"
 msgstr "Kezd el saját Zulip szerveződésed"
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2269,8 +1745,8 @@ msgstr ""
 "Ha nem te voltál, keress bennünket haladéktalanul a <%(support_email)s> "
 "címen."
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2278,113 +1754,113 @@ msgid ""
 "please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr "E-mail változtatás megerősítése"
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr "Épp most regisztráltál a Zulip-ba. Kiváló!"
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr "Kattints az alábbi gombra a regisztráció befejezéséhez."
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr "Regisztráció befejezése"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr "Kezd el saját Zulip szerveződésed"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr "Zulip fiók aktiválása"
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr "Kattints az alábbi linkre a regisztráció befejezéséhez."
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
 "— we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr "E-mail tulajdonságok kezelése"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr "Leiratkozás a marketing e-mailekről"
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
 "deactivated, and you will no longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr ""
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2392,22 +1868,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because your organization has "
@@ -2423,8 +1899,8 @@ msgstr ""
 "letiltotta, hogy <a class=\"content_disabled_help_link\" "
 "href=\"%(help_url)s\">az e-mail értesítésekben üzenetszöveg jelenjen meg</a>."
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because you have disabled <a "
@@ -2439,40 +1915,40 @@ msgstr ""
 "class=\"content_disabled_help_link\" href=\"%(alert_notif_url)s\">az e-mail "
 "értesítésekben üzenetszöveg jelenjen meg</a>."
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, fuzzy, python-format
 #| msgid "Click here to log in to Zulip and catch up."
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr "Kattints ide a Zulip belépéshez és kerülj képbe mielőbb."
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr "Leiratkozás az összefoglaló e-mailekről"
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr "Zulip összefoglaló %(realm_name)s számára"
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2489,8 +1965,8 @@ msgstr ""
 "letiltotta, hogy az e-mail értesítésekben üzenetszöveg jelenjen meg.\n"
 "További részletekért lásd a/az %(hide_content_url)s oldalt.\n"
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2506,41 +1982,38 @@ msgstr ""
 "mail értesítésekben üzenetszöveg jelenjen meg.\n"
 "További részletekért lásd a/az %(alert_notif_url)s oldalt.\n"
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, fuzzy, python-format
 #| msgid "Log in to your organization"
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr "Lépj be a saját szervezetedbe"
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr "E-mail tulajdonságok kezelése"
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr "Leiratkozás az összefoglaló e-mailekről:"
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr "Úszó hal"
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr "Köszönjük igénylésed!"
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
 "organizations:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
@@ -2549,33 +2022,29 @@ msgstr ""
 "E-mail címed %(email)s a következő Zulip szerveknél rendelkezik fiókkal "
 "%(external_host)s:"
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
 "href=\"%(help_reset_password_link)s\">reset your password</a>."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
 "%(external_host)s."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2583,38 +2052,35 @@ msgid ""
 "to find your account."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr "Zulip fiókjaid"
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
 "try another way to find your account (%(help_logging_in_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr "Szia,"
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
@@ -2623,19 +2089,19 @@ msgstr ""
 "%(referrer_name)s szeretné, ha csatlakoznál hozzá a Zulip-ban, ami egy "
 "hatékony csapatkommunikációs eszköz."
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr "A kezdéshez kattints az alábbi gombra."
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 "%(referrer_full_name)s meghívott, hogy csatlakozz %(referrer_realm_name)s -"
 "hez"
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
@@ -2644,17 +2110,17 @@ msgstr ""
 "%(referrer_full_name)s(%(referrer_email)s) szeretné, ha csatlakozná hozzá a "
 "Zulip-ban -- ami egy hatékony csapatkommunikációs eszköz."
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr "A kezdéshez kattints az alábbi linkre."
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr "Szia ismét,"
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
@@ -2663,13 +2129,13 @@ msgstr ""
 "Ez egy baráti emlékeztető arról, hogy %(referrer_name)s szeretné, ha "
 "csatlakoznál hozzá a Zulip-ban — ami egy hatékony csapatkommunikációs eszköz."
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr "Ez az utolsó emlékeztető, amit küldünk erről a meghívásról."
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
@@ -2678,14 +2144,14 @@ msgstr ""
 "Ez a meghívás két nap múlva lejár. Ha lejárt, %(referrer_name)stud újat "
 "küldeni."
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr ""
 "Emlékeztető: csatlakozz, %(referrer_name)s téged vár a/az "
 "%(referrer_realm_name)s -ban/ben"
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2696,72 +2162,70 @@ msgstr ""
 "szeretné, ha csatlakoznál hozzá a Zulip-ban -- ami egy hatékony "
 "csapatkommunikációs eszköz."
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at <a href=\"mailto:%(email)s\">%(email)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
 "%(email)s\">Contact us</a> — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
 "#%(channel_name)s > %(topic_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2769,21 +2233,21 @@ msgid ""
 "preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
@@ -2792,41 +2256,41 @@ msgstr ""
 "Ne válaszolj erre az e-mailre. Ezen a Zulip szerveren a bejövő levelek "
 "feldolgozása nincs beállítva (<a href=\"%(url)s\">súgó</a>)."
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr "Új üzenetek"
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
@@ -2834,7 +2298,7 @@ msgstr ""
 "Ne válaszolj erre az e-mailre. Ezen a Zulip szerveren a bejövő levelek "
 "feldolgozása nincs beállítva. Súgó:"
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2845,22 +2309,22 @@ msgstr ""
 "%(new_email)s. Ha nem te akartad a változtatást, sürgősen írj nekünk erre a "
 "címre: %(support_email)s."
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr "A legjobbakat,"
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr "Zulip csapat"
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr "Zulip email módosítva %(realm_name)s számára"
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2871,53 +2335,53 @@ msgstr ""
 "%(new_email)s. Ha nem te akartad a változtatást, sürgősen írj nekünk erre a "
 "címre: <%(support_email)s>."
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 msgstr ""
 "Szervezet: %(organization_url)s Időpont: %(login_time)s Email: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr "Egy új belépést láttunk az alábbi Zulip fióknál."
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr "Szervezet: %(organization_link)s"
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr "Email: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr "Időpont: %(login_time)s"
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr "Eszköz: %(device_browser)s böngésző %(device_os)s rendszeren."
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr "IP cím: %(device_ip)s"
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr "Ha te voltál, minden rendben! Nem kell semmit tenned."
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2928,33 +2392,33 @@ msgstr ""
 "href=\"%(reset_link)s\">változtass jelszót</a> vagy keress bennünket a/az "
 "%(support_email)s címen."
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr "Köszi,"
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr "Zulip Biztonsági Szolgálat"
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr "Leiratkozás a belépési értesítésekről"
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr ""
 "Új bejelentkezés a/az %(device_browser)s böngészővel %(device_os)s "
 "rendszerről"
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr "Szervezet: %(organization_url)s"
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2965,7 +2429,7 @@ msgstr ""
 "változtass jelszót itt: %(reset_link)s vagy keress bennünket haladéktalanul "
 "a/az %(support_email)s címen."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -2973,25 +2437,25 @@ msgid ""
 "Zulip</a> to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
 "with you and share their unique perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -2999,7 +2463,7 @@ msgid ""
 "experience how a new chat app will help your team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -3007,148 +2471,148 @@ msgid ""
 "action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
 "team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
 "organizations like yours!"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3156,11 +2620,11 @@ msgid ""
 "about…?”"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr "Példák rövid témákra"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3169,23 +2633,23 @@ msgid ""
 "href=\"%(move_channels_link)s\">move a topic to a different channel</a>."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr "Tovább a Zulipba"
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3194,23 +2658,23 @@ msgid ""
 "(%(move_channels_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
 "%(email)s on %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr "Kattints az alábbi gombra új jelszó készítéséhez."
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr "Új jelszó készítése"
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3221,48 +2685,48 @@ msgstr ""
 "letiltásra került. Vedd fel a kapcsolatot a szervezet adminisztrátoraival <a "
 "href=\"%(help_link)s\">a fiók aktívvá tételéhez</a>."
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr "Nincs fiókod ebben a Zulip szervezetben."
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr "Az alábbi szervezet(ek)ben van aktív fiókod."
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
 msgstr "Próbálj meg belépni a fenti szervezet(ek)be vagy új jelszót kérni."
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 "Ha nem ismerős a fenti aktivitás, nyugodtan hagyd figyelmen kívül ezt az "
 "üzenetet."
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr "Jelszó változtatási kérés %(realm_name)s számára"
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr "Kattints az alábbi hivatkozásra a jelszó megváltoztatásához."
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
 "You can contact an organization administrator to reactivate your account."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3272,7 +2736,7 @@ msgstr ""
 "A szervezeted, %(organization_name_with_link)s, átkerült a Zulip Cloud Free "
 "szerződésre, fizetetlen számlák miatt. Ezen számlák semmissé váltak."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
@@ -3281,7 +2745,7 @@ msgstr ""
 "Hogy folytathasd a Zulip Cloud Standard szerződés keretein belül, kérjük "
 "köss újra szerződést %(upgrade_url)s."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
@@ -3290,8 +2754,8 @@ msgstr ""
 "Ha úgy érzed, hibáztunk, vagy további infókra van szükséged, keress minket "
 "itt: %(support_email)s."
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid "You've joined the Zulip organization %(realm_name)s."
 msgid ""
@@ -3299,104 +2763,104 @@ msgid ""
 "%(localized_date)s."
 msgstr "Beléptél a(z) %(realm_name)s nevű Zulip szervezetbe."
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr "Kedves %(realm_name)s korábbi adminisztrátora,"
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip demo organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr "Kattints az alábbi gombra a szervezet újraaktivásálához."
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr "Szervezet újraaktiválása"
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
@@ -3404,370 +2868,370 @@ msgstr ""
 "Ha a kérés hiba következménye, nem kell semmit tenni, a hivatkozás 24 óra "
 "múlva lejár."
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Reactivate your Zulip organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "Aktiváld újra Zulip szervezetedet"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr "Aktiváld újra Zulip szervezetedet"
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr "Kattints az alábbi hivatkozásra a szervezet újraaktiválásához."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for <b>%(remote_server_hostname)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, fuzzy
 #| msgid "Click the button below to complete registration."
 msgid "Click the button below to log in."
 msgstr "Kattints az alábbi gombra a regisztráció befejezéséhez."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for %(remote_server_hostname)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
 "management for <b>%(remote_realm_host)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
 "management for %(remote_realm_host)s."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the <a href=\"%(plans_link)s\">Zulip Community plan</a>."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
 "website</a>, we would really appreciate it!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
 msgstr ""
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr "Keress meg Zulip fiókjaidat"
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
 "accounts for another email address</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr "E-mail cím"
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "Fiókok keresése"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr "Termék"
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr "Miért a Zulip"
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr "Jellemzők"
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr ""
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Zulip"
 msgid "Zulip Cloud"
 msgstr "Zulip"
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr ""
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr "Biztonság"
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "Integrációk"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr "Asztali és mobil alkalmazások"
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr "Új szervezet"
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr "Megoldások"
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr "Üzleti"
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr "Oktatás"
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr "Kutatás"
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr ""
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr "Nyílt kódú projektek"
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr "Közösségek"
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr "Felhasználói beszámolók"
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr ""
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr ""
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr "Kezdőlépések"
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr "Súgó Központ"
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr "Közösségi csevegés"
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr ""
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr "Zulip szerver telepítése"
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr "Zulip szerver frissítése"
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr ""
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr ""
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr "Fejlesztői közösség"
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr "Fordítás"
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr "GitHub"
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr "Rólunk"
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr "Csapat"
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "Előzmények"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr ""
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr "Munkalehetőségek"
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr "Blog"
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr "Támogasd a Zulipot"
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr ""
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr ""
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 msgid "Bluesky"
 msgstr ""
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr ""
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr "Szolgáltatási feltételek"
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr "Magánszféra védelme"
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr "Több, mint %(integrations_count_display)s natív integráció."
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 #, fuzzy
 #| msgid ""
 #| "And hundreds more through <a href=\"/integrations/doc/zapier\">Zapier</a> "
@@ -3779,51 +3243,47 @@ msgstr ""
 "És száz meg száz, hála a <a href=\"/integrations/doc/zapier\">Zapier</a> és "
 "<a href=\"/integrations/doc/ifttt\">IFTTT</a> appoknak."
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr "Kereső integrációk"
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr "Egyedi integrációk"
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr "Bejövő webhookok"
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr "Csevegő robotok"
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr "REST API"
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr "Érvénytelen email"
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3831,7 +3291,7 @@ msgid ""
 "emails with your email domain."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3839,7 +3299,7 @@ msgid ""
 "disposable email addresses."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3847,24 +3307,24 @@ msgid ""
 "emails that contain \"+\"."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3872,7 +3332,7 @@ msgid ""
 "%(support_email)s\">contact Zulip support</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3880,89 +3340,89 @@ msgid ""
 "%(support_email)s\">contact this Zulip server's administrators</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
 "management for your Zulip server."
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr "Érvénytelen vagy lejárt munkamenet."
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr "Belépés a Zulipba"
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr "Már regisztráltál ezzel az email címmel. Kérlek lépj be."
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr "E-mail vagy felhasználónév"
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "Felhasználónév"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr "Elfelejtetted a jelszót?"
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr "Belépés %(identity_provider)s-val/vel"
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr ""
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr "Nincs még fiókod? A szervezetbe belépéshez meghívóra van szükséged."
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> because all Zulip Cloud licenses are in use."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -3971,44 +3431,42 @@ msgid ""
 "or misconfiguration."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 #, fuzzy
 #| msgid "New organization"
 msgid "Demo organizations disabled"
 msgstr "Új szervezet"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr "Frissítés szükséges"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr "Töltsd le a legújabb verziót."
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -4016,22 +3474,21 @@ msgid ""
 "organization for more information."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -4039,47 +3496,45 @@ msgid ""
 "Zulip support</a> for assistance in resolving this issue."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr "Nem támogatott böngésző"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, fuzzy, python-format
 #| msgid "Presence is not supported for bot users."
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr "A jelenlét nincs követve robotok esetén."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
 "a> like Firefox, Chrome, and Edge."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr "A fiók letiltásra került"
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Invalid organization"
 msgid "Finalize organization import"
 msgstr "Hibás szervezet"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 msgid "Organization import completed!"
 msgstr "Szervezet importálás kész!"
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -4087,56 +3542,55 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Select your account"
 msgstr "Hozd létre fiókodat"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Create new account"
 msgstr "Hozd létre fiókodat"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr ""
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr "A szervezetedet sikeresen újraaktiváltuk."
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr "A szervezet újraaktiválási hivatkozás lejárt vagy érvénytelen."
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr "Lépj be a saját szervezetedbe"
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr "Nem ismered a szervezeted URL-jét?"
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr "Találd meg saját szervezetedet."
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr "Következő"
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4144,84 +3598,84 @@ msgid ""
 "have one yet."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 #, fuzzy
 #| msgid "Self-host Zulip"
 msgid "Self-hosting Zulip?"
 msgstr "Légy Zulip szerver-gazda"
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">log in to manage plans and billing.</a>"
 msgstr ""
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr "Jelszó visszaállítása"
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
 msgstr ""
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr "Visszaállító hivatkozás küldése"
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "Jelszó megerősítése"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr ""
 "Sajnos az általad használt link érvénytelen vagy már felhasználásra került."
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr ""
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr ""
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr "Kérjük, <a href=\"%(login_url)s\">jelentkezz be</a> új jelszavaddal."
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr "Az e-mailt elküldtük!"
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr "Nézz rá a leveleidre pár perc múlva a folyamat befejezéséhez."
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr ""
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4229,7 +3683,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4238,57 +3692,57 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr ""
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4296,7 +3750,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4304,20 +3758,20 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr "<h1 class=\"get-started\">Válaszd ki a fiókot</h1>"
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr "A GitHub fiókodhoz ellenőrizetlen e-mail címek vannak hozzárendelve."
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
@@ -4326,21 +3780,21 @@ msgstr ""
 "bejelentkezéshez, akkor először <a href=\"https://github.com/settings/"
 "emails\">ellenőrizd a GitHub segítségével </a>"
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr "Ismeretlen email leiratkozási kérés"
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4348,132 +3802,129 @@ msgid ""
 "away!"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr "Email beállítások frissítve"
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
 "href=\"%(realm_url)s/#settings/notifications\">notification settings</a>."
 msgstr ""
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr "Érvénytelen sorrend megfeleltetés."
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr ""
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr ""
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr ""
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr "feliratkozás"
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr ""
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr "{user} elfogadta a Zulip meghívódat!"
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 #, fuzzy
 #| msgid "Cannot deactivate the only {entity}."
 msgid "Cannot reactivate a deleted user"
 msgstr "Ez az egyetlen {entity}, ezért nem tiltható le."
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr "Mező id {id} nem található."
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr ""
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr ""
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr ""
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
@@ -4482,7 +3933,7 @@ msgstr ""
 "elküldhető meghívók számát. Mivel elérte a korlátot, nem küldtünk ki "
 "meghívót."
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
@@ -4490,169 +3941,166 @@ msgstr ""
 "A fiókod túl új ahhoz, hogy meghívókat küldhess ehhez a szervezethez. Kérj "
 "meg egy szervezeti adminisztrátort vagy egy tapasztaltabb felhasználót."
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr "Néhány e-mail nem volt érvényes, ezért egy meghívót sem küldtünk ki."
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr "Senki sem sikerült meghívnunk."
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr "Nincs változtatnivaló"
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr ""
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr ""
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr "Érvénytelen propagate_mode a téma szerkesztése nélkül"
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr ""
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr "A widgetek nem szerkeszthetőek."
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr "A szervezetben az üzenetek szerkesztésének lehetősége ki van kapcsolva"
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr "Nincs jogosultságod az üzenet szerkesztésére"
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr "Az üzenet módosítására rendelkezésre álló időkorlát letelt"
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr "{user} lezárta ezt a témát."
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr "{user} lezáratlannak jelölte ezt a témát."
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
 "{new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
 "{user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 #, fuzzy
 #| msgid "You don't have permission to delete this message"
 msgid "You don't have permission to resolve topics in this channel."
 msgstr "Az üzenet törléséhez nincs jogosultságod"
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr "Nincs engedélyed ennek az üzenetnek a mozgatásához"
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr ""
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr "Érvénytelen üzenet(ek)"
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr "Az üzenet megjelenítése nem sikerült"
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr "Érvénytelen adattípus a címzettek számára"
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 "A címzettek listája vagy e-maileket, vagy felhasználói azonosítókat "
 "tartalmazhat, de ezek nem vegyíthetőek."
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
 "but there is no channel with that ID."
 msgstr ""
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4660,36 +4108,36 @@ msgid ""
 "it."
 msgstr ""
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
 "The channel exists but does not have any subscribers."
 msgstr ""
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr ""
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr "Widgetek: az API programozó érvénytelen JSON tartalmat küldött"
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr "Widgetek: {error_msg}"
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4697,109 +4145,107 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr "Ilyen nevű egyedi hangulatjel már létezik."
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
 "authentication method."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr ""
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder could not be sent."
 msgstr "A token nem létezik"
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
 "the following error:"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr ""
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr ""
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr ""
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr ""
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr ""
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
 "**{old_policy}** to **{new_policy}**."
 msgstr ""
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -4808,51 +4254,49 @@ msgid ""
 "* **New**: {new_setting_description}\n"
 msgstr ""
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr "Nincs leírás."
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr ""
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr "Régi leírás"
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr "Új leírás"
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr "Örökre"
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr ""
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 msgstr ""
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr ""
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -4863,141 +4307,130 @@ msgid ""
 "{summary_line}"
 msgstr ""
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr "Nem csatolhatsz alüzenetet ezen üzenethez."
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr ""
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr ""
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr "Elégtelen jogosultság"
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr "Ez az API nem érhető el bejövő webhook robotok számára."
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr "A fiók nincs ehhez az aldomainhez rendelve"
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr "Ez a végpont nem fogad el robotoktól érkező kéréseket."
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr "Szerver adminisztrátornak kell lenned"
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr "Ez a végpont HTTP basic authentikációt igényel."
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr "Érvénytelen authorizációs fejléc basic authentikáció során"
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr "Hiányzó authorizációs fejléc a basic auth során"
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr "A webhook robotok csak webhookokat érhetnek el"
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr ""
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
 "organization administrator to reactivate it."
 msgstr ""
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr "A jelszó túl gyenge."
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr "Az aldomainnek legalább 3 karakter hosszúnak kell lennie."
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr "Az aldomain nem kezdődhet kötőjellel."
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr "Az aldomain nevében csak kisbetűk, számok és kötőjelek lehetnek."
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr "A valós e-mail címedet használd."
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr ""
 "Nem létezik a szervezet, amibe a/az {email} címmel megpróbálsz belépni."
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
@@ -5005,11 +4438,11 @@ msgstr ""
 "Kérjük igényelj egy invitációt a/az {email} címeddel a szervezet "
 "adminisztrátorától."
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
@@ -5018,12 +4451,12 @@ msgstr ""
 "A/az {email} email címed domain neve nincs azok között a domain nevek "
 "között, ahonnan engedélyezett a regisztráció ebbe a szervezetbe."
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr ""
 "Ebben a szervezetben a + jelet tartalmazó email címek nem használhatóak."
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
@@ -5033,41 +4466,40 @@ msgstr ""
 "lincenszük már használt. Kérjük, szólj a tagnak, aki meghívott, hogy "
 "növeljék a lincenszek számát, majd próbálkozz újra."
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 #, fuzzy
 #| msgid "Embedded bots are not enabled."
 msgid "Challenges are not enabled."
 msgstr "Beágyazott robotok használata nem engedélyezett."
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "Új jelszó"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr "Új jelszó megerősítése"
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "You're making too many attempts to sign in. Try again in "
 "{retry_after_string} or contact your organization administrator for help."
 msgstr ""
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
@@ -5075,90 +4507,88 @@ msgstr ""
 "A jelszavad túl gyengének bizonyult, ezért zároltuk. Állítsd vissza a "
 "jelszavad, hogy egy újat beállíthass."
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr "Token"
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr "Maximum 10 e-mail címet adhatsz meg."
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr "Nem találtuk meg ezt a Zulip szervezetet."
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr ""
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr "Hiányzó téma"
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr ""
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr ""
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr "Az üzenethez címzettnek is kell tartoznia"
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr "Érvénytelen üzenettípus"
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr "Érvénytelen csatolmány"
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr "Hiba történt a csatolmány törlése közben. Próbáld újra később."
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr "Az üzenethez tartoznia kell címzettnek!"
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Content can't be empty"
 msgid "Channel folder name can't be empty."
 msgstr "Tartalom nem maradhat üres"
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Invalid data export ID"
 msgid "Invalid channel folder ID"
 msgstr "Érvénytelen adat export ID"
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 #, fuzzy
 #| msgid "Enter your email address"
 msgid "Configure owner account email address."
 msgstr "Add meg az e-mail címed"
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5167,72 +4597,72 @@ msgid ""
 "organization]({convert_demo}).\n"
 msgstr ""
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a date"
 msgid "{var_name} is not Base64 encoded"
 msgstr "{var_name} nem dátum"
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 #, fuzzy
 #| msgid "Invalid emoji code."
 msgid "Invalid `device_id`"
 msgstr "Érvénytelen hangulatjel kód."
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr ""
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr "A domain nem lehet üres."
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr "A domainnek legalább egy pontot (.) kell tartalmaznia"
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr "A domain túl hosszú"
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr "A domain nem kezdődhet vagy végződhet ponttal (.)"
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr "Nem lehet több egymást követő '.' karakter."
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr "Az aldomain nem kezdődhet vagy végződhet kötőjellel."
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr "A domain csak betűket, számokat, pontot és kötőjelet tartalmazhat."
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr "Az időpont nem lehet negatív."
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr "A témakör nem tartalmazhat null byte-ot"
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr "A felhasználó letiltotta a piszkozatok összehangolását."
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr "Piszkozat nem található"
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5240,630 +4670,628 @@ msgid ""
 "{error_message}"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr "Nyisd meg a Zulipot, hogy lásd a zárolt tartalmat"
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr ""
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr "Érvénytelen cím."
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr "Kívül van a tartományodon."
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr "A + jeleket tartalmazó e-mail címek nem megengedettek."
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr "Robotok részére fenntartva."
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr "{email} már felhasználó"
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr "Már van fiókja."
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr "A fiók letiltásra került."
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr ""
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr "Érvénytelen egyedi hangulatjel."
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr "Érvénytelen egyedi hangulatjel név."
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr "Ez az egyedi hangulatjel deaktiválásra került."
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr "Érvénytelen hangulatjel kód."
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr "Érvénytelen hangulatjel név."
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr "Érvénytelen hangulatjel típus."
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr "Ehhez szervezeti adminisztrátornak vagy emoji szerzőnek kell lenned"
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr ""
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
 msgstr ""
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr "A hangulatjelnek nincs neve"
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr "Az esemény sor allokálása nem sikerült"
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr "Nem vagy bejelentkezve: API auth vagy felhasználói folyamat szükséges"
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr ""
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr "szervezet tulajdonosa"
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr "felhasználó"
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr "Ez az egyetlen {entity}, ezért nem tiltható le."
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr "Érvénytelen Markdown include statement: {include_statement}"
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr "Hibás formátumú JSON"
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr "Szervezeti adminisztrátornak kell lenned"
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr "A szervezet tulajdonosának kell lenned"
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Must be an organization owner"
 msgid "Must be a bot user"
 msgstr "A szervezet tulajdonosának kell lenned"
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr "A felhasználóneved vagy a jelszavad helytelen"
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr "Ez a szervezet letiltásra került"
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr "A jelszavas belépés ennél a szerveződésnél nem elérhető"
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr "A jelszavad el lett tiltva, állítsd vissza"
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr "Érvénytelen API kulcs"
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr "Hibás formátumú API kulcs"
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
 "webhook; ignoring"
 msgstr ""
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr "Érvénytelen subdomain"
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr ""
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr ""
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr "Hozzáférés megtagadva"
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} most recent messages in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr "Ez a reakció már létezik."
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr "Ez a reakció nem létezik."
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
 msgstr ""
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr ""
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr ""
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr ""
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr ""
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr ""
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Already has an account."
 msgid "Atlassian account ID"
 msgstr "Már van fiókja."
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Behance username"
 msgstr "Hibás név vagy felhasználói név"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 msgid "Bitbucket username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Codeberg username"
 msgstr "Hibás név vagy felhasználói név"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Dribbble username"
 msgstr "E-mail vagy felhasználónév"
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Facebook username"
 msgstr "Hibás név vagy felhasználói név"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "GitLab username"
 msgstr "E-mail vagy felhasználónév"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Instagram username"
 msgstr "Hibás név vagy felhasználói név"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 msgid "Mastodon profile"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Medium username"
 msgstr "Hibás név vagy felhasználói név"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Pinterest username"
 msgstr "Hibás név vagy felhasználói név"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Reddit username"
 msgstr "E-mail vagy felhasználónév"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 msgid "Snapchat username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Threads username"
 msgstr "Hibás név vagy felhasználói név"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "TikTok username"
 msgstr "E-mail vagy felhasználónév"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Twitch username"
 msgstr "E-mail vagy felhasználónév"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "Felhasználónév"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr "Érvénytelen külső fiók típus"
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr "Integrációs keretrendszerek"
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 #, fuzzy
 #| msgid "Billing"
 msgid "Video calling"
 msgstr "Számlázás"
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr "Folyamatos integráció"
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr "Ügyfélszolgálat"
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr "Telepítés"
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr "Szórakoztatás"
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr "Kommunikáció"
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr "Gazdasági"
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr ""
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr "Marketing"
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr "Egyéb"
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr ""
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr "Projekt menedzsment"
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr "Hatékonyság"
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr "Verziókezelés"
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr "Az üzenet nem lehet üres"
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr "Az üzenet nem tartalmazhat null byteokat"
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{fullname} moderation"
 msgstr "{full_name} kihívott téged:"
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr "Érvénytelen postosító kifejezés: {desc}"
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr ""
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr ""
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr "Üres az 'anchor' mező."
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 #, fuzzy
 #| msgid "Missing 'anchor' argument."
 msgid "Missing 'anchor_date' argument."
 msgstr "Üres az 'anchor' mező."
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr "Érvénytelen anchor"
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr ""
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 #, fuzzy
 #| msgid "Reaction doesn't exist."
 msgid "Navigation view does not exist."
 msgstr "Ez a reakció nem létezik."
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5871,7 +5299,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5879,7 +5307,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5887,7 +5315,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5895,7 +5323,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5905,14 +5333,14 @@ msgid ""
 "a permanent organization]({convert_demo_organization_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
 "them in your [Inbox](/#inbox).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5920,7 +5348,7 @@ msgid ""
 "({navigation_tour_video_url}) for a quick app overview.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5935,14 +5363,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -5950,7 +5378,7 @@ msgid ""
 "and edit your [profile information](/help/edit-your-profile).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -5961,7 +5389,7 @@ msgid ""
 "experience in your [Preferences](#settings/preferences).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5972,7 +5400,7 @@ msgid ""
 "[Browse and subscribe to channels]({settings_link}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -5989,7 +5417,7 @@ msgid ""
 "discussed.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -5998,7 +5426,7 @@ msgid ""
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -6010,7 +5438,7 @@ msgid ""
 "times, and more.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6020,7 +5448,7 @@ msgid ""
 "or browse the [help center](/help/) to learn more!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6028,7 +5456,7 @@ msgid ""
 "get help, try one of the following messages: {bot_commands}\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6040,13 +5468,13 @@ msgid ""
 "({move_content_another_channel_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6060,12 +5488,11 @@ msgid ""
 "and above.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr ""
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -6073,14 +5500,14 @@ msgid ""
 "no matter how many other conversations are going on.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
 "conversations with unread messages.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -6088,7 +5515,7 @@ msgid ""
 "the `+` button next to its name.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -6096,13 +5523,13 @@ msgid ""
 "can we chat about…?”\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6110,7 +5537,7 @@ msgid ""
 "({format_message_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6130,1250 +5557,1229 @@ msgid ""
 "```\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
 "teammates.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
 "conversation.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr ""
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr ""
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr ""
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr "Érvénytelen JSON érkezett vissza"
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr "Érvénytelen válasz format"
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr "Üres vagy érvénytelen hosszúságú token"
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr "Érvénytelen APNS token"
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr ""
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr "A token nem létezik"
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr "{full_name} megemlítette, hogy @{user_group_name}:"
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr "{full_name} kihívott téged:"
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr "{full_name} kihívott mindenkit:"
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "Új üzenet"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 #, fuzzy
 #| msgid "Invalid API key"
 msgid "Invalid `push_key`"
 msgstr "Érvénytelen API kulcs"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr "Erre a lekérdezésre a felhasználó nem jogosult"
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr "'{email}' már nem használja a Zulip-et."
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr ""
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr "{var_name} túl hosszú (korlátozva {max_length} karakter hosszúságban)"
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder does not exist"
 msgstr "A token nem létezik"
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr ""
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr ""
 "Nem tudtunk választani a/az '{var_name1}' és '{var_name2}' paraméterek közül"
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr "Hiányzó '{var_name}' érték"
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr "Rossz érték megadva ennél '{var_name}': {bad_value}"
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr ""
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr ""
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr ""
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr ""
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 #, fuzzy
 #| msgid "You don't have permission to delete this message"
 msgid "You do not have permission to create new topics in this channel."
 msgstr "Az üzenet törléséhez nincs jogosultságod"
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr ""
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr ""
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr ""
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr ""
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr ""
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr "Kép dekódolása sikertelen; biztosan képet töltöttél fel?"
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr "A kép mérete meghaladja a beállított korlátokat."
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr "{var_name} nem boolean"
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a float"
 msgid "{var_name} does not have the expected format"
 msgstr "{var_name} nem float"
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr "{var_name} nem dátum"
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr "{var_name} nem dict"
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr "Érvénytelen {var_name}"
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr "{var_name} nem float"
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr "{var_name} túl kicsi"
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr "{var_name} nem integer"
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr "{var_name} túl nagy"
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr "{var_name} nem lista"
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr "{var_name} túl hosszú (korlátozva {max_length} karakter hosszúságban)"
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr "{var_name} nem string"
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr "{var_name} túl hosszú (korlátozva {max_length} karakter hosszúságban)"
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr "{var_name} túl hosszú (korlátozva {max_length} karakter hosszúságban)"
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr "Sérült payload"
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr "{var_name} nem érvényes hex color code"
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr "Érvénytelen {setting_name}"
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr "A feltöltéseddel a szervezeted túllépné a rendelkezésre álló keretét."
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr ""
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr ""
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr "Érvénytelen felhasználói csoport"
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid user group"
 msgid "Invalid user group ID: {user_group_id}"
 msgstr "Érvénytelen felhasználói csoport"
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr ""
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr ""
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr ""
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr "Az ügyfél nem adott meg semmi új értéket."
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 "Az ügyfél kénytelen lesz megadni egy emoji_name ha meghatároztak egy "
 "emoji_code vagy reaction_type -ot."
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr "A név túl hosszú!"
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 #, fuzzy
 #| msgid "Message must not be empty"
 msgid "Name must not be empty!"
 msgstr "Az üzenet nem lehet üres"
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr "Érvénytelen karakter a névben!"
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr "Érvénytelen formátum!"
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr ""
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr ""
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr "Hibás név vagy felhasználói név"
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr ""
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr ""
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr ""
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr "Érvénytelen konfigurációs adat!"
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr "Érvénytelen robot típus"
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr "Érvénytelen interfész típus"
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr ""
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr "Nincs ilyen robot"
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr "Nincs ilyen felhasználó"
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr "A felhasználó letiltásra került"
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr "{item} nem lehet üres."
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr ""
 "{var_name} hossza {length}, ami érvénytelen; {target_length} hosszúnak "
 "kellene lennie"
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a string"
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr "{var_name} nem string"
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr "{container} pontosan {length} dolgot tartalmazzon"
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr "{key_name} kulcs hiányzik a {var_name} változóból"
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr ""
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr "{var_name} nem allowed_type"
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr "{variable} != {expected_value} ({value} hibás)"
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr "{var_name} nem URL"
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr ""
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr "'{item}' nem lehet üres."
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr ""
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr "'{value}' nem érvényes választási lehetőség '{field_name}' számára."
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr "{var_name} nem string vagy integer lista"
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr "{var_name} nem string vagy integer"
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr ""
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr "{var_name} hiányzik"
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr "Hiányzó HTTP esemény fejléc '{header}'"
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr "A zcommandban kezdő per jelnek kell szerepelnie."
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr ""
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr "CSRF hiba: {reason}"
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr "Külső fiók"
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr ""
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr "Senki"
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr ""
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "Tagok"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr ""
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Invalid characters in emoji name"
 msgid "Invalid auto-conversion field: empty field name."
 msgstr "Érvénytelen karakter a hangulatjel nevében"
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr ""
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr "Ismeretlen regex hiba"
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 msgid "Example input does not match the linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in alternative URL template is not present in linkifier "
 "pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in linkifier pattern is not present in alternative URL "
 "template."
 msgstr ""
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr "Unicode hangulatjel"
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "Egyedi hangulatjel"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr "Zulip extra hangulatjel"
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr "Érvénytelen karakter a hangulatjel nevében"
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr "Érvénytelen karakterek a pygments nyelvben"
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr ""
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr ""
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr ""
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr ""
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr ""
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr ""
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr ""
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr ""
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr "Nyilvános a weben"
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "Nyilvános"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr "Privát, közös korábbi üzenetek"
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr "Privát, védett korábbi üzenetek"
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr "Adminok, moderátorok, tagok és vendégek"
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr "Adminok, moderátorok, és tagok"
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr "Adminok és moderátorok"
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr "Csak adminisztrátorok"
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr ""
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr "Szervezet tulajdonosa"
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr "Szervezet adminisztrátora"
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr "Moderátor"
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "Tag"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "Vendég"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr "Ismeretlen IP cím"
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr "egy ismeretlen operációs rendszer"
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr "Egy ismeretlen böngésző"
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr "Hiányzó 'queue_id' paraméter"
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr "Hiányzó 'last_event_id' paraméter"
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr "Egy eseményt ami újabb, mint {event_id} már töröltek!"
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr "Az esemény {event_id} ebben a sorban nem található"
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr ""
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 #, fuzzy
 #| msgid "Failed to create Zoom call"
 msgid "Failed to generate challenge"
 msgstr "Nem sikerült Zoom hívást kezdeményezni"
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr ""
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr "Nem lett JSON web token megadva a request-ben"
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr "Hibás JSON web token"
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr ""
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr "Aldomain megadása kötelező"
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr "Helytelen jelszó."
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr "User-Agent fejléc hiányzik a kérésből"
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr "A címke nem lehet üres."
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr "A mezőnek legalább egy választási lehetőséggel rendelkeznie kell."
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 #, fuzzy
 #| msgid "Presence is not supported for bot users."
 msgid "Field type not supported for use for user matching."
 msgstr "A jelenlét nincs követve robotok esetén."
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr "Érvénytelen mezőtípus."
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr "Ilyen címkével már létezik mező."
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr "Alapértelmezett egyedi mező frissítése sikertelen."
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr "Éles környezetben hozzáférhetetlen endpoint."
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr "DevAuthBackend nincs engedélyezve."
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr ""
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr ""
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr ""
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr ""
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr ""
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr ""
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr "Nincs ilyen meghívó"
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid "Invitation already used or deactivated."
 msgstr "Ez a szervezet letiltásra került."
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr ""
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr ""
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr "Legalább egy e-mail cím megadása kötelező."
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
@@ -7381,105 +6787,103 @@ msgstr ""
 "Néhány címzett már használja a Zulipot, ezért nem küldtünk nekik meghívót. "
 "Mindenki másnak viszont igen!"
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr ""
 "Az üzenet szerkesztési előzmények elérése ebben a szervezetben le van tiltva"
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr "Az üzenet törléséhez nincs jogosultságod"
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr "Az üzenettörlésre rendelkezésre álló időkorlát letelt"
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr "Törölt üzenet"
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr ""
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr ""
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr ""
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr ""
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Zephyr mirroring is not allowed in this organization"
 msgid "Message reporting is not enabled in this organization."
 msgstr "Zephyr tükrözés nem engedélyezett ebben a szervezetben."
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr "Hiányzó küldő"
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr "Tükrözés nem engedélyezett a címzett felhasználó azonosítókkal"
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr "Érvénytelen tükrözött üzenet"
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr ""
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr ""
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr ""
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr "Önmagad nem némíthatod"
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr "Némított felhasználó"
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr "Felhasználó nincs lenémítva"
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 #, fuzzy
 #| msgid "Reaction already exists."
 msgid "Navigation view already exists."
 msgstr "Ez a reakció már létezik."
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7487,147 +6891,147 @@ msgid ""
 "later. Is this a good time?\n"
 msgstr ""
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr "A jelenlét nincs követve robotok esetén."
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr "Jelenléti adat hiányzik {user_id_or_email} felhasználónál"
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 #, fuzzy
 #| msgid "You don't have permission to delete this message"
 msgid "You do not have permission to manage plans and billing."
 msgstr "Az üzenet törléséhez nincs jogosultságod"
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr ""
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr ""
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr "Legalább egyet meg kell adni ezek közül: emoji_name, emoji_code"
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr ""
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr ""
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr "Valamilyen authentikációs lehetőséget meg kell adni."
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr ""
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr ""
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr "Csak bemutató szerveződés lehet."
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr ""
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr "A/az {domain} már része a szervezetednek."
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr "Nem találtunk a {domain} domain-re példát."
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr "Pontosan egy fájlt tölts fel."
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr ""
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 #, fuzzy
 #| msgid "Disposable email addresses are not allowed in this organization"
 msgid ""
@@ -7635,422 +7039,420 @@ msgid ""
 msgstr ""
 "Eldobható email címek használata ebben a szervezetben nem engedélyezett"
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr "Határtúllépés."
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr "Érvénytelen adat export ID"
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr "Törölt export"
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr ""
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr ""
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr "Pontosan egy ikont tölts fel."
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr "Linkifier nem található."
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr "Pontosan egy logo feltöltésére van szükség."
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid characters in pygments language"
 msgid "Invalid character in language: {character}"
 msgstr "Érvénytelen karakterek a pygments nyelvben"
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not an allowed_type"
 msgid "Language '{language}' is not allowed."
 msgstr "{var_name} nem allowed_type"
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr "Érvénytelen homokozó"
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr ""
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 msgid "Importing messages…"
 msgstr ""
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 msgid "Your name"
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr ""
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr ""
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr ""
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr "A \"new_description\" vagy a \"new_group_name\"-et kell átadnod."
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr ""
 "Érvényelen érték az \"op\"-ban. Használd az \"add\" vagy \"remove\" "
 "értékeket."
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr "Érvénytelen paraméterek"
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr ""
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr ""
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr ""
 "Nincs teendő meghatározva. Legalább az \"add\" vagy a \"delete\" megadása "
 "szükséges."
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr ""
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr ""
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr ""
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr ""
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
 "**"
 msgstr ""
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr ""
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr ""
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr ""
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr "Érvénytelen json a submessage számára"
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr ""
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr ""
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr "Nincs címzett megadva"
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr ""
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr "<p>Nincs jogosultságod a fálj megtekintéséhez.</p>"
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr "Érvénytelen token"
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr "Érvénytelen fájlnév"
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr "A feltöltéshez egy állományt kell megadni"
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr "Egyszerre csak egy állomány tölthető fel"
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr "Nincs megadva új adat"
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 msgstr ""
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr "A felhasználó {user_id} már tagja e csoportnak"
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr ""
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
 "subgroups."
 msgstr ""
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr "A profilkép változtatások ebben a szervezetben le vannak tiltva."
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr "Az email cím változtatás ebben a szervezetben le van tiltva."
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr "Érvénytelen default_language"
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr ""
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr ""
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr "A Zulip jelszavad LDAP-ban kezelhető"
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr "Hibás jelszó!"
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, fuzzy, python-brace-format
 #| msgid "You can try again in %(retry_after)s seconds."
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr "Próbálkozz újra %(retry_after)s másodperccel később."
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr "Az új jelszó túl gyenge!"
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr "Egyetlen avatar feltöltésére van szükség."
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr "A téma nincs lenémítva"
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr "A szervezet egyedüli tulajdonosa nem tiltható le"
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 msgid "User is not allowed to delete other user's messages."
 msgstr ""
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 "A tulajdonosi jogosultság nem törölhető a szervezet egyedüli tulajdonosánál."
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr ""
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr ""
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
@@ -8063,29 +7465,29 @@ msgstr ""
 "beállítva.\n"
 "Kérjük szólj a szerver adminnak."
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 #, fuzzy
 #| msgid "Email address"
 msgid "Email address already in use"
 msgstr "E-mail cím"
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr ""
 "Nincs ilyen felhasználó, a tulajdonos megváltoztatása ezért nem sikerült"
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr ""
 "A tulajdonos megváltoztatása sikertelen volt, a felhasználó le van tiltva"
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr ""
 "A robotok nem lehetnek más robotok tulajdonosai, a tulajdonos "
 "megváltoztatása sikertelen"
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
@@ -8094,292 +7496,292 @@ msgstr ""
 "beállítva.\n"
 "Kérjük szólj a szerver adminnak."
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr "Beágyazott robotok használata nem engedélyezett."
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr "Érvénytelen beágyazott robot név."
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr ""
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr "A/az '{email}' email cím nincs engedélyezve ebben a szervezetben"
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr ""
 "Eldobható email címek használata ebben a szervezetben nem engedélyezett"
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom access token"
 msgid "Invalid {provider_name} access token"
 msgstr "Érvénytelen Zoom access token"
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} call"
 msgstr "Nem sikerült Zoom hívást kezdeményezni"
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Zoom credentials have not been configured"
 msgid "{provider_name} credentials have not been configured"
 msgstr "Zoom jogosultsági beállítások hiányoznak"
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom credentials"
 msgid "Invalid {provider_name} credentials"
 msgstr "Érvénytelen Zoom jogosultságok"
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error connecting to the BigBlueButton server."
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr "Hiba történt a BigBlueButton szerverhez való csatlakozás közben."
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error authenticating to the BigBlueButton server."
 msgid "Error authenticating to the {provider_name} server"
 msgstr "Hiba történt a BigBlueButton szerver authentikációja során."
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "BigBlueButton server returned an unexpected error."
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr "BigBlueButton szerver váratlan hibát jelentett."
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom session identifier"
 msgid "Invalid {provider_name} session identifier"
 msgstr "Érvénytelen Zoom session identifier"
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr ""
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} public room."
 msgstr "Nem sikerült Zoom hívást kezdeményezni"
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr "Érvénytelen aláírás."
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{full_name}'s Zulip room"
 msgstr "{full_name} kihívott téged:"
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr "Érvénytelen payload adattartalom"
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr "Ismeretlen webhook kérés"
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr "A téma nem lehet üres"
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr "Tartalom nem maradhat üres"
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr ""
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr "Deformálódott JSON input"
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr ""
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr "Hiba: channels_map_to_topics paraméter más, mint 0 vagy 1"
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr ""
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
 "({export_settings_link})."
 msgstr ""
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr ""
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr ""
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr ""
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr ""
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr "Érvénytelen aldomain a push értesítés bouncerhez"
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr "Érvényesítsd a Zulip szervert érvényes API kulccsal"
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr "Érvénytelen UUID"
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr "Érvénytelen token típus"
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr ""
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr ""
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr ""
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr ""
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
 "try again later or reach out to {support_email} for assistance."
 msgstr ""
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr ""
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr ""
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr ""
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr ""
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
 "server: {reason}"
 msgstr ""
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr ""
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr ""
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr ""
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr "Váratlan adatrend."
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr ""
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr ""
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr "Kérj új jelszót."
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr "Hiányzó id_token paraméter"
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 #, fuzzy
 #| msgid "Missing id_token parameter"
 msgid "Missing idp param"
 msgstr "Hiányzó id_token paraméter"
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr "Érvénytelen OTP"
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr "Egyszerre nem használható a mobile_flow_otp és a desktop_flow_otp."
 

--- a/locale/id/LC_MESSAGES/django.po
+++ b/locale/id/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 19:16+0000\n"
 "Last-Translator: Alex Vandiver <alexmv@zulip.com>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/zulip/django/"
@@ -23,50 +23,50 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr ""
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr ""
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr ""
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr ""
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr ""
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr "Data analisis tidak tersedia. Mohon hubungi administrator server anda."
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -75,7 +75,7 @@ msgid ""
 "users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -83,7 +83,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than one user to join."
 msgstr ""
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -91,7 +91,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than two users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -99,7 +99,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than three users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -108,148 +108,147 @@ msgid ""
 "({billing_page_link}) is greater than the current number of users."
 msgstr ""
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr ""
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr ""
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
 "(minimum {min_licenses})."
 msgstr ""
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
 "page. To complete the upgrade, please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr ""
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr ""
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr ""
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr ""
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr ""
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr ""
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
 msgstr ""
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
 msgstr ""
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
 "licenses."
 msgstr ""
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
 "billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr ""
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr ""
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr ""
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -259,100 +258,97 @@ msgid ""
 "we would really appreciate it!"
 msgstr ""
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
 "{support_email}"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr ""
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr ""
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr ""
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
 "%(support_email)s\">contact support</a>."
 msgstr ""
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr ""
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
 msgstr ""
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr ""
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
 msgstr ""
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr ""
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr "Eror internal server"
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
 msgstr ""
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -360,289 +356,270 @@ msgid ""
 "a> with any questions."
 msgstr ""
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
 "a> for support."
 msgstr ""
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
 "href=\"%(troubleshooting_url)s\">Zulip server troubleshooting guide</a>."
 msgstr ""
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr ""
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr ""
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr ""
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr ""
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr ""
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr ""
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr ""
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr ""
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr ""
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "Pengguna aktif"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr ""
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr ""
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr ""
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "Pengguna"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr "Pesan terkirim berdasarkan jenis penerima"
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "Saya"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "Semua orang"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "Minggu lalu"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "Bulan lalu"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "Tahun lalu"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "Semua waktu"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr "Pesan terkirim sepanjang waktu"
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "Harian"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "Mingguan"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr "Kumulatif"
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "Manusia"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "Bot"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr ""
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr "Pesan terkirim oleh klien"
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr "Pembaruan terakhir"
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr "Email berubah!"
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
 "%(old_email_html_tag)s to %(new_email_html_tag)s"
 msgstr ""
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr ""
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
 msgstr ""
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "Batal"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr ""
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr ""
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -653,19 +630,19 @@ msgid ""
 "server."
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -673,790 +650,299 @@ msgid ""
 "%(support_email)s'>contact support</a> with any questions."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, python-format
 msgid "You can try again in %(retry_after_string)s."
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr ""
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr ""
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr "Saring berdasarkan kategori"
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "Semua"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr "Kategori"
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr ""
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr ""
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr ""
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr ""
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr ""
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "Buat organisasi"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr ""
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr ""
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr ""
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr ""
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 msgid "Zulip for open source"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Messages sent over time"
 msgid "Message with code"
 msgstr "Pesan terkirim sepanjang waktu"
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr "Organisasi"
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
 msgstr ""
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 msgid "Get started"
 msgstr ""
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
 "continue."
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "Email"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1464,78 +950,77 @@ msgid ""
 "from Zulip."
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
 msgstr ""
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr ""
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr ""
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr ""
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr ""
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr ""
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr ""
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr ""
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
 msgstr ""
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1543,212 +1028,205 @@ msgid ""
 "href=\"%(doc_url)s\">documentation</a>."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr "Akun Zulip tidak ditemukan."
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, python-format
 msgid "No account found for %(email)s."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Create a new Zulip organization"
 msgid "Try Zulip in a demo organization"
 msgstr "Buat organisasi Zulip baru"
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Why Zulip"
 msgid "Try Zulip"
 msgstr "Mengapa Zulip"
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "Create a new organization"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr "Buat organisasi Zulip baru"
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr "Masukkan alamat email anda"
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid "Import chat history?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr "Nama organisasi"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "URL Organisasi"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr "Gunakan %(external_host)s"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "OR"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "Mendaftar"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "Mendaftar ke Zulip"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr "Anda memerlukan undangan untuk bergabung di organisasi ini."
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "Masuk"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1756,125 +1234,124 @@ msgid ""
 "noreferrer\">after you join</a>."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "Ubah"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr "Akun anda"
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "Nama"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "Kata Sandi"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 "Ini digunakan untuk aplikasi seluler dan perangkat lain yang memerlukan kata "
 "sandi."
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr "Kekuatan kata sandi"
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr ""
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">Terms of Service</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr "Organisasi yang dideaktivasi"
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr ""
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -1882,45 +1359,45 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 msgid ""
 "This organization has been deactivated, and all organization data has been "
 "deleted."
 msgstr ""
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
 "inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
 "administrators</a> to inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 msgid "This organization has been deactivated."
 msgstr ""
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
 "%(support_email)s\">contact Zulip support</a> to reactivate it."
 msgstr ""
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -1928,165 +1405,164 @@ msgid ""
 "reactivate it."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "Copy"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "Administrator"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "Pengguna biasa"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "Tutup"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "Perbarui"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr "Zulip"
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
 "<b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr "Selamat datang di Zulip!"
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
 "href=\"%(apps_page_link)s\">mobile and desktop</a> apps:"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
 "href=\"%(getting_user_started_link)s\">getting started guide</a>!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2094,83 +1570,83 @@ msgid ""
 "Zulip</a>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
 "to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
 "desktop apps (%(apps_page_link)s):"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
 "(%(getting_user_started_link)s)!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
 "(%(getting_organization_started_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2178,32 +1654,32 @@ msgid ""
 "password for this account, please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "%(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 msgid "Verify your email address for your Zulip demo organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "<%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2211,113 +1687,113 @@ msgid ""
 "please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
 "— we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
 "deactivated, and you will no longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr ""
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2325,22 +1801,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because your organization <a "
@@ -2348,8 +1824,8 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to <a "
@@ -2357,40 +1833,40 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, fuzzy, python-format
 #| msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr "Mohon <a href=\"%(login_url)s\">masuk</a> dengan kata sandi baru."
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr ""
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because your organization hides "
@@ -2398,81 +1874,74 @@ msgid ""
 "details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to hide "
 "message content in email notifications. See %(help_url)s for more details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr ""
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
 "organizations:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
 "organizations hosted by %(external_host)s:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
 "href=\"%(help_reset_password_link)s\">reset your password</a>."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
 "%(external_host)s."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2480,97 +1949,94 @@ msgid ""
 "to find your account."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
 "try another way to find your account (%(help_logging_in_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
 "communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr ""
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
 "-- the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
 "Zulip &mdash; the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
 "to ask %(referrer_name)s for another one."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2578,72 +2044,70 @@ msgid ""
 "productivity."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at <a href=\"mailto:%(email)s\">%(email)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
 "%(email)s\">Contact us</a> — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
 "#%(channel_name)s > %(topic_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2651,68 +2115,68 @@ msgid ""
 "preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails (<a href=\"%(url)s\">help</a>)."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2720,22 +2184,22 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2743,52 +2207,52 @@ msgid ""
 "immediately at <%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2796,31 +2260,31 @@ msgid ""
 "contact us immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2828,7 +2292,7 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -2836,25 +2300,25 @@ msgid ""
 "Zulip</a> to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
 "with you and share their unique perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -2862,7 +2326,7 @@ msgid ""
 "experience how a new chat app will help your team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -2870,148 +2334,148 @@ msgid ""
 "action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
 "team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
 "organizations like yours!"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3019,11 +2483,11 @@ msgid ""
 "about…?”"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3032,23 +2496,23 @@ msgid ""
 "href=\"%(move_channels_link)s\">move a topic to a different channel</a>."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr "Pergi ke Zulip"
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3057,23 +2521,23 @@ msgid ""
 "(%(move_channels_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
 "%(email)s on %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr "Reset kata sandi"
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3081,46 +2545,46 @@ msgid ""
 "href=\"%(help_link)s\">reactivate your account</a>."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
 "You can contact an organization administrator to reactivate your account."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3128,543 +2592,539 @@ msgid ""
 "have been voided."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
 "to %(upgrade_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip demo organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip demo organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Deactivated organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "Organisasi yang dideaktivasi"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for <b>%(remote_server_hostname)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 msgid "Click the button below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for %(remote_server_hostname)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
 "management for <b>%(remote_realm_host)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
 "management for %(remote_realm_host)s."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the <a href=\"%(plans_link)s\">Zulip Community plan</a>."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
 "website</a>, we would really appreciate it!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
 msgstr ""
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr "Temukan akun Zulip anda"
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
 "accounts for another email address</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr "Alamat email"
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "Temukan akun"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr ""
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr "Mengapa Zulip"
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr "Fitur"
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr ""
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Zulip"
 msgid "Zulip Cloud"
 msgstr "Zulip"
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr ""
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr ""
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "Integrasi"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr "Aplikasi desktop & mobile"
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr "Organisasi baru"
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr ""
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr ""
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr ""
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr ""
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr ""
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr ""
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr ""
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr ""
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr ""
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr ""
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr ""
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr "Pusat bantuan"
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr "Percakapan komunitas"
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr ""
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr ""
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr ""
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr ""
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr ""
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr ""
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr ""
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr "Tim"
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "History"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr ""
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr ""
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr ""
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr ""
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr ""
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 msgid "Bluesky"
 msgstr ""
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr ""
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr "Ketentuan Layanan"
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr "Kebijakan privasi"
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 msgid ""
 "And hundreds more through <a href=\"/integrations/zapier\">Zapier</a> and <a "
 "href=\"/integrations/ifttt\">IFTTT</a>."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr "Cari integrasi"
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr "Robot interaktif"
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3672,7 +3132,7 @@ msgid ""
 "emails with your email domain."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3680,7 +3140,7 @@ msgid ""
 "disposable email addresses."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3688,24 +3148,24 @@ msgid ""
 "emails that contain \"+\"."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3713,7 +3173,7 @@ msgid ""
 "%(support_email)s\">contact Zulip support</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3721,89 +3181,89 @@ msgid ""
 "%(support_email)s\">contact this Zulip server's administrators</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
 "management for your Zulip server."
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr ""
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr ""
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr "Email atau username"
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "Username"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr ""
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr ""
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr ""
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> because all Zulip Cloud licenses are in use."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -3812,44 +3272,42 @@ msgid ""
 "or misconfiguration."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 #, fuzzy
 #| msgid "New organization"
 msgid "Demo organizations disabled"
 msgstr "Organisasi baru"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -3857,22 +3315,21 @@ msgid ""
 "organization for more information."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -3880,48 +3337,46 @@ msgid ""
 "Zulip support</a> for assistance in resolving this issue."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
 "a> like Firefox, Chrome, and Edge."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create organization"
 msgid "Finalize organization import"
 msgstr "Buat organisasi"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Organization name"
 msgid "Organization import completed!"
 msgstr "Nama organisasi"
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -3929,56 +3384,55 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Your account"
 msgid "Select your account"
 msgstr "Akun anda"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create a new organization"
 msgid "Create new account"
 msgstr "Create a new organization"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr ""
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -3986,81 +3440,81 @@ msgid ""
 "have one yet."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 msgid "Self-hosting Zulip?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">log in to manage plans and billing.</a>"
 msgstr ""
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr "Reset kata sandi anda"
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
 msgstr ""
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "Konfirmasi kata sandi"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr "Maaf, link yang Anda berikan invalid atau telah digunakan."
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr ""
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr ""
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr "Mohon <a href=\"%(login_url)s\">masuk</a> dengan kata sandi baru."
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr "Reset kata sandi dikirim!"
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr ""
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr ""
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4068,7 +3522,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4077,57 +3531,57 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr ""
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4135,7 +3589,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4143,40 +3597,40 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr "Permintaan email berhenti berlanggan tidak diketahui"
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4184,304 +3638,298 @@ msgid ""
 "away!"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr "Pengaturan email diperbarui"
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
 "href=\"%(realm_url)s/#settings/notifications\">notification settings</a>."
 msgstr ""
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr ""
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr ""
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr ""
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr ""
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr ""
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr ""
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr ""
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 msgid "Cannot reactivate a deleted user"
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr ""
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr ""
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr ""
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr ""
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
 msgstr ""
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
 msgstr ""
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 "Beberapa email tidak tervalidasi, jadi kami tidak mengirimkan undangan "
 "apapun."
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr "Kami tidak dapat mengundang siapapun."
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr "Tidak ada yang dapat diubah"
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr ""
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr ""
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr ""
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr ""
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr ""
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr "Organisasi Anda telah menonaktifkan penyuntingan pesan"
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr "Anda tidak memiliki ijin untuk mengedit pesan ini"
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr ""
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
 "{new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
 "{user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 #, fuzzy
 #| msgid "You don't have permission to edit this message"
 msgid "You don't have permission to resolve topics in this channel."
 msgstr "Anda tidak memiliki ijin untuk mengedit pesan ini"
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr ""
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr ""
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr "Pesan invalid"
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr "Tidak dapat menampilkan pesan"
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr ""
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
 "but there is no channel with that ID."
 msgstr ""
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4489,36 +3937,36 @@ msgid ""
 "it."
 msgstr ""
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
 "The channel exists but does not have any subscribers."
 msgstr ""
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr ""
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr ""
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr ""
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4526,109 +3974,107 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
 "authentication method."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr ""
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder could not be sent."
 msgstr "Token tidak ada"
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
 "the following error:"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr ""
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr ""
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr ""
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr ""
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr ""
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
 "**{old_policy}** to **{new_policy}**."
 msgstr ""
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -4637,51 +4083,49 @@ msgid ""
 "* **New**: {new_setting_description}\n"
 msgstr ""
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr ""
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr ""
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr ""
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr ""
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr ""
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr ""
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 msgstr ""
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr ""
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -4692,151 +4136,140 @@ msgid ""
 "{summary_line}"
 msgstr ""
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr ""
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr ""
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr ""
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr "Tidak cukup izin"
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr "API ini tidak tersedia untuk robot yang menerapkan incoming webhook."
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr "Akun ini tidak terasosiasi dengan subdomain ini"
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr "Endpoint ini tidak menerima request dari robot."
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr ""
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr "Endpoint ini memerlukan autentikasi sederhana HTTP."
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr "Header otorisasi invalid untuk auth sederhana"
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr "Robot webhook hanya dapat mengakses webhook"
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr ""
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
 "organization administrator to reactivate it."
 msgstr ""
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr ""
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr "Subdomain harus memiliki panjang lebih dari atau sama dengan 3."
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr "Subdomain tidak dapat dimulai atau diakhiri dengan '-'."
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr "Subdomain hanya dapat mengandung huruf kecil, angka, dan '-'."
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr "Mohon gunakan email asli Anda."
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr "Organisasi yang Anda coba gabung menggunakan {email} tidak tersedia."
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr ""
 "Silakan meminta sebuah undangan untuk {email} dari pengurus organisasi."
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
@@ -4845,139 +4278,136 @@ msgstr ""
 "Alamat email Anda, {email}, tidak termasuk dalam salah satu domain yang "
 "diperbolehkan untuk mendaftar akun pada organisasi ini."
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr ""
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 msgid "Challenges are not enabled."
 msgstr ""
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr ""
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr ""
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "You're making too many attempts to sign in. Try again in "
 "{retry_after_string} or contact your organization administrator for help."
 msgstr ""
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
 msgstr ""
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr ""
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr "Tolong masukkan paling banyak 10 email."
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr ""
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr ""
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr "Topik tidak ada"
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr ""
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr ""
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr "Pesan harus memiliki penerima"
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr "Tipe pesan tidak valid"
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr "Lampiran invalid"
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr ""
 "Sebuah eror telah terjadi saat menghapus lampiran tersebut. Silakan coba "
 "lagi nanti."
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Content can't be empty"
 msgid "Channel folder name can't be empty."
 msgstr "Konten tidak boleh kosong"
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 msgid "Invalid channel folder ID"
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 #, fuzzy
 #| msgid "Enter your email address"
 msgid "Configure owner account email address."
 msgstr "Masukkan alamat email anda"
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4986,69 +4416,69 @@ msgid ""
 "organization]({convert_demo}).\n"
 msgstr ""
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, python-brace-format
 msgid "{var_name} is not Base64 encoded"
 msgstr ""
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 msgid "Invalid `device_id`"
 msgstr ""
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr ""
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr "Domain tidak bisa kosong."
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr "Domain paling tidak harus mempunyai satu titik (.)"
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr ""
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr "Domain tidak dapat dimulai atau diakhiri dengan titik (.)"
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr "Tanda '.' secara berurutan tidak diperbolehkan."
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr "Subdomain tidak dapat dimulai atau diakhiri dengan '-'."
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr "Domain hanya dapat menggunakan huruf, angka, '.' dan '-'."
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr ""
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr ""
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5056,625 +4486,623 @@ msgid ""
 "{error_message}"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr ""
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr "Alamat tidak valid."
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr "Diluar domain Anda."
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr ""
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr ""
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr ""
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr "Telah mempunyai akun."
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr ""
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr ""
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr ""
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr "Nama emoji invalid."
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr "Jenis emoji invalid."
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr ""
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr ""
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
 msgstr ""
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr ""
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr "Tidak dapat mengalokasi antrian event"
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr "Belum masuk: Autentikasi API atau sesi pengguna dibutuhkan"
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr ""
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr ""
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr ""
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr "Kesalahan bentuk JSON"
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr ""
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 msgid "Must be a bot user"
 msgstr ""
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr ""
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr ""
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr ""
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr "API key tidak valid"
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
 "webhook; ignoring"
 msgstr ""
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr "Subdomain tidak valid"
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr ""
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr ""
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr "Akses ditolak"
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} most recent messages in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr "Reaksi sudah ada."
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr "Reaksi tidak ada."
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
 msgstr ""
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr ""
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr ""
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr ""
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr ""
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr ""
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Already has an account."
 msgid "Atlassian account ID"
 msgstr "Telah mempunyai akun."
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Behance username"
 msgstr "Nama atau username tidak dibenarkan"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 msgid "Bitbucket username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Codeberg username"
 msgstr "Nama atau username tidak dibenarkan"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Dribbble username"
 msgstr "Email atau username"
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Facebook username"
 msgstr "Nama atau username tidak dibenarkan"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "GitLab username"
 msgstr "Email atau username"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Instagram username"
 msgstr "Nama atau username tidak dibenarkan"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 msgid "Mastodon profile"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Medium username"
 msgstr "Nama atau username tidak dibenarkan"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Pinterest username"
 msgstr "Nama atau username tidak dibenarkan"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Reddit username"
 msgstr "Email atau username"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 msgid "Snapchat username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Threads username"
 msgstr "Nama atau username tidak dibenarkan"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "TikTok username"
 msgstr "Email atau username"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Twitch username"
 msgstr "Email atau username"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "Username"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr ""
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr "Kerangka integrasi"
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 msgid "Video calling"
 msgstr ""
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr "Integrasi berkelanjutan"
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr "Layanan customer"
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr "Penyebaran"
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr ""
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr "Komunikasi"
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr "Finansial"
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr ""
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr "Marketing"
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr "Lain-lain"
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr ""
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr "Manajemen proyek"
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr "Produktivitas"
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr "Kontrol versi"
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr "Pesan harus tidak boleh kosong"
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr "Pesan harus tidak mengandung null bytes"
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "{fullname} moderation"
 msgstr ""
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr "Operator batas invalid: {desc}"
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr ""
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr ""
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 #, fuzzy
 #| msgid "Missing '{var_name}' argument"
 msgid "Missing 'anchor_date' argument."
 msgstr "Tidak ada argumen '{var_name}'"
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr ""
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 #, fuzzy
 #| msgid "Reaction doesn't exist."
 msgid "Navigation view does not exist."
 msgstr "Reaksi tidak ada."
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5682,7 +5110,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5690,7 +5118,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5698,7 +5126,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5706,7 +5134,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5716,14 +5144,14 @@ msgid ""
 "a permanent organization]({convert_demo_organization_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
 "them in your [Inbox](/#inbox).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5731,7 +5159,7 @@ msgid ""
 "({navigation_tour_video_url}) for a quick app overview.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5746,14 +5174,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -5761,7 +5189,7 @@ msgid ""
 "and edit your [profile information](/help/edit-your-profile).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -5772,7 +5200,7 @@ msgid ""
 "experience in your [Preferences](#settings/preferences).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5783,7 +5211,7 @@ msgid ""
 "[Browse and subscribe to channels]({settings_link}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -5800,7 +5228,7 @@ msgid ""
 "discussed.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -5809,7 +5237,7 @@ msgid ""
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -5821,7 +5249,7 @@ msgid ""
 "times, and more.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5831,7 +5259,7 @@ msgid ""
 "or browse the [help center](/help/) to learn more!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5839,7 +5267,7 @@ msgid ""
 "get help, try one of the following messages: {bot_commands}\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5851,13 +5279,13 @@ msgid ""
 "({move_content_another_channel_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5871,12 +5299,11 @@ msgid ""
 "and above.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr ""
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -5884,14 +5311,14 @@ msgid ""
 "no matter how many other conversations are going on.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
 "conversations with unread messages.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -5899,7 +5326,7 @@ msgid ""
 "the `+` button next to its name.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -5907,13 +5334,13 @@ msgid ""
 "can we chat about…?”\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5921,7 +5348,7 @@ msgid ""
 "({format_message_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5941,1234 +5368,1213 @@ msgid ""
 "```\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
 "teammates.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
 "conversation.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr ""
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr ""
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr ""
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr "Token APNS invalid"
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr ""
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr "Token tidak ada"
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 #, fuzzy
 #| msgid "Invalid API key"
 msgid "Invalid `push_key`"
 msgstr "API key tidak valid"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
 msgstr[0] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr "Pengguna tidak berotoritas untuk melakukan perintah ini"
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr ""
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr ""
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr ""
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder does not exist"
 msgstr "Token tidak ada"
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr ""
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr ""
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr "Tidak ada argumen '{var_name}'"
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr "Nilai tidak baik untuk '{var_name}': {bad_value}"
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr ""
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr ""
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr ""
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr ""
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 #, fuzzy
 #| msgid "You don't have permission to edit this message"
 msgid "You do not have permission to create new topics in this channel."
 msgstr "Anda tidak memiliki ijin untuk mengedit pesan ini"
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr ""
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr ""
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr ""
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr ""
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr ""
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr ""
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} does not have the expected format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid emoji name."
 msgid "Invalid {setting_name}"
 msgstr "Nama emoji invalid."
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr ""
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr ""
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr "Grup pengguna invalid"
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid user group"
 msgid "Invalid user group ID: {user_group_id}"
 msgstr "Grup pengguna invalid"
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr ""
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr ""
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr ""
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr ""
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr "Nama terlalu panjang!"
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 #, fuzzy
 #| msgid "Message must not be empty"
 msgid "Name must not be empty!"
 msgstr "Pesan harus tidak boleh kosong"
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr "Karakter pada nama invalid!"
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr ""
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr ""
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr ""
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr "Nama atau username tidak dibenarkan"
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr ""
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr ""
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr ""
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr ""
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr "Tipe robot invalid"
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr "Tipe antarmuka invalid"
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr ""
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr "Tidak ada robot demikian"
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr "Tidak ada pengguna tersebut"
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr ""
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr ""
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr ""
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr ""
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr ""
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr ""
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr ""
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr ""
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr ""
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr ""
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr ""
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr ""
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr ""
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr ""
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr ""
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr ""
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr ""
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr ""
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr ""
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr ""
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr ""
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "Anggota"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr ""
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Invalid characters in emoji name"
 msgid "Invalid auto-conversion field: empty field name."
 msgstr "Karakter pada nama emoji invalid"
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr ""
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr ""
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 msgid "Example input does not match the linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in alternative URL template is not present in linkifier "
 "pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in linkifier pattern is not present in alternative URL "
 "template."
 msgstr ""
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr "Emoji unicode"
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "Emoji khusus"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr "Ekstra emoji Zulip"
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr "Karakter pada nama emoji invalid"
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr ""
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr ""
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr ""
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr ""
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr ""
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr ""
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr ""
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr ""
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr ""
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "Publik"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr ""
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr ""
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr ""
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr ""
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr ""
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr ""
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr ""
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr ""
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr ""
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr ""
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr ""
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr ""
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr ""
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr ""
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr "Tidak ada argumen 'queue_id'"
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr "Tidak ada argumen 'last_event_id'"
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr ""
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr ""
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 msgid "Failed to generate challenge"
 msgstr ""
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr ""
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr "Tidak ada token web JSON yang diberikan dalam request"
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr "Token web JSON tidak dibenarkan"
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr ""
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr "Subdomain dibutuhkan"
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr ""
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for use for user matching."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr ""
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr ""
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr ""
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr ""
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr ""
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr ""
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr ""
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr "Tidak ada undangan tersebut"
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 msgid "Invitation already used or deactivated."
 msgstr ""
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr ""
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr ""
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr "Anda harus menentukan minimal satu alamat email."
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
@@ -7177,104 +6583,102 @@ msgstr ""
 "mengirimkan mereka undangan. Namun kami mengirimkan undangan kepada orang-"
 "orang yang lain!"
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr "Riwayat penyuntingan pesan dinonaktifkan di organisasi ini"
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr ""
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr ""
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr ""
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr ""
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr ""
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr ""
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr ""
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Message edit history is disabled in this organization"
 msgid "Message reporting is not enabled in this organization."
 msgstr "Riwayat penyuntingan pesan dinonaktifkan di organisasi ini"
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr "Pengirim tidak ada"
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr ""
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr ""
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr ""
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr ""
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr ""
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr ""
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr ""
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr ""
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 #, fuzzy
 #| msgid "Reaction already exists."
 msgid "Navigation view already exists."
 msgstr "Reaksi sudah ada."
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7282,564 +6686,562 @@ msgid ""
 "later. Is this a good time?\n"
 msgstr ""
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr ""
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr ""
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 #, fuzzy
 #| msgid "You don't have permission to edit this message"
 msgid "You do not have permission to manage plans and billing."
 msgstr "Anda tidak memiliki ijin untuk mengedit pesan ini"
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr ""
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr ""
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr ""
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr ""
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr ""
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr "Setidaknya satu metode autentikasi harus diaktifkan."
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr ""
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr ""
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr ""
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr ""
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr "Anda harus mengunggah tepat satu file."
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr ""
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 #, fuzzy
 #| msgid "Message edit history is disabled in this organization"
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr "Riwayat penyuntingan pesan dinonaktifkan di organisasi ini"
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr ""
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr ""
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr ""
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr ""
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr ""
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr "Anda harus mengunggah tepat satu ikon."
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr ""
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid characters in name!"
 msgid "Invalid character in language: {character}"
 msgstr "Karakter pada nama invalid!"
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Language '{language}' is not allowed."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr ""
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr ""
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 msgid "Importing messages…"
 msgstr ""
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 msgid "Your name"
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr ""
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr ""
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr ""
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr ""
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr ""
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr ""
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr ""
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr ""
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr ""
 "Tidak ada yang dapat dilakukan. Spesifikasikan setidaknya satu dari 'tambah' "
 "atau 'hapus'."
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr ""
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr ""
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr ""
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr ""
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
 "**"
 msgstr ""
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr ""
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr ""
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr ""
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr ""
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr ""
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr ""
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr ""
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr ""
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr ""
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr ""
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr ""
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr "Anda hanya dapat mengunggah file satu per satu"
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr "Tidak ada data baru diberikan"
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 msgstr ""
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr ""
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr ""
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
 "subgroups."
 msgstr ""
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr ""
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr ""
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr ""
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr ""
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr "Kata sandi salah!"
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr ""
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr ""
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr "Anda harus mengunggah tepat satu avatar."
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr ""
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr ""
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 msgid "User is not allowed to delete other user's messages."
 msgstr ""
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr ""
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr ""
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "No analytics data available. Please contact your server administrator."
@@ -7848,305 +7250,305 @@ msgid ""
 "Please contact your server administrator."
 msgstr "Data analisis tidak tersedia. Mohon hubungi administrator server anda."
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 #, fuzzy
 #| msgid "Email address"
 msgid "Email address already in use"
 msgstr "Alamat email"
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr ""
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr ""
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr ""
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 msgstr ""
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr ""
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr ""
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr ""
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr ""
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr ""
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} access token"
 msgstr ""
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} call"
 msgstr ""
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} credentials have not been configured"
 msgstr ""
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} credentials"
 msgstr ""
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr ""
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error authenticating to the {provider_name} server"
 msgstr ""
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr ""
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} session identifier"
 msgstr ""
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr ""
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} public room."
 msgstr ""
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr ""
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{full_name}'s Zulip room"
 msgstr ""
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr ""
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr ""
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr "Topik tidak boleh kosong"
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr "Konten tidak boleh kosong"
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr ""
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr ""
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr ""
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr ""
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr ""
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
 "({export_settings_link})."
 msgstr ""
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr ""
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr ""
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr ""
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr ""
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr "Subdomain invalid untuk bouncer push notifications"
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr ""
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr ""
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr "Tipe token invalid"
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr ""
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr ""
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr ""
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr ""
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
 "try again later or reach out to {support_email} for assistance."
 msgstr ""
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr ""
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr ""
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr ""
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr ""
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
 "server: {reason}"
 msgstr ""
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr ""
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr ""
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr ""
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr ""
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr ""
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr ""
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr ""
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr ""
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 #, fuzzy
 #| msgid "Missing sender"
 msgid "Missing idp param"
 msgstr "Pengirim tidak ada"
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr "OTP tidak valid"
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr ""
 

--- a/locale/it/LC_MESSAGES/django.po
+++ b/locale/it/LC_MESSAGES/django.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 19:22+0000\n"
 "Last-Translator: Andrea <andrea.soccal@elmospa.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/zulip/django/it/"
@@ -32,53 +32,53 @@ msgstr ""
 "1 : 2;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "Non permesso agli utenti ospiti"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "Organizzazione non valida"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr "Canali pubblici"
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr "Canali privati"
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr "Messaggi privati"
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr "Messaggi privati di gruppo"
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr "Canale mancante per il grafico: {chart_name}"
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr "Nome del grafico sconosciuto: {chart_name}"
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr ""
 "L'ora di inizio è successiva all'ora di fine. Inizio: {start}, Fine: {end}"
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr ""
 "Nessun dato analitico disponibile. Si prega di contattare l'amministratore "
 "del server."
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -91,7 +91,7 @@ msgstr ""
 "o [disattiva gli utenti inattivi]({deactivate_user_help_page_link}) per "
 "consentire ai nuovi utenti di iscriversi."
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -103,7 +103,7 @@ msgstr ""
 "inattivi]({deactivate_user_help_page_link}) per consentire a più di un "
 "utente di partecipare."
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -115,7 +115,7 @@ msgstr ""
 "inattivi]({deactivate_user_help_page_link}) per consentire a più di due "
 "utenti di partecipare."
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -127,7 +127,7 @@ msgstr ""
 "inattivi]({deactivate_user_help_page_link}) per consentire a più di tre "
 "utenti di partecipare."
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -141,7 +141,7 @@ msgstr ""
 "fatturazione corrente e successivo]({billing_page_link}) sia maggiore del "
 "numero attuale di utenti."
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
@@ -149,7 +149,7 @@ msgstr ""
 "La tua organizzazione non ha abbastanza licenze Zulip. Gli inviti non sono "
 "stati inviati."
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
@@ -157,16 +157,15 @@ msgstr ""
 "La tua organizzazione non dispone di sufficienti licenze Zulip per "
 "modificare il ruolo di un utente ospite."
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr "La registrazione è disattivata"
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr "Server remoto non valido."
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
@@ -175,7 +174,7 @@ msgstr ""
 "È necessario acquistare licenze per tutti gli utenti attivi nella tua "
 "organizzazione (minimo {min_licenses})."
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
@@ -184,46 +183,46 @@ msgstr ""
 "Le fatture con più di {max_licenses} licenze non possono essere elaborate da "
 "questa pagina. Per completare l'aggiornamento, contattare {email}."
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr "Nessun metodo di pagamento registrato."
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr "{brand} termina in {last4}"
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr "Metodo di pagamento sconosciuto. Si prega di contattare {email}."
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr "Qualcosa è andato storto. Per favore contatta {email}."
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "Qualcosa è andato storto. Si prega di ricaricare la pagina."
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr ""
 "Qualcosa è andato storto. Per favore attendi qualche secondo e riprova."
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 "Si prega di aggiungere una carta di credito prima di iniziare la prova "
 "gratuita."
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr ""
 "Per favore aggiungi una carta di credito per pianificare l'aggiornamento."
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
@@ -231,18 +230,18 @@ msgstr ""
 "Impossibile aggiornare il piano. Il piano è scaduto e sostituito con un "
 "nuovo piano."
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr "Impossibile aggiornare il piano. Il piano è terminato."
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 "Non è possibile aggiornare le licenze nel periodo di fatturazione corrente "
 "per il piano di prova gratuito."
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
@@ -250,7 +249,7 @@ msgstr ""
 "Impossibile aggiornare le licenze manualmente. Il tuo piano prevede la "
 "gestione automatica delle licenze."
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
@@ -258,12 +257,12 @@ msgstr ""
 "Il tuo piano è già su licenze {licenses} nel periodo di fatturazione "
 "corrente."
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr ""
 "Non è possibile ridurre le licenze nel periodo di fatturazione corrente."
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
@@ -271,7 +270,7 @@ msgstr ""
 "Non è possibile modificare le licenze per il prossimo ciclo di fatturazione "
 "per un piano che sta venendo declassato."
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
@@ -280,7 +279,7 @@ msgstr ""
 "Il tuo piano è già programmato per il rinnovo con licenze "
 "{licenses_at_next_renewal}."
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
@@ -289,27 +288,27 @@ msgstr ""
 "Hai già acquistato {licenses_at_next_renewal} licenze per il prossimo "
 "periodo di fatturazione."
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr "Niente da cambiare."
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr "Nessun cliente per questa organizzazione!"
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr "Sessione non trovata"
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr "Tentativo di pagamento non trovato"
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr "Pass stripe_session_id or stripe_invoice_id"
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -324,20 +323,19 @@ msgstr ""
 "Se potessi {begin_link}indicare Zulip come sponsor sul tuo sito "
 "web{end_link}, saremmo davvero grati!"
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr "Il parametro 'confirmed' è richiesto"
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr "L'accesso al token di fatturazione è scaduto."
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr "Token di accesso alla fatturazione non valido."
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
@@ -346,40 +344,39 @@ msgstr ""
 "Impossibile riconciliare i dati di fatturazione tra server e dominio. "
 "Contatta {support_email}"
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr "L'account utente non esiste ancora."
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr "Devi accettare i Termini di Servizio per procedere."
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 "Questo zulip_org_id non è registrato nel sistema di gestione della "
 "fatturazione di Zulip."
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr "Chiave zulip_org_key non valida per questo zulip_org_id."
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr "La registrazione del tuo server è stata disattivata."
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "Errore"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr "Pagina non trovata (404)"
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
@@ -388,11 +385,11 @@ msgstr ""
 "Se questo errore è inaspettato, puoi <a href=\"mailto:"
 "%(support_email)s\">contatta il supporto</a>."
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr "Accesso vietato (403)"
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
@@ -401,11 +398,11 @@ msgstr ""
 "le credenziali necessarie per autenticare l'accesso. Per risolvere questo "
 "problema:"
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr "Assicurati che il tuo browser consenta i cookie per questo sito."
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
@@ -413,22 +410,21 @@ msgstr ""
 "Controlla eventuali impostazioni sulla privacy del browser o estensioni che "
 "bloccano le intestazioni Referer e disattivale per questo sito."
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr "Metodo non consentito (405)"
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr "Errore interno server"
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
 msgstr ""
 
-#: templates/500.html:27
+#: templates/500.html
 #, fuzzy, python-format
 #| msgid ""
 #| "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -443,13 +439,13 @@ msgstr ""
 "un elenco dei tuoi account Zulip Cloud</a> o <a href=\"mailto:"
 "%(support_email)s\">contatta l'assistenza Zulip</a>."
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
@@ -458,7 +454,7 @@ msgstr ""
 "<a href=\"mailto:%(support_email)s\">Contatta l'amministratore di questo "
 "server</a> per supporto."
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
@@ -468,138 +464,136 @@ msgstr ""
 "href=\"%(troubleshooting_url)s\">Guida alla risoluzione dei problemi del "
 "server Zulip</a>."
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr "Analisi per %(target_name)s | Zulip"
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 "Le statistiche sono completamente disponibili 24 ore dopo la creazione "
 "dell'organizzazione."
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr "Statistiche Zulip per %(target_name)s"
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr "Riepilogo dell'organizzazione"
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr "Numero di utenti"
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr "Utenti attivi negli ultimi 15 giorni"
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr "Numero di ospiti"
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr "Numero totali di messaggi"
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr "Numero di messaggi negli ultimi 30 giorni"
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr "Archiviazione file in uso"
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "Utenti attivi"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr "Attivazioni giornaliere"
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr "Attività di 15 giorni"
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr "Totale utenti"
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "Utenti"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr "Messaggi inviati per tipo di destinatario"
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "Io"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "Tutti"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "Scorsa settimana"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "Il mese scorso"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "L'anno scorso"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "Sempre"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr "Messaggi inviati nel tempo"
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "Giornalmente"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "Settimanale"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr "Cumulativo"
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "Umani"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "Bot"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr "Messaggi letti nel tempo"
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr "Messaggi inviati dal client"
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr "Ultimo aggiornamento"
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
@@ -607,15 +601,15 @@ msgstr ""
 "Un aggiornamento completo di tutti i grafici avviene una volta al giorno. Il "
 "grafico “messaggi spediti nel tempo” viene aggiornato una volta ogni ora."
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr "E-mail modificata"
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr "Email cambiata!"
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
@@ -624,21 +618,21 @@ msgstr ""
 "Questo conferma che il tuo indirizzo email dell'account Zulip è cambiato da "
 "%(old_email_html_tag)s a %(new_email_html_tag)s"
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr "Conferma il tuo indirizzo email"
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr "Il link di conferma non esiste"
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr "Ops. Non siamo riusciti a trovare il tuo link di conferma nel sistema."
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
@@ -647,28 +641,28 @@ msgstr ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr "Link di conferma scaduto o disattivato"
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr "Ops. Il link di conferma è scaduto o è stato disattivato."
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr ""
 "Contatta l'amministratore della tua organizzazione per un nuovo collegamento."
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr "Link di conferma non corretto"
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr "Ops. Il collegamento di conferma non è corretto."
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
@@ -677,72 +671,55 @@ msgstr ""
 "ancora visualizzando questa pagina, probabilmente è colpa nostra. Ci "
 "dispiace."
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr "Fatturazione"
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr "Chiudi finestra"
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr "Non importa"
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr "Downgrade"
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "Annulla"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr "Confermare"
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr "Annulla aggiornamento"
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr "Stato di fatturazione"
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr "Disattivare la registrazione del server?"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr "Gestione del piano non disponibile"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -759,7 +736,7 @@ msgstr ""
 "billing#log-in-to-billing-management\">delle istruzioni di accesso</a> per "
 "amministrare il piano per il tuo server Zulip."
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
@@ -767,7 +744,7 @@ msgstr ""
 "Per spostare il piano dal server a questa organizzazione o per altre "
 "domande, <a href=\"mailto:{{ support_email }}\">contatta l'assistenza</a>."
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
@@ -775,7 +752,7 @@ msgstr ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -787,17 +764,17 @@ msgstr ""
 "invece, oppure <a href='mailto:%(support_email)s'>contatta il supporto</a> "
 "per qualsiasi domanda."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr "Limite di tariffa superato"
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr "Limite tariffa superato."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
@@ -805,720 +782,230 @@ msgstr ""
 "Il tuo server ha superato il limite di come spesso questa azione può essere "
 "eseguita."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, fuzzy, python-format
 #| msgid "You can try again in %(retry_after)s seconds."
 msgid "You can try again in %(retry_after_string)s."
 msgstr "Poi riprovare tra %(retry_after)s secondi."
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr "Upgrade"
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr "Invia la fattura e avvia la prova gratuita"
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr "Inviare la fattura"
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr "Directory delle comunità aperte"
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr "Filtra per categoria"
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "Tutto"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr "Categorie"
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr "10.000 messaggi"
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr "Illimitato"
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr "File fino a 10 MB"
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr "File fino a 1 GB"
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr "Supportato"
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr "Autogestito"
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr "Per organizzazioni con un massimo di 10 utenti"
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr "Minimo 25 utenti"
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr "Non disponibile"
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr "La comunità di sviluppo di Zulip"
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr "Iscriviti come utente"
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr "Partecipa come self-hoster"
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr "Unisciti come contributore"
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "Crea organizzazione"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr "Ottieni una demo"
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr "Zulip on promise"
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr "Richiedi sponsorizzazione"
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr "Prezzi per l'istruzione"
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr "Visualizza i prezzi"
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr "Zulip per business"
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Zulip guide for open-source projects"
 msgid "Zulip for open source"
 msgstr "Guida Zulip per progetti open-source"
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "start a conversation"
 msgid "Screenshot of Zulip conversation"
 msgstr "iniziare una conversazione"
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Messages sent over time"
 msgid "Message with code"
 msgstr "Messaggi inviati nel tempo"
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr "Fulmine"
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr "Link"
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr "Contatta il supporto"
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr "Da"
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr "Organizzazione"
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr "Oggetto"
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr "Messaggio"
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr "Invia"
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr "Grazie per averci contattato"
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr "Grazie per averci contattato!"
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr "Ti contatteremo presto."
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
@@ -1526,13 +1013,13 @@ msgstr ""
 "Puoi trovare le risposte alle domande più frequenti in <a href=\"/help/"
 "\">Centro assistenza Zulip</a>."
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 #, fuzzy
 #| msgid "Getting started"
 msgid "Get started"
 msgstr "Inziare"
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
@@ -1541,50 +1028,49 @@ msgstr ""
 "Questa team chat è ora ospitata su Zulip Cloud. Accetta i <a href=\"https://"
 "zulip.com/policies/terms\">Termini di servizio di Zulip</a> per continuare."
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr "O, in alternativa, usa uno dei tuoi telefoni di backup:"
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr "Come ultima risorsa, puoi utilizzare un token di backup:"
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr "Utilizza il token di backup"
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr "Accetta i Termini di servizio"
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr "Benvenuto su Zulip"
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "Email"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr ""
 "Iscriviti alla newsletter a basso traffico di Zulip (poche email all'anno)."
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr "Continua"
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr "Conferma il tuo indirizzo email"
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1595,7 +1081,7 @@ msgstr ""
 "class=\"user_email semi-bold\">%(email)s</span>) per un'email di conferma da "
 "Zulip."
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
@@ -1604,12 +1090,12 @@ msgstr ""
 "o nella cartella dello spam, possiamo <a href=\"#\" "
 "id=\"resend_email_link\">inviartela di nuovo</a>."
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr "Visualizzazione pubblica di {org_name} | Chat del team Zulip"
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
@@ -1617,19 +1103,19 @@ msgstr ""
 "Esplora i canali accessibili al pubblico in {org_name} senza effettuare "
 "l'accesso."
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
@@ -1637,39 +1123,38 @@ msgstr ""
 "Se questo messaggio non scompare, prova a <a class=\"reload-"
 "lnk\">ricaricare</a> la pagina."
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 "Errore durante il caricamento di Zulip. Prova a <a class=\"reload-"
 "lnk\">ricaricare</a> la pagina."
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr "Nessuna conversazione corrisponde ai tuoi filtri."
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr "Questa vista sta ancora caricando i messaggi."
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr "Carica di più"
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr "Videochiamata terminata"
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr "Ora puoi chiudere questa finestra."
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr "Errore di configurazione"
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
@@ -1678,7 +1163,7 @@ msgstr ""
 "un'organizzazione. Utilizza EmailAuthBackend per creare la tua "
 "organizzazione e riprova."
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1689,73 +1174,71 @@ msgstr ""
 "how to configure push notifications, please see the <a "
 "href=\"%(doc_url)s\">documentation</a>."
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr "Account non trovato"
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr "Account Zulip non trovato."
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, fuzzy, python-format
 #| msgid "Your account email: %(email)s"
 msgid "No account found for %(email)s."
 msgstr "L'e-mail del tuo account: %(email)s"
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr "Accedi con un altro account"
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr "Continua la registrazione"
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Must be a demo organization."
 msgid "Try Zulip in a demo organization"
 msgstr "Deve essere un'organizzazione demo."
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Try Zulip now"
 msgid "Try Zulip"
 msgstr "Prova subito Zulip"
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "Crea nuova organizzazione"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr "Crea una nuova organizzazione Zulip"
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr "Inserisci il tuo indirizzo email"
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr "La tua email"
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
@@ -1765,11 +1248,11 @@ msgstr ""
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr "Come hai sentito parlare per la prima volta di Zulip?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
@@ -1777,42 +1260,41 @@ msgstr ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr "Seleziona un'opzione"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr "Per favore descrivi"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr "Dove hai visto l'annuncio?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr "Quale organizzazione?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr "Quale?"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr "Selezionane uno"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr "Tipo di organizzazione"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr "Lingua dell'organizzazione"
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
@@ -1822,74 +1304,70 @@ msgstr ""
 "mattermost\">Mattermost</a> o <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 #, fuzzy
 #| msgid "Private, shared history"
 msgid "Import chat history?"
 msgstr "Privato, storico accessibile"
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr "Nome dell'organizzazione"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "URL dell'organizzazione"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr "Usa %(external_host)s"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "O"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "Iscriviti"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "Iscriviti a Zulip"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr "Hai bisogno di un invito per entrare in questa organizzazione."
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr "Iscriviti con %(identity_provider)s"
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr "Hai già un account?"
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "Accedi"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr "Configura la privacy dell'indirizzo e-mail"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
@@ -1897,7 +1375,7 @@ msgstr ""
 "Zulip ti consente di controllare quali ruoli nell'organizzazione possono "
 "visualizzare il tuo indirizzo email."
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
@@ -1905,11 +1383,11 @@ msgstr ""
 "Vuoi modificare l'impostazione della privacy per la tua email rispetto alla "
 "configurazione predefinita per questa organizzazione?"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr "Chi può accedere al tuo indirizzo email"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1920,7 +1398,7 @@ msgstr ""
 "configure-email-visibility\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">dopo esserti iscritto</a>."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
@@ -1928,7 +1406,7 @@ msgstr ""
 "Gli amministratori di questa organizzazione Zulip potranno vedere questo "
 "indirizzo email."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
@@ -1936,13 +1414,13 @@ msgstr ""
 "Gli amministratori e i moderatori di questa organizzazione Zulip potranno "
 "vedere questo indirizzo email."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 "Nessuno in questa organizzazione Zulip potrà vedere questo indirizzo email."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
@@ -1950,81 +1428,80 @@ msgstr ""
 "Gli altri utenti di questa organizzazione Zulip potranno vedere questo "
 "indirizzo email."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "Modifica"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr "Registrazione"
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr "Crea la tua organizzazione"
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr "Crea il tuo account"
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr ""
 "<p>Inserisci i dettagli del tuo account per completare la registrazione.</p>"
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr "Tua organizzazione"
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr "Il tuo account"
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr "Don&rsquo;t importa configurazione"
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr "Importa impostazioni da un account Zulip esistente"
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr "Il tuo nome completo"
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "Nome"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr "Ecco come viene visualizzato il tuo account su Zulip."
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "Password"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr "Inserisci la tua LDAP/Active Directory password."
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 "Questo è usato per le applicazioni mobili e altri strumenti che richiedono "
 "una password."
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr "Sicurezza Password"
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr "Cosa ti interessa?"
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
@@ -2033,15 +1510,15 @@ msgstr ""
 "Accetto i <a href=\"%(root_domain_url)s/policies/terms\" target=\"_blank\" "
 "rel=\"noopener noreferrer\">Termini del servizio</a>."
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr "Organizzazione disattivata"
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr "Organizzazione spostata"
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
@@ -2050,7 +1527,7 @@ msgstr ""
 "Questa organizzazione si è trasferita a <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -2058,7 +1535,7 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid ""
@@ -2066,7 +1543,7 @@ msgid ""
 "deleted."
 msgstr "L'organizzazione è stata disattivata"
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
@@ -2076,7 +1553,7 @@ msgstr ""
 "per chiedere informazion sul riutilizzo di questo URL per una nuova "
 "organizzazione."
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2094,13 +1571,13 @@ msgstr ""
 "                this server's administrators</a> for support.\n"
 "                "
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid "This organization has been deactivated."
 msgstr "L'organizzazione è stata disattivata"
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -2109,14 +1586,14 @@ msgstr ""
 "Se sei il proprietario di questa organizzazione, puoi <a href=\"mailto:"
 "%(support_email)s\">contattare il supporto Zulip</a> per riattivarlo."
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -2127,15 +1604,15 @@ msgstr ""
 "%(support_email)s\">contact this Zulip server's administrators</a> to "
 "reactivate it."
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr "Completa l'accesso all'app desktop"
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr "Termina l'accesso Desktop"
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
@@ -2143,92 +1620,91 @@ msgstr ""
 "Utilizzare il browser Web per completare l'accesso, quindi torna qui per "
 "incollare il token di accesso."
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr "Copia il token qui"
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr "Finito"
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr "Token non corretto."
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr "Token accettato. Accesso in corso…"
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr "Accedi all'app desktop"
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 "Copia questo token di accesso e torna all'app Zulip per completare l'accesso:"
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "Copia"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr "È quindi possibile chiudere questa finestra."
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr "O, continua nel tuo browser."
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr "Utente anonimo"
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr "Proprietari"
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "Amministratori"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr "Moderatori"
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr "Utenti guest"
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "Utenti normali"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr "Inoltra le email a un account di posta elettronica"
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "Chiudi"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "Aggiorna"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr "Zulip"
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr "Sommario"
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
@@ -2237,18 +1713,18 @@ msgstr ""
 "Congratulazioni, hai creato una nuova organizzazione Zulip: "
 "<b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr "Benvenuto in Zulip!"
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr ""
 "Sei entrato a far parte dell'organizzazione Zulip . <b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
@@ -2257,36 +1733,36 @@ msgstr ""
 "Utilizzerai le seguenti informazioni per accedere alle app Web, <a "
 "href=\"%(apps_page_link)s\">mobile e desktop</a> di Zulip:"
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr "URL Organizzazione: %(organization_url)s"
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr "Il tuo nome utente:: %(ldap_username)s"
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr "Usa il tuo account LDAP per accedere"
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr "L'e-mail del tuo account: %(email)s"
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr "Vai all'organizzazione"
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
@@ -2295,7 +1771,7 @@ msgstr ""
 "Se sei nuovo su Zulip, dai un'occhiata alla nostra <a "
 "href=\"%(getting_user_started_link)s\">guida introduttiva</a>!"
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2306,7 +1782,7 @@ msgstr ""
 "href=\"%(getting_organization_started_link)s\">trasferire la tua "
 "organizzazione su Zulip</a>."
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
@@ -2315,29 +1791,29 @@ msgstr ""
 "Domande? <a href=\"mailto:%(support_email)s\">Contattaci</a> — Saremo lieti "
 "di aiutarti!"
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr "%(realm_name)s in Zulip: I dettagli della tua nuova organizzazione"
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr "%(realm_name)s in Zulip: I dettagli del tuo nuovo account"
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr ""
 "Congratulazioni, hai creato una nuova organizzazione Zulip: %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr "Sei entrato nell'organizzazione Zulip %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
@@ -2346,7 +1822,7 @@ msgstr ""
 "Utilizzerai le seguenti informazioni per accedere alle app Zulip web, mobile "
 "e desktop (%(apps_page_link)s):"
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
@@ -2355,7 +1831,7 @@ msgstr ""
 "Se sei nuovo su Zulip, dai un'occhiata alla nostra guida introduttiva "
 "(%(getting_user_started_link)s)!"
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
@@ -2364,17 +1840,17 @@ msgstr ""
 "Disponiamo anche di una guida per trasferire la tua organizzazione su Zulip "
 "(%(getting_organization_started_link)s)."
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr "Domande? Contattaci a %(support_email)s — ci piacerebbe aiutarti!"
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2383,17 +1859,17 @@ msgstr ""
 "In caso di domande, contattare gli amministratori di questo server Zulip "
 "all'indirizzo %(support_email)s."
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr "Ciao,"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2405,12 +1881,12 @@ msgstr ""
 "%(realm_url)s. Per confermare questa modifica e impostare una password per "
 "questo account, fai clic sul link di seguito:"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr "Conferma e imposta la password"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2419,15 +1895,15 @@ msgstr ""
 "Se non hai richiesto questo cambio, per favore contattaci immediatamente a "
 "%(support_email)s."
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 #, fuzzy
 #| msgid "Verify your new email address for your demo Zulip organization"
 msgid "Verify your email address for your Zulip demo organization"
 msgstr ""
 "Verifica il tuo nuovo indirizzo email per la tua organizzazione demo Zulip"
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2436,8 +1912,8 @@ msgstr ""
 "Se non hai richiesto questo cambiamento, ti preghiamo di contattarci "
 "immediatamente a <%(support_email)s>."
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2448,33 +1924,33 @@ msgstr ""
 "l'account Zulip su %(realm_url)s da %(old_email)s a %(new_email)s. Per "
 "confermare questa modifica, per favore clicca sul link di seguito:"
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr "Conferma la modifica dell'email"
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr "Verifica il tuo nuovo indirizzo email per %(organization_host)s"
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr "Hai richiesto una nuova organizzazione Zulip:"
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr "Tipo di organizzazione: %(organization_type)s"
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr "Di recente ti sei iscritto a Zulip. Eccezionale!"
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
@@ -2483,33 +1959,33 @@ msgstr ""
 "tuo account. Sarai in grado di aggiornare le informazioni sopra se lo "
 "desideri."
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr "Clicca sul bottone sotto per completare la registrazione."
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr "Completa la registrazione"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr "Crea la tua organizzazione Zulip"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr "Attiva il tuo account Zulip"
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr "Clicca sul link sotto per completare la registrazione."
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
@@ -2518,20 +1994,20 @@ msgstr ""
 "Hai domande o feedback da condividere? Contattaci a %(support_email)s— ci "
 "piacerebbe aiutarti!"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr "Gestisci le preferenze email:"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr "Annulla l'iscrizione alle e-mail di marketing"
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
@@ -2540,17 +2016,17 @@ msgstr ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
 "deactivated, and you will no longer be able to log in."
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr "Gli amministratori hanno fornito il seguente commento:"
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr "Notifica di disattivazione dell'account attivata su%(realm_name)s"
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
@@ -2559,11 +2035,11 @@ msgstr ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr "Nuovi canali"
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2571,22 +2047,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because your organization has "
@@ -2603,8 +2079,8 @@ msgstr ""
 "href=\"%(help_url)s\">contenuto del messaggio che appare nelle notifiche e-"
 "mail</a>."
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to <a "
@@ -2615,39 +2091,39 @@ msgstr ""
 "class=\"content_disabled_help_link\" href=\"%(help_url)s\">nascondere il "
 "contenuto dei messaggi</a> nelle  notifiche email."
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr "<a href=\"%(realm_url)s\">Accedi</a> a Zulip per aggiornarti."
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr "Annulla l'iscrizione alle e-mail riassuntive"
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr "Riassunto di Zulip per %(realm_name)s"
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2665,8 +2141,8 @@ msgstr ""
 "mail.\n"
 "Guarda%(hide_content_url)s per ulteriori dettagli.\n"
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2682,33 +2158,31 @@ msgstr ""
 "il contenuto del messaggio che appare nelle notifiche e-mail.\n"
 "Guarda%(alert_notif_url)s per ulteriori dettagli.\n"
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, fuzzy, python-format
 #| msgid "Click here to log in to Zulip and catch up: %(organization_url)s."
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr "Clicca qui per accedere a Zulip e aggiornarti: .%(organization_url)s."
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr "Gestisci le preferenze email:"
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr "Annulla l'iscrizione alle e-mail riassuntive:"
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr "Pesce che nuota"
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr "Grazie per la sua richiesta!"
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
@@ -2717,8 +2191,7 @@ msgstr ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
 "organizations:"
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
@@ -2727,7 +2200,7 @@ msgstr ""
 "Il tuo indirizzo email %(email)s ha un account con queste organizzazioni "
 "Zulip hostate su %(external_host)s:"
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
@@ -2736,19 +2209,15 @@ msgstr ""
 "Se hai problemi ad accedere, puoi <a "
 "href=\"%(help_reset_password_link)s\">reimpostare la tua password</a>."
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr "Hai richiesto un elenco di account Zulip per questo indirizzo email."
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr "Purtroppo non sono stati trovati account Zulip Cloud."
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
@@ -2757,7 +2226,7 @@ msgstr ""
 "Sfortunatamente non è stato trovato alcun account nelle organizzazioni Zulip "
 "ospitate da %(external_host)s."
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2768,28 +2237,25 @@ msgstr ""
 "un'altra email, o <a href =\"%(help_logging_in_link)s\">provare un altro "
 "modo</a> per trovare il tuo account."
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 "Se non riconosci questa richiesta, puoi tranquillamente ignorare questa e-"
 "mail."
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr "I tuoi account Zulip"
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr "Nessun account Zulip trovato"
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr "Se riscontri problemi nell'accesso, puoi reimpostare la password."
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
@@ -2798,12 +2264,12 @@ msgstr ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
 "try another way to find your account (%(help_logging_in_link)s)."
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr "Ciao,"
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
@@ -2812,18 +2278,18 @@ msgstr ""
 "%(referrer_name)s vuole che tu ti unisca a loro su Zulip &mdash; lo "
 "strumento di comunicazione del team progettato per la produttività."
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr "Per iniziare, clicca sul bottone sotto."
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 "%(referrer_full_name)s ti ha invitato ad unirti a %(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
@@ -2832,17 +2298,17 @@ msgstr ""
 "%(referrer_full_name)s(%(referrer_email)s) vuole che tu ti unisca a loro su "
 "Zulip - lo strumento di comunicazione di team progettato per la produttività."
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr "Per iniziare, clicca sul link sotto."
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr "Ciao di nuovo,"
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
@@ -2852,13 +2318,13 @@ msgstr ""
 "a loro su Zulip &mdash; lo strumento di comunicazione del team progettato "
 "per la produttività."
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr "Questo è l'ultimo promemoria che riceverai per questo invito."
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
@@ -2867,12 +2333,12 @@ msgstr ""
 "Questo invito scade tra due giorni. Se l'invito scade, dovrai chiedere a "
 "%(referrer_name)s per ricevere un altro invito."
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr "Promemoria: Unisci %(referrer_name)sal %(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2883,7 +2349,7 @@ msgstr ""
 "(%(referrer_email)s)vuole che tu ti unisca a loro su Zulip -- lo strumento "
 "di comunicazione di team progettato per la produttività."
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2892,7 +2358,7 @@ msgstr ""
 "Se hai domande, contatta gli amministratori di questo server Zulip "
 "all'indirizzo <a href=\"mailto:%(email)s\">%(email)s</a>."
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
@@ -2901,13 +2367,13 @@ msgstr ""
 "Hai domande o feedback da condividere? <a href=\"mailto:"
 "%(email)s\">Contattaci</a> - saremmo felici di aiutarti!"
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr "Lo ricevi perché sei stato menzionato personalmente."
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
@@ -2915,10 +2381,8 @@ msgstr ""
 "Stai ricevendo questo perché @%(mentioned_user_group_name)s è stato "
 "menzionato."
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
@@ -2927,8 +2391,8 @@ msgstr ""
 "You are receiving this because all topic participants were mentioned in "
 "#%(channel_name)s > %(topic_name)s."
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
@@ -2936,8 +2400,8 @@ msgstr ""
 "Stai ricevendo questo perché hai le notifiche di menzione con caratteri "
 "jolly abilitate per gli argomenti che segui."
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
@@ -2945,8 +2409,8 @@ msgstr ""
 "Stai ricevendo questo messaggio perché tutti sono stati menzionati in "
 "#%(channel_name)s."
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
@@ -2954,8 +2418,8 @@ msgstr ""
 "Ricevi questo messaggio perché hai abilitato le notifiche via email per gli "
 "argomenti che segui."
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
@@ -2964,7 +2428,7 @@ msgstr ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2975,7 +2439,7 @@ msgstr ""
 "dentro in %(realm_name)s Zulip</a>, o <a href=\"%(notif_url)s\">gestisci le "
 "preferenze e-mail</a>."
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
@@ -2984,7 +2448,7 @@ msgstr ""
 "<a href=\"%(narrow_url)s\">Visualizza o rispondi in %(realm_name)s Zulip</"
 "a>, o <a href=\"%(notif_url)s\">gestisci le preferenze email</a>."
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
@@ -2993,7 +2457,7 @@ msgstr ""
 "<a href=\"%(narrow_url)s\">Rispondi in %(realm_name)s Zulip</a>, o <a "
 "href=\"%(notif_url)s\">gestisci le preferenze email</a>."
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
@@ -3002,42 +2466,42 @@ msgstr ""
 "Non rispondere a questa email. Questo server Zulip non è configurato per "
 "accettare email in arrivo (<a href=\"%(url)s\">aiuto</a>)."
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr "Messaggi privati di gruppo con %(direct_message_group_display_name)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr "Messaggio privato con %(sender_str)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr "[risolto] #%(channel_name)s > %(topic_name)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr "Nuovi messaggi"
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 "Rispondi direttamente a questa email o visualizzala in %(realm_name)s Zulip:"
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr "Visualizza o rispondi in %(realm_name)s Zulip:"
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr "Rispondi in %(realm_name)s Zulip:"
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
@@ -3045,7 +2509,7 @@ msgstr ""
 "Non rispondere a questa email. Questo server Zulip non è configurato per "
 "accettare email in arrivo. Aiuto:"
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -3056,22 +2520,22 @@ msgstr ""
 "%(new_email)s. Se non hai richiesto questo cambiamento, per favore "
 "contattaci immediatamente su %(support_email)s."
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr "Grazie,"
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr "Team Zulip"
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr "Email di Zulip cambiata per %(realm_name)s"
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -3082,7 +2546,7 @@ msgstr ""
 "%(new_email)s. Se non hai richiesto questo cambiamento, per favore "
 "contattaci immediatamente a <%(support_email)s>."
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
@@ -3090,46 +2554,46 @@ msgstr ""
 "Organizzazione: %(organization_url)s Ora: %(login_time)s Email: "
 "%(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr "Abbiamo notato un accesso recente per il seguente account Zulip."
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr "Organizzazione: %(organization_link)s"
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr "Email: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr "Orario: %(login_time)s"
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr "Dispositivo: %(device_browser)s su %(device_os)s."
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr "Indirizzo IP: %(device_ip)s"
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr "Se sei stato tu, fantastico! Non c'è nient'altro che devi fare."
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3140,31 +2604,31 @@ msgstr ""
 "stato compromesso, per cortesia <a href=\"%(reset_link)s\">reimposta la tua "
 "password</a> o contattaci immediatamente su %(support_email)s."
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr "Grazie,"
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr "Sicurezza Zulip"
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr "Annulla l'iscrizione delle notifiche del login"
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr "Nuovo accesso da %(device_browser)s in %(device_os)s"
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr "Organizzazione: %(organization_url)s"
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3175,7 +2639,7 @@ msgstr ""
 "stato compromesso, reimposta la password su%(reset_link)s o contattaci "
 "immediatamente su %(support_email)s."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -3186,7 +2650,7 @@ msgstr ""
 "usare la nostra <a href=\"%(get_organization_started)s\">guida per passare a "
 "Zulip</a> per iniziare."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
@@ -3194,7 +2658,7 @@ msgstr ""
 "Altrimenti, ecco alcuni consigli che spesso sentiamo dai clienti per "
 "valutare <i>qualsiasi</i> prodotto di team chat:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
@@ -3203,12 +2667,12 @@ msgstr ""
 "<a href=\"%(invite_users)s\"><b>Invita i tuoi compagni di squadra</b></a> ad "
 "esplorare con te e condividere le loro prospettive uniche."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr "Usa l'app stessa per chattare delle tue impressioni."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -3220,7 +2684,7 @@ msgstr ""
 "l'unico modo per vivere veramente come una nuova app di chat aiuterà il tuo "
 "team a comunicare."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -3231,21 +2695,21 @@ msgstr ""
 "comunicazione efficiente</a>, e speriamo che questi suggerimenti aiutino la "
 "tua squadra a sperimentarlo in azione."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr "Annulla l'iscrizione alle email di benvenuto per %(realm_name)s"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr "Scegliere l'app di chat per il tuo team"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
@@ -3253,7 +2717,7 @@ msgstr ""
 "Se hai già deciso di usare Zulip per la tua organizzazione, benvenuto! Puoi "
 "usare la nostra guida per passare a Zulip per iniziare."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
@@ -3261,7 +2725,7 @@ msgstr ""
 "Altrimenti, ecco alcuni consigli che spesso sentiamo dai clienti per "
 "valutare qualsiasi prodotto di team chat:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
@@ -3269,7 +2733,7 @@ msgstr ""
 "Invita i tuoi compagni di squadra ad esplorare con te e condividere le loro "
 "prospettive uniche."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
@@ -3279,7 +2743,7 @@ msgstr ""
 "strumenti di chat. Questo è l'unico modo per vivere veramente come una nuova "
 "app di chat aiuterà il tuo team a comunicare."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
@@ -3287,8 +2751,8 @@ msgstr ""
 "Zulip è progettato per consentire una comunicazione efficiente e speriamo "
 "che questi suggerimenti aiutino il tuo team a sperimentarlo in azione."
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
@@ -3298,71 +2762,71 @@ msgstr ""
 "funzionare al meglio per le tue esigenze. Dai un'occhiata a questa guida "
 "alle principali funzionalità di Zulip per organizzazioni come la tua!"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr "Visualizza la guida Zulip per le aziende"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr "Visualizza la guida Zulip per i progetti open source"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr "Visualizza la guida Zulip per l'istruzione"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr "Visualizza la guida Zulip per la ricerca"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr "Consulta la guida Zulip per eventi e convegni"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr "Visualizza la guida Zulip per le organizzazioni non profit"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr "Visualizza la guida Zulip per le comunità"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr "Guida Zulip per le imprese"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr "Guida Zulip per progetti open-source"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr "Zulip guida per l'istruzione"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr "Guida Zulip per la ricerca"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr "Guida Zulip per eventi e convegni"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr "Guida Zulip per organizzazioni non profit"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr "Guida Zulip per le comunità"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
@@ -3370,7 +2834,7 @@ msgstr ""
 "Ecco alcuni suggerimenti per mantenere le tue conversazioni Zulip "
 "organizzate con argomenti."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
@@ -3378,8 +2842,8 @@ msgstr ""
 "In Zulip, i <b>canali</b> determinano chi riceve il messaggio. Gli "
 "<b>argomenti</b> ti dicono di che cosa parla il messaggio."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
@@ -3388,12 +2852,12 @@ msgstr ""
 "Vedrai ogni messaggio nel contesto, indipendentemente dal numero di "
 "discussioni in corso."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr "Canali e argomenti nell'app Zulip"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3405,11 +2869,11 @@ msgstr ""
 "discussioni in corso. Per un buon nome per l'argomento, pensa a completare "
 "la frase: “Ehi, possiamo parlare di...?”"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr "Esempi di brevi argomenti"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3422,17 +2886,17 @@ msgstr ""
 "a>, <a href=\"%(rename_topics_link)s\">rename topics</a>, or even <a "
 "href=\"%(move_channels_link)s\">move a topic to a different channel</a>."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr "Vai a Zulip"
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr "Mantieni le tue conversazioni organizzate con argomenti"
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
@@ -3440,7 +2904,7 @@ msgstr ""
 "In Zulip, i canali determinano chi riceve un messaggio. Gli argomenti ti "
 "dicono di cosa tratta il messaggio."
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3453,8 +2917,8 @@ msgstr ""
 "topics (%(rename_topics_link)s), or even move a topic to a different channel "
 "(%(move_channels_link)s)."
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
@@ -3463,15 +2927,15 @@ msgstr ""
 "Somebody (possibly you) requested a new password for the Zulip account "
 "%(email)s on %(realm_url)s."
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr "Clicca sul bottone sotto per reimpostare la tua password."
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr "Resetta la password"
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3482,18 +2946,18 @@ msgstr ""
 "disattivato. Puoi contattare l'amministratore dell'organizzazione per <a "
 "href=\"%(help_link)s\">riattivare il tuo account</a>."
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr "Non hai un account in quella organizzazione in Zulip."
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr "Non hai account attivi in questa organizzazione(i)."
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
@@ -3501,23 +2965,23 @@ msgstr ""
 "Puoi provare ad accedere o reimpostare la tua password nelle "
 "organizzazione(i) di cui sopra."
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 "Se non riconosci questa attività, puoi tranquillamente ignorare questa email."
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr "Richiesta di reimpostazione della password per %(realm_name)s"
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr "Clicca su link sotto per reimpostare la tua password."
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
@@ -3526,7 +2990,7 @@ msgstr ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
 "You can contact an organization administrator to reactivate your account."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3537,7 +3001,7 @@ msgstr ""
 "su Zulip Cloud Piano gratuito a causa di fatture non pagate. Le fatture non "
 "pagate sono state annullate."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
@@ -3546,7 +3010,7 @@ msgstr ""
 "Per continuare con il piano Zulip Cloud Standard, aggiorna di nuovo andando "
 "su %(upgrade_url)s."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
@@ -3555,8 +3019,8 @@ msgstr ""
 "Se ritieni che sia stato un errore o hai bisogno di maggiori dettagli, "
 "contattaci a %(support_email)s."
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "You have deactivated your Zulip organization, %(realm_name)s, on "
@@ -3568,8 +3032,8 @@ msgstr ""
 "Hai disattivato la tua organizzazione Zulip,%(realm_name)s, "
 "SU%(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "Your Zulip organization, %(realm_name)s, was deactivated by "
@@ -3581,8 +3045,8 @@ msgstr ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "Your Zulip organization, %(realm_name)s, was deactivated on "
@@ -3594,8 +3058,8 @@ msgstr ""
 "La tua organizzazione Zulip,%(realm_name)s, è stato disattivato "
 "il%(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
@@ -3604,8 +3068,8 @@ msgstr ""
 "Hai disattivato la tua organizzazione Zulip,%(realm_name)s, "
 "SU%(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
@@ -3614,8 +3078,8 @@ msgstr ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
@@ -3624,16 +3088,16 @@ msgstr ""
 "La tua organizzazione Zulip,%(realm_name)s, è stato disattivato "
 "il%(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 "Tutti i dati associati a questa organizzazione sono stati eliminati "
 "definitivamente."
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
@@ -3642,8 +3106,8 @@ msgstr ""
 "Tutti i dati associati a questa organizzazione verranno eliminati "
 "definitivamente il %(deletion_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
@@ -3651,19 +3115,19 @@ msgstr ""
 "In caso di domande o dubbi, ti preghiamo di rispondere a questa e-mail il "
 "prima possibile."
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr "La tua organizzazione Zulip%(realm_name)sè stato disattivato"
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr "Cari ex amministratori di %(realm_name)s,"
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "One of your administrators requested reactivation of the previously "
@@ -3675,8 +3139,8 @@ msgstr ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organization hosted at %(realm_url)s."
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
@@ -3685,16 +3149,16 @@ msgstr ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organization hosted at %(realm_url)s."
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr "Fai clic sul pulsante qui sotto per riattivare la tua organizzazione."
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr "Riattiva l'organizzazione"
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
@@ -3702,21 +3166,21 @@ msgstr ""
 "Se la richiesta era sbagliata, puoi non intraprendere alcuna azione e questo "
 "link scadrà tra 24 ore."
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Reactivate your Zulip organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "Riattiva la tua organizzazione Zulip"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr "Riattiva la tua organizzazione Zulip"
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr "Clicca sul link sotto per riattivare la tua organizzazione."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3725,20 +3189,20 @@ msgstr ""
 "Tu o qualcuno per tuo conto ha richiesto un link di accesso per gestire il "
 "piano Zulip per <b>%(remote_server_hostname)s</b>."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, fuzzy
 #| msgid "Click the link below to log in."
 msgid "Click the button below to log in."
 msgstr "Clicca sul link sottostante per accedere."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr "Questo link scadrà tra %(validity_in_hours)s ore."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
@@ -3747,11 +3211,11 @@ msgstr ""
 "Domande? <a href=\"%(billing_help_link)s\">Scopri di più</a> o contatta "
 "%(billing_contact_email)s."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr "Accedi alla gestione del piano Zulip"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3760,12 +3224,12 @@ msgstr ""
 "Tu o qualcun altro per tuo conto, ha richiesto un link di accesso per "
 "gestire il piano Zulip per %(remote_server_hostname)s."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr "Clicca sul link sottostante per accedere."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
@@ -3774,7 +3238,7 @@ msgstr ""
 "Domande? Per saperne di più, visita %(billing_help_link)s o contatta "
 "%(billing_contact_email)s."
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
@@ -3783,16 +3247,16 @@ msgstr ""
 "Fai clic sul pulsante in basso per confermare la tua email e accedere alla "
 "gestione del piano Zulip per <b>%(remote_realm_host)s</b>."
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr "Conferma e accedi"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr "Conferma email per la gestione del piano Zulip"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
@@ -3801,7 +3265,7 @@ msgstr ""
 "Clicca sul link sottostante per confermare la tua email e accedere alla "
 "gestione del piano Zulip per %(remote_realm_host)s."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
@@ -3811,7 +3275,7 @@ msgstr ""
 "organizzazione è stata aggiornata al <a href=\"%(plans_link)s\">Piano "
 "Comunità Zulip</a>."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
@@ -3820,13 +3284,13 @@ msgstr ""
 "Se potessi <a href=\"%(link_to_zulip)s\">elencare Zulip come sponsor sul tuo "
 "sito web</a>, lo apprezzeremmo davvero!"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr ""
 "Piano di sponsorizzazione della comunità approvato per %(billing_entity)s!"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
@@ -3834,7 +3298,7 @@ msgstr ""
 "La tua richiesta di sponsorizzazione Zulip è stata approvata! La tua "
 "organizzazione è stata aggiornata al piano Zulip Community."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
@@ -3842,21 +3306,21 @@ msgstr ""
 "Se potessi elencare Zulip come sponsor sul tuo sito web, lo apprezzeremmo "
 "davvero!"
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr "Trova i tuoi account"
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr "Trova il tuo account Zulip"
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 "Email inviate! Di seguito gli indirizzi inseriti nella pagina precedente:"
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
@@ -3865,7 +3329,7 @@ msgstr ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
 "accounts for another email address</a>."
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
@@ -3873,7 +3337,7 @@ msgstr ""
 "Inserisci il tuo indirizzo email per ricevere un'email con gli URL di tutte "
 "le organizzazioni Zulip Cloud in cui hai account attivi."
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
@@ -3881,7 +3345,7 @@ msgstr ""
 "Inserisci il tuo indirizzo email per ricevere un'email con gli URL di tutte "
 "le organizzazioni Zulip su questo server in cui hai account attivi."
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
@@ -3889,216 +3353,216 @@ msgstr ""
 "Se hai dimenticato anche la password, puoi <a href=\"/help/change-your-"
 "password\">reimpostarla</a>."
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr "Indirizzo email"
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "Trova account"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr "Prodotto"
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr "Perché Zulip"
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr "Caratteristiche"
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr "Piani e prezzi"
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Zulip Cloud status"
 msgid "Zulip Cloud"
 msgstr "Stato Zulip Cloud"
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr "Self-hosting"
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr "Sicurezza"
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "Integrazioni"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr "Desktop e mobile apps"
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr "Nuova organizzazione"
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr "Soluzioni"
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr "Business"
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr "Educazione"
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr "Ricerca"
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr "Eventi e conferenze"
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr "Progetti Open source"
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr "Communities"
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr "Ingegneri"
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr "Storie dei clienti"
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr "Comunità aperte"
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr "Risorse"
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr "Inziare"
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr "Centro di supporto"
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr "Community chat"
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr "Partners"
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr "Stato Zulip Cloud"
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr "Trasferirsi a Zulip"
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr "Installazione di un server Zulip"
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr "Aggiornare un server Zulip"
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr "Contribuire"
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr "Guida al contributo"
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr "Community di sviluppo"
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr "Traduzione"
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr "GitHub"
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr "Chi siamo"
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr "Squadra"
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "Storico"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr "Valori"
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr "Lavori"
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr "Blog"
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr "Supporta Zulip"
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr "Mastodon"
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Values"
 msgid "Bluesky"
 msgstr "Valori"
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr "Termini di utilizzo"
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr "Norme sulla privacy"
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr "Attribuzioni del sito web"
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr "Oltre %(integrations_count_display)sintegrazioni native."
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 #, fuzzy
 #| msgid ""
 #| "And hundreds more through <a href=\"/integrations/doc/zapier\">Zapier</a> "
@@ -4110,51 +3574,47 @@ msgstr ""
 "E altre centinaia attraverso <a href=\"/integrations/doc/zapier\">Zapier</a> "
 "e <a href=\"/integrations/doc/ifttt\">IFTTT</a>."
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr "Cerca integrazioni"
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr "Integrazioni personalizzate"
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr "Webhook in arrivo"
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr "Bot interattivi"
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr "REST API"
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr "Mail non valida"
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr "E-mail non consentita"
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr "L'indirizzo e-mail con cui stai tentando di registrarti non è valido."
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4165,7 +3625,7 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>, does not allow signups using "
 "emails with your email domain."
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4176,7 +3636,7 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>, does not allow signups using "
 "disposable email addresses."
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4187,24 +3647,24 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>, does not allow signups using "
 "emails that contain \"+\"."
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr "Si prega di registrarsi utilizzando un indirizzo email valido."
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr "Si prega di registrarsi utilizzando un indirizzo email consentito."
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr "Nessuna organizzazione trovata"
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr "Non esiste alcuna organizzazione Zulip a <b>%(current_url)s</b>."
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -4215,7 +3675,7 @@ msgstr ""
 "un elenco dei tuoi account Zulip Cloud</a> o <a href=\"mailto:"
 "%(support_email)s\">contatta l'assistenza Zulip</a>."
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -4226,7 +3686,7 @@ msgstr ""
 "un elenco dei tuoi account</a> su questo server o <a href=\"mailto:"
 "%(support_email)s\">contatta gli amministratori di questo server Zulip</a>."
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
@@ -4235,59 +3695,59 @@ msgstr ""
 "<a href=\"%(current_url)s/serverlogin/\">Clicca qui</a> per accedere alla "
 "gestione dei piani per il tuo server Zulip."
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr "Sessione di accesso non valida o scaduta"
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr "Sessione di login non valida o scaduta."
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr "Accedi a Zulip"
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr "Ti sei già registrato con questa email. Effettua il login qui sotto."
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr "Email o nome utente"
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "Nome utente"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr "Hai dimenticato la password?"
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr "Accedi con %(identity_provider)s"
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr "Visualizza senza un account"
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 "Non hai ancora un account? Devi essere invitato per far parte di questa "
 "organizzazione."
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr "Nessuna licenza disponibile"
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr "L'organizzazione non può accettare nuovi membri in questo momento"
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
@@ -4296,7 +3756,7 @@ msgstr ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> because all Zulip Cloud licenses are in use."
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
@@ -4304,19 +3764,19 @@ msgstr ""
 "Contatta la persona che ti ha invitato e chiedile di aumentare il numero di "
 "licenze, quindi riprova."
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr "Skip to main content"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr "Errore di sottodominio di autenticazione"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr "Sottodominio di autenticazione"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -4331,18 +3791,17 @@ msgstr ""
 "accedere, molto probabilmente si tratta di un bug del server o di un'errata "
 "configurazione."
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 #, fuzzy
 #| msgid "No organization found"
 msgid "Demo organizations disabled"
 msgstr "Nessuna organizzazione trovata"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr "Aggiornamento richiesto"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
@@ -4350,7 +3809,7 @@ msgstr ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
@@ -4358,22 +3817,21 @@ msgstr ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr "Scarica l'ultima versione."
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 "You have exceeded the limit for how often a user can perform this action."
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr "Collegamento per la creazione dell'organizzazione richiesto"
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -4385,12 +3843,11 @@ msgstr ""
 "production/multiple-organizations.html\">documentation</a> on creating a new "
 "organization for more information."
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr "Link per la creazione dell'organizzazione scaduto o non valido"
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
@@ -4398,11 +3855,11 @@ msgstr ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr "Registrazione imprevista del server Zulip"
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -4413,17 +3870,16 @@ msgstr ""
 "server installation. Please <a href=\"mailto:%(support_email)s\">contact "
 "Zulip support</a> for assistance in resolving this issue."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr "Browser non supportato"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr "%(browser_name)s non è supportato da Zulip."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
@@ -4432,7 +3888,7 @@ msgstr ""
 "Zulip supporta <a href=\"%(supported_browsers_page_link)s\">browser moderni</"
 "a> come Firefox, Chrome ed Edge."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
@@ -4440,25 +3896,24 @@ msgstr ""
 "Puoi anche usare <a href=\"%(apps_page_link)s\">Applicazione desktop Zulip</"
 "a>."
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr "L'account è disattivato"
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Invalid organization"
 msgid "Finalize organization import"
 msgstr "Organizzazione non valida"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Organization moved"
 msgid "Organization import completed!"
 msgstr "Organizzazione spostata"
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -4466,56 +3921,55 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Select your account"
 msgstr "Crea il tuo account"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Create new account"
 msgstr "Crea il tuo account"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr "Organizzazione riattivata con successo"
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr "La tua organizzazione è stata riattivata con successo."
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr "Link di riattivazione dell'organizzazione scaduto o non valido"
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr "Il link di riattivazione dell'organizzazione è scaduto o non è valido."
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr "Accedi nella tua organizzazione"
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr "la-tua-organizzazione"
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr "Non conosci il l'URL della tua organizzazione?"
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr "Trova la tua organizzazione."
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr "Prossimo"
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4526,13 +3980,13 @@ msgstr ""
 "href=\"%(org_creation_link)s\">Crea una nuova organizzazione</a> se non ne "
 "hai ancora una."
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 #, fuzzy
 #| msgid "Self-host Zulip"
 msgid "Self-hosting Zulip?"
 msgstr "Zulip on promise"
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4542,11 +3996,11 @@ msgstr ""
 "href=\"%(self_hosted_login_help)s\">accedere per gestire i piani pagamenti.</"
 "a>"
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr "Resetta password"
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
@@ -4554,64 +4008,64 @@ msgstr ""
 "Hai dimenticato la password? Nessun problema, ti invieremo un link per "
 "reimpostare la tua password all'email con cui ti sei registrato."
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr "Manda il link di reset"
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr "Imposta una nuova password"
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "Conferma password"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr ""
 "Spiacenti, il link che hai fornito non è valido o è già stato utilizzato."
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr "Nuova password impostata correttamente"
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr "Hai impostato una nuova password!"
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr ""
 "Per favore <a href=\"%(login_url)s\">accedi</a> con la tua nuova password."
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr "E-mail di reimpostazione password inviata"
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr "Reimpostazione della password inviata!"
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr "Controlla la tua mail tra pochi minuti per finire il processo."
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 #, fuzzy
 #| msgid "Export still in progress"
 msgid "Import progress"
 msgstr "L'esportazione è ancora in corso"
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4619,7 +4073,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4628,30 +4082,30 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 #, fuzzy
 #| msgid ""
 #| "Nobody in this Zulip organization will be able to see this email address."
@@ -4659,30 +4113,30 @@ msgid "Who will be allowed to see other users' email addresses?"
 msgstr ""
 "Nessuno in questa organizzazione Zulip potrà vedere questo indirizzo email."
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4690,7 +4144,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4698,22 +4152,22 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr "Seleziona l'account per l'autenticazione"
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr "<h1 class=\"get-started\">Seleziona account</h1>"
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 "Il tuo account GitHub ha anche indirizzi email non verificati ad esso "
 "associato."
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
@@ -4721,15 +4175,15 @@ msgstr ""
 "Per utilizzare uno di questi per accedere a Zulip, devi prima <a "
 "href=\"https://github.com/settings/emails\">verificarlo con GitHub.</a>"
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr "Errore durante l'annullamento dell'e-mail"
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr "Email sconosciuta per la richiesta di annullamento iscrizione"
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
@@ -4737,7 +4191,7 @@ msgstr ""
 "Ciao! Sembra che tu abbia tentato di annullare l'iscrizione a qualcosa, ma "
 "non riconosciamo l'URL."
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4747,12 +4201,11 @@ msgstr ""
 "Ricontrolla di avere l'URL completo e riprova, oppure <a href=\"mailto:"
 "%(support_email)s\">inviaci un'email</a> e risolveremo il problema!"
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr "Impostazioni email aggiornate"
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
@@ -4761,7 +4214,7 @@ msgstr ""
 "Hai annullato con successo l'iscrizione a Zulip %(subscription_type)s emails "
 "per <a href=\"%(realm_url)s\">%(realm_name)s</a>."
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
@@ -4770,51 +4223,50 @@ msgstr ""
 "You can undo this change or review your preferences in your <a "
 "href=\"%(realm_url)s/#settings/notifications\">notification settings</a>."
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr "Mappatura degli ordini non valida."
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr "Domande e discussioni sull'utilizzo di Zulip."
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr "Fai un esperimento con Zulip qui. :test_tube:"
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr "Per conversazioni a livello di team"
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr "iscrizioni"
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr "{user} joined this organization."
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr "{user} ha accettato il tuo invito ad unirsi a Zulip!"
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 "Impossibile attivare un account segnaposto; chiedi all'utente di registrarsi "
 "invece."
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 #, fuzzy
 #| msgid "Cannot deactivate user group in use."
 msgid "Cannot reactivate a deleted user"
 msgstr "Impossibile disattivare il gruppo utenti in uso."
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
@@ -4822,26 +4274,25 @@ msgstr ""
 "Non ti è consentito modificare questo campo. Contatta un amministratore per "
 "aggiornarlo."
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr "Id campo {id} non trovato."
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr "Nome del gruppo di canali predefinito non valido '{group_name}'"
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 "Il nome predefinito del gruppo di canali è troppo lungo (limite: "
 "{max_length} caratteri)"
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
@@ -4849,12 +4300,12 @@ msgstr ""
 "Il nome predefinito del gruppo di canali '{group_name}' contiene caratteri "
 "NULL (0x00)."
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr "Gruppo di canali predefinito non valido {group_name}"
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
@@ -4862,12 +4313,12 @@ msgstr ""
 "'{channel_name}' è un canale predefinito e non può essere aggiunto a "
 "'{group_name}'"
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr "Il gruppo di canali predefinito '{group_name}' esiste già"
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
@@ -4876,7 +4327,7 @@ msgstr ""
 "Il canale '{channel_name}' è già presente nel gruppo di canali predefinito "
 "'{group_name}'"
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
@@ -4885,12 +4336,12 @@ msgstr ""
 "Il canale '{channel_name}' non è presente nel gruppo di canali predefinito "
 "'{group_name}'"
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr "Questo gruppo di canali predefinito è già denominato '{group_name}'"
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
@@ -4898,7 +4349,7 @@ msgstr ""
 "Per proteggere gli utenti, Zulip limita il numero di inviti che puoi inviare "
 "in un giorno. Poiché hai raggiunto il limite, non sono stati inviati inviti."
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
@@ -4906,79 +4357,79 @@ msgstr ""
 "Il tuo account è troppo recente per poter spedire inviti per questa "
 "organizzazione. Chiedi ad un amministratore, o a un utente più anziano."
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 "Alcune email non sono valide, quindi non abbiamo inviato nessun invito."
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr "Non siamo stati in grado di invitare nessuno."
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr "Niente da cambiare"
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr "I messaggi diretti non possono essere spostati nei canali."
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr "I messaggi privati non possono avere argomenti."
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr "Propagate_mode non valida senza modifica dell'argomento"
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr "La chat generale non può essere contrassegnata come risolta"
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 "Non è possibile modificare il contenuto del messaggio durante il cambio "
 "canale"
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr "I widget non possono essere modificati."
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr "La tua organizzazione ha disattivato la modifica dei messaggi"
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr "Non hai il permesso di modificare questo messaggio"
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr "Il tempo massimo per editare il messaggio è trascorso"
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr "{user} ha contrassegnato questo argomento come risolto."
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr "{user} ha contrassegnato questo argomento come non risolto."
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr "Questo argomento è stato spostato in {new_location} da {user}."
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr ""
 "Un messaggio è stato spostato da questo argomento a {new_location} da {user}."
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
@@ -4987,12 +4438,12 @@ msgstr ""
 "{changed_messages_count} messaggi sono stati spostati da questo argomento a "
 "{new_location} da {user}."
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr "Questo argomento è stato spostato qui da {old_location} da {user}."
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
@@ -5000,7 +4451,7 @@ msgstr ""
 "[Un messaggio]({message_link}) è stato spostato qui da {old_location} da "
 "{user}."
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
@@ -5009,70 +4460,67 @@ msgstr ""
 "{changed_messages_count} messaggi sono stati spostati qui da {old_location} "
 "da {user}."
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 #, fuzzy
 #| msgid "You do not have permission to post in this channel."
 msgid "You don't have permission to resolve topics in this channel."
 msgstr "Non hai l'autorizzazione per postare su questo canale."
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr ""
 "Il limite di tempo per modificare l'argomento di questo messaggio è scaduto."
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr "Non hai il permesso di spostare questo messaggio"
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr ""
 "Il limite di tempo per la modifica del canale di questo messaggio è scaduto"
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr "Flag non valido: '{flag}'"
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr "Flag non modificabile: '{flag}'"
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr "Operazione non valida del flag del messaggio: '{operation}'"
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr "Messaggio(i) non valido"
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr "Impossibile rilasciare il messaggio"
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr "Previsto esattamente un canale"
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr "Tipo di dati non valido per il canale"
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr "Tipo di dato non valido per i destinatari"
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 "Gli elenchi dei destinatari possono contenere e-mail o ID , ma non entrambi."
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
@@ -5081,7 +4529,7 @@ msgstr ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
 "but there is no channel with that ID."
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -5092,7 +4540,7 @@ msgstr ""
 "but that channel does not exist. Click [here]({new_channel_link}) to create "
 "it."
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
@@ -5101,29 +4549,29 @@ msgstr ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
 "The channel exists but does not have any subscribers."
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr "Non hai il permesso di accedere ad alcuni dei destinatari."
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr "Widget: il programmatore API ha inviato contenuto JSON non valido"
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr "Widgets: {error_msg}"
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr "{user} ha fatto le seguenti modifiche al tuo account."
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5131,27 +4579,25 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr "Esiste già un'emoji personalizzata con questo nome."
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr "Formato immagine non valido"
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr "L'elenco ordinato non deve contenere linkifiers duplicati"
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 "L'elenco ordinato deve enumerare tutti gli esistenti linkifiers esattamente "
 "una volta"
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
@@ -5160,41 +4606,41 @@ msgstr ""
 "Per utilizzare questo metodo di autenticazione è necessario effettuare "
 "l'upgrade al piano {required_upgrade_plan_name}."
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 "Metodo di autenticazione non valido: {name}. I metodi validi sono: {methods}"
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 "Il metodo di autenticazione {name} non è disponibile nel tuo piano attuale."
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr "Il canale della richiesta di moderazione deve essere privato."
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr "Il frammento salvato non esiste."
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr "Il messaggio programmato è già stato inviato"
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder could not be sent."
 msgstr "Token inesistente"
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr "Non è stato possibile inviare il messaggio all'orario pianificato."
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
@@ -5203,40 +4649,40 @@ msgstr ""
 "Il messaggio pianificato per le ore {delivery_datetime} non è stato inviato "
 "a causa del seguente errore:"
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr "[Vedi messaggi pianificati](#scheduled)"
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr "Il canale è già disattivato"
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, fuzzy, python-brace-format
 #| msgid "Channel {channel_name} has been archived."
 msgid "Channel #**{channel_name}** has been archived."
 msgstr "Il canale {channel_name} è stato archiviato."
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr "Il canale non è attualmente disattivato"
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr "Il canale denominato {channel_name} esiste già"
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr "Il canale è privato e non ha iscritti"
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, fuzzy, python-brace-format
 #| msgid "Channel {channel_name} has been archived."
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr "Il canale {channel_name} è stato archiviato."
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
@@ -5245,7 +4691,7 @@ msgstr ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
 "**{old_policy}** to **{new_policy}**."
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -5259,41 +4705,39 @@ msgstr ""
 "* **Vecchio**: {old_setting_description}\n"
 "* **Nuovo**: {new_setting_description}\n"
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 "{user_name} ha rinominato il canale {old_channel_name} in {new_channel_name}."
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr "Nessuna descrizione."
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr "{user} ha cambiato la descrizione di questo canale."
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr "Vecchia descrizione"
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr "Nuova descrizione"
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr "Per sempre"
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr "{number_of_days} giorni"
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
@@ -5302,11 +4746,11 @@ msgstr ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr "I messaggi in questo canale verranno ora conservati per sempre."
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -5323,99 +4767,89 @@ msgstr ""
 "\n"
 "{summary_line}"
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr "Automatico"
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr "Non puoi allegare un sotto messaggio a questo messaggio."
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr "ID utente {user_id} non valido"
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr "Il gruppo utenti '{group_name}' esiste già."
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr "Permessi insufficienti"
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr "Questa API non è disponibile per i webhook bot in arrivo."
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr "L'Account non è associato con questo sottodominio"
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr "L'endpoint non accetta richieste bot."
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr "Devi essere un amministratore del server"
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr "L'endpoint richiede HTTP basic authentication."
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr "Header invalido di autorizzazione per l'autenticazione di base"
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr "Authorization header mancante per l'autenticazione di base"
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr "I bot Webhook possono accedere solo ai webhook"
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr "Email o password errate."
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
@@ -5424,42 +4858,41 @@ msgstr ""
 "Il tuo account {username} è stato disattivato. Contatta l'amministratore "
 "della tua organizzazione per riattivarlo."
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr "La password è troppo debole."
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr "Il sottodominio deve avere una lunghezza minima di 3 o maggiore."
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr "Il sottodominio non può iniziare o finire con '-'."
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr "Il sottodominio può solo avere lettere minuscole, numeri, e '-'s."
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr "Il sottodominio è già in uso. Scegline uno diverso."
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr "Sottodominio riservato. Scegline un altro."
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr "Per favore usa un'email reale."
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr ""
 "L'organizzazione in cui stai provando a entrare usando {email} non esiste."
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
@@ -5467,11 +4900,11 @@ msgstr ""
 "Per favore richiedi un invito per {email} dall'amministratore "
 "dell'organizzazione."
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
@@ -5480,12 +4913,12 @@ msgstr ""
 "Il tuo indirizzo email, {email}, non appartiene a uno dei domini che sono "
 "autorizzati a registrarsi in questa organizzazione."
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr ""
 "Gli indirizzi email contenenti + non sono ammessi in questa organizzazione."
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
@@ -5495,34 +4928,33 @@ msgstr ""
 "licenze Zulip sono in uso. Contatta la persona che ti ha invitato e chiedile "
 "di aumentare il numero di licenze, quindi riprova."
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 #, fuzzy
 #| msgid "Embedded bots are not enabled."
 msgid "Challenges are not enabled."
 msgstr "I bot integrati non sono abilitati."
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "Nuova password"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr "Conferma nuova password"
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "You're making too many attempts to sign in. Try again in {seconds} "
@@ -5534,7 +4966,7 @@ msgstr ""
 "Stai facendo troppi tentativi di accesso. Riprova tra {seconds} secondi o "
 "contatta l'amministratore dell'organizzazione per assistenza."
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
@@ -5542,95 +4974,93 @@ msgstr ""
 "La tua password è stata disabilitata perché troppo debole. Reimposta la "
 "password per crearne una nuova."
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr "Token"
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr "Suggerimento: puoi inserire più indirizzi email separati da virgole."
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr "Si prega di inserire al massimo 10 e-mail."
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr "Non siamo riusciti a trovare questa l'organizzazione Zulip."
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr "Email '{email}' non valido"
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr "Argomento mancante"
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr "Non è possibile inviare a più canali"
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr "Canale mancante"
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr "Il messaggio deve avere destinatari"
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr "Tipo di messaggio non valido"
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr "Allegato non valido"
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr ""
 "Si è verificato un errore durante la cancellazione dell'allegato. Per favore "
 "riprova più tardi."
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr "Il messaggio deve avere destinatari!"
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Channel name can't be empty."
 msgid "Channel folder name can't be empty."
 msgstr "Il nome del canale non può essere vuoto."
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid character in channel name, at position {position}."
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr "Carattere non valido nel nome del canale, nella posizione {position}."
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Channel name is already in use."
 msgid "Channel folder name already in use"
 msgstr "Il nome del canale è già in uso."
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Invalid channel ID"
 msgid "Invalid channel folder ID"
 msgstr "ID canale non valido"
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 #, fuzzy
 #| msgid "Confirm your email address"
 msgid "Configure owner account email address."
 msgstr "Conferma il tuo indirizzo email"
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "\n"
@@ -5651,73 +5081,73 @@ msgstr ""
 "[convertita\n"
 "in un'organizzazione permanente]({convert_demo_organization_help_url}).\n"
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a date"
 msgid "{var_name} is not Base64 encoded"
 msgstr "{var_name} non è una data"
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 #, fuzzy
 #| msgid "Invalid emoji code."
 msgid "Invalid `device_id`"
 msgstr "Codice emoji non valido."
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr "{service_name} riepilogo"
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr "Il dominio non può essere vuoto."
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr "Il dominio deve avere almeno un punto (.)"
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr "Dominio è troppo lungo"
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr "Il dominio non può iniziare o finire con un punto (.)"
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr "Non sono permessi '.' consecutivi."
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr "I sottodomini non posso iniziare o finire con il '-'."
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr "Il dominio può contenere solo lettere, numeri, '.' e '-'s."
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr "Il timestamp non deve essere negativo."
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr "L'argomento non deve contenere byte nulli"
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 "È necessario specificare esattamente 1 ID canale per i messaggi del canale"
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr "L'utente ha disabilitato la sincronizzazione delle bozze."
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr "La bozza non esiste"
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5728,87 +5158,87 @@ msgstr ""
 "email reply:\n"
 "{error_message}"
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr "Email senza oggetto"
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr "Apri Zulip per vedere il contenuto dello spoiler"
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr "Notifiche di {service_name}"
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr "Indirizzo non valido."
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr "Fuori del tuo dominio."
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr "Gli indirizzi email contenenti + non sono accettati."
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr "Riservato ai bot di sistema."
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr "{email} ha già un account"
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr "Hai già un account."
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr "L'account è stato disattivato."
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr "Emoji '{emoji_name}' non esiste"
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr "Emoji personalizzata non valida."
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr "Nome emoji personalizzato non valido."
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr "Questa emoji personalizzata è stata disattivata."
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr "Codice emoji non valido."
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr "Nome emoji non valido."
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr "Tipo di emoji non valido."
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr ""
 "Deve essere un amministratore dell''organizzazione o un autore di emoji"
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr "I nomi delle emoji devono terminare con una lettera o una cifra."
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
@@ -5816,97 +5246,96 @@ msgstr ""
 "I nomi delle emoji devono contenere solo lettere inglesi minuscole, cifre, "
 "spazi, trattini e caratteri di sottolineatura."
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr "Manca il nome del Emoji"
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr "Impossibile allocare la coda degli eventi"
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr "Non loggato in: autenticazione API o sessione utente richiesta"
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, fuzzy, python-brace-format
 #| msgid "Channel named {channel_name} already exists"
 msgid "Channel '{channel_name}' already exists"
 msgstr "Il canale denominato {channel_name} esiste già"
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr "Il canale '{stream}' non esiste"
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr "Il canale con ID '{stream_id}' non esiste"
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr "Combinazione di parametri non supportata: {parameters}"
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr "proprietario organizzazione"
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr "utente"
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr "Impossibile disattivare l'unica {entity}."
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr "Dichiarazione include Markdown non valida: {include_statement}"
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr "JSON malformato"
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr "Deve essere un amministratore dell'organizzazione"
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr "Deve essere un proprietario dell'organizzazione"
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Must be an organization owner"
 msgid "Must be a bot user"
 msgstr "Deve essere un proprietario dell'organizzazione"
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr "Il nome utente o la password sono errati"
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr "L'organizzazione è stata disattivata"
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
@@ -5914,24 +5343,24 @@ msgstr ""
 "La registrazione del servizio di notifica push mobile per il tuo server è "
 "stata disattivata"
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr ""
 "L'autenticazione della password è disabilitata in questa organizzazione"
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr "La tua password è stata disabilitata e deve essere reimpostata"
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr "Chiave API invalida"
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr "Chiave API non valida"
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
@@ -5940,58 +5369,57 @@ msgstr ""
 "L'evento '{event_type}' non è attualmente supportato dal webhook "
 "{webhook_name}; ignorando"
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 "Impossibile analizzare la richiesta: {webhook_name} ha generato questo "
 "evento?"
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr "Utente non autenticato"
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr "Sotto dominio non valido"
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr "You do not have permission to initiate direct message conversations."
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr "I messaggi privati sono disattivati in questa organizzazione."
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr "Questa conversazione non include alcun utente che possa autorizzarla."
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr "Accesso negato"
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
@@ -6000,15 +5428,15 @@ msgstr ""
 "Hai solo il permesso di spostare i {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} messaggi più recenti in questo argomento."
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr "La reazione esiste già."
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr "La reazione non esiste."
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
@@ -6016,367 +5444,367 @@ msgstr ""
 "La tua organizzazione è registrata su un server Zulip diverso. Contatta il "
 "supporto di Zulip per assistenza nella risoluzione di questo problema."
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr "Organizzazione non registrata"
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 "Non hai l'autorizzazione per utilizzare le menzioni jolly in questo canale."
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 "Non hai il permesso di utilizzare menzioni con il carattere chiocciola per "
 "questo argomento."
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr "Il valore '{field_name}' non corrisponde al valore previsto."
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr "'{setting_name}' deve essere un gruppo utenti di sistema."
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr "Impossibile disattivare il gruppo utenti in uso."
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr "Non hai l'autorizzazione per amministrare questo canale."
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr "Non hai l'autorizzazione per modificare i canali predefiniti."
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr "L'email è già in uso."
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr "L'orario di consegna programmato deve essere nel futuro."
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Server doesn't use the push notification service"
 msgid "Server is not configured to use push notification service."
 msgstr "Il server non utilizza il servizio di notifica push"
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Already has an account."
 msgid "Atlassian account ID"
 msgstr "Hai già un account."
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Behance username"
 msgstr "Nome o nome utente non buono"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Bitbucket username"
 msgstr "Username di GitHub"
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Codeberg username"
 msgstr "Username di Twitter"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Dribbble username"
 msgstr "Username di GitHub"
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Facebook username"
 msgstr "Nome o nome utente non buono"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr "Username di GitHub"
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "GitLab username"
 msgstr "Username di GitHub"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Instagram username"
 msgstr "Username di Twitter"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Mastodon"
 msgid "Mastodon profile"
 msgstr "Mastodon"
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Medium username"
 msgstr "Username di GitHub"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Pinterest username"
 msgstr "Username di Twitter"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Reddit username"
 msgstr "Username di GitHub"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Snapchat username"
 msgstr "Username di GitHub"
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Threads username"
 msgstr "Username di Twitter"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "TikTok username"
 msgstr "Username di Twitter"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Twitch username"
 msgstr "Username di Twitter"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "Nome utente"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr "Tipo di account esterno non valido"
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr "Frameworks di integrazione"
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 #, fuzzy
 #| msgid "Video call ended"
 msgid "Video calling"
 msgstr "Videochiamata terminata"
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr "Integrazione continua"
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr "Supporto clienti"
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr "Distribuzione"
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr "Intrattenimento"
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr "Comunicazione"
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr "Finanziario"
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr "Risorse umane"
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr "Marketing"
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr "Varie"
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr "Monitoraggio"
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr "Gestione del progetto"
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr "Produttività"
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr "Controlla versione"
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr "Il messaggio non può essere vuoto"
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr "Il messaggio non deve contenere byte null"
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr "Non ti è consentito menzionare il gruppo utenti '{user_group_name}'."
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "{fullname} moderation"
 msgstr "moderazione di {fullname}"
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr "Operatore raggruppato non valido: {desc}"
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr "Combinazione di operatori ristretta non valida: {desc}"
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr "Duplica gli operatori \"con\"."
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr "Operatore \"con\" non valido"
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr "Argomento 'anchor' mancante."
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 #, fuzzy
 #| msgid "Missing 'anchor' argument."
 msgid "Missing 'anchor_date' argument."
 msgstr "Argomento 'anchor' mancante."
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr "Anchor non valido"
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr "Operatore {operator} non supportato."
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr "Operando {operand} non supportato."
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 #, fuzzy
 #| msgid "Confirmation link does not exist"
 msgid "Navigation view does not exist."
 msgstr "Il link di conferma non esiste"
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6387,7 +5815,7 @@ msgstr ""
 "Per saperne di più, consulta la nostra guida [sull'uso di Zulip per una "
 "lezione]({getting_started_url})!\n"
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6398,7 +5826,7 @@ msgstr ""
 "Per saperne di più, consulta la nostra [guida introduttiva]"
 "({getting_started_url})!\n"
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6409,7 +5837,7 @@ msgstr ""
 "Disponiamo anche di una guida per [impostare Zulip per una classe]"
 "({organization_setup_url}).\n"
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6420,7 +5848,7 @@ msgstr ""
 "Disponiamo anche di una guida per [spostare la tua organizzazione su Zulip]"
 "({organization_setup_url}).\n"
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "\n"
@@ -6442,7 +5870,7 @@ msgstr ""
 "[convertita\n"
 "in un'organizzazione permanente]({convert_demo_organization_help_url}).\n"
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
@@ -6452,7 +5880,7 @@ msgstr ""
 "I've kicked off some conversations to help you get started. You can find\n"
 "them in your [Inbox](/#inbox).\n"
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6463,7 +5891,7 @@ msgstr ""
 "Puoi sempre tornare al [Video di benvenuto su Zulip]"
 "({navigation_tour_video_url}) per una rapida panoramica dell'app.\n"
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6488,7 +5916,7 @@ msgstr ""
 "{demo_organization_text}\n"
 "\n"
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
@@ -6498,7 +5926,7 @@ msgstr ""
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -6510,7 +5938,7 @@ msgstr ""
 "change-your-profile-picture)\n"
 "and edit your [profile information](/help/edit-your-profile).\n"
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -6528,7 +5956,7 @@ msgstr ""
 "Zulip\n"
 "experience in your [Preferences](#settings/preferences).\n"
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6545,7 +5973,7 @@ msgstr ""
 "\n"
 "[Browse and subscribe to channels]({settings_link}).\n"
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -6575,7 +6003,7 @@ msgstr ""
 "being\n"
 "discussed.\n"
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -6589,7 +6017,7 @@ msgstr ""
 "\n"
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -6609,7 +6037,7 @@ msgstr ""
 "global\n"
 "times, and more.\n"
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "\n"
@@ -6630,7 +6058,7 @@ msgstr ""
 "Check out our [Getting started guide](/help/getting-started-with-zulip),\n"
 "or browse the [Help center](/help/) to learn more!\n"
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6641,7 +6069,7 @@ msgstr ""
 "You can chat with me as much as you like! To\n"
 "get help, try one of the following messages: {bot_commands}\n"
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6660,7 +6088,7 @@ msgstr ""
 "or even move a topic [to a different channel]"
 "({move_content_another_channel_help_url}).\n"
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
@@ -6668,7 +6096,7 @@ msgstr ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6692,12 +6120,11 @@ msgstr ""
 "laterale di sinistra\n"
 "e al di sopra.\n"
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr "Benvenuti in Zulip!"
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -6709,7 +6136,7 @@ msgstr ""
 "context,\n"
 "no matter how many other conversations are going on.\n"
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
@@ -6719,7 +6146,7 @@ msgstr ""
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
 "conversations with unread messages.\n"
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -6731,7 +6158,7 @@ msgstr ""
 "laterale sinistra e clicca\n"
 "sul pulsante `+` accanto al suo nome.\n"
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -6743,7 +6170,7 @@ msgstr ""
 "frase: “Ehi,\n"
 "possiamo parlare di...?”\n"
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
@@ -6751,7 +6178,7 @@ msgstr ""
 "\n"
 ":point_right: Prova ad avviare una nuova conversazione in questo canale.\n"
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6762,7 +6189,7 @@ msgstr ""
 ":point_right:  Use this topic to try out [Zulip's messaging features]"
 "({format_message_help_url}).\n"
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6797,7 +6224,7 @@ msgstr ""
 "\n"
 "```\n"
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
@@ -6807,7 +6234,7 @@ msgstr ""
 "This **greetings** topic is a great place to say “hi” :wave: to your "
 "teammates.\n"
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
@@ -6817,117 +6244,117 @@ msgstr ""
 ":point_right: Click on this message to start a new message in the same "
 "conversation.\n"
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr "spostamento messaggi"
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr "esperimenti"
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr "iniziare una conversazione"
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr "saluti"
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr "JSON non valido nella risposta"
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr "Formato della risposta non valido"
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr "Token di lunghezza vuoto o non valido"
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr "Token APNS non valido"
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr "Opzione GCM non valida per bouncer: priorità {priority!r}"
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr "Opzioni GCM non valide per il bouncer: {options}"
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr "Token inesistente"
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr "{full_name} ha menzionato @{user_group_name}:"
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr "{full_name} ti ha menzionato:"
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr "{full_name} ha menzionato tutti:"
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "Nuovo messaggio"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr "Notifica di prova"
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr "Questa è una notifica di prova da {realm_name} ({realm_url})."
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr "Dispositivo non riconosciuto"
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr "Il dispositivo non viene riconosciuto dal push bouncer"
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 #, fuzzy
 #| msgid "Server doesn't use the push notification service"
 msgid "Network error while connecting to Zulip push notification service."
 msgstr "Il server non utilizza il servizio di notifica push"
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 #, fuzzy
 #| msgid "Server doesn't use the push notification service"
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr "Il server non utilizza il servizio di notifica push"
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 #, fuzzy
 #| msgid "Invalid API key"
 msgid "Invalid `push_key`"
 msgstr "Chiave API invalida"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
@@ -6935,744 +6362,726 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr "Tipo di dati non valido per l'ID canale"
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr "Utente non autorizzato per questa query"
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr "'{email}' non sta più usando Zulip."
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr ""
 "Non puoi inviare messaggi privati al di fuori della tua organizzazione."
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "Channel name too long (limit: {max_length} characters)."
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr "Nome del canale troppo lungo (limite: {max_length} caratteri)."
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder does not exist"
 msgstr "Token inesistente"
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr "Push notifications bouncer errore: {error}"
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr "Impossibile decidere tra gli argomenti '{var_name1}' e '{var_name2}'"
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr "Argument '{var_name}' perso"
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr "Valore errato per '{var_name}': {bad_value}"
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr "Il messaggio programmato non esiste"
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr "account di sicurezza {service_name}"
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr "Un canale predefinito non può essere privato."
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr "I canali web pubblici non sono abilitati."
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr "Non hai l'autorizzazione per postare su questo canale."
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr "Non autorizzato a inviare al canale '{channel_name}'"
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 #, fuzzy
 #| msgid "You do not have permission to post in this channel."
 msgid "You do not have permission to create new topics in this channel."
 msgstr "Non hai l'autorizzazione per postare su questo canale."
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr "ID canale non valido"
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr "Nome canale non valido '{channel_name}'"
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr "Il/I canale(i) ({channel_names}) non esiste/no"
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr "Il gruppo di canali predefinito con ID '{group_id}' non esiste."
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr "Il nome del canale non può essere vuoto."
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr "Nome del canale troppo lungo (limite: {max_length} caratteri)."
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr "Carattere non valido nel nome del canale, nella posizione {position}."
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr "Carattere non valido nell'argomento, alla posizione {position}!"
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr "I dati degli iscritti non sono disponibili per questo canale"
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr "Impossibile recuperare gli iscritti al canale privato"
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr "Impossibile decodificare l'immagine; hai caricato un file immagine?"
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr "Le dimensioni dell'immagine superano il limite."
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr "L'immagine è danneggiata o troncata"
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr "{var_name} non è un booleano"
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} does not have a length"
 msgid "{var_name} does not have the expected format"
 msgstr "{var_name} non ha una lunghezza"
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr "{var_name} non è una data"
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr "{var_name} non è un dict"
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr "Non valida {var_name}"
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr "Argomento \"{argument}\" a {var_name} è inatteso"
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr "{var_name} non è un galleggiante"
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr "{var_name} è troppo piccolo"
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr "{var_name} non è un numero intero"
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr "{var_name} non è un JSON valido"
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr "{var_name} è troppo grande"
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr "{var_name} non è una lista"
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr "{var_name} è troppo lungo (limit: {max_length} characters)"
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr "{var_name} è troppo corto."
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr "{var_name} non è una stringa"
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr "{var_name} ha un formato non valido"
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr "{var_name} non è di lunghezza {length}"
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr "{var_name} è troppo lungo (limit: {max_length} characters)"
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr "{var_name} è troppo lungo (limit: {max_length} characters)"
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr "{var_name} non può essere vuoto"
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr "Invalido {var_name}: {msg}"
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr "{var_name} manca il campo: {msg}"
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr "Paypload malformato"
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr "Non presente nell'elenco dei valori possibili"
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr "Not a URL"
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr "Non è un fuso orario riconosciuto"
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr "{var_name} non è un codice colore esadecimale valido"
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr "Non valida {setting_name}"
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr ""
 "Il caricamento supererebbe la quota di caricamento dell'organizzazione."
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr "La dimensione dell'immagine supera il limite"
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr "Il gruppo utenti è disattivato."
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr "Gruppo di utenti non valido"
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {user_group_id}"
 msgstr "ID gruppo utenti non valido : {user_group_id}"
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr "Nome del gruppo di sistema non valido."
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr "ID gruppo utenti : {group_id} non valido"
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 "La configurazione '{setting_name}' non può essere impostata sul gruppo 'role:"
 "internet'."
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 "La configurazione '{setting_name}' non può essere impostata sul gruppo 'role:"
 "nobody'."
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 "La configurazione '{setting_name}' non può essere impostata sul gruppo 'role:"
 "everyone'."
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 "L'impostazione '{setting_name}' non può essere impostata sul gruppo "
 "'{group_name}'."
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr "Il nome del gruppo utenti non può essere vuoto!"
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr "Il nome del gruppo utenti non può superare {max_length} caratteri."
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr "Il nome del gruppo utenti non può iniziare con '{prefix}'."
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr "Il client non ha passato nessun nuovo valore."
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr "Il client deve passare emoji_name se passa emoji_code o reaction_type."
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr "Nome troppo lungo!"
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 #, fuzzy
 #| msgid "Message must not be empty"
 msgid "Name must not be empty!"
 msgstr "Il messaggio non può essere vuoto"
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr "Carattere non valido nel nome!"
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr "Formato non valido!"
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr "Questa organizzazione richiede nomi univoci."
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr "Il nome è già in uso."
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr "Nome o nome utente non buono"
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr "Integrazione '{integration_name}' non valida."
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr "Parametri di configurazione mancanti: {keys}"
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr "Valore {key} non valido {value} ({error})"
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr "Dati di configurazione non validi!"
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr "Tipo di bot non valido"
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr "Tipo di interfaccia non valido"
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr "ID utente non valido: {user_id}"
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr "Nessun bot"
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr "Nessun utente"
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr "L'utente è disattivato"
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr "'{item}' non può essere vuoto."
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr ""
 "{var_name} ha lunghezza errata {length}; dovrebbe essere {target_length}"
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a string"
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr "{var_name} non è una stringa"
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr "{container} deve avere esattamente {length} elementi"
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr "{key_name} manca la chiave da {var_name}"
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr "Argomenti inaspettati: {keys}"
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr "{var_name} non è un allowed_type"
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr "{variable} != {expected_value} ({value} è sbagliata )"
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr "{var_name} non è un URL"
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr "Il pattern URL deve contenere '%(username)s'."
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr "'{item}' non può essere vuoto."
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr "Il campo non deve avere scelte duplicate."
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr "'{value}' non è una scelta valida per '{field_name}'."
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr "{var_name} non è una stringa o un elenco intero"
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr "{var_name} non è una stringa o un numero intero"
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr "{var_name} non ha una lunghezza"
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr "{var_name} è mancante"
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr "Manca l'intestazione dell'evento HTTP '{header}'"
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr "L'algoritmo '{algorithm}' non è supportato."
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr "Ci dovrebbe essere una barra principale nello zcommand."
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr "Nessun comando: {command}"
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 "`zulip_update_announcements_stream` è stato disattivato inaspettatamente."
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr "Errore CSRF: {reason}"
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr "Reverse proxy configurazione errata: {proxy_reason}"
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr "ID utente non valido: {invalid_ids}"
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr "Utente con ID {user_id} è disattivato"
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr "Utente con ID {user_id} è un bot"
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr "Menu a discesa"
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr "Paragrafo"
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr "Data"
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr "Account esterno"
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr "Pronomi"
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr "Nessuno"
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr "Membri effettivi"
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "Membri"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr "Tutti su Internet"
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Invalid characters in emoji name"
 msgid "Invalid auto-conversion field: empty field name."
 msgstr "Carattere non valido nel nome dell'emoji"
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid ""
@@ -7681,20 +7090,20 @@ msgstr ""
 "Il gruppo %(name)r nel modello di URL non è presente nel pattern del "
 "linkifier."
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr "Espressione regolare non valida: {regex}"
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr "Errore sconosciuto nell'espressione regolare"
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr "Modello di URL non valido."
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid "Example input does not match the linkifier pattern."
@@ -7702,33 +7111,33 @@ msgstr ""
 "Il gruppo %(name)r nel modello di URL non è presente nel pattern del "
 "linkifier."
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 "Il gruppo %(name)r nel modello di URL non è presente nel pattern del "
 "linkifier."
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 "Il gruppo %(name)r nel modello di linkifier non è presente nel modello di "
 "URL."
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid ""
@@ -7738,7 +7147,7 @@ msgstr ""
 "Il gruppo %(name)r nel modello di URL non è presente nel pattern del "
 "linkifier."
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgid ""
@@ -7748,244 +7157,244 @@ msgstr ""
 "Il gruppo %(name)r nel modello di linkifier non è presente nel modello di "
 "URL."
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr "Emoji Unicode"
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "Emoji personalizzate"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr "Emoji extra di Zulip"
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr "Carattere non valido nel nome dell'emoji"
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr "Caratteri non validi nella lingua dei pigmenti"
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr "Manca la variabile richiesta \"code\" nel modello di URL"
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr "\"code\" dovrebbe essere l'unica variabile presente nel modello URL"
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr "sandbox"
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr "generale"
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr "eventi del canale"
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr "Spam"
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr "Molestie"
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr "Aggiornamenti Zulip"
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr "Disponibile su Zulip Cloud Standard. Esegui l'upgrade per accedere."
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr "Disponibile su Zulip Cloud Plus. Aggiorna per accedere."
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr "Consenti GIF classificate G (pubblico generico)"
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr "Consenti GIF con classificazione PG (Guida dei genitori)"
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 "Consenti GIF classificate PG-13 (Guida dei genitori - minori di 13 anni)"
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr "Consenti GIF classificate R (limitate)"
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr "Web pubblico"
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "Pubblico"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr "Privato, storico accessibile"
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr "Privato, storico non accessibile"
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr "Amministratori, moderatori, membri e ospiti"
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr "Amministratori, moderatori e membri"
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr "Amministratori e moderatori"
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr "Solo amministratori"
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr "Utente sconosciuto"
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr "Proprietario dell'organizzazione"
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr "Amministratore dell''organizzazione"
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr "Moderatore"
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "Membro"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "Ospite"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr "Indirizzo IP sconosciuto"
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr "un sistema operativo sconosciuto"
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr "Browser sconosciuto"
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr "Argomento 'queue_is' mancante"
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr "Argomento 'last_event_is' mancante"
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr "Un evento più recente di {event_id} è già stato eliminato!"
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr "Evento {event_id} non è in questa coda"
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr "ID coda eventi non valido: {queue_id}"
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 #, fuzzy
 #| msgid "Failed to create Zoom call"
 msgid "Failed to generate challenge"
 msgstr "Creazione della chiamata Zoom fallita"
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr "L'autenticazione JWT non è abilitata per questa organizzazione"
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr "Nessun token Web JSON inoltrato in richiesta"
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr "JSON web token errato"
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr ""
 "Nessun indirizzo email specificato nelle attestazioni di token Web JSON"
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr "Sotto dominio richiesto"
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr "Password non corretta."
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr "User-Agent header mancante dalla richiesta"
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr "L'etichetta non può essere vuota."
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr "Il campo deve avere almeno una scelta."
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr ""
 "Tipo di campo non supportato per la visualizzazione nel riepilogo del "
 "profilo."
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 #, fuzzy
 #| msgid "Field type not supported for display in profile summary."
 msgid "Field type not supported for use for user matching."
@@ -7993,96 +7402,93 @@ msgstr ""
 "Tipo di campo non supportato per la visualizzazione nel riepilogo del "
 "profilo."
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr "Tipo campo non valido."
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 "Nel riepilogo del profilo possono essere visualizzati solo 2 campi "
 "personalizzati."
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr "Un campo con quell'etichetta esiste già."
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr "Il campo personalizzato predefinito non può essere aggiornato."
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr "Endpoint non disponibile in produzione."
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr "DevAuthBackend non abilitato."
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr "Parametro '{key}' non valido per la richiesta anonima"
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr "Il database è vuoto"
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr "Non è possibile interrogare postgresql"
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr "Impossibile connettersi a RabbitMQ"
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr "Impossibile interrogare RabbitMQ"
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr "Impossibile interrogare Redis"
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr "Impossibile interrogare memcached"
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr "Impossibile interrogare memcached"
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr "Nessun invito"
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 #, fuzzy
 #| msgid "Invitation has already been revoked"
 msgid "Invitation already used or deactivated."
 msgstr "L'invito è già stato revocato"
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr "L'invito è già stato revocato"
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr "ID canale non valido {channel_id}. Nessun invito inviato."
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr "Non hai l'autorizzazione per iscrivere altri utenti ai canali."
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr "Devi specificare almeno un indirizzo email."
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
@@ -8090,110 +7496,108 @@ msgstr ""
 "Alcuni di questi indirizzi stanno già utilizzando Zulip, quindi non possiamo "
 "inviare l'invito. Abbiamo inviato inviti a tutti gli altri!"
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr ""
 "La modifica dei messaggi nello storico è disabilitata da questa "
 "organizzazione"
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr "Non hai il permesso di cancellare questo messaggio"
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr "Il tempo limite per cancellare questo messaggio è trascorso"
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr "Messaggio già cancellato"
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr "Troppe richieste di messaggi (massimo {max_messages})."
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr "L'ancora può essere esclusa solo alla fine del range"
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr "Non esiste alcun argomento '{topic}'"
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Channel content access is required."
 msgid "An explanation is required."
 msgstr "È richiesto l'accesso ai contenuti del canale."
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Zephyr mirroring is not allowed in this organization"
 msgid "Message reporting is not enabled in this organization."
 msgstr "Il mirroring Zephyr non è permesso in questa organizzazione"
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr "Mittente mancante"
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr "Il mirroring non è consentito con gli ID utente del destinatario"
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr "Messaggio con mirroring non valido"
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr "Le funzionalità di IA non sono abilitate su questo server."
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr "Raggiunto il limite mensile per i crediti AI."
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr "Nessun messaggio nella conversazione da riassumere"
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr "Impossibile mutare se stesso"
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr "Utente già in muto"
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr "L'utente non è in muto"
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 #, fuzzy
 #| msgid "{hostname} is not a valid hostname"
 msgid "Custom views must have a valid name."
 msgstr "{hostname} non è un hostname valido"
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 #, fuzzy
 #| msgid "Reaction already exists."
 msgid "Navigation view already exists."
 msgstr "La reazione esiste già"
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr "Sconosciuto onboarding_step: {onboarding_step}"
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -8204,58 +7608,58 @@ msgstr ""
 "Hai chiesto di guardare il [Video di benvenuto a Zulip]"
 "({navigation_tour_video_url}) più tardi. È un buon momento?\n"
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr "La presenza non è supportata per gli utenti di bot."
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr "Nessun dato di presenza per {user_id_or_email}"
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr "Stato non valido: {status}"
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 #, fuzzy
 #| msgid "You do not have permission to change default channels."
 msgid "You do not have permission to manage plans and billing."
 msgstr "Non hai l'autorizzazione per modificare i canali predefiniti."
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr "Il server non utilizza il servizio di notifica push"
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr "Errore restituito dal bouncer: {result}"
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr "Segreto di verifica non preparato"
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
@@ -8263,49 +7667,49 @@ msgstr ""
 "Almeno uno dei seguenti argomenti deve essere presente: emoji_name, "
 "emoji_code"
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr "Le conferme di lettura sono disabilitate in questa organizzazione."
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr "Lingua '{language}' non valida"
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr "Almeno un metodo di autenticazione deve essere abilitato."
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr "video_chat_provider {video_chat_provider} non valido"
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr "Valore non valido per  gif_rating_policy {gif_rating_policy}"
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr "Deve essere un'organizzazione demo."
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
@@ -8313,7 +7717,7 @@ msgstr ""
 "L'eliminazione dei dati deve avvenire al massimo entro {max_allowed_days} "
 "giorni nel futuro."
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
@@ -8321,243 +7725,242 @@ msgstr ""
 "L'eliminazione dei dati deve avvenire almeno entro {min_allowed_days} giorni "
 "nel futuro."
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr "Dominio non valido: {error}"
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr "Il dominio {domain} fa già parte della tua organizzazione."
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr "Nessuna voce trovata per il dominio {domain}."
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr "Devi caricare esattamente un file."
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr "Solo gli amministratori possono ignorare le emoji predefinite."
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr "Il file caricato è più grande del limite consentito di {max_size} MB"
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 #, fuzzy
 #| msgid "JWT authentication is not enabled for this organization"
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr "L'autenticazione JWT non è abilitata per questa organizzazione"
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr "Limite di velocità superato."
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr "ID esportazione dati non valido"
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr "Export già cancellato"
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr "Esportazione fallita, niente da eliminare"
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr "L'esportazione è ancora in corso"
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr "Devi caricare esattamente un'icona."
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr "Linkifier non trovato."
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr "Devi caricare esattamente un logo."
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid characters in pygments language"
 msgid "Invalid character in language: {character}"
 msgstr "Caratteri non validi nella lingua dei pigmenti"
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid language '{language}'"
 msgid "Language '{language}' is not allowed."
 msgstr "Lingua '{language}' non valida"
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr "Playground non valido"
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "User not authenticated"
 msgid "Unauthenticated"
 msgstr "Utente non autenticato"
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "moving messages"
 msgid "Importing messages…"
 msgstr "spostamento messaggi"
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr "Fatto!"
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "Your full name"
 msgid "Your name"
 msgstr "Il tuo nome completo"
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr ""
 "Destinatario richiesto durante l'aggiornamento del tipo di messaggio "
 "programmato."
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 "Argomento obbligatorio quando si aggiorna il tipo di messaggio pianificato "
 "sul canale."
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr "Formato della richiesta non valido"
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr "DSN non valido"
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr "I canali privati non possono essere impostati come predefiniti."
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr "Devi passare \"new_description\" o \"new_group_name\"."
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr ""
 "Valore non valido per \"op\". Specificare uno di \"aggiungi\" o \"rimuovi\"."
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr "Parametri non validi"
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr "È richiesto l'accesso ai contenuti del canale."
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr "Il canale ha già quel nome."
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr "Niente da fare. Specifica almeno uno da 'aggiungere' o da 'eliminare'."
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, fuzzy, python-brace-format
 #| msgid "{user_full_name} subscribed you to the channel {channel_name}."
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr "{user_full_name} ti ha iscritto al canale {channel_name}."
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr "{user_full_name} ti ha iscritto ai seguenti canali:"
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr "Impossibile accedere al canale ({channel_name})."
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr "{user_name} ha creato i seguenti canali: {new_channels}."
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr "{user_name} ha creato un nuovo canale {new_channels}."
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr "nuovi canali"
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr "canale  **pubblico sul web** creato da {user_name}. **Descrizione:**"
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr "canale **pubblico** creato da {user_name}. **Descrizione:**"
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, fuzzy, python-brace-format
 #| msgid "**{policy}** channel created by {user_name}. **Description:**"
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr "**{policy}** canale creato da {user_name}. **Descrizione:**"
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, fuzzy, python-brace-format
 #| msgid "**{policy}** channel created by {user_name}. **Description:**"
 msgid ""
@@ -8565,26 +7968,26 @@ msgid ""
 "**"
 msgstr "**{policy}** canale creato da {user_name}. **Descrizione:**"
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr "{property} non è un booleano"
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr "Proprietà di sottoscrizione sconosciuta: {property}"
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr "Non iscritto al canale ID {channel_id}"
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr "JSON invalido per sottomissione"
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
@@ -8593,7 +7996,7 @@ msgstr ""
 "Il file è più grande della dimensione massima di caricamento ({max_size} MB) "
 "consentita dal piano della tua organizzazione."
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
@@ -8602,7 +8005,7 @@ msgstr ""
 "Il file è più grande della dimensione massima di caricamento configurata su "
 "questo server ({max_size} MB)."
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "Uploaded file is larger than the allowed limit of {max_file_size} MiB"
@@ -8612,55 +8015,54 @@ msgid ""
 msgstr ""
 "Il file caricato è più grande del limite consentito di {max_file_size} MB"
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 "L'utente ha disabilitato le notifiche di digitazione per i messaggi del "
 "canale"
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr "Manca l'argomento 'a'"
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr "Elenco 'a' vuoto"
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr ""
 "L'utente ha disattivato le notifiche di digitazione per i messaggi privati"
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr "<p>Questo file non esiste o è stato eliminato.</p>"
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr "<p>Non sei autorizzato a visualizzare questo file.</p>"
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr "Tipo di token non valido"
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr "Nome del file non valido"
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr "Devi specificare un file da caricare"
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr "Puoi caricare solo un file alla volta"
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr "Nessun nuovo dato fornito"
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
@@ -8668,32 +8070,32 @@ msgstr ""
 "Niente da fare. Specificare almeno uno tra \"add\", \"delete\", "
 "\"add_subgroups\" o \"delete_subgroups\"."
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr "{user_full_name} ti ha aggiunto al gruppo {group_name}."
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr "{user_full_name} ti ha rimosso dal gruppo {group_name}."
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr "L'utente {user_id} è già membro di questo gruppo"
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr "Non esiste un membro '{user_id}' in questo gruppo utente"
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr "Il gruppo utenti {group_id} è già un sottogruppo di questo gruppo."
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
@@ -8702,79 +8104,79 @@ msgstr ""
 "Il gruppo utente {user_group_id} è già un sottogruppo di uno dei sottogruppi "
 "passati."
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr "Il gruppo utenti {group_id} non è un sottogruppo di questo gruppo."
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr "Le modifiche dell'avatar sono disabilitate in questa organizzazione."
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr ""
 "Le modifiche dell'indirizzo email sono disabilitate in questa organizzazione."
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr "default_language non valido"
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr "Suono di notifica non valido '{notification_sound}'"
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr "Periodo di batching email : {seconds} secondi non valido"
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr "La tua password di Zulip è gestita in LDAP"
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr "Password errata!"
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, fuzzy, python-brace-format
 #| msgid "You're making too many attempts! Try again in {seconds} seconds."
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr "Stai facendo troppi tentativi! Riprova tra {seconds} secondi."
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr "La nuova password è troppo semplice!"
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr "Devi caricare esattamente un avatar."
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr "L'argomento non è silenziato"
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr "Non si può disattivare l'unico amministratore dell'organizzazione"
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Nobody in this Zulip organization will be able to see this email address."
@@ -8782,27 +8184,27 @@ msgid "User is not allowed to delete other user's messages."
 msgstr ""
 "Nessuno in questa organizzazione Zulip potrà vedere questo indirizzo email."
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr "Utente non autorizzato a modificare le email utente"
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 "L'autorizzazione del proprietario non può essere rimossa dall'unico "
 "proprietario dell'organizzazione."
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr "Nuovo indirizzo email non valido."
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr "E-mail nuovo errore valore: {message}"
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
@@ -8815,26 +8217,26 @@ msgstr ""
 "configurato\n"
 "Si prega di contattare l'amministratore del server."
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 #, fuzzy
 #| msgid "Email is already in use."
 msgid "Email address already in use"
 msgstr "L'email è già in uso."
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr "Cambio proprietario fallito, non trovo l'utente"
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr "Cambio proprietario fallito, l'utente è disattivato"
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr ""
 "Impossibile cambiare proprietario, i bot non possono possedere altri bot"
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
@@ -8843,141 +8245,141 @@ msgstr ""
 "configurato\n"
 "Si prega di contattare l'amministratore del server."
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr "I bot integrati non sono abilitati."
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr "Nome del bot incorporato non valido."
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr "L'utente non è autorizzato a creare utenti"
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr "L'email '{email}' non è consentita in questa organizzazione"
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr ""
 "Gli indirizzi email monouso non sono consentiti in questa organizzazione"
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom access token"
 msgid "Invalid {provider_name} access token"
 msgstr "Token di accesso Zoom non valido"
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} call"
 msgstr "Creazione della chiamata Zoom fallita"
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Zoom credentials have not been configured"
 msgid "{provider_name} credentials have not been configured"
 msgstr "Le credenziali di Zoom non sono state configurate"
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom credentials"
 msgid "Invalid {provider_name} credentials"
 msgstr "Credenziali di Zoom non valide"
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error connecting to the BigBlueButton server."
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr "Errore di connessione al Big Blue Button server."
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error authenticating to the BigBlueButton server."
 msgid "Error authenticating to the {provider_name} server"
 msgstr "Errore di autenticazione al Big Blue Button server."
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "BigBlueButton server returned an unexpected error."
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr "Il Big Blue Botton server ha restituito un errore imprevisto."
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom session identifier"
 msgid "Invalid {provider_name} session identifier"
 msgstr "Identificatore di sessione Zoom non valido"
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr "Email utente Zoom sconosciuto"
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} public room."
 msgstr "Creazione della chiamata Zoom fallita"
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr "Firma non valida."
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{full_name}'s Zulip room"
 msgstr "{full_name} ti ha menzionato:"
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 "I progetti che utilizzano questo provider del sistema di controllo della "
 "versione non sono supportati"
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr "Payload non valido"
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr "Richiesta webhook sconosciuta"
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr "L'argomento non può essere vuoto"
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr "Il contenuto non può essere vuoto"
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr "Impossibile gestire il payload Jotform"
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr "Input JSON rovinato"
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr "La chiave degli eventi non è presente nel payload"
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr "Errore: parametro channels_map_to_topics diverso da 0 o 1"
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr "Azione webhook WordPress : {hook} sconosciuta"
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
@@ -8986,77 +8388,77 @@ msgstr ""
 "La tua esportazione dati è completa. [Visualizza e scarica le esportazioni]"
 "({export_settings_link})."
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr "Il codice di verifica è scaduto"
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr "Il codice di verifica non è valido"
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr "Il codice di verifica è malformato"
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr "Il codice di verifica è per un nome host diverso"
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr "Sottodominio non valido per bouncer di notifiche push"
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr "È necessario convalidare con la chiave API del server Zulip valida"
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr "UUID non valido"
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr "Tipo di token non valido"
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 "{hostname} contiene componenti non validi (ad esempio percorso, query, "
 "frammento)."
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr "{hostname} non è un hostname valido"
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr "{hostname} non ancora registrato"
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr "{domain} non è valido perché non ha alcun record MX"
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr "{domain} non esiste"
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
@@ -9065,29 +8467,29 @@ msgstr ""
 "Sono stati raggiunti i limiti globali per l'utilizzo recente di questo "
 "endpoint. Riprova più tardi o contatta {support_email} per assistenza."
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr "Registrazione non trovata per questo nome host"
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr "L'host ha segnalato di non avere alcun codice di verifica."
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, fuzzy, python-brace-format
 #| msgid "Error response received from the host: {status_code}"
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr "Risposta di errore ricevuta dall'host: {status_code}"
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr "ios_app_id mancante"
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr "User_id o user_uuid mancanti"
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
@@ -9096,50 +8498,50 @@ msgstr ""
 "Il tuo piano non consente l'invio di notifiche push. Motivo fornito dal "
 "server: {reason}"
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr "Il tuo piano non consente l'invio di notifiche push."
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr "Proprietà {property} non valida"
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr "Tipo di evento non valido."
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr "I dati sono fuori servizio."
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr "Rilevata duplicazione di registrazione."
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr "Dati di registro di audit malformati"
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr "È necessario reimpostare la password."
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr "Parametri id_token mancanti"
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 #, fuzzy
 #| msgid "Missing id_token parameter"
 msgid "Missing idp param"
 msgstr "Parametri id_token mancanti"
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr "OTP non valido"
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr "Non puoi usare entrambi mobile_flow_otp e desktop_flow_otp insieme."
 

--- a/locale/ja/LC_MESSAGES/django.po
+++ b/locale/ja/LC_MESSAGES/django.po
@@ -20,7 +20,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-04-13 16:12+0000\n"
 "Last-Translator: r mhs <rmhs81vmon@gmail.com>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/zulip/django/ja/"
@@ -32,50 +32,50 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "ゲストに許可しない"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "無効な組織"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr "パブリックチャンネル"
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr "プライベートチャンネル"
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr "ダイレクトメッセージ"
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr "グループのダイレクトメッセージ"
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr "チャートのチャンネルが見つかりません: {chart_name}"
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr "不明なチャート名: {chart_name}"
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr "開始時刻が終了時刻より遅いです。 開始：{start}、終了：{end}"
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr "解析用データが利用できません。サーバー管理者に連絡してください。"
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -88,7 +88,7 @@ msgstr ""
 "非アクティブ化]({deactivate_user_help_page_link})すると、複数のユーザーを追加"
 "できるようになります。"
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -100,7 +100,7 @@ msgstr ""
 "({deactivate_user_help_page_link})すると、複数のユーザーを追加できるようにな"
 "ります。"
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -112,7 +112,7 @@ msgstr ""
 "({deactivate_user_help_page_link})すると、複数のユーザーを追加できるようにな"
 "ります。"
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -124,7 +124,7 @@ msgstr ""
 "({deactivate_user_help_page_link})すると、複数のユーザーを追加できるようにな"
 "ります。"
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -137,14 +137,14 @@ msgstr ""
 "ス数]({billing_page_link})が現在のユーザー数より多くなっているか確認してくだ"
 "さい。"
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr ""
 "組織の Zulip ライセンスが不足しています。招待状は送信されませんでした。"
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
@@ -152,16 +152,15 @@ msgstr ""
 "組織の Zulip ライセンスが不足しているため、ゲストユーザーのロールを変更できま"
 "せん。"
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr "新規登録は無効になっています"
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr "無効なリモートサーバーです。"
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
@@ -170,7 +169,7 @@ msgstr ""
 "組織内のすべてのアクティブなユーザーに対してライセンスを購入する必要がありま"
 "す（最小 {min_licenses} ライセンス）。"
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
@@ -179,42 +178,42 @@ msgstr ""
 "{max_licenses} ライセンスを超える請求書は、このページからは処理できません。"
 "アップグレードを完了するには、{email} までご連絡ください。"
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr "登録されている支払い方法がありません。"
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr "{brand} / 末尾 {last4}"
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr "不明なお支払い方法です。{email} にお問い合わせください。"
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr "エラーが発生しました。{email} に問い合わせてください。"
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "エラーが発生しました。ページを再読み込みしてください。"
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr "エラーが発生しました。少し待ってからもう一度試してください。"
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr "無料トライアルを開始する前に、クレジットカードを登録してください。"
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr "アップグレードを予約するために、クレジットカードを登録してください。"
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
@@ -222,18 +221,18 @@ msgstr ""
 "プランを更新できません。このプランは終了し、新しいプランに置き換えられまし"
 "た。"
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr "プランを更新できません。このプランは終了しました。"
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 "無料トライアルプランでは、現在の請求期間のライセンス数を更新することはできま"
 "せん。"
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
@@ -241,18 +240,18 @@ msgstr ""
 "ライセンスを手動で更新できません。現在、自動ライセンス管理のプランを使用して"
 "います。"
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr ""
 "現在の請求期間において、プランはすでに {licenses} ライセンスになっています。"
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr "現在の支払い期間のライセンスは下げられません"
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
@@ -260,7 +259,7 @@ msgstr ""
 "ダウングレード中のプランについては、次回の請求サイクルのライセンス数を変更す"
 "ることはできません。"
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
@@ -269,7 +268,7 @@ msgstr ""
 "プランはすでに {licenses_at_next_renewal} ライセンスで更新されるように予約さ"
 "れています。"
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
@@ -278,27 +277,27 @@ msgstr ""
 "次回の請求期間向けに、すでに {licenses_at_next_renewal} ライセンスを購入済み"
 "です。"
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr "変更するものがありません"
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr "この組織の顧客情報が見つかりません！"
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr "セッションが見つかりません"
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr "支払インテントが見つかりません"
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr "stripe_session_id または stripe_invoice_id を渡してください"
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -313,20 +312,19 @@ msgstr ""
 "もしよろしければ、{begin_link}あなたのウェブサイトで Zulip をスポンサーとして"
 "掲載{end_link}していただけますと、大変励みになります！"
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr "パラメーター 'confirmed' は必須です"
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr "支払いアクセストークンの有効期限が切れました。"
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr "支払いアクセストークンが無効です。"
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
@@ -335,38 +333,37 @@ msgstr ""
 "サーバーとレルム（組織）間で支払いデータの整合性を確認できませんでした。 "
 "{support_email} までお問い合わせください"
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr "ユーザーアカウントがまだ存在しません。"
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr "進めるには、利用規約に同意する必要があります。"
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr "この zulip_org_id は、Zulip の支払い管理システムに登録されていません。"
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr "この zulip_org_id に対して、指定された zulip_org_key が無効です。"
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr "サーバーの登録が解除（無効化）されました。"
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "エラー"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr "ページが見つかりません（404）"
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
@@ -375,11 +372,11 @@ msgstr ""
 "このエラーが予期しないものである場合は、<a href=\"mailto:%(support_email)s\">"
 "サポートにお問い合わせください</a>。"
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr "アクセスが禁止されています (403)"
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
@@ -387,13 +384,13 @@ msgstr ""
 "ブラウザがアクセス認証に必要な資格情報を送信しなかったため、リクエストを完了"
 "できませんでした。この問題を解決するには："
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr ""
 "お使いのブラウザで、このサイトのクッキー（Cookie）を許可していることを確認し"
 "てください。"
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
@@ -401,16 +398,15 @@ msgstr ""
 "ブラウザのプライバシー設定や拡張機能でRefererヘッダーをブロックしていないか確"
 "認し、このサイトに対してはそれらを無効にしてください。"
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr "メソッドは許可されていません (405)"
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr "内部のサーバーエラー"
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
@@ -418,7 +414,7 @@ msgstr ""
 "問題が発生しました。申し訳ありません！現在問題を把握しており、解決に向けて取"
 "り組んでいます。復旧次第、Zulipは自動的に読み込まれます。"
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -429,7 +425,7 @@ msgstr ""
 "明な点は<a href=\"mailto:%(support_email)s\">Zulipサポートまでお問い合わせく"
 "ださい</a>。"
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
@@ -437,7 +433,7 @@ msgstr ""
 "問題が発生しました。申し訳ありません！復旧次第、Zulipは自動的に読み込まれま"
 "す。"
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
@@ -446,7 +442,7 @@ msgstr ""
 "サポートについては、<a href=\"mailto:%(support_email)s\">このサーバーの管理者"
 "にお問い合わせください</a>。"
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
@@ -455,136 +451,134 @@ msgstr ""
 "このサーバーの管理者の場合は、<a href=\"%(troubleshooting_url)s\">Zulipサー"
 "バーのトラブルシューティングガイド</a>を確認してください。"
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr "%(target_name)s の統計情報 | Zulip"
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr "アナリティクスは組織の作成後24時間以内に有効になります。"
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr "%(target_name)sのZulipアナリティクス"
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr "組織の概要"
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr "ユーザー数"
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr "15日以内にアクティブなユーザー"
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr "ゲスト数"
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr "メッセージの累計"
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr "過去30日のメッセージの累計"
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr "使用中のファイルストレージ"
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "オンラインのユーザー"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr "1日ごとのアクティブユーザー"
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr "15日以内のアクティブユーザー"
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr "すべてのユーザー数"
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "ユーザー"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr "宛先タイプ毎の送信メッセージ数"
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "自分"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "全員"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "先週"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "先月"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "昨年"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "全期間"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr "時間毎の送信メッセージ数"
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "日次"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "週次"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr "累積"
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "人間"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "ボット"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr "時間ごとの既読メッセージ数"
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr "クライアント毎の送信メッセージ数"
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr "最終更新"
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
@@ -592,15 +586,15 @@ msgstr ""
 "グラフの完全な更新は１日に１回行われます。「時間ごとの送信メッセージ数」グラ"
 "フは１時間に１回更新されます。"
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr "メールアドレスを変更しました"
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr "メールアドレスを変更しました"
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
@@ -609,21 +603,21 @@ msgstr ""
 "これはあなたのZulipアカウントのメールアドレスが変更されたことを確認するもので"
 "す。 変更元： %(old_email_html_tag)s 変更先： %(new_email_html_tag)s"
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr "メールアドレスを承認"
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr "承認リンクが存在しません"
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr "確認リンクが見つかりませんでした。"
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
@@ -632,27 +626,27 @@ msgstr ""
 "とりあえず、%(support_email_html_tag)s までご連絡ください。すぐに解決いたしま"
 "す。"
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr "確認リンクの期限が切れているか、無効化されています"
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr "確認リンクは有効期限切れか無効化されています。"
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr "組織の管理者に問い合わせて、新しいリンクを受け取ってください。"
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr "確認リンクの形式が正しくありません"
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr "不正な形式の確認リンクです。"
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
@@ -660,72 +654,55 @@ msgstr ""
 "リンクを正しくブラウザーにコピーしているか確認してください。リンクが正しい場"
 "合、おそらく私たち側の問題です。申し訳ございません。"
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr "請求書"
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr "この画面を閉じる"
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr "気にしないで"
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr "ダウングレード"
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "キャンセル"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr "確認"
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr "アップグレードをキャンセル"
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr "請求状況"
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr "サーバーの登録を無効化しますか？"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr "プラン管理は利用できません"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -742,7 +719,7 @@ msgstr ""
 "management\">ログイン手順</a>の<b>サーバーレベルの請求</b>タブを参照してくだ"
 "さい。"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
@@ -750,7 +727,7 @@ msgstr ""
 "プランをサーバーからこの組織へ移動する場合や、その他のご質問については、<a "
 "href=\"mailto:{{ support_email }}\">サポートにお問い合わせください</a>。"
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
@@ -758,7 +735,7 @@ msgstr ""
 "このサーバー上の少なくとも1つの組織で既にプランが有効なため、サーバーレベルの"
 "プラン管理は利用できません。"
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -766,736 +743,246 @@ msgid ""
 "%(support_email)s'>contact support</a> with any questions."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr "レート制限を超えました"
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr "レート制限を超えました。"
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr "お使いのサーバーで、この操作の実行回数制限を超えました。"
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, fuzzy, python-format
 #| msgid "You can try again in %(retry_after)s seconds."
 msgid "You can try again in %(retry_after_string)s."
 msgstr "%(retry_after)s 秒後に再試行できます。"
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr "アップグレード"
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr "請求書を送付して無料トライアルを開始"
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr "請求書を送付"
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr "コミュニティ一覧を開く"
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr "カテゴリーでフィルター"
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "全て"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr "カテゴリー"
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr "10,000メッセージ"
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr "無制限"
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr "最大10MBのファイル"
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr "最大1GBのファイル"
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr "対応"
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr "セルフマネージド"
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr "10名以下の組織向け"
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr "最小25ユーザー"
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr "利用不可"
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr "「Zulip」開発コミュニティ"
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr "ユーザーとして参加"
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr "セルフホスターとして参加"
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr "貢献する"
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "組織を作成"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr ""
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr "セルフホストZulip"
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr "スポンサーシップのご提案"
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr "教育用価格"
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr "料金設定を見る"
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr "ビジネスのためのZulip"
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Zulip for business"
 msgid "Zulip for open source"
 msgstr "ビジネスのためのZulip"
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Create your Zulip organization"
 msgid "Screenshot of Zulip conversation"
 msgstr "Zulipであなたの組織を作成"
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Messages sent over time"
 msgid "Message with code"
 msgstr "時間毎の送信メッセージ数"
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr "リンク"
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr "サポートに問い合わせ"
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr "フォーム"
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr "組織"
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr "件名"
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr "メッセージ"
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr "送信"
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr "ご連絡ありがとうございます。"
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr "ご連絡ありがとうございます！"
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr "早急にご返信いたしますので、しばらくお待ちください。"
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
@@ -1503,62 +990,61 @@ msgstr ""
 "よくある質問への回答は、 <a href=\"/help/\">Zulip ヘルプセンター</a>でご確認"
 "いただけます。"
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 #, fuzzy
 #| msgid "Getting started"
 msgid "Get started"
 msgstr "はじめる"
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
 "continue."
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr "あるいは、予備の電話を使うのもいいでしょう。"
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr "最後の手段として、バックアップトークンを使用することができます。"
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr "バックアップトークンを使用する"
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr "このサービス利用規約に同意する"
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "メール"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr "Zulip の低頻度のニュースレターを受け取る（年に数回）"
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr "続行"
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr "メールアドレスを承認"
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1569,7 +1055,7 @@ msgstr ""
 "bold\">%(email)s</span>）に届いている Zulip からの確認メールをチェックしてく"
 "ださい。"
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
@@ -1577,30 +1063,30 @@ msgstr ""
 "受信トレイや迷惑メールフォルダに確認メールが見つからない場合は、<a "
 "href=\"#\" id=\"resend_email_link\">再送する</a>ことができます。"
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr ""
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
@@ -1608,45 +1094,44 @@ msgstr ""
 "このメッセージが消えない場合、ページを<a class=\"reload-lnk\">再読み込み</a>"
 "してみてください。"
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 "Zulipの読み込みに失敗しました。ページを<a class=\"reload-lnk\">再読み込み</a>"
 "してみてください。"
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr "検索に一致する会話が存在しません。"
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr "このビューはまだメッセージを読み込み中です。"
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr "さらに読み込む"
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr "通話が終了しました"
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr "このウィンドウを閉じることができます。"
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr "構成エラー"
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
 msgstr ""
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1654,199 +1139,192 @@ msgid ""
 "href=\"%(doc_url)s\">documentation</a>."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr "アカウントが見つかりません"
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr "Zulipアカウントが存在しません。"
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, fuzzy, python-format
 #| msgid "No entry found for domain {domain}."
 msgid "No account found for %(email)s."
 msgstr "ドメイン「{domain}」の項目が見つかりませんでした"
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr "ほかのアカウントでログイン"
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr "登録を続ける"
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Create your Zulip organization"
 msgid "Try Zulip in a demo organization"
 msgstr "Zulipであなたの組織を作成"
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Try Zulip now"
 msgid "Try Zulip"
 msgstr "Zulipを試す"
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "新しい組織を作成"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr "新しいZulip組織を作成"
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr "メールアドレスを入力してください"
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr "あなたのメールアドレス"
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr "Zulipを知ったきっかけは何ですか？"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr "組織のタイプ"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr "組織の言語"
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 #, fuzzy
 #| msgid "Private, shared history"
 msgid "Import chat history?"
 msgstr "プライベート・履歴を共有"
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr "組織名"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "組織のURL"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr "%(external_host)sを使用"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "か"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "登録"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "Zulipに登録する"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr "この組織に参加するには招待を受ける必要があります。"
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr "%(identity_provider)sでサインアップ"
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr "すでにアカウントをお持ちですか？"
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "ログイン"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
@@ -1854,17 +1332,17 @@ msgstr ""
 "Zulipでは組織内のどの役割があなたのメールアドレスを閲覧できるかを設定できま"
 "す。"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr "メールアドレスの公開範囲"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1872,25 +1350,25 @@ msgid ""
 "noreferrer\">after you join</a>."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 "このZulip組織の管理者は、このメールアドレスを表示できるようになります。"
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
@@ -1898,78 +1376,77 @@ msgstr ""
 "この Zulip 組織内の他のユーザーが、このメールアドレスを表示できるようになりま"
 "す。"
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "変更"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr "登録"
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr "組織を作成"
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr "アカウントを作成"
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr "<p>登録を完了するため、アカウントの詳細を入力してください。</p>"
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr "あなたの組織"
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr "アカウント"
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr "設定をインポートしない"
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr "すでにあるZulipアカウントから設定をインポート"
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr "フルネーム"
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "名前"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr "Zulip上でアカウントの表示に使われます。"
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "パスワード"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr "LDAP／Active Directoryのパスワードを入力してください。"
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr "パスワードを必要とするモバイルアプリや他のツールで使います。"
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr "パスワード強度"
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr "何に興味がありますか？"
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
@@ -1978,15 +1455,15 @@ msgstr ""
 "<a href=\"%(root_domain_url)s/policies/terms\" target=\"_blank\" "
 "rel=\"noopener noreferrer\">利用規約</a>に同意します。"
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr "無効化された組織"
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr "組織が移動しました"
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
@@ -1995,7 +1472,7 @@ msgstr ""
 "この組織は <a href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a> "
 "へ移動しました。"
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -2003,7 +1480,7 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid ""
@@ -2011,41 +1488,41 @@ msgid ""
 "deleted."
 msgstr "組織は無効化されました"
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
 "inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
 "administrators</a> to inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid "This organization has been deactivated."
 msgstr "組織は無効化されました"
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
 "%(support_email)s\">contact Zulip support</a> to reactivate it."
 msgstr ""
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -2053,15 +1530,15 @@ msgid ""
 "reactivate it."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr "デスクトップアプリへのログインを完了"
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr "デスクトップログインを完了"
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
@@ -2069,93 +1546,92 @@ msgstr ""
 "ブラウザを開いてログインを完了させて、ここに戻ってログイントークンをペースト"
 "してください。"
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr "トークンをここにペースト"
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr "完了"
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr "トークンが正しくありません。"
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr "トークンが承認されました。ログインしています…"
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr "デスクトップアプリにログイン"
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 "このログイントークンをコピーして、Zulipアプリに戻ってログインを完了させてくだ"
 "さい："
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "コピー"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr "このウィンドウを閉じることができます"
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr "またはブラウザで続ける"
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr "匿名のユーザー"
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr "オーナー"
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "管理者"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr "モデレーター"
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr "ゲストユーザー"
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "一般ユーザー"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "閉じる"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "アップデート"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr "Zulip"
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr "ダイジェスト"
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, fuzzy, python-format
 #| msgid "You've joined the Zulip organization %(realm_name)s."
 msgid ""
@@ -2163,61 +1639,61 @@ msgid ""
 "<b>%(realm_name)s</b>."
 msgstr "Zulip組織 %(realm_name)s に参加しました。"
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr "Zulipへようこそ！"
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, fuzzy, python-format
 #| msgid "You've joined the Zulip organization %(realm_name)s."
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr "Zulip組織 %(realm_name)s に参加しました。"
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
 "href=\"%(apps_page_link)s\">mobile and desktop</a> apps:"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr "組織のURL：%(organization_url)s"
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr "LDAPアカウントを使用してログインしてください"
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
 "href=\"%(getting_user_started_link)s\">getting started guide</a>!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2225,83 +1701,83 @@ msgid ""
 "Zulip</a>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
 "to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr "Zulip上の%(realm_name)s：新しい組織の詳細"
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr "Zulip上の%(realm_name)s：新しいアカウントの詳細"
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr "Zulip組織 %(realm_name)s に参加しました。"
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
 "desktop apps (%(apps_page_link)s):"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
 "(%(getting_user_started_link)s)!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
 "(%(getting_organization_started_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr "こんにちは、"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2309,12 +1785,12 @@ msgid ""
 "password for this account, please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2323,14 +1799,14 @@ msgstr ""
 "この変更をリクエストしていない場合は、すぐに %(support_email)s までご連絡くだ"
 "さい。"
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 #, fuzzy
 #| msgid "Create your Zulip organization"
 msgid "Verify your email address for your Zulip demo organization"
 msgstr "Zulipであなたの組織を作成"
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2339,8 +1815,8 @@ msgstr ""
 "もしこの変更を要求していない場合は、すぐに%(support_email)sまでお問い合わせく"
 "ださい。"
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2348,113 +1824,113 @@ msgid ""
 "please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr "メールアカウントの変更を確認"
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr "あなたは最近Zulipに登録しました。ようこそ！"
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr "以下のボタンをクリックして登録を完了させてください。"
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr "登録を完了"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr "Zulipであなたの組織を作成"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr "Zulipアカウントを有効化"
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr "以下のリンクをクリックして登録を完了させてください。"
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
 "— we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr "メール設定を管理"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr "広告メールを受け取らない"
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
 "deactivated, and you will no longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr "管理者が次のコメントを提供しました:"
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr "%(realm_name)sのアカウント停止のお知らせ"
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr ""
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2462,22 +1938,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because your organization has "
@@ -2493,8 +1969,8 @@ msgstr ""
 "知にメッセージ内容を表示</a>しないように設定されているため、このメールにメッ"
 "セージの内容は含まれていません。"
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because you have disabled <a "
@@ -2509,40 +1985,40 @@ msgstr ""
 "メール通知にメッセージ内容を表示</a>しないように設定しているため、このメール"
 "にメッセージの内容は含まれていません。"
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, fuzzy, python-format
 #| msgid "Click here to log in to Zulip and catch up."
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr "ここをクリックしてZulipにログイン"
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr "ダイジェストメールを受け取らない"
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr "%(realm_name)sのZulipダイジェスト"
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2559,8 +2035,8 @@ msgstr ""
 "メールにメッセージの内容は含まれていません。\n"
 "%(hide_content_url)s で詳細を確認してください。\n"
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2576,41 +2052,38 @@ msgstr ""
 "メールにメッセージの内容は含まれていません。\n"
 "%(alert_notif_url)s で詳細を確認してください。\n"
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, fuzzy, python-format
 #| msgid "Click here to log in to Zulip and catch up: %(organization_url)s."
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr "以下のリンクをクリックしてZulipにログイン: %(organization_url)s."
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr "メール設定を管理"
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr "ダイジェストメールを受け取らない"
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr "泳いでいる魚"
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr "リクエストを受け付けました"
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
 "organizations:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
@@ -2619,33 +2092,29 @@ msgstr ""
 "あなたのメール アドレス %(email)s には、%(external_host)s がホストする以下の"
 "Zulip組織アカウントがあります:"
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
 "href=\"%(help_reset_password_link)s\">reset your password</a>."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
 "%(external_host)s."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2653,38 +2122,35 @@ msgid ""
 "to find your account."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr "あなたのZulipアカウント"
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
 "try another way to find your account (%(help_logging_in_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr "こんにちは、"
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
@@ -2693,17 +2159,17 @@ msgstr ""
 "%(referrer_name)sがあなたがZulip に参加することを望んでいます\n"
 "Zulip &mdash; 生産性のために設計されたチームコミュニケーションツール"
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr "始めるには以下のボタンをクリックしてください"
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
@@ -2713,17 +2179,17 @@ msgstr ""
 "んでいます\n"
 "Zulip -- 生産性のために設計されたチームコミュニケーションツール"
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr "始めるには以下のリンクをクリックしてください"
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr "こんにちは、"
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
@@ -2733,13 +2199,13 @@ msgstr ""
 "でいます\n"
 "Zulip &mdash; 生産性のために設計されたチームコミュニケーションツール"
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr "これは最後の招待を受けるリマインダーです。"
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
@@ -2748,12 +2214,12 @@ msgstr ""
 "この招待は２日後に有効期限が切れます。有効期限が切れた場合"
 "は%(referrer_name)s に新しい招待を要求してください。"
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr "リマインダー：%(referrer_realm_name)sから%(referrer_name)sに参加する　"
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2764,72 +2230,70 @@ msgstr ""
 "Zulip に参加することを望んでいます\n"
 "Zulip -- 生産性のために設計されたチームコミュニケーションツール"
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at <a href=\"mailto:%(email)s\">%(email)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
 "%(email)s\">Contact us</a> — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
 "#%(channel_name)s > %(topic_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2837,21 +2301,21 @@ msgid ""
 "preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
@@ -2860,41 +2324,41 @@ msgstr ""
 "このメールに返信しないでください。このZulipサーバーはメール受信をするように設"
 "定されていません（<a href=\"%(url)s\">ヘルプ</a>）"
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr "新しいメッセージ"
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
@@ -2902,7 +2366,7 @@ msgstr ""
 "このメールに返信しないでください。このZulipサーバーはメール受信をするように設"
 "定されていません。ヘルプ："
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2913,22 +2377,22 @@ msgstr ""
 "ました。もしこの変更をリクエストしていない場合は、すぐに%(support_email)sまで"
 "お問い合わせください。"
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr "敬具"
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr "チームZulip"
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr "%(realm_name)sのZulipメールアドレスは変更されました。"
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2939,7 +2403,7 @@ msgstr ""
 "れました。もしこの変更をリクエストしていない場合は、すぐに<%(support_email)s>"
 "までお問い合わせください。"
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
@@ -2947,46 +2411,46 @@ msgstr ""
 "組織：%(organization_url)s　時刻：%(login_time)s　メールアドレス："
 "%(user_email)s　"
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr "以下のZulipアカウントに最近ログインされたことをお知らせします。"
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr "組織：%(organization_link)s"
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr "メールアドレス：%(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr "時刻：%(login_time)s"
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr "端末：%(device_browser)s　OS：%(device_os)s"
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr "IPアドレス：%(device_ip)s"
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr "もしあなた自身が行ったものであれば何もする必要はありません。"
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2997,31 +2461,31 @@ msgstr ""
 "ある場合は<a href=\"%(reset_link)s\">パスワードをリセット</a>するか、すぐ"
 "に%(support_email)sまでお問い合わせください。"
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr "ありがとう、"
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr "Zulip セキュリティー"
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr "ログイン通知を受け取らない"
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr "%(device_os)sの%(device_browser)sからの新しいログイン"
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr "組織：%(organization_url)s"
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3032,7 +2496,7 @@ msgstr ""
 "ある場合は %(reset_link)s からパスワードをリセットするか、すぐに "
 "%(support_email)s までお問い合わせください。"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -3040,25 +2504,25 @@ msgid ""
 "Zulip</a> to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
 "with you and share their unique perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr "アプリそのものを使って、感想を語り合いましょう。"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -3066,7 +2530,7 @@ msgid ""
 "experience how a new chat app will help your team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -3074,137 +2538,137 @@ msgid ""
 "action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
 "team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
 "organizations like yours!"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
@@ -3213,12 +2677,12 @@ msgstr ""
 "異なる議論が並行して進んでいても、それぞれのメッセージを文脈に沿って確認する"
 "ことが可能です。"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3230,11 +2694,11 @@ msgstr ""
 "ます。適切なトピック名を決めるコツは、「ねえ、これについて話さない？」という"
 "文章の続きをイメージすることです"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr "ショートトピックの例"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3243,23 +2707,23 @@ msgid ""
 "href=\"%(move_channels_link)s\">move a topic to a different channel</a>."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr "Zulipへ移動"
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3268,23 +2732,23 @@ msgid ""
 "(%(move_channels_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
 "%(email)s on %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr "以下のボタンをクリックしてパスワードをリセットしてください。"
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr "パスワードをリセット"
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3295,47 +2759,47 @@ msgstr ""
 "います。組織の管理者に連絡して<a href=\"%(help_link)s\">アカウントを有効化</"
 "a>することができます。"
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr "あなたはこのZulip組織でアカウントを持っていません。"
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr "あなたは以下の組織（たち）で有効なアカウントを持っています。"
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
 msgstr ""
 "以下の組織（たち）にログインするかパスワードをリセットすることができます。"
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr "身に覚えがない場合はこのメールを無視することができます。"
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr "%(realm_name)s でのパスワードリセットリクエスト"
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr "以下のボタンをクリックしてパスワードをリセットしてください。"
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
 "You can contact an organization administrator to reactivate your account."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3343,14 +2807,14 @@ msgid ""
 "have been voided."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
 "to %(upgrade_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, fuzzy, python-format
 #| msgid ""
 #| "If you did not request this change, please contact us immediately at "
@@ -3362,8 +2826,8 @@ msgstr ""
 "この変更をリクエストしていない場合は、すぐに %(support_email)s までご連絡くだ"
 "さい。"
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid "You've joined the Zulip organization %(realm_name)s."
 msgid ""
@@ -3371,104 +2835,104 @@ msgid ""
 "%(localized_date)s."
 msgstr "Zulip組織 %(realm_name)s に参加しました。"
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr "%(realm_name)sの以前の管理者の方へ"
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip demo organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr "以下のボタンをクリックして組織を再有効化してください。"
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr "組織を再有効化"
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
@@ -3476,157 +2940,157 @@ msgstr ""
 "もし手違いでリクエストが送信されてしまった場合、なにもしなければ24時間後にリ"
 "ンクの有効期限が切れます。"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Reactivate your Zulip organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "Zulip組織を再有効化"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr "Zulip組織を再有効化"
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr "以下のリンクをクリックして組織を再有効化してください。"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for <b>%(remote_server_hostname)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, fuzzy
 #| msgid "Click the button below to complete registration."
 msgid "Click the button below to log in."
 msgstr "以下のボタンをクリックして登録を完了させてください。"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for %(remote_server_hostname)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
 "management for <b>%(remote_realm_host)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
 "management for %(remote_realm_host)s."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the <a href=\"%(plans_link)s\">Zulip Community plan</a>."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
 "website</a>, we would really appreciate it!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
 msgstr ""
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr "あなたのZulipアカウントを探す"
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
 "accounts for another email address</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
@@ -3634,264 +3098,260 @@ msgstr ""
 "パスワードもお忘れの場合は、<a href=\"/help/change-your-password\">こちらから"
 "リセット</a>できます。"
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr "Eメールアドレス"
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "アカウントを探す"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr "製品"
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr "Zulipを選ぶ理由"
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr "機能"
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr ""
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Zulip"
 msgid "Zulip Cloud"
 msgstr "Zulip"
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr "セルフホスティング"
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr "安全性"
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "統合"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr "デスクトップアプリとモバイルアプリ"
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr "新しい組織"
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr "ソリューション"
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr "ビジネス"
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr "教育"
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr "研究"
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr ""
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr "オープンソースプロジェクト"
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr "コミュニティー"
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr "お客様の事例"
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr ""
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr ""
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr "はじめる"
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr "ヘルプセンター"
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr "コミュニティーチャット"
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr ""
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr "Zulip サーバーのインストール"
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr "Zulip サーバーのアップグレード"
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr ""
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr "貢献ガイド"
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr "開発コミュニティー"
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr "翻訳"
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr "GitHub"
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr "私たちについて"
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr "チーム"
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "履歴"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr ""
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr "仕事"
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr "ブログ"
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr "Zulipをサポート"
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr "Mastodon"
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr ""
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 msgid "Bluesky"
 msgstr ""
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr ""
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr "サービス利用規約"
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr "プライバシーポリシー"
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr "帰属表記"
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr "%(integrations_count_display)s以上のネイティヴインテグレーション。"
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 msgid ""
 "And hundreds more through <a href=\"/integrations/zapier\">Zapier</a> and <a "
 "href=\"/integrations/ifttt\">IFTTT</a>."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr "インテグレーションを検索"
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr "カスタムインテグレーション"
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr "Incoming webhook"
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr "インタラクティブボット"
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr "REST API"
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr "不正なメールアドレス"
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3899,7 +3359,7 @@ msgid ""
 "emails with your email domain."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3907,7 +3367,7 @@ msgid ""
 "disposable email addresses."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3915,24 +3375,24 @@ msgid ""
 "emails that contain \"+\"."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3940,7 +3400,7 @@ msgid ""
 "%(support_email)s\">contact Zulip support</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3948,91 +3408,91 @@ msgid ""
 "%(support_email)s\">contact this Zulip server's administrators</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
 "management for your Zulip server."
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr "正しくない／有効期限切れのログインセッション"
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr "Zulipにログイン"
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr "このメールアドレスですでに登録済みです。以下からログインしてください。"
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr "メールまたはユーザー名"
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "ユーザー名"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr "パスワードを忘れた"
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr "%(identity_provider)sでログイン"
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr "アカウントなしで閲覧"
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 "アカウントを持っていませんか？この組織に参加するには招待を受ける必要がありま"
 "す。"
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr "使用可能なライセンスがありません"
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> because all Zulip Cloud licenses are in use."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr "認証用サブドメインのエラー"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr "認証用サブドメイン"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -4046,44 +3506,42 @@ msgstr ""
 "インの途中でこの画面から進まなくなったのであれば、サーバー側のバグや設定ミス"
 "の可能性が高いです。"
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 #, fuzzy
 #| msgid "New organization"
 msgid "Demo organizations disabled"
 msgstr "新しい組織"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr "アップデートが必要です"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr "最新のリリースをダウンロード"
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -4091,22 +3549,21 @@ msgid ""
 "organization for more information."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -4114,49 +3571,47 @@ msgid ""
 "Zulip support</a> for assistance in resolving this issue."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr "非対応のブラウザ"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, fuzzy, python-format
 #| msgid "Presence is not supported for bot users."
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr "プレゼンスはBotユーザーでサポートされていません"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
 "a> like Firefox, Chrome, and Edge."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr "アカウントは無効化されています"
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Invalid organization"
 msgid "Finalize organization import"
 msgstr "無効な組織"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Organization type"
 msgid "Organization import completed!"
 msgstr "組織のタイプ"
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -4164,56 +3619,55 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Select your account"
 msgstr "アカウントを作成"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Create new account"
 msgstr "アカウントを作成"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr ""
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr "組織は正常に再有効化されました。"
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr "組織の再有効化リンクは有効期限切れか正しくありません。"
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr "組織にログイン"
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr "組織のURLを知りませんか？"
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr "組織を探す"
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr "次へ"
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4221,24 +3675,24 @@ msgid ""
 "have one yet."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 #, fuzzy
 #| msgid "Self-host Zulip"
 msgid "Self-hosting Zulip?"
 msgstr "セルフホストZulip"
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">log in to manage plans and billing.</a>"
 msgstr ""
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr "パスワードをリセット"
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
@@ -4246,61 +3700,61 @@ msgstr ""
 "パスワードをお忘れですか？ ご安心ください。登録したメールアドレスにパスワード"
 "リセット用のリンクをお送りします。"
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr "リセットリンクを送信"
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr "新しいパスワードを設定"
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "パスワードを確認"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr "すみません。このリンクは不正か、すでに使われています。"
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr "パスワードの更新に成功しました"
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr "パスワードが更新されました！"
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr ""
 "新しいパスワードで <a href=\"%(login_url)s\">ログイン</a> してください。"
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr "パスワードリセット用のメールを送信"
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr "パスワードリセットを送信しました！"
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr "数分後にメールを確認して処理を完了させてください。"
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr "Slack からインポート"
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr "インポートの進捗状況"
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr "インポートステータスを確認中…"
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4308,7 +3762,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4317,45 +3771,45 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr "アップロードされたエクスポートファイル"
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr ""
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr "インポートを開始"
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
@@ -4363,13 +3817,13 @@ msgstr ""
 "いったん画面を離れても大丈夫です。メール内の<b>登録を完了する</b>ボタンをク"
 "リックすれば、<br />いつでもこのページに戻って続きから再開できます。"
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4377,7 +3831,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4385,21 +3839,21 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr "認証のためのアカウントを選択"
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr "<h1 class=\"get-started\">アカウントを選択</h1>"
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 "GitHubアカウントに紐付けられているメールアドレスが 検証されていません。"
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
@@ -4407,21 +3861,21 @@ msgstr ""
 "これらのうちどれかをZulipへのログインに使用する場合、 まず<a href=\"https://"
 "github.com/settings/emails\">GitHubで検証</a>する必要があります。"
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr "メールアドレスの登録を解除できませんでした"
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr "購読解除リクエストのメールアドレスがみつかりません"
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4431,19 +3885,18 @@ msgstr ""
 "正しいURLであるか再確認してからやり直すか、<a href=\"mailto:"
 "%(support_email)s\">メールでお問い合わせ</a>ください。"
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr "Eメールの設定を更新しました"
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
@@ -4452,49 +3905,48 @@ msgstr ""
 "この変更を元に戻すか、<a href=\"%(realm_url)s/#settings/notifications\">通知"
 "設定</a>で設定内容を確認できます。"
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr "不正な順序マッピング"
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr "Zulip の使用方法に関する質問や議論。"
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr "ここで Zulip を試してみましょう。 :test_tube:"
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr "チーム全体での会話に"
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr "登録"
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr "{user}がこの組織に参加しました。"
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr "{user}はZulipへの招待を受け入れました"
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 #, fuzzy
 #| msgid "Cannot deactivate the only {entity}."
 msgid "Cannot reactivate a deleted user"
 msgstr "唯一の{entity}を無効化できません"
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
@@ -4502,65 +3954,64 @@ msgstr ""
 "あなたはこのフィールドの変更を許可されていません。管理者に連絡して更新してく"
 "ださい。"
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr "フィールドID {id} が見つかりませんでした"
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr "無効なデフォルトチャンネルグループ名 '{group_name}' です"
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr "無効なデフォルトチャンネルグループ {group_name} です"
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr ""
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr ""
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
@@ -4568,7 +4019,7 @@ msgstr ""
 "ユーザーの安全のため、1日に送信可能な招待数には制限があります。制限に達したた"
 "め、招待状を送信できませんでした。"
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
@@ -4576,77 +4027,77 @@ msgstr ""
 "あなたのアカウントはこの組織への招待を作成するには新しすぎます。組織管理者ま"
 "たは経験のあるユーザーにお問い合わせください。"
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 "いくつかのメールアドレスが検証されていないため、招待を送信しませんでした。"
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr "誰も招待することができません"
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr "変更するものがありません"
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr "ダイレクトメッセージはチャンネルに移動できません。"
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr "ダイレクトメッセージではトピックを作成できません"
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr "トピック編集がない不正なpropagate_modeです"
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr ""
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr "ウィジェットを編集できません。"
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr "組織のメッセージ編集を禁止しました"
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr "このメッセージを編集する権限がありません"
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr "このメッセージを編集できる時間制限が過ぎました"
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr "{user}がこのトピックを解決済みにしました。"
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr "{user}がこのトピックを未解決にしました。"
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr "{user}がこのトピックを {new_location} に移動しました。"
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr ""
 "{user}が1件のメッセージをこのトピックから {new_location} に移動しました。"
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
@@ -4655,12 +4106,12 @@ msgstr ""
 "{user}が{changed_messages_count}件のメッセージをこのトピックから "
 "{new_location} に移動しました。"
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr "{user}がこのトピックを {old_location} からここに移動しました。"
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
@@ -4668,7 +4119,7 @@ msgstr ""
 "{user}が[1件のメッセージ]({message_link})を {old_location} からここに移動しま"
 "した。"
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
@@ -4677,69 +4128,66 @@ msgstr ""
 "{user}が{changed_messages_count}件のメッセージを {old_location} からここに移"
 "動しました。"
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 #, fuzzy
 #| msgid "You do not have permission to post in this channel."
 msgid "You don't have permission to resolve topics in this channel."
 msgstr "このチャンネルに送信する権限がありません。"
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr "このメッセージのトピックを編集可能な制限時間が過ぎました。"
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr "このメッセージを移動する権限がありません"
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr "このメッセージのチャンネルを編集可能な制限時間が過ぎました"
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr "無効なフラグ: '{flag}'"
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr "フラグは編集できません: '{flag}'"
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr "無効なメッセージフラグ操作: '{operation}'"
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr "不正なメッセージ"
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr "メッセージをレンダリングできません"
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr "チャンネルが1つだけ指定されている必要があります"
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr "チャンネルのデータタイプが不正です"
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr "受信者のデータータイプが不正です"
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 "受信者リストはメールアドレスかユーザーIDのどちらかを含むことができますが、両"
 "方を含むことはできません。"
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
@@ -4748,7 +4196,7 @@ msgstr ""
 "あなたのボット {bot_identity} がチャンネルID {channel_id} にメッセージを送信"
 "しようとしましたが、そのIDのチャンネルは存在しません。"
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4759,7 +4207,7 @@ msgstr ""
 "しようとしましたが、そのチャンネルは存在しません。[こちら]"
 "({new_channel_link})をクリックしてチャンネルを作成してください。"
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
@@ -4768,29 +4216,29 @@ msgstr ""
 "あなたのボット {bot_identity} がチャンネル {channel_name} にメッセージを送信"
 "しようとしました。チャンネルは存在しますが、購読者が一人もいません。"
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr "一部の宛先にアクセスする権限がありません。"
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr "ウィジェット：APIプログラマは不正なJSONを送信しました"
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr "ウィジェット：{error_msg}"
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4798,27 +4246,25 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr "この名前のカスタム絵文字はすでに存在します。"
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr "無効な画像形式"
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr ""
 "並べ替えられたリストに重複したリンク化機能（linkifiers）を含めることはできま"
 "せん"
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr "並べ替えられたリストに重複したリンク化機能を含めることはできません"
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
@@ -4827,39 +4273,39 @@ msgstr ""
 "この認証方法を使用するには、{required_upgrade_plan_name}プランにアップグレー"
 "ドする必要があります。"
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr "無効な認証方法です: {name}。有効な方法は次の通りです: {methods}"
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr ""
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr "予約メッセージが送信されました"
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder could not be sent."
 msgstr "トークンがありません"
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr "メッセージを予定した時刻に送信できませんでした。"
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
@@ -4868,38 +4314,38 @@ msgstr ""
 "{delivery_datetime} に予定されていたメッセージは、以下のエラーのため送信され"
 "ませんでした："
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr "[予定されたメッセージを表示](#scheduled)"
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr "チャンネルは既に無効化されています"
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr "チャンネル #{channel_name} がアーカイブされました。"
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr "チャンネルは現在無効化されていません"
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr "{channel_name} という名前のチャンネルは既に存在します"
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr "チャンネルはプライベートで、購読者がいません"
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr "チャンネル #{channel_name} アーカイブが解除されました。"
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
@@ -4908,7 +4354,7 @@ msgstr ""
 "{user} がこのチャンネルの[アクセス権限]({help_link})を **{old_policy}** から "
 "**{new_policy}** に変更しました。"
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -4921,42 +4367,40 @@ msgstr ""
 "* **変更前**: {old_setting_description}\n"
 "* **変更後**: {new_setting_description}\n"
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 "{user_name}がチャンネル「{old_channel_name}」を「{new_channel_name}」に名前変"
 "更しました。"
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr "説明がありません。"
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr "{user}がこのチャンネルの説明を変更しました。"
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr "以前の説明"
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr "新しい説明"
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr "永久に"
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr "{number_of_days} 日"
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
@@ -4965,11 +4409,11 @@ msgstr ""
 "このチャンネルのメッセージは、送信から {number_of_days} 日後に自動的に削除さ"
 "れるようになります。"
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr "このチャンネルのメッセージは、今後、永久に保持されます。"
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -4985,26 +4429,26 @@ msgstr ""
 "\n"
 "{summary_line}"
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr "自動"
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
@@ -5013,73 +4457,63 @@ msgstr ""
 "{user_name} が「一般チャット トピックへの投稿を許可しますか？」の設定を "
 "{old_topics_policy} から {new_topics_policy} に変更しました。"
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr ""
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr "無効なユーザー ID {user_id} です"
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr ""
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr "権限が足りません"
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr "このAPIはincoming webhookボットに利用できません。"
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr "アカウントはこのサブドメインに関連付けられていません"
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr "このエンドポイントはボットからのリクエストを受け付けません。"
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr "サーバー管理者である必要があります"
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr "このエンドポイントはHTTPのベーシック認証を必要とします。"
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr "不正なベーシック認証の認証ヘッダー"
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr "Basic認証の認証ヘッダがありません"
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr "Webhookボットはwebhookだけにアクセスできます"
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr ""
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
@@ -5088,51 +4522,50 @@ msgstr ""
 "あなたのアカウント{username}は無効化されました。再度アクティブにするには、組"
 "織の管理者に連絡してください。"
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr "パスワードが弱すぎます"
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr "サブドメインは3文字以上必要です。"
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr "サブドメインは '-' で始まる、もしくは終わることができません。"
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr "サブドメインには小文字と数字と '-' だけが使えます。"
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr "本物のメールアドレスを使ってください。"
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr "{email} で参加しようとしている組織が存在しません。"
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr "組織の管理者から {email} を招待してもらうようにしてください。"
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
@@ -5141,11 +4574,11 @@ msgstr ""
 "あなたのメールアドレス {email} はこの組織のアカウントに登録できるドメインでは"
 "ありません。"
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr "この組織では「+」が含まれるメールアドレスは許可されていません。"
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
@@ -5154,132 +4587,129 @@ msgstr ""
 "全てのZulipライセンスが使用中のため、この組織には現在、新規の参加ができませ"
 "ん。招待者にライセンス数の追加を依頼してから、再度お試しください。"
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 #, fuzzy
 #| msgid "Embedded bots are not enabled."
 msgid "Challenges are not enabled."
 msgstr "埋め込みBotは有効化されていません。"
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "新しいパスワード"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr "新しいパスワードの確認"
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "You're making too many attempts to sign in. Try again in "
 "{retry_after_string} or contact your organization administrator for help."
 msgstr ""
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
 msgstr ""
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr "トークン"
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr "最大10個のメールアドレスを入力してください。"
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr "Zulip組織が見つかりませんでした。"
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr "無効なメールアドレス '{email}' です"
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr "トピックがありません"
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr ""
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr ""
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr "メッセージは受信者が必要です"
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr "不正なメッセージ種別"
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr "不正な添付ファイル"
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr ""
 "添付ファイルを削除するときにエラーが発生しました。後で再度お試しください。"
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr "メッセージは受信者が必要です"
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Content can't be empty"
 msgid "Channel folder name can't be empty."
 msgstr "コンテンツを入力してください"
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr ""
 "チャンネルフォルダ名の {position} 文字目に、無効な文字が含まれています。"
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Invalid data export ID"
 msgid "Invalid channel folder ID"
 msgstr "不正なデーターエクスポートID"
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 #, fuzzy
 #| msgid "Confirm your email address"
 msgid "Configure owner account email address."
 msgstr "メールアドレスを承認"
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5288,72 +4718,72 @@ msgid ""
 "organization]({convert_demo}).\n"
 msgstr ""
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a date"
 msgid "{var_name} is not Base64 encoded"
 msgstr "{var_name}が日付ではありません"
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 #, fuzzy
 #| msgid "Invalid emoji code."
 msgid "Invalid `device_id`"
 msgstr "不正な絵文字コード"
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr "{service_name} ダイジェスト"
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr "ドメインを入力してください。"
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr "ドメインは最低1つのドット (.) が必要です"
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr "ドメインが長すぎます"
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr "ドメインはドット (.) で始める、または終えることができません"
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr "ドメインは '..' を含むことができません。"
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr "サブドメインは '-' で始める、または終えることができません。"
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr "ドメインには文字や数字と '.' と '-' だけが使えます。"
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr "タイムスタンプは負数であってはなりません"
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr "トピックはNULLバイトを含んではなりません"
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr ""
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr "下書きが存在しません"
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5361,86 +4791,86 @@ msgid ""
 "{error_message}"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr "Zulipを開いてネタバレを表示する"
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr ""
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr "不正なメールアドレス"
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr "ドメイン外です。"
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr "「+」が含まれるメールアドレスは許可されていません。"
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr "システムBotに予約されています"
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr "{email} のアカウントはすでに存在します"
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr "アカウントはすでにあります"
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr "アカウントは無効化されました"
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr ""
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr "不正なカスタム絵文字"
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr "不正なカスタム絵文字名"
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr "このカスタム絵文字は無効化されました"
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr "不正な絵文字コード"
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr "不正な絵文字名"
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr "不正な絵文字種別"
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr "組織管理者か絵文字の作者である必要があります"
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr ""
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
@@ -5448,549 +4878,547 @@ msgstr ""
 "絵文字の名前は、英小文字、数字、スペース、ハイフン、アンダースコアのみで入力"
 "してください。"
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr "絵文字名が入力されていません"
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr "イベントキューを割り当てることができませんでした"
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr "ログインしていません: API 認証かユーザーログインが必要です"
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr ""
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr "組織オーナー"
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr "ユーザー"
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr "唯一の{entity}を無効化できません"
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr "不正なMarkdown include文：{include_statement}"
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr "不正なJSON"
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr "組織管理者である必要があります"
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr "組織オーナーである必要があります"
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Must be an organization owner"
 msgid "Must be a bot user"
 msgstr "組織オーナーである必要があります"
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr "ユーザー名かパスワードが間違っています"
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr "組織は無効化されました"
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr "この組織ではパスワード認証が無効化されています"
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr "あなたのパスワードは無効化され、リセットが必要です"
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr "不正なAPIキー"
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr "不正な形式のAPIキー"
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
 "webhook; ignoring"
 msgstr ""
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr "不正なサブドメイン"
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr "この組織では、ダイレクトメッセージが無効化されています。"
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr "この会話には、承認権限を持つユーザーが含まれていません。"
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr "アクセスが拒否されました"
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} most recent messages in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr "リアクションはすでに存在します"
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr "リアクションが存在しません"
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
 msgstr ""
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr ""
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr ""
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr ""
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr ""
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr ""
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Already has an account."
 msgid "Atlassian account ID"
 msgstr "アカウントはすでにあります"
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Behance username"
 msgstr "利用できない名前またはユーザー名"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Bitbucket username"
 msgstr "GitHub ユーザー名"
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Codeberg username"
 msgstr "Twitter ユーザー名"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Dribbble username"
 msgstr "GitHub ユーザー名"
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Facebook username"
 msgstr "利用できない名前またはユーザー名"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr "GitHub ユーザー名"
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "GitLab username"
 msgstr "GitHub ユーザー名"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Instagram username"
 msgstr "Twitter ユーザー名"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 msgid "Mastodon profile"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Medium username"
 msgstr "GitHub ユーザー名"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Pinterest username"
 msgstr "Twitter ユーザー名"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Reddit username"
 msgstr "GitHub ユーザー名"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Snapchat username"
 msgstr "GitHub ユーザー名"
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Threads username"
 msgstr "Twitter ユーザー名"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "TikTok username"
 msgstr "Twitter ユーザー名"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Twitch username"
 msgstr "Twitter ユーザー名"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "ユーザー名"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr "不正な外部アカウントタイプ"
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr "インテグレーションフレームワーク"
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 #, fuzzy
 #| msgid "Video call ended"
 msgid "Video calling"
 msgstr "通話が終了しました"
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr "継続的インテグレーション"
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr "顧客サポート"
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr "デプロイ"
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr "エンターテイメント"
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr "コミュニケーション"
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr "財務"
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr "人事"
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr "マーケティング"
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr "その他"
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr "監視"
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr "プロジェクト管理"
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr "生産性"
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr "バージョン管理"
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr "メッセージを入力する必要があります"
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr "メッセージにNULL文字を含んではいけません"
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{fullname} moderation"
 msgstr "{full_name}があなたにメンションしました："
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr "不正な絞り込みオペレーター: {desc}"
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr ""
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr ""
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr "引数'anchor'がありません"
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 #, fuzzy
 #| msgid "Missing 'anchor' argument."
 msgid "Missing 'anchor_date' argument."
 msgstr "引数'anchor'がありません"
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr "不正なアンカー"
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr ""
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 #, fuzzy
 #| msgid "Confirmation link does not exist"
 msgid "Navigation view does not exist."
 msgstr "承認リンクが存在しません"
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr "{admin_group_syntax} からのお知らせ："
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6001,7 +5429,7 @@ msgstr ""
 "詳細については、[チーム向けZulip利用ガイド]({getting_started_url})をご覧くだ"
 "さい！\n"
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6011,7 +5439,7 @@ msgstr ""
 "\n"
 "詳細については、[Zulip利用ガイド]({getting_started_url})をご覧ください！\n"
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6019,7 +5447,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6027,7 +5455,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6037,7 +5465,7 @@ msgid ""
 "a permanent organization]({convert_demo_organization_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
@@ -6047,7 +5475,7 @@ msgstr ""
 "スムーズに使い始めていただけるよう、いくつか会話を開始しておきました。\n"
 "[受信箱](/#inbox) からご確認いただけます。\n"
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6058,7 +5486,7 @@ msgstr ""
 "アプリの概要をさっと確認したいときは、いつでもこちらの[Zulip紹介動画]"
 "({navigation_tour_video_url})に戻ってご覧いただけます。\n"
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6083,14 +5511,14 @@ msgstr ""
 "{demo_organization_text}\n"
 "\n"
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -6098,7 +5526,7 @@ msgid ""
 "and edit your [profile information](/help/edit-your-profile).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -6109,7 +5537,7 @@ msgid ""
 "experience in your [Preferences](#settings/preferences).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6120,7 +5548,7 @@ msgid ""
 "[Browse and subscribe to channels]({settings_link}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -6137,7 +5565,7 @@ msgid ""
 "discussed.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -6146,7 +5574,7 @@ msgid ""
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -6158,7 +5586,7 @@ msgid ""
 "times, and more.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6168,7 +5596,7 @@ msgid ""
 "or browse the [help center](/help/) to learn more!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6176,7 +5604,7 @@ msgid ""
 "get help, try one of the following messages: {bot_commands}\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6194,7 +5622,7 @@ msgstr ""
 "らにはトピックごと[別のチャンネルへ移動]"
 "({move_content_another_channel_help_url})させることも簡単にできます。\n"
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
@@ -6203,7 +5631,7 @@ msgstr ""
 ":point_right: このメッセージを別のトピックに移動してから、元に戻してみてくだ"
 "さい。\n"
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6224,12 +5652,11 @@ msgstr ""
 "#**{zulip_discussion_channel_name}** チャンネルの「{topic_name}」トピックに含"
 "まれています。\n"
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr ""
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -6237,7 +5664,7 @@ msgid ""
 "no matter how many other conversations are going on.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
@@ -6247,7 +5674,7 @@ msgstr ""
 ":point_right: 準備ができたら、[受信箱](/#inbox)を確認して、未読メッセージがあ"
 "る他の会話をチェックしましょう。\n"
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -6255,7 +5682,7 @@ msgid ""
 "the `+` button next to its name.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -6263,7 +5690,7 @@ msgid ""
 "can we chat about…?”\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
@@ -6271,7 +5698,7 @@ msgstr ""
 "\n"
 ":point_right: このチャンネルで新しい会話を始めてみましょう。\n"
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6282,7 +5709,7 @@ msgstr ""
 ":point_right: このトピックを使って、[Zulipのメッセージ機能]"
 "({format_message_help_url})を試してみましょう。\n"
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6317,7 +5744,7 @@ msgstr ""
 "\n"
 "```\n"
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
@@ -6327,7 +5754,7 @@ msgstr ""
 "この **挨拶** トピックは、チームメイトに「こんにちは」 :wave: と伝えるのに最"
 "適な場所です。\n"
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
@@ -6337,145 +5764,143 @@ msgstr ""
 ":point_right: このメッセージをクリックして、同じ会話内で新しいメッセージを開"
 "始しましょう。\n"
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr "メッセージの移動"
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr "実験"
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr ""
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr "挨拶"
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr "レスポンスが不正なJSONです"
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr "不正なレスポンスのフォーマットです"
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr "空か、トークンの長さが不正です"
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr "不正なAPNSトークン"
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr ""
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr "トークンがありません"
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr "{full_name}があなたにメンションしました："
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr "{full_name}が全員にメンションしました："
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "新しいメッセージ"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr "認識されていないデバイス"
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr "プッシュ通知バウンサーによって認識されていないデバイス"
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr "アクティブに登録されたプッシュ通知デバイスがありません"
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 #, fuzzy
 #| msgid "Invalid API key"
 msgid "Invalid `push_key`"
 msgstr "不正なAPIキー"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
 msgstr[0] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr "このクエリーを許可されていないユーザーです"
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr "'{email}'はZulipを使っていません。"
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr "組織の外部にダイレクトメッセージは送信できません。"
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr "{var_name}が長すぎます（制限：{max_length}文字）"
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "You requested a reminder for the following direct message. Note:\n"
@@ -6487,13 +5912,13 @@ msgstr ""
 "以下のダイレクトメッセージに関するリマインダーが設定されています。メモ:\n"
 " > {note}"
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 #, fuzzy
 #| msgid "You requested a reminder for the following direct message."
 msgid "You requested a reminder for the following message."
 msgstr "以下のダイレクトメッセージに関するリマインダーが設定されています。"
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
@@ -6502,1076 +5927,1057 @@ msgstr ""
 "以下のダイレクトメッセージに関するリマインダーが設定されています。メモ:\n"
 " > {note}"
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr "以下のダイレクトメッセージに関するリマインダーが設定されています。"
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder does not exist"
 msgstr "トークンがありません"
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr ""
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr "引数「{var_name1}」と「{var_name2}」を決定できませんでした"
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr "'{var_name}' 引数がありません"
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr "'{var_name}' の不正な値: {bad_value}"
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr "予約メッセージがありません"
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr ""
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr ""
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr ""
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr "このチャンネルに送信する権限がありません。"
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 #, fuzzy
 #| msgid "You do not have permission to post in this channel."
 msgid "You do not have permission to create new topics in this channel."
 msgstr "このチャンネルに送信する権限がありません。"
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr ""
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr ""
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr ""
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr ""
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr ""
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr "画像をデコードできません。画像ファイルをアップロードしましたか？"
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr "画像サイズが制限を超えています。"
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr "{var_name}が真偽値でありません"
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a float"
 msgid "{var_name} does not have the expected format"
 msgstr "{var_name}が浮動小数点数ではありません"
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr "{var_name}が日付ではありません"
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr "{var_name}は辞書でありません"
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr "不正な{var_name}"
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr "{var_name}が浮動小数点数ではありません"
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr "{var_name} は小さすぎます"
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr "{var_name}が整数でありません"
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr "{var_name} は大きすぎます"
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr "{var_name}がリストでありません"
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr "{var_name}が長すぎます（制限：{max_length}文字）"
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr "{var_name}が文字列でありません"
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr "{var_name}が長すぎます（制限：{max_length}文字）"
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr "{var_name}が長すぎます（制限：{max_length}文字）"
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr "不正なペイロード"
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr "URLではありません"
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr "{var_name}が正しい16進カラーコードでありません"
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr "不正な{setting_name}"
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr "アップロードが組織の上限アップロード容量を超えています。"
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr ""
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr ""
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr "不正なユーザーグループ"
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid user group"
 msgid "Invalid user group ID: {user_group_id}"
 msgstr "不正なユーザーグループ"
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr ""
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr ""
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr ""
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr "クライアントは新しい値を渡しませんでした"
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr "名前が長すぎます！"
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 #, fuzzy
 #| msgid "Message must not be empty"
 msgid "Name must not be empty!"
 msgstr "メッセージを入力する必要があります"
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr "名前に不正な文字があります！"
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr "不正なフォーマット"
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr ""
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr ""
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr "利用できない名前またはユーザー名"
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr ""
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr ""
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr "無効な {key} の値 {value} ({error})"
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr "不正な設定データー"
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr "不正なボット種別"
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr "不正なインターフェース種別"
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr ""
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr "ボットが存在しません"
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr "ユーザーが存在しません"
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr "ユーザーは無効化されています"
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr "{item}は空白であることはできません"
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr ""
 "{var_name}は不正な長さ {length}です。{target_length}である必要があります"
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a string"
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr "{var_name}が文字列でありません"
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr "{container}はちょうど{length}のアイテムを持つべきです"
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr "{var_name}にはキー {key_name} がありません"
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr ""
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr "{var_name}が許可された型でありません"
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr "{variable} != {expected_value} （{value}が不正です）"
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr "{var_name}がURLでありません"
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr ""
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr "{item}は空白であることはできません"
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr ""
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr "{value}は{field_name}の正しい選択肢でありません"
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr "{var_name}が文字列か整数のリストでありません"
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr "{var_name}が文字列か整数でありません"
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr ""
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr "{var_name}が見つかりません"
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr "HTTPイベントヘッダー「{header}」がありません"
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr "zcommandには先頭にスラッシュが必要です"
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr ""
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr "CSRFエラー：{reason}"
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr "日付"
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr "外部アカウント"
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr "代名詞"
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr "誰も"
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr "正式メンバー"
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "メンバー"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr "インターネット上の全員"
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Invalid characters in emoji name"
 msgid "Invalid auto-conversion field: empty field name."
 msgstr "絵文字名に不正な文字"
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr ""
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr "未知の正規表現エラー"
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 msgid "Example input does not match the linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in alternative URL template is not present in linkifier "
 "pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in linkifier pattern is not present in alternative URL "
 "template."
 msgstr ""
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr "Unicode絵文字"
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "カスタム絵文字"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr "Zulip拡張絵文字"
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr "絵文字名に不正な文字"
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr "pygments言語に不正な文字があります"
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr ""
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr ""
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr ""
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr "チャンネルイベント"
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr ""
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr "G指定（全年齢向け）のGIFを許可する"
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr "PG指定（要保護者の指導）のGIFを許可する"
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr "PG-13指定（13歳未満は要保護者の指導）のGIFを許可する"
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr "R指定（制限あり）のGIFを許可する"
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr "Web公開"
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "パブリック"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr "プライベート・履歴を共有"
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr "プライベート・履歴を保護"
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr "管理者・モデレーター・メンバー・ゲスト"
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr "管理者・モデレーター・メンバー"
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr "管理者・モデレーター"
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr "管理者限定"
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr "不明なユーザー"
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr "組織オーナー"
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr "組織の管理者"
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr "モデレーター"
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "メンバー"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "ゲスト"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr "不明なIPアドレス"
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr "不明なOS"
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr "不明なブラウザ"
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr "'queue_id' 引数がありません"
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr "'last_event_id' 引数がありません"
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr "{event_id}より新しいイベントはすでにpruneされています。"
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr "イベント {event_id}はこのキューに存在しません"
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr ""
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 #, fuzzy
 #| msgid "Failed to create Zoom call"
 msgid "Failed to generate challenge"
 msgstr "Zoomコールの作成に失敗しました"
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr ""
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr "リクエストにJWT"
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr "不正なJSON Web Tokenです"
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr ""
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr "サブドメインが必要です"
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr "正しいパスワードを入力してください"
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr "リクエストにUser-Agentヘッダがありません"
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr "ラベルは空白であることができません"
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr "フィールドは最低１つの選択肢が必要です"
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr "フィールドタイプは、プロフィール概要ではサポートされていません。"
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 #, fuzzy
 #| msgid "Field type not supported for display in profile summary."
 msgid "Field type not supported for use for user matching."
 msgstr "フィールドタイプは、プロフィール概要ではサポートされていません。"
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr "不正なフィールド種別。"
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 "プロファイルの概要に表示できるカスタムプロファイルフィールドは２つまでです。"
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr "そのラベルのフィールドはすでに存在します"
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr "デフォルトカスタムフィールドは更新できません"
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr "エンドポイントはプロダクションで利用できません"
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr "DevAuthBackendは有効でありません"
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr ""
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr ""
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr ""
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr ""
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr ""
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr ""
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr "そのような招待がありません"
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 #, fuzzy
 #| msgid "Confirmation link expired or deactivated"
 msgid "Invitation already used or deactivated."
 msgstr "確認リンクの期限が切れているか、無効化されています"
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr ""
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr ""
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr "メールアドレスを指定してください。"
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
@@ -7579,104 +6985,102 @@ msgstr ""
 "これらのアドレスの中にはZulipをすでに使用している人がいたため、その人には招待"
 "を送信しませんでした。他の人には招待を送信しました。"
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr "この組織のメッセージの編集履歴は無効です"
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr "このメッセージを削除する権限がありません"
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr "このメッセージを削除できる時間が過ぎました"
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr "メッセージはすでに削除されています"
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr ""
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr ""
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr ""
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr ""
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Zephyr mirroring is not allowed in this organization"
 msgid "Message reporting is not enabled in this organization."
 msgstr "Zephyr ミラーリングはこの組織で許可されていません"
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr "送信者がいません"
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr "受信者のユーザーIDでミラーリングは認められていません"
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr "不正なミラーリングされたメッセージ"
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr ""
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr ""
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr ""
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr "自分自身をミュートできません"
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr "ユーザーはすでにミュートされています"
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr "ユーザーはミュートされていません"
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 #, fuzzy
 #| msgid "Reaction already exists."
 msgid "Navigation view already exists."
 msgstr "リアクションはすでに存在します"
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7684,346 +7088,345 @@ msgid ""
 "later. Is this a good time?\n"
 msgstr ""
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr "プレゼンスはBotユーザーでサポートされていません"
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr "{user_id_or_email}のプレゼンスデーターがありません"
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 #, fuzzy
 #| msgid "You do not have permission to post in this channel."
 msgid "You do not have permission to manage plans and billing."
 msgstr "このチャンネルに送信する権限がありません。"
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr ""
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr ""
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr "これらのうち１つ以上の引数が渡されるべきです：emoji_name, emoji_code"
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr "この組織では既読表示が無効化されています。"
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr ""
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr "有効な認証方法が必要です。"
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr ""
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr ""
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr ""
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr "ドメイン「{domain}」はすでにあなたの組織の一部です"
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr "ドメイン「{domain}」の項目が見つかりませんでした"
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr "ファイルは1つだけアップロードしてください。"
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr ""
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 #, fuzzy
 #| msgid "Disposable email addresses are not allowed in this organization"
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr "使い捨てメールアドレスはこの組織で許可されていません。"
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr "レートリミットを超えています"
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr "不正なデーターエクスポートID"
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr "エクスポートはすでに削除されています"
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr ""
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr ""
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr "アイコンは1つだけアップロードしてください。"
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr "Linkifierが見つかりません"
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr "ちょうど１つのロゴをアップロードするべきです"
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid characters in pygments language"
 msgid "Invalid character in language: {character}"
 msgstr "pygments言語に不正な文字があります"
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not an allowed_type"
 msgid "Language '{language}' is not allowed."
 msgstr "{var_name}が許可された型でありません"
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr "不正なプレイグラウンド"
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr ""
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "Direct messages"
 msgid "Importing messages…"
 msgstr "ダイレクトメッセージ"
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "Your full name"
 msgid "Your name"
 msgstr "フルネーム"
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr ""
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr ""
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr ""
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr "\"new_description\"か\"new_group_name\"を指定すべきです"
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr "\"op\"の値が不正です。\"add\"または\"remove\"を指定してください。"
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr "不正なパラメーター"
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr ""
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr ""
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr "なにもしません。\"add\"か\"delete\"のうち一つ以上を指定してください。"
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr "{user_full_name} があなたを {channel_name} に追加しました。"
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr "{user_full_name} があなたを以下のチャンネルに登録しました："
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr ""
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr "{user_name}が新しいチャンネル {new_channels} を作成しました。"
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr "新しいチャンネル"
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr "{user_name}が**Webパブリック**チャンネルを作成しました。 **説明:**"
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr "{user_name}が**パブリック**チャンネルを作成しました。 **説明:**"
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 "{user_name}が**プライベート（履歴共有）**チャンネルを作成しました。 **説明:**"
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
@@ -8031,225 +7434,224 @@ msgid ""
 msgstr ""
 "{user_name}が**プライベート（履歴保護）**チャンネルを作成しました。 **説明:**"
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr ""
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr ""
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr ""
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr "不正なサブメッセージのJSON"
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr ""
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr ""
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr "'to'リストが空白です"
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr "ユーザーがダイレクトメッセージでの「入力中」表示を無効化しています"
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr "<p>このファイルの表示を許可されていません。</p>"
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr "不正なトークン"
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr "不正なファイル名"
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr "ファイルを指定してアップロードしてください。"
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr "一度に1つのファイルだけアップロードできます"
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr "新しいデータがありません。"
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 msgstr ""
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr "{user_full_name} があなたをグループ {group_name} から削除しました。"
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr "ユーザー {user_id} はすでにこのグループのメンバーです。"
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr ""
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
 "subgroups."
 msgstr ""
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr "この組織ではアバターの変更が無効になっています。"
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr "この組織のメールアドレス変更は無効です。"
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr "不正なdefault_language"
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr ""
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr ""
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr "ZulipのパスワードはLDAPで管理されています"
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr "パスワードが間違っています！"
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, fuzzy, python-brace-format
 #| msgid "You can try again in %(retry_after)s seconds."
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr "%(retry_after)s 秒後に再試行できます。"
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr "新しいパスワードが弱すぎます"
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr "アバターは1つだけアップロードしてください。"
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr "トピックはミュートされていません"
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr "唯一の組織オーナーを無効化できません"
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 msgid "User is not allowed to delete other user's messages."
 msgstr ""
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 "組織にオーナーが一人しか存在しない場合、オーナー権限を削除することはできませ"
 "ん"
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr ""
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr "新しいメールアドレスの値にエラーがあります: {message}"
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
@@ -8261,25 +7663,25 @@ msgstr ""
 "FAKE_EMAIL_DOMAINが正しく設定されるまでBotを作成できません。\n"
 "サーバー管理者にお問い合わせください。"
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 #, fuzzy
 #| msgid "Email address"
 msgid "Email address already in use"
 msgstr "メールアドレス"
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr "オーナーの変更に失敗しました。ユーザーがいません。"
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr "オーナーの変更に失敗しました。ユーザーが無効です。"
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr "オーナーの変更に失敗しました。BotはほかのBotを所有できません"
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
@@ -8287,288 +7689,288 @@ msgstr ""
 "FAKE_EMAIL_DOMAINが正しく設定されるまでBotを作成できません。\n"
 "サーバー管理者にお問い合わせください。"
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr "埋め込みBotは有効化されていません。"
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr "不正な埋め込みBot名。"
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr ""
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr "メールアドレス「{email}」はこの組織で許可されていません。"
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr "使い捨てメールアドレスはこの組織で許可されていません。"
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom access token"
 msgid "Invalid {provider_name} access token"
 msgstr "不正なZoomアクセストークン"
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} call"
 msgstr "Zoomコールの作成に失敗しました"
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Zoom credentials have not been configured"
 msgid "{provider_name} credentials have not been configured"
 msgstr "Zoomの認証情報が設定されていません"
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom credentials"
 msgid "Invalid {provider_name} credentials"
 msgstr "不正なZoom認証情報"
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr ""
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error authenticating to the {provider_name} server"
 msgstr ""
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr ""
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom session identifier"
 msgid "Invalid {provider_name} session identifier"
 msgstr "不正なZoomセッション識別子"
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr ""
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} public room."
 msgstr "Zoomコールの作成に失敗しました"
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr ""
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{full_name}'s Zulip room"
 msgstr "{full_name}があなたにメンションしました："
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr "不正なペイロード"
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr "不明なwebhookリクエスト"
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr "トピックを入力してください"
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr "コンテンツを入力してください"
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr ""
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr "不正なJSON入力"
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr ""
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr "エラー: channels_map_to_topics パラメーターに0と1は設定できません"
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr ""
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
 "({export_settings_link})."
 msgstr ""
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr ""
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr ""
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr ""
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr ""
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr "Push通知転送サービス用のサブドメインが不正です"
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr "正しいZulipサーバーでAPIキーを検証する必要があります"
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr ""
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr "不正なトークン種別"
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr ""
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr ""
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr ""
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr ""
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
 "try again later or reach out to {support_email} for assistance."
 msgstr ""
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr ""
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr ""
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr ""
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr ""
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
 "server: {reason}"
 msgstr ""
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr ""
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr ""
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr ""
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr "データが破損しています"
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr ""
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr ""
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr "パスワードをリセットする必要があります"
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr "id_token パラメータがありません"
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 #, fuzzy
 #| msgid "Missing id_token parameter"
 msgid "Missing idp param"
 msgstr "id_token パラメータがありません"
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr "不正なOTP"
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr "mobile_flow_otp とdesktop_flow_otp を同時に使用できません。"
 

--- a/locale/kk/LC_MESSAGES/django.po
+++ b/locale/kk/LC_MESSAGES/django.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 19:19+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Kazakh <https://hosted.weblate.org/projects/zulip/django/kk/"
@@ -17,50 +17,50 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr ""
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr ""
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr ""
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr ""
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr ""
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr ""
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -69,7 +69,7 @@ msgid ""
 "users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -77,7 +77,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than one user to join."
 msgstr ""
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -85,7 +85,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than two users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -93,7 +93,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than three users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -102,148 +102,147 @@ msgid ""
 "({billing_page_link}) is greater than the current number of users."
 msgstr ""
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr ""
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr ""
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
 "(minimum {min_licenses})."
 msgstr ""
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
 "page. To complete the upgrade, please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr ""
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr ""
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr ""
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr ""
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr ""
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr ""
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
 msgstr ""
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
 msgstr ""
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
 "licenses."
 msgstr ""
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
 "billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr ""
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr ""
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr ""
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -253,100 +252,97 @@ msgid ""
 "we would really appreciate it!"
 msgstr ""
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
 "{support_email}"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr ""
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr ""
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr ""
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
 "%(support_email)s\">contact support</a>."
 msgstr ""
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr ""
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
 msgstr ""
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr ""
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
 msgstr ""
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr ""
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr ""
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
 msgstr ""
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -354,289 +350,270 @@ msgid ""
 "a> with any questions."
 msgstr ""
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
 "a> for support."
 msgstr ""
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
 "href=\"%(troubleshooting_url)s\">Zulip server troubleshooting guide</a>."
 msgstr ""
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr ""
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr ""
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr ""
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr ""
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr ""
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr ""
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr ""
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr ""
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr ""
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr ""
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr ""
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr ""
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr ""
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr ""
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr ""
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr ""
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr ""
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr ""
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr ""
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr ""
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr ""
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr ""
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr ""
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr ""
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr ""
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr ""
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr ""
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr ""
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr ""
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr ""
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
 "%(old_email_html_tag)s to %(new_email_html_tag)s"
 msgstr ""
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr ""
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
 msgstr ""
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr ""
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr ""
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -647,19 +624,19 @@ msgid ""
 "server."
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -667,788 +644,297 @@ msgid ""
 "%(support_email)s'>contact support</a> with any questions."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, python-format
 msgid "You can try again in %(retry_after_string)s."
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr ""
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr ""
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr ""
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr ""
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr ""
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr ""
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr ""
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr ""
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr ""
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr ""
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr ""
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr ""
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr ""
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr ""
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 msgid "Zulip for open source"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 msgid "Message with code"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
 msgstr ""
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 msgid "Get started"
 msgstr ""
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
 "continue."
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1456,78 +942,77 @@ msgid ""
 "from Zulip."
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
 msgstr ""
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr ""
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr ""
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr ""
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr ""
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr ""
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr ""
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr ""
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
 msgstr ""
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1535,208 +1020,201 @@ msgid ""
 "href=\"%(doc_url)s\">documentation</a>."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, python-format
 msgid "No account found for %(email)s."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 msgid "Try Zulip in a demo organization"
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 msgid "Try Zulip"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid "Import chat history?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1744,123 +1222,122 @@ msgid ""
 "noreferrer\">after you join</a>."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr ""
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">Terms of Service</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr ""
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr ""
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -1868,45 +1345,45 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 msgid ""
 "This organization has been deactivated, and all organization data has been "
 "deleted."
 msgstr ""
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
 "inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
 "administrators</a> to inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 msgid "This organization has been deactivated."
 msgstr ""
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
 "%(support_email)s\">contact Zulip support</a> to reactivate it."
 msgstr ""
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -1914,165 +1391,164 @@ msgid ""
 "reactivate it."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr ""
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr ""
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
 "<b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
 "href=\"%(apps_page_link)s\">mobile and desktop</a> apps:"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
 "href=\"%(getting_user_started_link)s\">getting started guide</a>!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2080,83 +1556,83 @@ msgid ""
 "Zulip</a>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
 "to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
 "desktop apps (%(apps_page_link)s):"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
 "(%(getting_user_started_link)s)!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
 "(%(getting_organization_started_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2164,32 +1640,32 @@ msgid ""
 "password for this account, please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "%(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 msgid "Verify your email address for your Zulip demo organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "<%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2197,113 +1673,113 @@ msgid ""
 "please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
 "— we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
 "deactivated, and you will no longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr ""
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2311,22 +1787,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because your organization <a "
@@ -2334,8 +1810,8 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to <a "
@@ -2343,39 +1819,39 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr ""
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because your organization hides "
@@ -2383,81 +1859,74 @@ msgid ""
 "details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to hide "
 "message content in email notifications. See %(help_url)s for more details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr ""
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
 "organizations:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
 "organizations hosted by %(external_host)s:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
 "href=\"%(help_reset_password_link)s\">reset your password</a>."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
 "%(external_host)s."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2465,97 +1934,94 @@ msgid ""
 "to find your account."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
 "try another way to find your account (%(help_logging_in_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
 "communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr ""
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
 "-- the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
 "Zulip &mdash; the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
 "to ask %(referrer_name)s for another one."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2563,72 +2029,70 @@ msgid ""
 "productivity."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at <a href=\"mailto:%(email)s\">%(email)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
 "%(email)s\">Contact us</a> — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
 "#%(channel_name)s > %(topic_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2636,68 +2100,68 @@ msgid ""
 "preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails (<a href=\"%(url)s\">help</a>)."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2705,22 +2169,22 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2728,52 +2192,52 @@ msgid ""
 "immediately at <%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2781,31 +2245,31 @@ msgid ""
 "contact us immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2813,7 +2277,7 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -2821,25 +2285,25 @@ msgid ""
 "Zulip</a> to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
 "with you and share their unique perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -2847,7 +2311,7 @@ msgid ""
 "experience how a new chat app will help your team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -2855,148 +2319,148 @@ msgid ""
 "action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
 "team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
 "organizations like yours!"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3004,11 +2468,11 @@ msgid ""
 "about…?”"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3017,23 +2481,23 @@ msgid ""
 "href=\"%(move_channels_link)s\">move a topic to a different channel</a>."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3042,23 +2506,23 @@ msgid ""
 "(%(move_channels_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
 "%(email)s on %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3066,46 +2530,46 @@ msgid ""
 "href=\"%(help_link)s\">reactivate your account</a>."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
 "You can contact an organization administrator to reactivate your account."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3113,539 +2577,535 @@ msgid ""
 "have been voided."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
 "to %(upgrade_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip demo organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip demo organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip demo organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for <b>%(remote_server_hostname)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 msgid "Click the button below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for %(remote_server_hostname)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
 "management for <b>%(remote_realm_host)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
 "management for %(remote_realm_host)s."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the <a href=\"%(plans_link)s\">Zulip Community plan</a>."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
 "website</a>, we would really appreciate it!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
 msgstr ""
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
 "accounts for another email address</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr ""
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr ""
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr ""
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr ""
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr ""
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 msgid "Zulip Cloud"
 msgstr ""
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr ""
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr ""
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr ""
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr ""
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr ""
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr ""
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr ""
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr ""
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr ""
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr ""
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr ""
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr ""
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr ""
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr ""
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr ""
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr ""
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr ""
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr ""
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr ""
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr ""
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr ""
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr ""
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr ""
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr ""
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr ""
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr ""
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr ""
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr ""
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr ""
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr ""
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr ""
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr ""
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 msgid "Bluesky"
 msgstr ""
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr ""
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr ""
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr ""
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 msgid ""
 "And hundreds more through <a href=\"/integrations/zapier\">Zapier</a> and <a "
 "href=\"/integrations/ifttt\">IFTTT</a>."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3653,7 +3113,7 @@ msgid ""
 "emails with your email domain."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3661,7 +3121,7 @@ msgid ""
 "disposable email addresses."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3669,24 +3129,24 @@ msgid ""
 "emails that contain \"+\"."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3694,7 +3154,7 @@ msgid ""
 "%(support_email)s\">contact Zulip support</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3702,89 +3162,89 @@ msgid ""
 "%(support_email)s\">contact this Zulip server's administrators</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
 "management for your Zulip server."
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr ""
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr ""
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr ""
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr ""
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr ""
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr ""
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr ""
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> because all Zulip Cloud licenses are in use."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -3793,42 +3253,40 @@ msgid ""
 "or misconfiguration."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 msgid "Demo organizations disabled"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -3836,22 +3294,21 @@ msgid ""
 "organization for more information."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -3859,44 +3316,42 @@ msgid ""
 "Zulip support</a> for assistance in resolving this issue."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
 "a> like Firefox, Chrome, and Edge."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 msgid "Finalize organization import"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 msgid "Organization import completed!"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -3904,52 +3359,51 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 msgid "Select your account"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 msgid "Create new account"
 msgstr ""
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr ""
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -3957,81 +3411,81 @@ msgid ""
 "have one yet."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 msgid "Self-hosting Zulip?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">log in to manage plans and billing.</a>"
 msgstr ""
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr ""
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
 msgstr ""
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr ""
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr ""
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr ""
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr ""
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr ""
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4039,7 +3493,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4048,57 +3502,57 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr ""
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4106,7 +3560,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4114,40 +3568,40 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4155,300 +3609,294 @@ msgid ""
 "away!"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
 "href=\"%(realm_url)s/#settings/notifications\">notification settings</a>."
 msgstr ""
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr ""
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr ""
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr ""
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr ""
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr ""
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr ""
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr ""
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 msgid "Cannot reactivate a deleted user"
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr ""
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr ""
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr ""
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr ""
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
 msgstr ""
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
 msgstr ""
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr ""
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr ""
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr ""
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr ""
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr ""
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr ""
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr ""
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr ""
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr ""
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr ""
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
 "{new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
 "{user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to resolve topics in this channel."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr ""
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr ""
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr ""
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr ""
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr ""
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
 "but there is no channel with that ID."
 msgstr ""
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4456,36 +3904,36 @@ msgid ""
 "it."
 msgstr ""
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
 "The channel exists but does not have any subscribers."
 msgstr ""
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr ""
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr ""
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr ""
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4493,107 +3941,105 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
 "authentication method."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr ""
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 msgid "Reminder could not be sent."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
 "the following error:"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr ""
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr ""
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr ""
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr ""
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr ""
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
 "**{old_policy}** to **{new_policy}**."
 msgstr ""
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -4602,51 +4048,49 @@ msgid ""
 "* **New**: {new_setting_description}\n"
 msgstr ""
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr ""
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr ""
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr ""
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr ""
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr ""
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr ""
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 msgstr ""
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr ""
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -4657,283 +4101,269 @@ msgid ""
 "{summary_line}"
 msgstr ""
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr ""
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr ""
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr ""
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr ""
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr ""
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr ""
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr ""
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr ""
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr ""
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr ""
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr ""
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
 "organization administrator to reactivate it."
 msgstr ""
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr ""
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr ""
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr ""
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr ""
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr ""
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr ""
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr ""
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
 "to register for accounts in this organization."
 msgstr ""
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr ""
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 msgid "Challenges are not enabled."
 msgstr ""
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr ""
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr ""
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "You're making too many attempts to sign in. Try again in "
 "{retry_after_string} or contact your organization administrator for help."
 msgstr ""
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
 msgstr ""
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr ""
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr ""
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr ""
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr ""
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr ""
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr ""
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr ""
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr ""
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr ""
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr ""
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr ""
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name can't be empty."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 msgid "Invalid channel folder ID"
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 msgid "Configure owner account email address."
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4942,69 +4372,69 @@ msgid ""
 "organization]({convert_demo}).\n"
 msgstr ""
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, python-brace-format
 msgid "{var_name} is not Base64 encoded"
 msgstr ""
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 msgid "Invalid `device_id`"
 msgstr ""
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr ""
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr ""
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr ""
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr ""
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr ""
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr ""
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr ""
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr ""
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr ""
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr ""
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5012,593 +4442,591 @@ msgid ""
 "{error_message}"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr ""
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr ""
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr ""
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr ""
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr ""
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr ""
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr ""
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr ""
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr ""
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr ""
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr ""
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr ""
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr ""
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
 msgstr ""
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr ""
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr ""
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr ""
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr ""
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr ""
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr ""
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr ""
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr ""
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 msgid "Must be a bot user"
 msgstr ""
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr ""
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr ""
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr ""
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
 "webhook; ignoring"
 msgstr ""
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr ""
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr ""
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr ""
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr ""
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} most recent messages in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr ""
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr ""
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
 msgstr ""
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr ""
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr ""
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr ""
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr ""
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr ""
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 msgid "Atlassian account ID"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 msgid "Behance username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 msgid "Bitbucket username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 msgid "Codeberg username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 msgid "Dribbble username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 msgid "Facebook username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 msgid "GitLab username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 msgid "Instagram username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 msgid "Mastodon profile"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 msgid "Medium username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 msgid "Pinterest username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 msgid "Reddit username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 msgid "Snapchat username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 msgid "Threads username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 msgid "TikTok username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 msgid "Twitch username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 msgid "X username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr ""
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr ""
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 msgid "Video calling"
 msgstr ""
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr ""
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr ""
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr ""
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr ""
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr ""
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr ""
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr ""
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr ""
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr ""
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr ""
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr ""
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr ""
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr ""
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr ""
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "{fullname} moderation"
 msgstr ""
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr ""
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr ""
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor_date' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr ""
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 msgid "Navigation view does not exist."
 msgstr ""
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5606,7 +5034,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5614,7 +5042,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5622,7 +5050,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5630,7 +5058,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5640,14 +5068,14 @@ msgid ""
 "a permanent organization]({convert_demo_organization_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
 "them in your [Inbox](/#inbox).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5655,7 +5083,7 @@ msgid ""
 "({navigation_tour_video_url}) for a quick app overview.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5670,14 +5098,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -5685,7 +5113,7 @@ msgid ""
 "and edit your [profile information](/help/edit-your-profile).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -5696,7 +5124,7 @@ msgid ""
 "experience in your [Preferences](#settings/preferences).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5707,7 +5135,7 @@ msgid ""
 "[Browse and subscribe to channels]({settings_link}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -5724,7 +5152,7 @@ msgid ""
 "discussed.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -5733,7 +5161,7 @@ msgid ""
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -5745,7 +5173,7 @@ msgid ""
 "times, and more.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5755,7 +5183,7 @@ msgid ""
 "or browse the [help center](/help/) to learn more!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5763,7 +5191,7 @@ msgid ""
 "get help, try one of the following messages: {bot_commands}\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5775,13 +5203,13 @@ msgid ""
 "({move_content_another_channel_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5795,12 +5223,11 @@ msgid ""
 "and above.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr ""
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -5808,14 +5235,14 @@ msgid ""
 "no matter how many other conversations are going on.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
 "conversations with unread messages.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -5823,7 +5250,7 @@ msgid ""
 "the `+` button next to its name.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -5831,13 +5258,13 @@ msgid ""
 "can we chat about…?”\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5845,7 +5272,7 @@ msgid ""
 "({format_message_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5865,1322 +5292,1299 @@ msgid ""
 "```\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
 "teammates.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
 "conversation.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr ""
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr ""
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr ""
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr ""
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 msgid "Invalid `push_key`"
 msgstr ""
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr ""
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr ""
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr ""
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 msgid "Reminder does not exist"
 msgstr ""
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr ""
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr ""
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr ""
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr ""
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr ""
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr ""
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr ""
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr ""
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 msgid "You do not have permission to create new topics in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr ""
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr ""
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr ""
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr ""
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr ""
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr ""
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} does not have the expected format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr ""
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr ""
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr ""
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {user_group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr ""
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr ""
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr ""
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr ""
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr ""
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 msgid "Name must not be empty!"
 msgstr ""
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr ""
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr ""
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr ""
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr ""
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr ""
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr ""
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr ""
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr ""
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr ""
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr ""
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr ""
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr ""
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr ""
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr ""
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr ""
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr ""
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr ""
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr ""
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr ""
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr ""
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr ""
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr ""
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr ""
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr ""
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr ""
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr ""
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr ""
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr ""
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr ""
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr ""
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr ""
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr ""
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr ""
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr ""
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr ""
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr ""
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr ""
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: empty field name."
 msgstr ""
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr ""
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr ""
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 msgid "Example input does not match the linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in alternative URL template is not present in linkifier "
 "pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in linkifier pattern is not present in alternative URL "
 "template."
 msgstr ""
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr ""
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr ""
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr ""
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr ""
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr ""
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr ""
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr ""
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr ""
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr ""
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr ""
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr ""
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr ""
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr ""
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr ""
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr ""
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr ""
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr ""
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr ""
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr ""
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr ""
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr ""
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr ""
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr ""
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr ""
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr ""
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr ""
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr ""
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr ""
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr ""
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 msgid "Failed to generate challenge"
 msgstr ""
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr ""
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr ""
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr ""
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr ""
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr ""
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr ""
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for use for user matching."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr ""
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr ""
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr ""
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr ""
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr ""
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr ""
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr ""
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr ""
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 msgid "Invitation already used or deactivated."
 msgstr ""
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr ""
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr ""
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr ""
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
 msgstr ""
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr ""
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr ""
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr ""
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr ""
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr ""
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr ""
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr ""
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr ""
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 msgid "Message reporting is not enabled in this organization."
 msgstr ""
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr ""
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr ""
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr ""
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr ""
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr ""
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr ""
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr ""
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr ""
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr ""
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 msgid "Navigation view already exists."
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7188,856 +6592,854 @@ msgid ""
 "later. Is this a good time?\n"
 msgstr ""
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr ""
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr ""
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 msgid "You do not have permission to manage plans and billing."
 msgstr ""
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr ""
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr ""
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr ""
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr ""
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr ""
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr ""
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr ""
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr ""
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr ""
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr ""
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr ""
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr ""
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr ""
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr ""
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr ""
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr ""
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr ""
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr ""
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr ""
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Invalid character in language: {character}"
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Language '{language}' is not allowed."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr ""
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr ""
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 msgid "Importing messages…"
 msgstr ""
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 msgid "Your name"
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr ""
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr ""
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr ""
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr ""
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr ""
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr ""
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr ""
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr ""
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr ""
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr ""
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr ""
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr ""
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr ""
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
 "**"
 msgstr ""
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr ""
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr ""
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr ""
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr ""
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr ""
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr ""
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr ""
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr ""
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr ""
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr ""
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr ""
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr ""
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr ""
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 msgstr ""
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr ""
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr ""
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
 "subgroups."
 msgstr ""
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr ""
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr ""
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr ""
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr ""
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr ""
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr ""
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr ""
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr ""
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr ""
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr ""
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 msgid "User is not allowed to delete other user's messages."
 msgstr ""
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr ""
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr ""
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 msgid ""
 "Can't change bot email until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 msgstr ""
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 msgid "Email address already in use"
 msgstr ""
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr ""
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr ""
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr ""
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 msgstr ""
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr ""
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr ""
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr ""
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr ""
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr ""
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} access token"
 msgstr ""
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} call"
 msgstr ""
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} credentials have not been configured"
 msgstr ""
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} credentials"
 msgstr ""
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr ""
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error authenticating to the {provider_name} server"
 msgstr ""
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr ""
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} session identifier"
 msgstr ""
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr ""
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} public room."
 msgstr ""
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr ""
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{full_name}'s Zulip room"
 msgstr ""
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr ""
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr ""
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr ""
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr ""
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr ""
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr ""
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr ""
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr ""
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr ""
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
 "({export_settings_link})."
 msgstr ""
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr ""
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr ""
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr ""
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr ""
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr ""
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr ""
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr ""
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr ""
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr ""
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr ""
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr ""
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr ""
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
 "try again later or reach out to {support_email} for assistance."
 msgstr ""
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr ""
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr ""
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr ""
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr ""
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
 "server: {reason}"
 msgstr ""
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr ""
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr ""
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr ""
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr ""
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr ""
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr ""
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr ""
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr ""
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 msgid "Missing idp param"
 msgstr ""
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr ""
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr ""

--- a/locale/ko/LC_MESSAGES/django.po
+++ b/locale/ko/LC_MESSAGES/django.po
@@ -22,7 +22,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 19:15+0000\n"
 "Last-Translator: Hosted Weblate user 141821 <clearstripe@users.noreply."
 "hosted.weblate.org>\n"
@@ -35,50 +35,50 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "게스트 사용자에게 허용되지 않음"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "유효하지 않은 조직"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr "공용 채널"
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr "개인 채널"
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr "시작시간이 종료시간 보다 늦습니다. 시작시간: {start}, 종료시간: {end}"
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr "이용가는한 분석 데이터가 없습니다. 서버 운영자에게 문의하세요."
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -87,7 +87,7 @@ msgid ""
 "users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -95,7 +95,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than one user to join."
 msgstr ""
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -103,7 +103,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than two users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -111,7 +111,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than three users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -123,148 +123,147 @@ msgstr ""
 "없습니다.새 사용자의 가입을 허용하려면 [현재 및 다음 청구 기간의 라이센스 "
 "수] ({billing_page_link}) 가 현재 사용자 수보다 커야 합니다."
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr ""
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr ""
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
 "(minimum {min_licenses})."
 msgstr ""
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
 "page. To complete the upgrade, please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr ""
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr "{last4}로 끝나는 {brand}"
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr "알수없는 지불 방법입니다. {email}로 연락해주세요."
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr "문제가 발생했습니다. {email}로 연락해주세요."
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "무언가 잘못 되었습니다. 페이지를 새로고침하세요."
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr "무언가 잘못 되었습니다. 몇 초간 기다린 후 다시 시도 해보세요."
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr ""
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr ""
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
 msgstr ""
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
 msgstr ""
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
 "licenses."
 msgstr ""
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
 "billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr ""
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr ""
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr ""
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -274,69 +273,67 @@ msgid ""
 "we would really appreciate it!"
 msgstr ""
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
 "{support_email}"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr ""
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "에러"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr ""
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
 "%(support_email)s\">contact support</a>."
 msgstr ""
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr ""
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
@@ -345,11 +342,11 @@ msgstr ""
 "청이 액세스를 인증하도록 요청하지 않았습니다.이 문제를 해결하려면 다음과 같이"
 "하십시오:"
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr ""
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
@@ -357,16 +354,15 @@ msgstr ""
 "블록의 위험자를 찾아 보려면 브라우저 개인 정보 설정이나 확장 프로그램을 확인 "
 "하고이 사이트 의이 기능을 비활성화하십시오."
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr ""
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr "내부 서버 오류"
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
@@ -374,7 +370,7 @@ msgstr ""
 "뭔가 웡이 죄송합니다. 그럼에 대해 미안해! 앙드러가 해결되어 협회가되었습니"
 "다. Zulip이 다시 작업하는 경우 자동으로로드됩니다."
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -382,157 +378,155 @@ msgid ""
 "a> with any questions."
 msgstr ""
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
 "a> for support."
 msgstr ""
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
 "href=\"%(troubleshooting_url)s\">Zulip server troubleshooting guide</a>."
 msgstr ""
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, fuzzy, python-format
 #| msgid "Zulip analytics for %(target_name)s"
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr "%(target_name)s를 위한 Zulip 분석"
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr "Analytics 는 조직 생성후 24시간 뒤에 완전히 사용가능합니다."
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr "%(target_name)s를 위한 Zulip 분석"
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr ""
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr ""
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr ""
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr ""
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr ""
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr ""
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr ""
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "활성 사용자"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr "하루 활동들"
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr "15일 활동들"
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr "전체 사용자들"
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "사용자"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr "받는 사람 유형별로 보낸 메시지"
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "나"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "모든 사람"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "지난 주"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "지난 달"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "작년"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "모든 시간"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr "시간 경과에 따라 메시지 전송"
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "매일"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "매주"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr "누적"
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "사람"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "봇"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr "시간 경과에 따른 메시지 읽음"
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr "클라이언트가 보낸 메시지"
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr "최근 업데이트"
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
@@ -540,15 +534,15 @@ msgstr ""
 "모든 그래프의 전체 업데이트는 하루에 한 번 합니다. \"메세지가 보내진지 시간 "
 "경과된\" 그래프는 한 시간에 한 번 업데이트 됩니다."
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr "이메일이 변경되었습니다!"
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
@@ -557,48 +551,48 @@ msgstr ""
 "이것은 너의 Zulip 계정에 있는 이메일 주소가 변경되었는지 확인한다. from 전 이"
 "메일%(old_email_html_tag)s to 현재 새로운 이메일%(new_email_html_tag)s"
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr "오류. 우리는 이 시스템에서 너를 확인할 만한 것을 찾지 못했습니다."
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr ""
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr "오류. 확인 링크가 만료되었거나 비활성화 되었습니다."
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr "너의 조직 관리자에게 새로운 링크로 연락해라"
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr "오류. 이 확인 링크는 형식화되지 않았습니다."
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
@@ -606,72 +600,55 @@ msgstr ""
 "너의 브라우저에 올바른 링크를 복사하는 것을 확실히 해주십시오. 이 페이지가 계"
 "속 생성될 경우, 아마도 오류가 생겼습니다. 죄송합니다."
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr "청구서"
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr "현재 창을 종료"
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "취소"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr "확인"
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr ""
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr ""
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -682,13 +659,13 @@ msgid ""
 "server."
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
@@ -696,7 +673,7 @@ msgstr ""
 "이 서버의 계획 관리 사용 가능하지 않음이 서버에 Active Plan에서 주최 된 덜 배"
 "우는 덜 배우기가 있습니다."
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -704,790 +681,299 @@ msgid ""
 "%(support_email)s'>contact support</a> with any questions."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, python-format
 msgid "You can try again in %(retry_after_string)s."
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr ""
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr ""
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr "카테고리로 필터하기"
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "전체"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr "카테고리들"
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr ""
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr ""
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr ""
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr ""
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr ""
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "조직 생성하기"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr ""
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr ""
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr ""
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr ""
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 msgid "Zulip for open source"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Messages sent over time"
 msgid "Message with code"
 msgstr "시간 경과에 따라 메시지 전송"
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr "연결"
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr "고객지원 연결"
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr "조직"
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr "제출"
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
 msgstr ""
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 msgid "Get started"
 msgstr ""
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
 "continue."
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr "또는 예비 전화 번호 중 하나를 사용하십시오."
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr "마지막으로 예비 토큰을 사용하실 수 있습니다."
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr "예비 토큰을 사용"
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "이메일"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1495,72 +981,71 @@ msgid ""
 "from Zulip."
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
 msgstr ""
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr ""
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr ""
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr ""
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr ""
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr ""
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr ""
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr ""
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
@@ -1568,7 +1053,7 @@ msgstr ""
 "조직을 처음 만들지 않고 LDAP를 사용하여 로그인하려고합니다. 이메일 택시 트리"
 "를 사용하여 조직을 만들고 평화를 다시하십시오."
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1576,214 +1061,207 @@ msgid ""
 "href=\"%(doc_url)s\">documentation</a>."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr "Zulip 계정이 없습니다."
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, python-format
 msgid "No account found for %(email)s."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr "다른 계정으로 로그인하기"
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr "등록을 계속하세요"
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Create a new Zulip organization"
 msgid "Try Zulip in a demo organization"
 msgstr "새로운 Zulip 조직 생성"
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Why Zulip"
 msgid "Try Zulip"
 msgstr "왜 Zulip인가?"
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "새 조직 만들기"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr "새로운 Zulip 조직 생성"
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr "귀하의 이메일 주소를 등록하세요."
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 msgstr "이 페이지는 호텔에서 새로운 판매입니다."
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 #, fuzzy
 #| msgid "Private, shared history"
 msgid "Import chat history?"
 msgstr "개인적이고 공유된 기록"
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr "조직명"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "조직 URL"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr "%(external_host)s 사용"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "또는"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "가입하기"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "Zulip에 가입하기"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr "이 조직에 가입하기 위해 초대가 필요합니다."
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr "%(identity_provider)s로 가입"
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "로그인"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
 msgstr "조직의 기본 프로세스에서 기본 프로세스에서 개인 처리를 변경하려면?"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1791,123 +1269,122 @@ msgid ""
 "noreferrer\">after you join</a>."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "변경"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr "귀하의 계정"
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "이름"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "비밀번호"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr "이것은 모바일 응용 프로그램 및 암호가 필요한 기타 도구에 사용됩니다."
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr "비밀번호 강도"
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr ""
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">Terms of Service</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr "비활성화된 조직"
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr ""
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -1915,7 +1392,7 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid ""
@@ -1923,34 +1400,34 @@ msgid ""
 "deleted."
 msgstr "이 조직은 비활성화되었습니다"
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
 "inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
 "administrators</a> to inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid "This organization has been deactivated."
 msgstr "이 조직은 비활성화되었습니다"
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
 "%(support_email)s\">contact Zulip support</a> to reactivate it."
 msgstr ""
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
@@ -1959,7 +1436,7 @@ msgstr ""
 "조직의 구성원이고 뼈가 비활성화 된 이유에 대한 자세한 내용은 조직의 관리자에"
 "게 직접 도착하십시오."
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -1967,15 +1444,15 @@ msgid ""
 "reactivate it."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
@@ -1983,151 +1460,150 @@ msgstr ""
 "웹 브라우저를 사용하여 로깅을 완료하고, 귀하의 로그인 토큰에 뒤에서 뒤로 오"
 "는 데 있습니다."
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr "여기에 토큰 붙여넣기"
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr "종료"
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr "잘못된 토큰"
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr "토큰 확인됨, 접속중…"
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "복사"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr "소유자"
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "관리자"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr "중재자들"
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr "손님 사용자"
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "일반 사용자"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "닫기"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "업데이트"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr "Zulip"
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
 "<b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr "Zulip에 오신 것을 환영합니다!"
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
 "href=\"%(apps_page_link)s\">mobile and desktop</a> apps:"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
 "href=\"%(getting_user_started_link)s\">getting started guide</a>!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2135,83 +1611,83 @@ msgid ""
 "Zulip</a>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
 "to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
 "desktop apps (%(apps_page_link)s):"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
 "(%(getting_user_started_link)s)!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
 "(%(getting_organization_started_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr "안녕하세요,"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2219,34 +1695,34 @@ msgid ""
 "password for this account, please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "%(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 #, fuzzy
 #| msgid "Disposable email addresses are not allowed in this organization"
 msgid "Verify your email address for your Zulip demo organization"
 msgstr "여기서는 1회용 이메일 주소는 사용하실 수 없습니다."
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "<%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2254,33 +1730,33 @@ msgid ""
 "please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr "이메일 변경을 확인하세요"
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr "귀하는 최근에 Zulip에 가입하셨습니다. 훌륭합니다!"
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
@@ -2288,81 +1764,81 @@ msgstr ""
 "아래의 Butone을 클릭하고 조직을 만들고 똑같이 당신의 보이스 흡입 착탈에 대해"
 "서는 Qude를 뒤에서 묻습니다."
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr "등록 완료"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
 "— we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
 "deactivated, and you will no longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr ""
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2370,22 +1846,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because your organization <a "
@@ -2393,8 +1869,8 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to <a "
@@ -2402,40 +1878,40 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, fuzzy, python-format
 #| msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr "귀하의 새 비밀번호로 <a href=\"%(login_url)s\">로그인</a>하세요."
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr ""
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because your organization hides "
@@ -2443,81 +1919,74 @@ msgid ""
 "details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to hide "
 "message content in email notifications. See %(help_url)s for more details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr ""
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
 "organizations:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
 "organizations hosted by %(external_host)s:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
 "href=\"%(help_reset_password_link)s\">reset your password</a>."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
 "%(external_host)s."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2525,97 +1994,94 @@ msgid ""
 "to find your account."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
 "try another way to find your account (%(help_logging_in_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr "안녕하세요,"
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
 "communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr ""
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
 "-- the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr "다시 한 번 안녕하십니까,"
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
 "Zulip &mdash; the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
 "to ask %(referrer_name)s for another one."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2623,72 +2089,70 @@ msgid ""
 "productivity."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at <a href=\"mailto:%(email)s\">%(email)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
 "%(email)s\">Contact us</a> — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
 "#%(channel_name)s > %(topic_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2696,68 +2160,68 @@ msgid ""
 "preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails (<a href=\"%(url)s\">help</a>)."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2765,22 +2229,22 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr "Zulip 팀"
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2788,52 +2252,52 @@ msgid ""
 "immediately at <%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2841,31 +2305,31 @@ msgid ""
 "contact us immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2873,7 +2337,7 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -2881,25 +2345,25 @@ msgid ""
 "Zulip</a> to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
 "with you and share their unique perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -2907,7 +2371,7 @@ msgid ""
 "experience how a new chat app will help your team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -2915,21 +2379,21 @@ msgid ""
 "action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
@@ -2937,19 +2401,19 @@ msgstr ""
 "조리개를 위해 Zulip을 사용하기로 결정한 경우, 웰빙! 짐벌로 이동하기 위해 슈"
 "트 가이드를 사용하여 시작할 수 있습니다."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
@@ -2958,7 +2422,7 @@ msgstr ""
 "팀과 함께 주간의 평가를 실행하지만 다른 도구를 사용하십시오. 이것은 Typwy 경"
 "험을위한 유일한 방법입니다. 전화가 전화를 걸 것입니다."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
@@ -2966,8 +2430,8 @@ msgstr ""
 "Zulip은 휘두모 커뮤니케이션을 가능하게하기 위해 설계되었으며 짹짹 팁이 귀하"
 "의 팀이 행동을 경험할 수 있도록 희망합니다."
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
@@ -2977,84 +2441,84 @@ msgstr ""
 "수 있습니다 .이 가이드를 확인 하십시오. 이 가 이드를 확인하십시오. 이 가이드"
 "를 Zipip 기능에 대한 조치를 취하십시오!"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
@@ -3062,12 +2526,12 @@ msgstr ""
 "주제를 사용하면 한 번에 Zulip 한 전환을 읽을 수 있습니다. 여러 가지 토론이 얼"
 "마나 뛰어나지 않는 한 상황에 대한 메시지가 표시됩니다."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3079,11 +2543,11 @@ msgstr ""
 "을 위해, 샌프란을 끝내고 생각해보십시오. \"헤이, 캔트와 대화를 싸구음에 대해"
 "서 ...\""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3092,23 +2556,23 @@ msgid ""
 "href=\"%(move_channels_link)s\">move a topic to a different channel</a>."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr "Zulip으로 가기"
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3117,23 +2581,23 @@ msgid ""
 "(%(move_channels_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
 "%(email)s on %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr "비밀번호 초기화"
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3141,46 +2605,46 @@ msgid ""
 "href=\"%(help_link)s\">reactivate your account</a>."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
 "You can contact an organization administrator to reactivate your account."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3188,236 +2652,236 @@ msgid ""
 "have been voided."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
 "to %(upgrade_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip demo organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip demo organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
 msgstr "요청은 악기에 있었고 행동을 취하지 않으며 24 시간 만료됩니다."
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Deactivated organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "비활성화된 조직"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for <b>%(remote_server_hostname)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 msgid "Click the button below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for %(remote_server_hostname)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
 "management for <b>%(remote_realm_host)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
 "management for %(remote_realm_host)s."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the <a href=\"%(plans_link)s\">Zulip Community plan</a>."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
 "website</a>, we would really appreciate it!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
@@ -3425,33 +2889,33 @@ msgstr ""
 "Zulip Sponsorip Hand 의 요청이 승인되었습니다. 조직은 Zulip Community Plan으"
 "로 업그레이드되었습니다."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
 msgstr ""
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr "귀하의 Zulip 계정을 찾으세요."
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
 "accounts for another email address</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
@@ -3459,7 +2923,7 @@ msgstr ""
 "집에있는 판매자를 보내 주시로 귀하의 이메일을 입력하십시오. 집에있는 봉제가 "
 "이행에서 강행하여 강물을 강하게 배달하십시오."
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
@@ -3467,270 +2931,266 @@ msgstr ""
 "이 서비스는이 서비스에 이번 서비스를 Entail Exiri에 의해 주소로 입력하도록 "
 "Anda Ans AnS Acs 계정이 서비스에이를 서비스에 입력하십시오."
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr "이메일 주소"
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "계정 찾기"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr ""
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr "왜 Zulip인가?"
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr "특징"
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr ""
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Zulip"
 msgid "Zulip Cloud"
 msgstr "Zulip"
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr ""
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr ""
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "통합"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr "데스크탑 & 모바일 앱"
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr "새로운 조직"
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr ""
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr ""
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr ""
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr ""
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr ""
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr ""
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr ""
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr ""
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr ""
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr ""
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr ""
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr "도움 센터"
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr "커뮤니티 챗"
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr ""
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr ""
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr ""
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr ""
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr ""
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr ""
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr ""
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr "팀"
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "기록"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr ""
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr ""
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr ""
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr "Zulip에 도움"
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr ""
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr ""
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 msgid "Bluesky"
 msgstr ""
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr ""
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr "서비스 약관"
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr "개인정보 보호정책"
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr "%(integrations_count_display)s개 이상의 integration."
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 msgid ""
 "And hundreds more through <a href=\"/integrations/zapier\">Zapier</a> and <a "
 "href=\"/integrations/ifttt\">IFTTT</a>."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr "Integration 찾기"
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr "대화형 봇"
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr "유효하지 않은 이메일"
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3738,7 +3198,7 @@ msgid ""
 "emails with your email domain."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3746,7 +3206,7 @@ msgid ""
 "disposable email addresses."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3754,24 +3214,24 @@ msgid ""
 "emails that contain \"+\"."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3779,7 +3239,7 @@ msgid ""
 "%(support_email)s\">contact Zulip support</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3787,71 +3247,71 @@ msgid ""
 "%(support_email)s\">contact this Zulip server's administrators</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
 "management for your Zulip server."
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr ""
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr "Zulip에 로그인"
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr "귀하는 이미 이 이메일 주소로 등록되어 있습니다. 아래에서 로그인하세요."
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr "이메일 혹은 사용자명"
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "사용자명"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr "비밀번호를 잊으셨습니까?"
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr "%(identity_provider)s와 로그인"
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr ""
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> because all Zulip Cloud licenses are in use."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
@@ -3859,19 +3319,19 @@ msgstr ""
 "당신을 초대 한 사람에게 연락하여 루니를 늘리려고 요청하십시오. Thry는 뛰어납"
 "니다."
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -3884,44 +3344,42 @@ msgstr ""
 "만들어 내고 Toileing을 로그인 할 수 있습니다. 이는 서버 버그 또는 잘못 구성 "
 "할 가능성이 큽니다."
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 #, fuzzy
 #| msgid "New organization"
 msgid "Demo organizations disabled"
 msgstr "새로운 조직"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -3929,22 +3387,21 @@ msgid ""
 "organization for more information."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -3952,49 +3409,47 @@ msgid ""
 "Zulip support</a> for assistance in resolving this issue."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, fuzzy, python-format
 #| msgid "Presence is not supported for bot users."
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr "현재 상태는 봇 사용자에게는 지원되지 않습니다."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
 "a> like Firefox, Chrome, and Edge."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr "계정이 비활성화되었습니다"
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Invalid organization"
 msgid "Finalize organization import"
 msgstr "유효하지 않은 조직"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Organization name"
 msgid "Organization import completed!"
 msgstr "조직명"
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -4002,56 +3457,55 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Your account"
 msgid "Select your account"
 msgstr "귀하의 계정"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create a new organization"
 msgid "Create new account"
 msgstr "새 조직 만들기"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr ""
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4059,22 +3513,22 @@ msgid ""
 "have one yet."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 msgid "Self-hosting Zulip?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">log in to manage plans and billing.</a>"
 msgstr ""
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr "귀하의 비밀번호를 초기화하세요."
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
@@ -4082,60 +3536,60 @@ msgstr ""
 "비밀번호를 잊으셨습니까? 문제 없으면, 당신은 암호를 다시 입력하여 이메일로 다"
 "시 설정해야합니다."
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr "새로 지정된 링크를 보내십시오"
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "비밀번호 확인"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr "죄송합니다. 귀하가 제공한 링크가 유효하지 않거나 이미 사용중입니다."
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr ""
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr ""
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr "귀하의 새 비밀번호로 <a href=\"%(login_url)s\">로그인</a>하세요."
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr "비밀번호 초기화를 보냈습니다!"
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr "프로세스를 끝내기 위해 귀하의 이메일을 몇 분 안에 확인하십시오."
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr ""
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4143,7 +3597,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4152,57 +3606,57 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr ""
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4210,7 +3664,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4218,40 +3672,40 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr "알 수 없는 이메일 구독 취소 요청"
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4259,130 +3713,127 @@ msgid ""
 "away!"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr "이메일 설정 업데이트 됨"
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
 "href=\"%(realm_url)s/#settings/notifications\">notification settings</a>."
 msgstr ""
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr ""
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr ""
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr ""
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr ""
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr ""
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr ""
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr ""
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 msgid "Cannot reactivate a deleted user"
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr "필드 ID {id} 를 찾을 수 없습니다."
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr ""
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr ""
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr ""
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
@@ -4390,7 +3841,7 @@ msgstr ""
 "사용자를 보호하기 위해 Zulip은 하루에 보내는 초대장의 수를 제한합니다. 한계"
 "를 다시 초래 했으므로 초대장의 웨스트가 보냈습니다."
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
@@ -4398,167 +3849,164 @@ msgstr ""
 "당신의 계정이 이 조직에 초대를 보내기에는 너무 최근에 만들어졌습니다. 조직 관"
 "리자에게 문의하거나, 더 경험있는 사용자에게 물어보세요."
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr "일부 이메일은 확인되지 않았으므로 초대장을 보내지 않았습니다."
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr "우리는 누구도 초대할 수 없었습니다."
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr "변경 사항 없음"
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr ""
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr ""
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr ""
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr ""
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr "위젯들은 편집되지 않습니다."
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr "조직에서 메시지 편집을 중단시켰습니다."
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr "이 메시지를 편집할 수있는 권한이 없습니다."
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr "이 메시지를 편집하는데 시간 제한이 지났습니다."
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
 "{new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
 "{user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 #, fuzzy
 #| msgid "You don't have permission to delete this message"
 msgid "You don't have permission to resolve topics in this channel."
 msgstr "이 메시지를 삭제할 수 있는 권한이 없습니다"
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr ""
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr ""
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr "유효하지 않은 메시지"
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr "메시지를 렌더링 할 수 없습니다."
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr ""
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
 "but there is no channel with that ID."
 msgstr ""
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4566,36 +4014,36 @@ msgid ""
 "it."
 msgstr ""
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
 "The channel exists but does not have any subscribers."
 msgstr ""
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr ""
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr "위젯: API 프로그래머가 유효하지 않은 JSON 콘텐츠를 보냈습니다"
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr ""
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4603,109 +4051,107 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr "이 이름을 가진 사용자 정의 이모티콘이 이미 존재합니다."
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
 "authentication method."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr ""
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder could not be sent."
 msgstr "토큰이 존재하지 않습니다."
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
 "the following error:"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr ""
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr ""
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr ""
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr ""
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr ""
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
 "**{old_policy}** to **{new_policy}**."
 msgstr ""
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -4714,51 +4160,49 @@ msgid ""
 "* **New**: {new_setting_description}\n"
 msgstr ""
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr "설명이 없습니다."
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr ""
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr ""
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr ""
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr ""
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr ""
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 msgstr ""
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr ""
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -4769,150 +4213,139 @@ msgid ""
 "{summary_line}"
 msgstr ""
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr ""
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr ""
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr ""
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr "불충분한 권한"
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr "이 API는 수신 webhook 봇에서 사용할 수 없습니다."
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr "계정이 하위 도메인과 연결되어 있지 않습니다."
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr "이 엔드 포인트는 봇 요청을 허용하지 않습니다."
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr "서버 운영자여야 합니다"
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr "이 엔드 포인트는 HTTP 기본 인증이 필요합니다."
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr "기본 승인에 대한 권한 헤더가 유효하지 않습니다."
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr "기본 승인에 대한 권한 헤더가 없습니다"
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr "Webhook 봇은 Webhook에만 액세스 할 수 있습니다."
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr ""
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
 "organization administrator to reactivate it."
 msgstr ""
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr ""
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr "하위 도메인의 길이는 3 이상이어야합니다."
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr "하위 도메인은 '-'로 시작하거나 끝낼 수 없습니다."
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr "하위 도메인은 소문자, 숫자 및 '-'만 가질 수 있습니다."
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr "귀하의 실제 이메일 주소를 사용하십시오."
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr "{email}을 사용하여 가입하려는 조직이 존재하지 않습니다."
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr "조직 관리자에게 {email} 초대장을 요청하십시오."
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
@@ -4921,11 +4354,11 @@ msgstr ""
 "귀하의 이메일 주소인 {email}은 이 조직의 계정에 등록 할 수있는 도메인에 속해 "
 "있지 않습니다."
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr "이 조직에는 +가 포함된 이메일 주소가 허용되지 않았습니다."
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
@@ -4934,41 +4367,40 @@ msgstr ""
 "새로운 회원은이 조직에 참여할 수 없을 때 모든 Zulip 사용권이 사용중인 경우에 "
 "문의하십시오. 귀하를 초대 한 사람에게 문의하여 테마를 요청할 수 있습니다."
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 #, fuzzy
 #| msgid "Embedded bots are not enabled."
 msgid "Challenges are not enabled."
 msgstr "임베디드 봇은 사용할 수 없습니다."
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "새로운 비밀번호"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr ""
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "You're making too many attempts to sign in. Try again in "
 "{retry_after_string} or contact your organization administrator for help."
 msgstr ""
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
@@ -4976,89 +4408,87 @@ msgstr ""
 "비밀번호가 악영향을 겪었습니다. 이전에 toise가 뒤에 벗어났습니다. 암호를 재설"
 "정하여 새 하나를 만듭니다."
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr "흔적"
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr "최대 10개의 이메일을 입력하십시오."
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr ""
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr ""
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr "누락된 주제"
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr ""
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr ""
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr "메시지에 수신자가 있어야합니다."
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr "유효하지 않은 메시지 유형"
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr "유효하지 않은 첨부 파일"
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr ""
 "첨부 파일을 삭제하는 중 오류가 발생했습니다. 나중에 다시 시도 해주십시오."
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Content can't be empty"
 msgid "Channel folder name can't be empty."
 msgstr "내용은 비워 둘 수 없습니다."
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 msgid "Invalid channel folder ID"
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 #, fuzzy
 #| msgid "Enter your email address"
 msgid "Configure owner account email address."
 msgstr "귀하의 이메일 주소를 등록하세요."
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5067,71 +4497,71 @@ msgid ""
 "organization]({convert_demo}).\n"
 msgstr ""
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, python-brace-format
 msgid "{var_name} is not Base64 encoded"
 msgstr ""
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 #, fuzzy
 #| msgid "Invalid emoji code."
 msgid "Invalid `device_id`"
 msgstr "유효하지 않은 이모티콘 코드."
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr ""
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr "도메인은 비워 둘 수 없습니다."
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr "도메인에는 점 (.)이 하나 이상 있어야 합니다."
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr "도메인이 너무 깁니다"
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr "도메인은 도트 (.)로 시작하거나 끝낼 수 없습니다."
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr "연속 '.'는 허용되지 않습니다."
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr "하위 도메인은 '-'로 시작하거나 끝낼 수 없습니다."
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr "도메인은 글자, 숫자, '.' 그리고 '-' 만 가질 수 있습니다."
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr ""
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr ""
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5139,627 +4569,625 @@ msgid ""
 "{error_message}"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr ""
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr "유효하지 않은 주소."
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr "도메인 외부."
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr "+가 포함된 이메일 주소는 허용되지 않습니다."
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr ""
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr ""
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr "이미 계정이 있습니다."
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr ""
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr "유효하지 않은 사용자 정의 이모티콘."
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr "유효하지 않은 사용자 정의 이모티콘 이름."
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr "이 사용자 지정 이모티콘은 비활성화되어 있습니다."
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr "유효하지 않은 이모티콘 코드."
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr "이모티콘 이름이 유효하지 않습니다."
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr "이모티콘 형식이 유효하지 않습니다."
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr "조직 관리자나 이모티콘 작성자여야 합니다"
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr ""
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
 msgstr ""
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr ""
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr "이벤트 큐를 할당 할 수 없습니다."
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr "로그인하지 않음 : API 인증 또는 사용자 세션 필요"
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr ""
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr ""
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr ""
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr "조작된 JSON"
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr "조직 관리자여야 합니다."
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 msgid "Must be a bot user"
 msgstr ""
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr ""
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr "이 조직은 비활성화되었습니다"
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr ""
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr ""
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr "유효하지 않은 API 키"
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
 "webhook; ignoring"
 msgstr ""
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr "유효하지 않은 하위 도메인"
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr ""
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr ""
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr "접근 불가"
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} most recent messages in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr "반응이 이미 존재합니다."
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr "반응이 존재하지 않습니다."
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
 msgstr "조직 영역 응용 프로그램.이 문제를 해결하는 알 수집."
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr ""
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr ""
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr ""
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr ""
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr ""
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Already has an account."
 msgid "Atlassian account ID"
 msgstr "이미 계정이 있습니다."
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Behance username"
 msgstr "잘못된 이름 또는 사용자명"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 msgid "Bitbucket username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Codeberg username"
 msgstr "잘못된 이름 또는 사용자명"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Dribbble username"
 msgstr "이메일 혹은 사용자명"
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Facebook username"
 msgstr "잘못된 이름 또는 사용자명"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "GitLab username"
 msgstr "이메일 혹은 사용자명"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Instagram username"
 msgstr "잘못된 이름 또는 사용자명"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 msgid "Mastodon profile"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Medium username"
 msgstr "잘못된 이름 또는 사용자명"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Pinterest username"
 msgstr "잘못된 이름 또는 사용자명"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Reddit username"
 msgstr "이메일 혹은 사용자명"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 msgid "Snapchat username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Threads username"
 msgstr "잘못된 이름 또는 사용자명"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "TikTok username"
 msgstr "이메일 혹은 사용자명"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Twitch username"
 msgstr "이메일 혹은 사용자명"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "사용자명"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr ""
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr "통합 프레임 워크"
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 #, fuzzy
 #| msgid "Billing"
 msgid "Video calling"
 msgstr "청구서"
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr "지속적인 통합"
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr "고객 지원"
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr "전개"
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr ""
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr "통신"
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr "재정"
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr ""
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr "마케팅"
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr "기타"
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr ""
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr "프로젝트 관리"
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr "생산성"
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr "버전관리"
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr "메시지는 비워 둘 수 없습니다."
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr "메시지에 null 바이트가 없어야합니다."
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "{fullname} moderation"
 msgstr ""
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr "유효하지 않은 선택적 보기 연산자 : {desc}"
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr ""
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr ""
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 #, fuzzy
 #| msgid "Missing '{var_name}' argument"
 msgid "Missing 'anchor_date' argument."
 msgstr "'{var_name}'인수가 없습니다."
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr ""
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 #, fuzzy
 #| msgid "Reaction doesn't exist."
 msgid "Navigation view does not exist."
 msgstr "반응이 존재하지 않습니다."
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5767,7 +5195,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5775,7 +5203,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5783,7 +5211,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5791,7 +5219,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5801,14 +5229,14 @@ msgid ""
 "a permanent organization]({convert_demo_organization_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
 "them in your [Inbox](/#inbox).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5816,7 +5244,7 @@ msgid ""
 "({navigation_tour_video_url}) for a quick app overview.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5831,14 +5259,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -5846,7 +5274,7 @@ msgid ""
 "and edit your [profile information](/help/edit-your-profile).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -5857,7 +5285,7 @@ msgid ""
 "experience in your [Preferences](#settings/preferences).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5868,7 +5296,7 @@ msgid ""
 "[Browse and subscribe to channels]({settings_link}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -5885,7 +5313,7 @@ msgid ""
 "discussed.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -5894,7 +5322,7 @@ msgid ""
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -5906,7 +5334,7 @@ msgid ""
 "times, and more.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5916,7 +5344,7 @@ msgid ""
 "or browse the [help center](/help/) to learn more!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5924,7 +5352,7 @@ msgid ""
 "get help, try one of the following messages: {bot_commands}\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5936,13 +5364,13 @@ msgid ""
 "({move_content_another_channel_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5956,12 +5384,11 @@ msgid ""
 "and above.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr ""
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -5969,14 +5396,14 @@ msgid ""
 "no matter how many other conversations are going on.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
 "conversations with unread messages.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -5984,7 +5411,7 @@ msgid ""
 "the `+` button next to its name.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -5992,13 +5419,13 @@ msgid ""
 "can we chat about…?”\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6006,7 +5433,7 @@ msgid ""
 "({format_message_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6026,1241 +5453,1220 @@ msgid ""
 "```\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
 "teammates.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
 "conversation.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr ""
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr ""
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr ""
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr "비어 있거나 유효하지 않은 길이의 토큰입니다."
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr "APNS 토큰이 유효하지 않습니다."
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr ""
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr "토큰이 존재하지 않습니다."
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "새로운 메시지"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 #, fuzzy
 #| msgid "Invalid API key"
 msgid "Invalid `push_key`"
 msgstr "유효하지 않은 API 키"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
 msgstr[0] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr "이 쿼리에 대해 승인되지 않은 사용자"
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr ""
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr ""
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr "{var_name}이 너무 깁니다 (제한: {max_length} 글자)"
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder does not exist"
 msgstr "토큰이 존재하지 않습니다."
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr ""
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr ""
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr "'{var_name}'인수가 없습니다."
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr "'{var_name}'의 값이 잘못됨 : {bad_value}"
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr ""
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr ""
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr ""
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr ""
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 #, fuzzy
 #| msgid "You don't have permission to delete this message"
 msgid "You do not have permission to create new topics in this channel."
 msgstr "이 메시지를 삭제할 수 있는 권한이 없습니다"
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr ""
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr ""
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr ""
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr ""
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr ""
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr ""
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} does not have the expected format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr "{var_name}이 너무 깁니다 (제한: {max_length} 글자)"
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr "{var_name}이 너무 깁니다 (제한: {max_length} 글자)"
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr "{var_name}이 너무 깁니다 (제한: {max_length} 글자)"
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid emoji name."
 msgid "Invalid {setting_name}"
 msgstr "이모티콘 이름이 유효하지 않습니다."
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr "업로드가 귀하 조직의 업로드 할당량을 초과합니다."
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr ""
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr ""
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr "사용자 그룹이 유효하지 않습니다."
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid user group"
 msgid "Invalid user group ID: {user_group_id}"
 msgstr "사용자 그룹이 유효하지 않습니다."
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr ""
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr ""
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr ""
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr ""
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr "이름이 너무 깁니다!"
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 #, fuzzy
 #| msgid "Message must not be empty"
 msgid "Name must not be empty!"
 msgstr "메시지는 비워 둘 수 없습니다."
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr "이름에 유효하지 않은 문자가 있습니다!"
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr ""
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr ""
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr ""
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr "잘못된 이름 또는 사용자명"
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr ""
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr ""
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr ""
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr "유효하지 않은 구성 데이터!"
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr "유효하지 않은 봇 유형"
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr "인터페이스 유형이 유효하지 않습니다."
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr ""
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr "그러한 봇이 없습니다"
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr "그런 사용자가 없습니다."
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr "사용자가 비활성화되었습니다."
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr "{item} 은 비워 둘 수 없습니다."
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr ""
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr ""
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr ""
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr ""
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr ""
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr ""
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr ""
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr ""
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr ""
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr "'{item}'은 비워 둘 수 없습니다."
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr ""
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr "'{value}'는 '{field_name}'에 대한 유효한 선택이 아닙니다."
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr ""
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr ""
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr ""
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr "누락된 HTTP 이벤트 헤더 '{header}'"
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr ""
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr ""
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr ""
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr ""
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr "아무도 없음"
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr ""
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "구성원"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr ""
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Invalid characters in emoji name"
 msgid "Invalid auto-conversion field: empty field name."
 msgstr "이모티콘 이름에 유효하지 않은 문자가 있습니다."
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr ""
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr ""
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 msgid "Example input does not match the linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in alternative URL template is not present in linkifier "
 "pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in linkifier pattern is not present in alternative URL "
 "template."
 msgstr ""
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr "유니코드 이모티콘"
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "사용자 정의 이모티콘"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr "Zulip 추가 이모티콘"
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr "이모티콘 이름에 유효하지 않은 문자가 있습니다."
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr ""
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr ""
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr ""
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr ""
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr ""
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr ""
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr ""
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr ""
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr ""
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "공개"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr "개인적이고 공유된 기록"
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr "개인적이고 보호된 기록"
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr "관리자들과 중재자들 과 멤버들 그리고 손님들"
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr "관리자들과 중재자들 그리고 멤버들"
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr "관리자들과 중재자들"
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr "관리자만 가능"
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr ""
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr ""
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr ""
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr "중재자"
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "회원"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "손님"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr "알 수 없는 IP주소"
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr ""
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr "누락된 'queue_id' 인수"
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr "누락된 'last_event_id' 인수"
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr ""
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr ""
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 msgid "Failed to generate challenge"
 msgstr ""
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr ""
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr "요청시 전달 된 JSON 웹 토큰이 없습니다."
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr "JSON 웹 토큰이 잘못되었습니다."
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr ""
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr "하위 도메인 필요"
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr ""
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 #, fuzzy
 #| msgid "Presence is not supported for bot users."
 msgid "Field type not supported for use for user matching."
 msgstr "현재 상태는 봇 사용자에게는 지원되지 않습니다."
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr "필드 유형이 유효하지 않습니다."
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr ""
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr ""
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr ""
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr ""
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr ""
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr ""
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr ""
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr "그러한 초대장이 없습니다."
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid "Invitation already used or deactivated."
 msgstr "이 조직은 비활성화되었습니다"
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr ""
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr ""
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr "이메일 주소를 하나 이상 지정해야합니다."
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
@@ -7268,104 +6674,102 @@ msgstr ""
 "그 중 일부 주소는 이미 Zulip을 사용하고 있으므로 초대장을 보내지 않았습니다. "
 "우리는 다른 모든 사람들에게 초대장을 보냈습니다!"
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr "이 조직에서 메시지 편집 기록을 사용할 수 없습니다."
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr "이 메시지를 삭제할 수 있는 권한이 없습니다"
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr "이 메시지를 편집하는데 시간 제한이 지났습니다."
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr ""
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr ""
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr ""
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr ""
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr ""
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Zephyr mirroring is not allowed in this organization"
 msgid "Message reporting is not enabled in this organization."
 msgstr "이 조직에서 Zephyr 미러링은 사용하실 수 없습니다."
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr "누락된 발신자"
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr ""
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr "미러된 메시지가 유효하지 않습니다."
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr ""
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr ""
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr ""
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr ""
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr ""
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr ""
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 #, fuzzy
 #| msgid "Reaction already exists."
 msgid "Navigation view already exists."
 msgstr "반응이 이미 존재합니다."
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7373,216 +6777,216 @@ msgid ""
 "later. Is this a good time?\n"
 msgstr ""
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr "현재 상태는 봇 사용자에게는 지원되지 않습니다."
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr ""
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 #, fuzzy
 #| msgid "You don't have permission to delete this message"
 msgid "You do not have permission to manage plans and billing."
 msgstr "이 메시지를 삭제할 수 있는 권한이 없습니다"
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr ""
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr ""
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr ""
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr ""
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr ""
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr "하나 이상의 인증 방법이 사용 가능해야합니다."
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr ""
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr ""
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr ""
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr ""
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr "정확히 하나의 파일을 업로드해야합니다."
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr ""
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 #, fuzzy
 #| msgid "Disposable email addresses are not allowed in this organization"
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr "여기서는 1회용 이메일 주소는 사용하실 수 없습니다."
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr ""
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr ""
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr ""
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr ""
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr ""
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr "단 하나의 아이콘만 업로드해야합니다."
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr ""
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid characters in name!"
 msgid "Invalid character in language: {character}"
 msgstr "이름에 유효하지 않은 문자가 있습니다!"
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Language '{language}' is not allowed."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr ""
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr ""
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
@@ -7590,349 +6994,347 @@ msgstr ""
 "슬랙 데이터 변환 ... 이것은 엄지 손가락을받을 수 있습니다. 여기에서 여기를 반"
 "환 할 수 없습니다."
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 msgid "Importing messages…"
 msgstr ""
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 msgid "Your name"
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr ""
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr ""
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr ""
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr "\"new_description\"또는 \"new_group_name\"을 전달해야 합니다."
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr ""
 "\"op\"에 대한 값이 유효하지 않습니다. \"추가\"또는 \"제거\"중 하나를 지정하십"
 "시오."
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr "유효하지 않은 값들"
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr ""
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr ""
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr "할 것이 없다. \"추가\"또는 \"삭제\"중 적어도 하나를 지정하십시오."
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr ""
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr ""
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr ""
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr ""
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
 "**"
 msgstr ""
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr ""
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr ""
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr ""
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr ""
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr ""
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr ""
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr ""
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr ""
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr "<p>이 파일을 볼 수있는 권한이 없습니다.</p>"
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr ""
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr ""
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr "업로드 할 파일을 지정해야합니다."
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr "한 번에 하나의 파일만 업로드 할 수 있습니다."
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr "새로운 데이터가 제공되지 않았습니다."
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 msgstr ""
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr ""
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr ""
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
 "subgroups."
 msgstr ""
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr "아바타 변경은 이 조직에서 불가능합니다."
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr "이 조직에서는 전자 메일 주소 변경이 비활성화되어 있습니다."
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr ""
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr ""
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr ""
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr "귀하의 Zulip 비밀번호는 LDAP에서 관리됩니다."
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr "잘못된 비밀번호!"
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr ""
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr ""
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr "정확히 하나의 아바타를 업로드해야합니다."
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr "주제가 뮤트되어 있지 않습니다"
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr ""
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 msgid "User is not allowed to delete other user's messages."
 msgstr ""
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr ""
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr ""
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "No analytics data available. Please contact your server administrator."
@@ -7941,305 +7343,305 @@ msgid ""
 "Please contact your server administrator."
 msgstr "이용가는한 분석 데이터가 없습니다. 서버 운영자에게 문의하세요."
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 #, fuzzy
 #| msgid "Email address"
 msgid "Email address already in use"
 msgstr "이메일 주소"
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr "소유자를 변경하지 못했습니다, 사용자가 존재하지 않습니다."
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr "소유자를 변경하지 못했습니다, 사용자가 비활성화 되어있습니다"
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr "소유자를 변경하지 못했습니다. 봇은 다른 봇을 소유할 수 없습니다."
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 msgstr ""
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr "임베디드 봇은 사용할 수 없습니다."
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr "포함된 봇 이름이 유효하지 않습니다."
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr ""
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr ""
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr "여기서는 1회용 이메일 주소는 사용하실 수 없습니다."
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} access token"
 msgstr ""
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} call"
 msgstr ""
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} credentials have not been configured"
 msgstr ""
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} credentials"
 msgstr ""
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr ""
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error authenticating to the {provider_name} server"
 msgstr ""
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr ""
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} session identifier"
 msgstr ""
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr ""
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} public room."
 msgstr ""
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr ""
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{full_name}'s Zulip room"
 msgstr ""
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr ""
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr "알 수 없는 웹후크 요청"
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr "주제는 비워둘 수 없습니다."
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr "내용은 비워 둘 수 없습니다."
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr ""
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr "잘못된 JSON 입력"
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr ""
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr "오류: 0 또는 1 이외의 channels_map_to_topics 매개 변수"
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr ""
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
 "({export_settings_link})."
 msgstr ""
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr ""
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr ""
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr ""
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr ""
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr "푸시 알림 Bouncer의 하위 도메인이 유효하지 않습니다."
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr "유효한 Zulip 서버 API키로 유효화해야 한다."
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr ""
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr "유효하지 않은 토큰 타입"
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr ""
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr ""
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr ""
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr ""
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
 "try again later or reach out to {support_email} for assistance."
 msgstr ""
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr ""
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr ""
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr ""
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr ""
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
 "server: {reason}"
 msgstr ""
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr ""
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr ""
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr ""
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr ""
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr ""
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr ""
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr ""
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr ""
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 #, fuzzy
 #| msgid "Missing sender"
 msgid "Missing idp param"
 msgstr "누락된 발신자"
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr "OTP가 유효하지 않습니다."
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr ""
 

--- a/locale/lt/LC_MESSAGES/django.po
+++ b/locale/lt/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 19:39+0000\n"
 "Last-Translator: Alex Vandiver <alexmv@zulip.com>\n"
 "Language-Team: Lithuanian <https://hosted.weblate.org/projects/zulip/django/"
@@ -22,51 +22,51 @@ msgstr ""
 "1 : n % 1 != 0 ? 2: 3);\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr ""
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr ""
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr ""
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr ""
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr ""
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr ""
 "Analitiniai duomenys negalimi. Susisiekite su serverio administratoriumi."
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -75,7 +75,7 @@ msgid ""
 "users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -83,7 +83,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than one user to join."
 msgstr ""
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -91,7 +91,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than two users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -99,7 +99,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than three users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -108,148 +108,147 @@ msgid ""
 "({billing_page_link}) is greater than the current number of users."
 msgstr ""
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr ""
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr ""
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
 "(minimum {min_licenses})."
 msgstr ""
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
 "page. To complete the upgrade, please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr ""
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr ""
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr ""
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr ""
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr ""
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr ""
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
 msgstr ""
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
 msgstr ""
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
 "licenses."
 msgstr ""
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
 "billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr ""
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr ""
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr ""
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -259,100 +258,97 @@ msgid ""
 "we would really appreciate it!"
 msgstr ""
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
 "{support_email}"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr ""
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr ""
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr ""
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
 "%(support_email)s\">contact support</a>."
 msgstr ""
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr ""
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
 msgstr ""
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr ""
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
 msgstr ""
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr ""
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr "Vidinė serverio klaida"
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
 msgstr ""
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -360,289 +356,270 @@ msgid ""
 "a> with any questions."
 msgstr ""
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
 "a> for support."
 msgstr ""
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
 "href=\"%(troubleshooting_url)s\">Zulip server troubleshooting guide</a>."
 msgstr ""
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr ""
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr ""
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr ""
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr ""
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr ""
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr ""
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr ""
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr ""
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr ""
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr ""
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr ""
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr ""
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr ""
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "Naudotojai"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr ""
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr ""
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr ""
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr ""
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr ""
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr ""
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr ""
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr ""
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr ""
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr ""
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr ""
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr ""
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "Botai"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr ""
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr ""
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr ""
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
 "%(old_email_html_tag)s to %(new_email_html_tag)s"
 msgstr ""
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr ""
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
 msgstr ""
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "Atšaukti"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr ""
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr ""
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -653,19 +630,19 @@ msgid ""
 "server."
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -673,788 +650,297 @@ msgid ""
 "%(support_email)s'>contact support</a> with any questions."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, python-format
 msgid "You can try again in %(retry_after_string)s."
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr ""
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr ""
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr ""
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr ""
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr ""
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr ""
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr ""
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr ""
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr ""
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "Sukurti organizaciją"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr ""
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr ""
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr ""
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr ""
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 msgid "Zulip for open source"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 msgid "Message with code"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
 msgstr ""
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 msgid "Get started"
 msgstr ""
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
 "continue."
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "El. paštas"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1462,78 +948,77 @@ msgid ""
 "from Zulip."
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
 msgstr ""
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr ""
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr ""
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr ""
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr ""
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr ""
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr ""
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr ""
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
 msgstr ""
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1541,210 +1026,203 @@ msgid ""
 "href=\"%(doc_url)s\">documentation</a>."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, python-format
 msgid "No account found for %(email)s."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Create a new organization"
 msgid "Try Zulip in a demo organization"
 msgstr "Create a new organization"
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 msgid "Try Zulip"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "Create a new organization"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid "Import chat history?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr "Organizacijos pavadinimas"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "Organization URL"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "OR"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "Prisiregistruoti"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "Prisijungti"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1752,125 +1230,124 @@ msgid ""
 "noreferrer\">after you join</a>."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "Change"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr "Jūsų paskyra"
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "Slaptažodis"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 "Tai naudojama mobiliosioms programėlėms ir kitiems įrankiams, kuriems reikia "
 "slaptažodžio."
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr "Slaptažodžio patikimumas"
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr ""
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">Terms of Service</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr "Išaktyvuota organizacija"
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr ""
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -1878,45 +1355,45 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 msgid ""
 "This organization has been deactivated, and all organization data has been "
 "deleted."
 msgstr ""
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
 "inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
 "administrators</a> to inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 msgid "This organization has been deactivated."
 msgstr ""
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
 "%(support_email)s\">contact Zulip support</a> to reactivate it."
 msgstr ""
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -1924,165 +1401,164 @@ msgid ""
 "reactivate it."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "Copy"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "Administratoriai"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "Naudotojai"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "Uždaryti"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr ""
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr ""
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
 "<b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
 "href=\"%(apps_page_link)s\">mobile and desktop</a> apps:"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
 "href=\"%(getting_user_started_link)s\">getting started guide</a>!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2090,83 +1566,83 @@ msgid ""
 "Zulip</a>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
 "to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
 "desktop apps (%(apps_page_link)s):"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
 "(%(getting_user_started_link)s)!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
 "(%(getting_organization_started_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2174,32 +1650,32 @@ msgid ""
 "password for this account, please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "%(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 msgid "Verify your email address for your Zulip demo organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "<%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2207,113 +1683,113 @@ msgid ""
 "please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
 "— we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
 "deactivated, and you will no longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr ""
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2321,22 +1797,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because your organization <a "
@@ -2344,8 +1820,8 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to <a "
@@ -2353,39 +1829,39 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr ""
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because your organization hides "
@@ -2393,81 +1869,74 @@ msgid ""
 "details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to hide "
 "message content in email notifications. See %(help_url)s for more details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr ""
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
 "organizations:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
 "organizations hosted by %(external_host)s:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
 "href=\"%(help_reset_password_link)s\">reset your password</a>."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
 "%(external_host)s."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2475,97 +1944,94 @@ msgid ""
 "to find your account."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
 "try another way to find your account (%(help_logging_in_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
 "communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr ""
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
 "-- the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
 "Zulip &mdash; the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
 "to ask %(referrer_name)s for another one."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2573,72 +2039,70 @@ msgid ""
 "productivity."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at <a href=\"mailto:%(email)s\">%(email)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
 "%(email)s\">Contact us</a> — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
 "#%(channel_name)s > %(topic_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2646,68 +2110,68 @@ msgid ""
 "preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails (<a href=\"%(url)s\">help</a>)."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2715,22 +2179,22 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2738,52 +2202,52 @@ msgid ""
 "immediately at <%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2791,31 +2255,31 @@ msgid ""
 "contact us immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2823,7 +2287,7 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -2831,25 +2295,25 @@ msgid ""
 "Zulip</a> to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
 "with you and share their unique perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -2857,7 +2321,7 @@ msgid ""
 "experience how a new chat app will help your team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -2865,148 +2329,148 @@ msgid ""
 "action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
 "team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
 "organizations like yours!"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3014,11 +2478,11 @@ msgid ""
 "about…?”"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3027,23 +2491,23 @@ msgid ""
 "href=\"%(move_channels_link)s\">move a topic to a different channel</a>."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3052,23 +2516,23 @@ msgid ""
 "(%(move_channels_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
 "%(email)s on %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3076,46 +2540,46 @@ msgid ""
 "href=\"%(help_link)s\">reactivate your account</a>."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
 "You can contact an organization administrator to reactivate your account."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3123,541 +2587,537 @@ msgid ""
 "have been voided."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
 "to %(upgrade_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip demo organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip demo organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Deactivated organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "Išaktyvuota organizacija"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for <b>%(remote_server_hostname)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 msgid "Click the button below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for %(remote_server_hostname)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
 "management for <b>%(remote_realm_host)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
 "management for %(remote_realm_host)s."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the <a href=\"%(plans_link)s\">Zulip Community plan</a>."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
 "website</a>, we would really appreciate it!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
 msgstr ""
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
 "accounts for another email address</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr ""
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "Find accounts"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr ""
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr "Funkcijos"
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr ""
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 msgid "Zulip Cloud"
 msgstr ""
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr ""
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr ""
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "Integracijos"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr "Darbalaukis ir mobiliosios programėlės"
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr ""
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr ""
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr ""
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr ""
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr ""
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr ""
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr ""
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr ""
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr ""
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr ""
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr ""
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr ""
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr ""
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr ""
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr ""
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr ""
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr ""
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr ""
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr ""
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr ""
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr ""
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr ""
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "History"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr ""
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr ""
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr ""
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr ""
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr ""
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 msgid "Bluesky"
 msgstr ""
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr ""
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr ""
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr ""
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 msgid ""
 "And hundreds more through <a href=\"/integrations/zapier\">Zapier</a> and <a "
 "href=\"/integrations/ifttt\">IFTTT</a>."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3665,7 +3125,7 @@ msgid ""
 "emails with your email domain."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3673,7 +3133,7 @@ msgid ""
 "disposable email addresses."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3681,24 +3141,24 @@ msgid ""
 "emails that contain \"+\"."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3706,7 +3166,7 @@ msgid ""
 "%(support_email)s\">contact Zulip support</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3714,89 +3174,89 @@ msgid ""
 "%(support_email)s\">contact this Zulip server's administrators</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
 "management for your Zulip server."
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr ""
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr ""
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr ""
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr ""
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr ""
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr ""
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr ""
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> because all Zulip Cloud licenses are in use."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -3805,44 +3265,42 @@ msgid ""
 "or misconfiguration."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 #, fuzzy
 #| msgid "Organization name"
 msgid "Demo organizations disabled"
 msgstr "Organizacijos pavadinimas"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -3850,22 +3308,21 @@ msgid ""
 "organization for more information."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -3873,48 +3330,46 @@ msgid ""
 "Zulip support</a> for assistance in resolving this issue."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
 "a> like Firefox, Chrome, and Edge."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create organization"
 msgid "Finalize organization import"
 msgstr "Sukurti organizaciją"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Organization name"
 msgid "Organization import completed!"
 msgstr "Organizacijos pavadinimas"
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -3922,56 +3377,55 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Your account"
 msgid "Select your account"
 msgstr "Jūsų paskyra"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create a new organization"
 msgid "Create new account"
 msgstr "Create a new organization"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr ""
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -3979,81 +3433,81 @@ msgid ""
 "have one yet."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 msgid "Self-hosting Zulip?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">log in to manage plans and billing.</a>"
 msgstr ""
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr ""
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
 msgstr ""
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "Patvirtinti slaptažodį"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr "Deja, Jūsų pateikta nuoroda yra negaliojanti arba jau panaudota."
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr ""
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr ""
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr ""
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr ""
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4061,7 +3515,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4070,57 +3524,57 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr ""
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4128,7 +3582,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4136,40 +3590,40 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr "Nežinomo el. pašto prenumeratos atsisakymo prašymas"
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4177,303 +3631,297 @@ msgid ""
 "away!"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr "Laiškų nustatymai atnaujinti"
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
 "href=\"%(realm_url)s/#settings/notifications\">notification settings</a>."
 msgstr ""
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr ""
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr ""
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr ""
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr ""
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr ""
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr ""
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr ""
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 msgid "Cannot reactivate a deleted user"
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr ""
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr ""
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr ""
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr ""
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
 msgstr ""
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
 msgstr ""
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 "Kai kurie el. pašto adresai nepatvirtinti, todėl pakvietimų neišsiuntėme."
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr "Negalėjome nieko pakviesti."
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr "Nėra ko pakeisti"
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr ""
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr ""
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr ""
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr ""
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr ""
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr ""
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr "Neturite teisės redaguoti šios žinutės"
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr ""
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
 "{new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
 "{user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 #, fuzzy
 #| msgid "You don't have permission to edit this message"
 msgid "You don't have permission to resolve topics in this channel."
 msgstr "Neturite teisės redaguoti šios žinutės"
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr ""
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr ""
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr "Negaliojanti žinutė"
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr "Nepavyko perteikti žinutės"
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr ""
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
 "but there is no channel with that ID."
 msgstr ""
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4481,36 +3929,36 @@ msgid ""
 "it."
 msgstr ""
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
 "The channel exists but does not have any subscribers."
 msgstr ""
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr ""
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr ""
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr ""
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4518,109 +3966,107 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
 "authentication method."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr ""
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder could not be sent."
 msgstr "Tokenas neegzistuoja"
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
 "the following error:"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr ""
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr ""
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr ""
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr ""
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr ""
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
 "**{old_policy}** to **{new_policy}**."
 msgstr ""
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -4629,51 +4075,49 @@ msgid ""
 "* **New**: {new_setting_description}\n"
 msgstr ""
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr ""
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr ""
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr ""
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr ""
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr ""
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr ""
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 msgstr ""
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr ""
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -4684,287 +4128,273 @@ msgid ""
 "{summary_line}"
 msgstr ""
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr ""
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr ""
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr ""
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr "Nepakanka leidimo"
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr ""
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr "Paskyra nesusieta su šiuo subdomenu"
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr ""
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr ""
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr "Šis galutinis taškas reikalauja paprastos HTTP autentifikacijos."
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr "Negaliojanti autorizacija"
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr "„Webhook“ botai gali pasiekti tik „webhook“"
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr ""
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
 "organization administrator to reactivate it."
 msgstr ""
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr ""
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr "Subdomeno ilgis turi būti nuo 3 simbolių."
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr "Subdomenas negali prasidėti arba baigtis „-“."
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr "Subdomenas gali turėti tik mažąsias raides, skaičius ir „-“."
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr "Naudokite tikrą el. pašto adresą."
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr ""
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr ""
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
 "to register for accounts in this organization."
 msgstr ""
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr ""
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 msgid "Challenges are not enabled."
 msgstr ""
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr ""
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr ""
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "You're making too many attempts to sign in. Try again in "
 "{retry_after_string} or contact your organization administrator for help."
 msgstr ""
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
 msgstr ""
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr ""
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr ""
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr ""
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr ""
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr "Nėra temos"
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr ""
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr ""
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr "Žinutė turi turėti gavėjus"
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr "Neteisingas žinutės tipas"
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr "Negaliojantis priedas"
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr ""
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Content can't be empty"
 msgid "Channel folder name can't be empty."
 msgstr "Turinys negali būti tuščias"
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 msgid "Invalid channel folder ID"
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 #, fuzzy
 #| msgid "Please use your real email address."
 msgid "Configure owner account email address."
 msgstr "Naudokite tikrą el. pašto adresą."
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4973,69 +4403,69 @@ msgid ""
 "organization]({convert_demo}).\n"
 msgstr ""
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, python-brace-format
 msgid "{var_name} is not Base64 encoded"
 msgstr ""
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 msgid "Invalid `device_id`"
 msgstr ""
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr ""
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr "Domenas negali būti tuščias."
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr "Domenas privalo turėti bent vieną tašką (.)"
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr ""
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr "Domenas negali prasidėti arba baigtis tašku (.)"
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr "Nuoseklūs „.“ neleidžiami."
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr "Subdomenai negali prasidėti ar baigtis „-“."
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr "Domenas gali turėti tik raides, skaičius, „.“ ir „-“."
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr ""
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr ""
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5043,615 +4473,613 @@ msgid ""
 "{error_message}"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr ""
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr "Negaliojantis adresas."
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr "Už jūsų domeno ribų."
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr ""
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr ""
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr ""
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr "Jau turi paskyrą."
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr ""
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr ""
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr ""
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr ""
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr ""
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr ""
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
 msgstr ""
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr ""
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr "Nepavyko paskirti įvykio eilės"
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr "Neprisijungęs: API autentifikavimas arba naudotojo sesija nebegalioja"
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr ""
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr ""
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr ""
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr "Blogas JSON"
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr ""
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 msgid "Must be a bot user"
 msgstr ""
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr ""
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr ""
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr ""
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr "Negaliojantis API raktas"
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
 "webhook; ignoring"
 msgstr ""
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr "Negaliojantis subdomenas"
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr ""
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr ""
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr "Prieiga nesuteikta"
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} most recent messages in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr ""
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr ""
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
 msgstr ""
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr ""
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr ""
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr ""
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr ""
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr ""
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Already has an account."
 msgid "Atlassian account ID"
 msgstr "Jau turi paskyrą."
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Behance username"
 msgstr "Blogas vardas arba slapyvardis"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 msgid "Bitbucket username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Codeberg username"
 msgstr "Blogas vardas arba slapyvardis"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 msgid "Dribbble username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Facebook username"
 msgstr "Blogas vardas arba slapyvardis"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 msgid "GitLab username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Instagram username"
 msgstr "Blogas vardas arba slapyvardis"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 msgid "Mastodon profile"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Medium username"
 msgstr "Blogas vardas arba slapyvardis"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Pinterest username"
 msgstr "Blogas vardas arba slapyvardis"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 msgid "Reddit username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 msgid "Snapchat username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Threads username"
 msgstr "Blogas vardas arba slapyvardis"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 msgid "TikTok username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 msgid "Twitch username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "X username"
 msgstr "Blogas vardas arba slapyvardis"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr ""
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr ""
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 msgid "Video calling"
 msgstr ""
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr ""
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr ""
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr ""
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr ""
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr ""
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr ""
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr ""
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr ""
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr ""
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr ""
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr ""
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr ""
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr ""
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr "Žinutė negali būti tuščia"
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "{fullname} moderation"
 msgstr ""
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr ""
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr ""
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 #, fuzzy
 #| msgid "Missing 'last_event_id' argument"
 msgid "Missing 'anchor_date' argument."
 msgstr "Trūksta „paskutinio_įvykio_id“"
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr ""
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Navigation view does not exist."
 msgstr "Tokenas neegzistuoja"
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5659,7 +5087,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5667,7 +5095,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5675,7 +5103,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5683,7 +5111,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5693,14 +5121,14 @@ msgid ""
 "a permanent organization]({convert_demo_organization_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
 "them in your [Inbox](/#inbox).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5708,7 +5136,7 @@ msgid ""
 "({navigation_tour_video_url}) for a quick app overview.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5723,14 +5151,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -5738,7 +5166,7 @@ msgid ""
 "and edit your [profile information](/help/edit-your-profile).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -5749,7 +5177,7 @@ msgid ""
 "experience in your [Preferences](#settings/preferences).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5760,7 +5188,7 @@ msgid ""
 "[Browse and subscribe to channels]({settings_link}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -5777,7 +5205,7 @@ msgid ""
 "discussed.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -5786,7 +5214,7 @@ msgid ""
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -5798,7 +5226,7 @@ msgid ""
 "times, and more.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5808,7 +5236,7 @@ msgid ""
 "or browse the [help center](/help/) to learn more!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5816,7 +5244,7 @@ msgid ""
 "get help, try one of the following messages: {bot_commands}\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5828,13 +5256,13 @@ msgid ""
 "({move_content_another_channel_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5848,12 +5276,11 @@ msgid ""
 "and above.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr ""
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -5861,14 +5288,14 @@ msgid ""
 "no matter how many other conversations are going on.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
 "conversations with unread messages.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -5876,7 +5303,7 @@ msgid ""
 "the `+` button next to its name.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -5884,13 +5311,13 @@ msgid ""
 "can we chat about…?”\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5898,7 +5325,7 @@ msgid ""
 "({format_message_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5918,127 +5345,127 @@ msgid ""
 "```\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
 "teammates.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
 "conversation.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr ""
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr ""
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr ""
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr "Tuščias arba netinkamo ilgio tokenas"
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr ""
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr "Tokenas neegzistuoja"
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 #, fuzzy
 #| msgid "Invalid API key"
 msgid "Invalid `push_key`"
 msgstr "Negaliojantis API raktas"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
@@ -6047,1107 +5474,1086 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr "Naudotojas neturi teisių šiai užklausai"
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr ""
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr ""
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr ""
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder does not exist"
 msgstr "Tokenas neegzistuoja"
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr ""
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr ""
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr ""
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr ""
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr ""
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr ""
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr ""
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr ""
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 #, fuzzy
 #| msgid "You don't have permission to edit this message"
 msgid "You do not have permission to create new topics in this channel."
 msgstr "Neturite teisės redaguoti šios žinutės"
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr ""
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr ""
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr ""
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr ""
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr ""
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr ""
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} does not have the expected format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid attachment"
 msgid "Invalid {setting_name}"
 msgstr "Negaliojantis priedas"
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr ""
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr ""
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr ""
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {user_group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr ""
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr ""
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr ""
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr ""
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr "Per ilgas vardas"
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 #, fuzzy
 #| msgid "Message must not be empty"
 msgid "Name must not be empty!"
 msgstr "Žinutė negali būti tuščia"
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr "Pavadinime yra negaliojantis simbolis!"
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr ""
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr ""
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr ""
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr "Blogas vardas arba slapyvardis"
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr ""
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr ""
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr ""
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr ""
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr ""
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr ""
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr ""
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr "Tokio boto nėra"
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr "Tokio naudotojo nėra"
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr ""
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr ""
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr ""
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr ""
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr ""
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr ""
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr ""
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr ""
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr ""
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr ""
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr ""
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr ""
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr ""
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr ""
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr ""
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr ""
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr ""
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr ""
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr ""
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr ""
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr ""
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr ""
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr ""
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Invalid characters in emoji name"
 msgid "Invalid auto-conversion field: empty field name."
 msgstr "Negaliojantys simboliai šypsenėlės pavadinime"
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr ""
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr ""
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 msgid "Example input does not match the linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in alternative URL template is not present in linkifier "
 "pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in linkifier pattern is not present in alternative URL "
 "template."
 msgstr ""
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr ""
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "Tinkintos šypsenėlės"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr ""
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr "Negaliojantys simboliai šypsenėlės pavadinime"
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr ""
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr ""
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr ""
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr ""
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr ""
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr ""
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr ""
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr ""
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr ""
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr ""
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr ""
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr ""
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr ""
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr ""
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr ""
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr ""
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr ""
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr ""
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr ""
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr ""
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr ""
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr ""
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr ""
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr ""
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr "Trūksta „eilės_id“"
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr "Trūksta „paskutinio_įvykio_id“"
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr ""
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr ""
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 msgid "Failed to generate challenge"
 msgstr ""
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr ""
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr "JSON žiniatinklio tokenas neperduotas į prašymą"
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr "Blogas JSON žiniatinklio tokenas"
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr ""
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr "Privalomas subdomenas"
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr ""
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for use for user matching."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr ""
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr ""
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr ""
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr ""
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr ""
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr ""
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr ""
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr ""
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 msgid "Invitation already used or deactivated."
 msgstr ""
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr ""
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr ""
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr "Turite nurodyti bent vieną el. pašto adresą."
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
@@ -7155,102 +6561,100 @@ msgstr ""
 "Kai kuriuos el. pašto adresus turintys žmonės jau naudoja programėlę, todėl "
 "pakvietimo jiems neišsiuntėme. Tačiau visi kiti pakvietimą gavo!"
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr ""
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr ""
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr ""
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr ""
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr ""
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr ""
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr ""
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr ""
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Email address changes are disabled in this organization."
 msgid "Message reporting is not enabled in this organization."
 msgstr "El. pašto adreso pakeitimai šiai organizacijai išjungti."
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr "Nėra siuntėjo"
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr ""
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr "Negaliojanti veidrodinė žinutė"
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr ""
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr ""
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr ""
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr ""
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr ""
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr ""
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 msgid "Navigation view already exists."
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7258,562 +6662,560 @@ msgid ""
 "later. Is this a good time?\n"
 msgstr ""
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr ""
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr ""
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 #, fuzzy
 #| msgid "You don't have permission to edit this message"
 msgid "You do not have permission to manage plans and billing."
 msgstr "Neturite teisės redaguoti šios žinutės"
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr ""
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr ""
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr ""
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr ""
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr ""
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr "Turi būti įgalintas bent vienas autentifikacijos būdas."
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr ""
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr ""
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr ""
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr ""
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr ""
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 #, fuzzy
 #| msgid "Email address changes are disabled in this organization."
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr "El. pašto adreso pakeitimai šiai organizacijai išjungti."
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr ""
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr ""
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr ""
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr ""
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr ""
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr "Turite įkelti vieną ikonėlę."
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr ""
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid characters in name!"
 msgid "Invalid character in language: {character}"
 msgstr "Pavadinime yra negaliojantis simbolis!"
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Language '{language}' is not allowed."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr ""
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr ""
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 msgid "Importing messages…"
 msgstr ""
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 msgid "Your name"
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr ""
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr ""
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr ""
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr ""
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr ""
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr ""
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr ""
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr ""
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr "Veiksmo nėra. Nurodykite „pridėti“ ar „ištrinti“."
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr ""
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr ""
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr ""
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr ""
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
 "**"
 msgstr ""
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr ""
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr ""
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr ""
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr ""
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr ""
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr ""
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr ""
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr ""
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr ""
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr ""
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr "Turite nurodyti norimą įkelti failą"
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr "Galite vienu metu kelti tik vieną failą"
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr "Nauji duomenys nepateikti"
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 msgstr ""
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr ""
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr ""
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
 "subgroups."
 msgstr ""
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr "El. pašto adreso pakeitimai šiai organizacijai išjungti."
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr ""
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr ""
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr ""
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr ""
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr "Blogas slaptažodis"
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr ""
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr ""
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr "Turite įkelti vieną avatarą."
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr ""
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr ""
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 msgid "User is not allowed to delete other user's messages."
 msgstr ""
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr ""
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr ""
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "No analytics data available. Please contact your server administrator."
@@ -7823,303 +7225,303 @@ msgid ""
 msgstr ""
 "Analitiniai duomenys negalimi. Susisiekite su serverio administratoriumi."
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 msgid "Email address already in use"
 msgstr ""
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr ""
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr ""
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr ""
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 msgstr ""
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr ""
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr ""
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr ""
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr ""
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr ""
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} access token"
 msgstr ""
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} call"
 msgstr ""
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} credentials have not been configured"
 msgstr ""
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} credentials"
 msgstr ""
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr ""
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error authenticating to the {provider_name} server"
 msgstr ""
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr ""
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} session identifier"
 msgstr ""
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr ""
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} public room."
 msgstr ""
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr ""
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{full_name}'s Zulip room"
 msgstr ""
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr ""
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr "Nežinomas „webhook“ prašymas"
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr "Temos vieta negali būti tuščia"
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr "Turinys negali būti tuščias"
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr ""
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr "Bloga JSON įvestis"
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr ""
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr "Klaida: channels_map_to_topics parametras nėra 0 arba 1"
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr ""
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
 "({export_settings_link})."
 msgstr ""
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr ""
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr ""
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr ""
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr ""
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr ""
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr ""
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr ""
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr ""
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr ""
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr ""
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr ""
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr ""
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
 "try again later or reach out to {support_email} for assistance."
 msgstr ""
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr ""
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr ""
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr ""
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr ""
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
 "server: {reason}"
 msgstr ""
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr ""
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr ""
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr ""
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr ""
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr ""
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr ""
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr ""
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr ""
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 #, fuzzy
 #| msgid "Missing sender"
 msgid "Missing idp param"
 msgstr "Nėra siuntėjo"
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr ""
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr ""
 

--- a/locale/lv/LC_MESSAGES/django.po
+++ b/locale/lv/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 19:23+0000\n"
 "Last-Translator: Alex Vandiver <alexmv@zulip.com>\n"
 "Language-Team: Latvian <https://hosted.weblate.org/projects/zulip/django/lv/"
@@ -19,50 +19,50 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr ""
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr ""
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr ""
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr ""
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr ""
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr ""
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -71,7 +71,7 @@ msgid ""
 "users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -79,7 +79,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than one user to join."
 msgstr ""
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -87,7 +87,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than two users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -95,7 +95,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than three users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -104,148 +104,147 @@ msgid ""
 "({billing_page_link}) is greater than the current number of users."
 msgstr ""
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr ""
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr ""
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
 "(minimum {min_licenses})."
 msgstr ""
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
 "page. To complete the upgrade, please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr ""
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr ""
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr ""
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr ""
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr ""
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr ""
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
 msgstr ""
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
 msgstr ""
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
 "licenses."
 msgstr ""
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
 "billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr ""
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr ""
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr ""
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -255,100 +254,97 @@ msgid ""
 "we would really appreciate it!"
 msgstr ""
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
 "{support_email}"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr ""
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "Kļūda"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr ""
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
 "%(support_email)s\">contact support</a>."
 msgstr ""
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr ""
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
 msgstr ""
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr ""
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
 msgstr ""
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr ""
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr ""
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
 msgstr ""
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -356,289 +352,270 @@ msgid ""
 "a> with any questions."
 msgstr ""
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
 "a> for support."
 msgstr ""
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
 "href=\"%(troubleshooting_url)s\">Zulip server troubleshooting guide</a>."
 msgstr ""
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr ""
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr ""
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr ""
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr ""
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr ""
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr ""
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr ""
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr ""
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr ""
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr ""
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr ""
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr ""
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr ""
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr ""
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr ""
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr ""
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr ""
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr ""
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr ""
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr ""
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr ""
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr ""
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr ""
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr ""
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr ""
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr ""
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr ""
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr ""
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr ""
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr ""
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
 "%(old_email_html_tag)s to %(new_email_html_tag)s"
 msgstr ""
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr ""
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
 msgstr ""
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "Atcelt"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr ""
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr ""
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -649,19 +626,19 @@ msgid ""
 "server."
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -669,788 +646,297 @@ msgid ""
 "%(support_email)s'>contact support</a> with any questions."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, python-format
 msgid "You can try again in %(retry_after_string)s."
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr ""
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr ""
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr ""
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr ""
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr ""
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr ""
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr ""
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr ""
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr ""
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr ""
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr ""
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr ""
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr ""
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr ""
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 msgid "Zulip for open source"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 msgid "Message with code"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr "Ziņojums"
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
 msgstr ""
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 msgid "Get started"
 msgstr ""
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
 "continue."
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "E-pasta adrese"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1458,78 +944,77 @@ msgid ""
 "from Zulip."
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
 msgstr ""
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr ""
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr ""
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr ""
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr ""
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr ""
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr ""
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr ""
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
 msgstr ""
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1537,210 +1022,203 @@ msgid ""
 "href=\"%(doc_url)s\">documentation</a>."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, python-format
 msgid "No account found for %(email)s."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Create a new organization"
 msgid "Try Zulip in a demo organization"
 msgstr "Izveidot jaunu organizāciju"
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 msgid "Try Zulip"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "Izveidot jaunu organizāciju"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid "Import chat history?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "Organizācijas URL"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "VAI"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "Autorizēties"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1748,123 +1226,122 @@ msgid ""
 "noreferrer\">after you join</a>."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "Mainīt"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "Nosaukums"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "Parole"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr ""
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">Terms of Service</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr ""
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr ""
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -1872,45 +1349,45 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 msgid ""
 "This organization has been deactivated, and all organization data has been "
 "deleted."
 msgstr ""
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
 "inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
 "administrators</a> to inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 msgid "This organization has been deactivated."
 msgstr ""
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
 "%(support_email)s\">contact Zulip support</a> to reactivate it."
 msgstr ""
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -1918,165 +1395,164 @@ msgid ""
 "reactivate it."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "Kopēt"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "Administratori"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "Normāli lietotāji"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "Aizvērt"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr ""
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr ""
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
 "<b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
 "href=\"%(apps_page_link)s\">mobile and desktop</a> apps:"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
 "href=\"%(getting_user_started_link)s\">getting started guide</a>!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2084,83 +1560,83 @@ msgid ""
 "Zulip</a>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
 "to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
 "desktop apps (%(apps_page_link)s):"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
 "(%(getting_user_started_link)s)!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
 "(%(getting_organization_started_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2168,32 +1644,32 @@ msgid ""
 "password for this account, please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "%(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 msgid "Verify your email address for your Zulip demo organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "<%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2201,113 +1677,113 @@ msgid ""
 "please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr "Pabeigt reģistrāciju"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
 "— we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
 "deactivated, and you will no longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr ""
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2315,22 +1791,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because your organization <a "
@@ -2338,8 +1814,8 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to <a "
@@ -2347,39 +1823,39 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr ""
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because your organization hides "
@@ -2387,81 +1863,74 @@ msgid ""
 "details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to hide "
 "message content in email notifications. See %(help_url)s for more details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr ""
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
 "organizations:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
 "organizations hosted by %(external_host)s:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
 "href=\"%(help_reset_password_link)s\">reset your password</a>."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
 "%(external_host)s."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2469,97 +1938,94 @@ msgid ""
 "to find your account."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
 "try another way to find your account (%(help_logging_in_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
 "communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr ""
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
 "-- the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
 "Zulip &mdash; the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
 "to ask %(referrer_name)s for another one."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2567,72 +2033,70 @@ msgid ""
 "productivity."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at <a href=\"mailto:%(email)s\">%(email)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
 "%(email)s\">Contact us</a> — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
 "#%(channel_name)s > %(topic_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2640,68 +2104,68 @@ msgid ""
 "preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails (<a href=\"%(url)s\">help</a>)."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2709,22 +2173,22 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2732,52 +2196,52 @@ msgid ""
 "immediately at <%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2785,31 +2249,31 @@ msgid ""
 "contact us immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2817,7 +2281,7 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -2825,25 +2289,25 @@ msgid ""
 "Zulip</a> to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
 "with you and share their unique perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -2851,7 +2315,7 @@ msgid ""
 "experience how a new chat app will help your team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -2859,148 +2323,148 @@ msgid ""
 "action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
 "team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
 "organizations like yours!"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3008,11 +2472,11 @@ msgid ""
 "about…?”"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3021,23 +2485,23 @@ msgid ""
 "href=\"%(move_channels_link)s\">move a topic to a different channel</a>."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3046,23 +2510,23 @@ msgid ""
 "(%(move_channels_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
 "%(email)s on %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3070,46 +2534,46 @@ msgid ""
 "href=\"%(help_link)s\">reactivate your account</a>."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
 "You can contact an organization administrator to reactivate your account."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3117,541 +2581,537 @@ msgid ""
 "have been voided."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
 "to %(upgrade_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip demo organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip demo organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Create a new organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "Izveidot jaunu organizāciju"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for <b>%(remote_server_hostname)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 msgid "Click the button below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for %(remote_server_hostname)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
 "management for <b>%(remote_realm_host)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
 "management for %(remote_realm_host)s."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the <a href=\"%(plans_link)s\">Zulip Community plan</a>."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
 "website</a>, we would really appreciate it!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
 msgstr ""
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
 "accounts for another email address</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr ""
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "Meklēt kontus"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr ""
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr ""
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr ""
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 msgid "Zulip Cloud"
 msgstr ""
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr ""
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr ""
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr ""
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr ""
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr ""
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr ""
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr ""
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr ""
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr ""
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr ""
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr ""
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr ""
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr ""
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr ""
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr ""
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr ""
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr ""
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr ""
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr ""
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr ""
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr ""
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr ""
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr ""
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr ""
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr ""
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr ""
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "Vēsture"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr ""
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr ""
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr ""
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr ""
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr ""
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 msgid "Bluesky"
 msgstr ""
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr ""
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr ""
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr ""
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 msgid ""
 "And hundreds more through <a href=\"/integrations/zapier\">Zapier</a> and <a "
 "href=\"/integrations/ifttt\">IFTTT</a>."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3659,7 +3119,7 @@ msgid ""
 "emails with your email domain."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3667,7 +3127,7 @@ msgid ""
 "disposable email addresses."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3675,24 +3135,24 @@ msgid ""
 "emails that contain \"+\"."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3700,7 +3160,7 @@ msgid ""
 "%(support_email)s\">contact Zulip support</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3708,89 +3168,89 @@ msgid ""
 "%(support_email)s\">contact this Zulip server's administrators</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
 "management for your Zulip server."
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr ""
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr ""
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr ""
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "Lietotājvārds"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr ""
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr ""
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr ""
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> because all Zulip Cloud licenses are in use."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -3799,42 +3259,40 @@ msgid ""
 "or misconfiguration."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 msgid "Demo organizations disabled"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -3842,22 +3300,21 @@ msgid ""
 "organization for more information."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -3865,44 +3322,42 @@ msgid ""
 "Zulip support</a> for assistance in resolving this issue."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
 "a> like Firefox, Chrome, and Edge."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 msgid "Finalize organization import"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 msgid "Organization import completed!"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -3910,54 +3365,53 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 msgid "Select your account"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create a new organization"
 msgid "Create new account"
 msgstr "Izveidot jaunu organizāciju"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr ""
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -3965,81 +3419,81 @@ msgid ""
 "have one yet."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 msgid "Self-hosting Zulip?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">log in to manage plans and billing.</a>"
 msgstr ""
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr ""
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
 msgstr ""
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr ""
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr ""
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr ""
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr ""
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr ""
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4047,7 +3501,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4056,57 +3510,57 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr ""
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4114,7 +3568,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4122,40 +3576,40 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4163,300 +3617,294 @@ msgid ""
 "away!"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
 "href=\"%(realm_url)s/#settings/notifications\">notification settings</a>."
 msgstr ""
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr ""
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr ""
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr ""
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr ""
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr ""
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr ""
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr ""
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 msgid "Cannot reactivate a deleted user"
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr ""
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr ""
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr ""
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr ""
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
 msgstr ""
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
 msgstr ""
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr ""
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr ""
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr ""
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr ""
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr ""
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr ""
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr ""
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr ""
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr ""
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr ""
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
 "{new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
 "{user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to resolve topics in this channel."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr ""
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr ""
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr ""
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr ""
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr ""
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
 "but there is no channel with that ID."
 msgstr ""
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4464,36 +3912,36 @@ msgid ""
 "it."
 msgstr ""
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
 "The channel exists but does not have any subscribers."
 msgstr ""
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr ""
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr ""
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr ""
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4501,107 +3949,105 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
 "authentication method."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr ""
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 msgid "Reminder could not be sent."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
 "the following error:"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr ""
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr ""
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr ""
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr ""
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr ""
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
 "**{old_policy}** to **{new_policy}**."
 msgstr ""
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -4610,51 +4056,49 @@ msgid ""
 "* **New**: {new_setting_description}\n"
 msgstr ""
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr ""
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr ""
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr ""
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr ""
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr ""
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr ""
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 msgstr ""
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr ""
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -4665,283 +4109,269 @@ msgid ""
 "{summary_line}"
 msgstr ""
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr ""
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr ""
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr ""
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr ""
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr ""
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr ""
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr ""
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr ""
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr ""
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr ""
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr ""
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
 "organization administrator to reactivate it."
 msgstr ""
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr ""
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr ""
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr ""
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr ""
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr ""
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr ""
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr ""
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
 "to register for accounts in this organization."
 msgstr ""
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr ""
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 msgid "Challenges are not enabled."
 msgstr ""
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr ""
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr ""
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "You're making too many attempts to sign in. Try again in "
 "{retry_after_string} or contact your organization administrator for help."
 msgstr ""
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
 msgstr ""
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr ""
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr ""
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr ""
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr ""
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr ""
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr ""
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr ""
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr ""
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr ""
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr ""
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr ""
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name can't be empty."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 msgid "Invalid channel folder ID"
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 msgid "Configure owner account email address."
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4950,69 +4380,69 @@ msgid ""
 "organization]({convert_demo}).\n"
 msgstr ""
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, python-brace-format
 msgid "{var_name} is not Base64 encoded"
 msgstr ""
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 msgid "Invalid `device_id`"
 msgstr ""
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr ""
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr ""
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr ""
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr ""
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr ""
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr ""
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr ""
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr ""
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr ""
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr ""
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5020,607 +4450,605 @@ msgid ""
 "{error_message}"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr ""
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr ""
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr ""
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr ""
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr ""
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr ""
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr ""
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr ""
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr ""
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr ""
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr ""
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr ""
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr ""
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
 msgstr ""
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr ""
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr ""
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr ""
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr ""
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr ""
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr ""
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr ""
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr ""
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 msgid "Must be a bot user"
 msgstr ""
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr ""
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr ""
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr ""
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
 "webhook; ignoring"
 msgstr ""
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr ""
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr ""
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr ""
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr ""
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} most recent messages in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr ""
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr ""
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
 msgstr ""
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr ""
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr ""
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr ""
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr ""
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr ""
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Find accounts"
 msgid "Atlassian account ID"
 msgstr "Meklēt kontus"
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 msgid "Behance username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 msgid "Bitbucket username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 msgid "Codeberg username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 msgid "Dribbble username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 msgid "Facebook username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "GitLab username"
 msgstr "Lietotājvārds"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 msgid "Instagram username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 msgid "Mastodon profile"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "Medium username"
 msgstr "Lietotājvārds"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 msgid "Pinterest username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "Reddit username"
 msgstr "Lietotājvārds"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 msgid "Snapchat username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 msgid "Threads username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "TikTok username"
 msgstr "Lietotājvārds"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "Twitch username"
 msgstr "Lietotājvārds"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "Lietotājvārds"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr ""
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr ""
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 msgid "Video calling"
 msgstr ""
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr ""
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr ""
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr ""
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr ""
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr ""
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr ""
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr ""
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr ""
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr ""
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr ""
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr ""
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr ""
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr ""
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr ""
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "{fullname} moderation"
 msgstr ""
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr ""
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr ""
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor_date' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr ""
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 msgid "Navigation view does not exist."
 msgstr ""
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5628,7 +5056,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5636,7 +5064,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5644,7 +5072,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5652,7 +5080,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5662,14 +5090,14 @@ msgid ""
 "a permanent organization]({convert_demo_organization_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
 "them in your [Inbox](/#inbox).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5677,7 +5105,7 @@ msgid ""
 "({navigation_tour_video_url}) for a quick app overview.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5692,14 +5120,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -5707,7 +5135,7 @@ msgid ""
 "and edit your [profile information](/help/edit-your-profile).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -5718,7 +5146,7 @@ msgid ""
 "experience in your [Preferences](#settings/preferences).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5729,7 +5157,7 @@ msgid ""
 "[Browse and subscribe to channels]({settings_link}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -5746,7 +5174,7 @@ msgid ""
 "discussed.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -5755,7 +5183,7 @@ msgid ""
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -5767,7 +5195,7 @@ msgid ""
 "times, and more.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5777,7 +5205,7 @@ msgid ""
 "or browse the [help center](/help/) to learn more!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5785,7 +5213,7 @@ msgid ""
 "get help, try one of the following messages: {bot_commands}\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5797,13 +5225,13 @@ msgid ""
 "({move_content_another_channel_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5817,12 +5245,11 @@ msgid ""
 "and above.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr ""
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -5830,14 +5257,14 @@ msgid ""
 "no matter how many other conversations are going on.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
 "conversations with unread messages.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -5845,7 +5272,7 @@ msgid ""
 "the `+` button next to its name.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -5853,13 +5280,13 @@ msgid ""
 "can we chat about…?”\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5867,7 +5294,7 @@ msgid ""
 "({format_message_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5887,125 +5314,125 @@ msgid ""
 "```\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
 "teammates.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
 "conversation.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr ""
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr ""
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr ""
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr ""
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 msgid "Invalid `push_key`"
 msgstr ""
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
@@ -6013,1197 +5440,1174 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr ""
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr ""
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr ""
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 msgid "Reminder does not exist"
 msgstr ""
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr ""
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr ""
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr ""
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr ""
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr ""
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr ""
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr ""
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr ""
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 msgid "You do not have permission to create new topics in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr ""
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr ""
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr ""
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr ""
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr ""
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr ""
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} does not have the expected format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr ""
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr ""
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr ""
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {user_group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr ""
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr ""
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr ""
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr ""
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr ""
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 msgid "Name must not be empty!"
 msgstr ""
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr ""
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr ""
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr ""
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr ""
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr ""
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr ""
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr ""
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr ""
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr ""
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr ""
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr ""
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr ""
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr ""
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr ""
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr ""
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr ""
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr ""
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr ""
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr ""
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr ""
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr ""
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr ""
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr ""
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr ""
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr ""
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr ""
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr ""
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr ""
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr ""
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr ""
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr ""
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr ""
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr ""
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr ""
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr ""
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr ""
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr ""
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: empty field name."
 msgstr ""
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr ""
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr ""
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 msgid "Example input does not match the linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in alternative URL template is not present in linkifier "
 "pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in linkifier pattern is not present in alternative URL "
 "template."
 msgstr ""
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr ""
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr ""
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr ""
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr ""
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr ""
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr ""
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr ""
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr ""
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr ""
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr ""
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr ""
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr ""
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "Publisks"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr ""
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr ""
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr ""
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr ""
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr ""
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr ""
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr ""
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr ""
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr ""
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr ""
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "Dalībnieks"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "Viesis"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr ""
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr ""
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr ""
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr ""
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 msgid "Failed to generate challenge"
 msgstr ""
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr ""
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr ""
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr ""
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr ""
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr ""
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr ""
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for use for user matching."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr ""
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr ""
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr ""
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr ""
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr ""
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr ""
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr ""
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr ""
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 msgid "Invitation already used or deactivated."
 msgstr ""
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr ""
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr ""
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr ""
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
 msgstr ""
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr ""
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr ""
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr ""
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr ""
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr ""
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr ""
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr ""
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr ""
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 msgid "Message reporting is not enabled in this organization."
 msgstr ""
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr ""
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr ""
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr ""
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr ""
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr ""
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr ""
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr ""
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr ""
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr ""
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 msgid "Navigation view already exists."
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7211,856 +6615,854 @@ msgid ""
 "later. Is this a good time?\n"
 msgstr ""
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr ""
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr ""
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 msgid "You do not have permission to manage plans and billing."
 msgstr ""
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr ""
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr ""
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr ""
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr ""
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr ""
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr ""
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr ""
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr ""
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr ""
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr ""
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr ""
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr ""
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr ""
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr ""
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr ""
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr ""
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr ""
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr ""
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr ""
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Invalid character in language: {character}"
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Language '{language}' is not allowed."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr ""
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr ""
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 msgid "Importing messages…"
 msgstr ""
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 msgid "Your name"
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr ""
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr ""
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr ""
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr ""
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr ""
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr ""
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr ""
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr ""
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr ""
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr ""
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr ""
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr ""
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr ""
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
 "**"
 msgstr ""
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr ""
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr ""
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr ""
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr ""
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr ""
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr ""
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr ""
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr ""
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr ""
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr ""
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr ""
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr ""
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr ""
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 msgstr ""
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr ""
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr ""
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
 "subgroups."
 msgstr ""
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr ""
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr ""
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr ""
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr ""
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr ""
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr ""
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr ""
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr ""
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr ""
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr ""
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 msgid "User is not allowed to delete other user's messages."
 msgstr ""
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr ""
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr ""
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 msgid ""
 "Can't change bot email until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 msgstr ""
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 msgid "Email address already in use"
 msgstr ""
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr ""
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr ""
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr ""
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 msgstr ""
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr ""
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr ""
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr ""
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr ""
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr ""
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} access token"
 msgstr ""
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} call"
 msgstr ""
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} credentials have not been configured"
 msgstr ""
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} credentials"
 msgstr ""
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr ""
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error authenticating to the {provider_name} server"
 msgstr ""
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr ""
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} session identifier"
 msgstr ""
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr ""
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} public room."
 msgstr ""
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr ""
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{full_name}'s Zulip room"
 msgstr ""
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr ""
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr ""
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr ""
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr ""
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr ""
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr ""
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr ""
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr ""
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr ""
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
 "({export_settings_link})."
 msgstr ""
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr ""
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr ""
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr ""
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr ""
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr ""
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr ""
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr ""
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr ""
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr ""
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr ""
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr ""
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr ""
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
 "try again later or reach out to {support_email} for assistance."
 msgstr ""
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr ""
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr ""
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr ""
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr ""
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
 "server: {reason}"
 msgstr ""
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr ""
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr ""
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr ""
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr ""
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr ""
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr ""
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr ""
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr ""
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 msgid "Missing idp param"
 msgstr ""
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr ""
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr ""

--- a/locale/ml/LC_MESSAGES/django.po
+++ b/locale/ml/LC_MESSAGES/django.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 19:51+0000\n"
 "Last-Translator: Alex Vandiver <alexmv@zulip.com>\n"
 "Language-Team: Malayalam <https://hosted.weblate.org/projects/zulip/django/"
@@ -21,51 +21,51 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr ""
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr ""
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr ""
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr ""
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr ""
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr ""
 "അനലിറ്റിക്സ് ഡാറ്റയൊന്നും ലഭ്യമല്ല. ദയവായി നിങ്ങളുടെ സെർവർ അഡ്മിനിസ്ട്രേറ്ററെ ബന്ധപ്പെടുക."
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -74,7 +74,7 @@ msgid ""
 "users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -82,7 +82,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than one user to join."
 msgstr ""
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -90,7 +90,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than two users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -98,7 +98,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than three users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -107,148 +107,147 @@ msgid ""
 "({billing_page_link}) is greater than the current number of users."
 msgstr ""
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr ""
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr ""
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
 "(minimum {min_licenses})."
 msgstr ""
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
 "page. To complete the upgrade, please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr ""
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr ""
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr ""
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr ""
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr ""
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr ""
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
 msgstr ""
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
 msgstr ""
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
 "licenses."
 msgstr ""
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
 "billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr ""
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr ""
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr ""
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -258,100 +257,97 @@ msgid ""
 "we would really appreciate it!"
 msgstr ""
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
 "{support_email}"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr ""
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr ""
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr ""
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
 "%(support_email)s\">contact support</a>."
 msgstr ""
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr ""
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
 msgstr ""
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr ""
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
 msgstr ""
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr ""
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr ""
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
 msgstr ""
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -359,289 +355,270 @@ msgid ""
 "a> with any questions."
 msgstr ""
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
 "a> for support."
 msgstr ""
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
 "href=\"%(troubleshooting_url)s\">Zulip server troubleshooting guide</a>."
 msgstr ""
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr ""
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr ""
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr ""
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr ""
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr ""
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr ""
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr ""
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr ""
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr ""
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr ""
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr ""
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr ""
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr ""
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "ഉപയോക്താക്കൾ"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr ""
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr ""
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr ""
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr ""
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr ""
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr ""
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr ""
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr ""
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr ""
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr ""
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr ""
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr ""
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "ബോട്ടുകൾ"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr ""
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr ""
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr ""
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
 "%(old_email_html_tag)s to %(new_email_html_tag)s"
 msgstr ""
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr ""
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
 msgstr ""
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "റദ്ദാക്കുക"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr ""
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr ""
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -652,19 +629,19 @@ msgid ""
 "server."
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -672,788 +649,297 @@ msgid ""
 "%(support_email)s'>contact support</a> with any questions."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, python-format
 msgid "You can try again in %(retry_after_string)s."
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr ""
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr ""
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr ""
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr ""
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr ""
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr ""
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr ""
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr ""
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr ""
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr ""
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr ""
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr ""
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr ""
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr ""
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 msgid "Zulip for open source"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 msgid "Message with code"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
 msgstr ""
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 msgid "Get started"
 msgstr ""
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
 "continue."
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "ഈമെയിൽ"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1461,78 +947,77 @@ msgid ""
 "from Zulip."
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
 msgstr ""
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr ""
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr ""
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr ""
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr ""
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr ""
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr ""
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr ""
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
 msgstr ""
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1540,210 +1025,203 @@ msgid ""
 "href=\"%(doc_url)s\">documentation</a>."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, python-format
 msgid "No account found for %(email)s."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Create a new organization"
 msgid "Try Zulip in a demo organization"
 msgstr "ഒരു പുതിയ ഓർഗനൈസേഷൻ സൃഷ്ടിക്കുക"
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 msgid "Try Zulip"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "ഒരു പുതിയ ഓർഗനൈസേഷൻ സൃഷ്ടിക്കുക"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid "Import chat history?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "ഓർ‌ഗനൈസേഷൻ‌ URL"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "അഥവാ"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "സൈനപ്പ്"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "ലൊഗിൻ"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1751,123 +1229,122 @@ msgid ""
 "noreferrer\">after you join</a>."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "മാറ്റുക"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "പേര്"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "രഹസ്യവാക്ക്"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr "രഹസ്യവാക്കിന്റെ ബലം"
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr ""
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">Terms of Service</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr "നിഷ്ക്രീയമാക്കിയ സംഘടന"
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr ""
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -1875,45 +1352,45 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 msgid ""
 "This organization has been deactivated, and all organization data has been "
 "deleted."
 msgstr ""
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
 "inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
 "administrators</a> to inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 msgid "This organization has been deactivated."
 msgstr ""
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
 "%(support_email)s\">contact Zulip support</a> to reactivate it."
 msgstr ""
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -1921,165 +1398,164 @@ msgid ""
 "reactivate it."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "പകർത്തുക"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "നടത്തിപ്പുകാർ"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "സാധാരണ ഉപയോക്താക്കൾ"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "അടയ്‌ക്കുക"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr ""
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr ""
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
 "<b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
 "href=\"%(apps_page_link)s\">mobile and desktop</a> apps:"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
 "href=\"%(getting_user_started_link)s\">getting started guide</a>!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2087,83 +1563,83 @@ msgid ""
 "Zulip</a>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
 "to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
 "desktop apps (%(apps_page_link)s):"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
 "(%(getting_user_started_link)s)!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
 "(%(getting_organization_started_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2171,32 +1647,32 @@ msgid ""
 "password for this account, please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "%(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 msgid "Verify your email address for your Zulip demo organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "<%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2204,113 +1680,113 @@ msgid ""
 "please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
 "— we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
 "deactivated, and you will no longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr ""
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2318,22 +1794,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because your organization <a "
@@ -2341,8 +1817,8 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to <a "
@@ -2350,39 +1826,39 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr ""
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because your organization hides "
@@ -2390,81 +1866,74 @@ msgid ""
 "details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to hide "
 "message content in email notifications. See %(help_url)s for more details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr ""
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
 "organizations:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
 "organizations hosted by %(external_host)s:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
 "href=\"%(help_reset_password_link)s\">reset your password</a>."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
 "%(external_host)s."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2472,97 +1941,94 @@ msgid ""
 "to find your account."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
 "try another way to find your account (%(help_logging_in_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
 "communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr ""
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
 "-- the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
 "Zulip &mdash; the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
 "to ask %(referrer_name)s for another one."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2570,72 +2036,70 @@ msgid ""
 "productivity."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at <a href=\"mailto:%(email)s\">%(email)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
 "%(email)s\">Contact us</a> — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
 "#%(channel_name)s > %(topic_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2643,68 +2107,68 @@ msgid ""
 "preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails (<a href=\"%(url)s\">help</a>)."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2712,22 +2176,22 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2735,52 +2199,52 @@ msgid ""
 "immediately at <%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2788,31 +2252,31 @@ msgid ""
 "contact us immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2820,7 +2284,7 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -2828,25 +2292,25 @@ msgid ""
 "Zulip</a> to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
 "with you and share their unique perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -2854,7 +2318,7 @@ msgid ""
 "experience how a new chat app will help your team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -2862,148 +2326,148 @@ msgid ""
 "action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
 "team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
 "organizations like yours!"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3011,11 +2475,11 @@ msgid ""
 "about…?”"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3024,23 +2488,23 @@ msgid ""
 "href=\"%(move_channels_link)s\">move a topic to a different channel</a>."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3049,23 +2513,23 @@ msgid ""
 "(%(move_channels_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
 "%(email)s on %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3073,46 +2537,46 @@ msgid ""
 "href=\"%(help_link)s\">reactivate your account</a>."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
 "You can contact an organization administrator to reactivate your account."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3120,541 +2584,537 @@ msgid ""
 "have been voided."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
 "to %(upgrade_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip demo organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip demo organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Deactivated organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "നിഷ്ക്രീയമാക്കിയ സംഘടന"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for <b>%(remote_server_hostname)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 msgid "Click the button below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for %(remote_server_hostname)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
 "management for <b>%(remote_realm_host)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
 "management for %(remote_realm_host)s."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the <a href=\"%(plans_link)s\">Zulip Community plan</a>."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
 "website</a>, we would really appreciate it!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
 msgstr ""
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
 "accounts for another email address</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr "ഈമെയിൽ വിലാസം"
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "അക്കൗണ്ടുകൾ കണ്ടെത്തുക"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr ""
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr ""
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr ""
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 msgid "Zulip Cloud"
 msgstr ""
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr ""
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr ""
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr ""
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr ""
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr ""
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr ""
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr ""
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr ""
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr ""
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr ""
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr ""
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr ""
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr ""
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr ""
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr ""
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr ""
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr ""
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr ""
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr ""
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr ""
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr ""
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr ""
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr ""
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr ""
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr ""
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr ""
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "ചരിത്രം"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr ""
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr ""
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr ""
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr ""
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr ""
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 msgid "Bluesky"
 msgstr ""
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr ""
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr "സേവന നിബന്ധനകൾ"
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr ""
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 msgid ""
 "And hundreds more through <a href=\"/integrations/zapier\">Zapier</a> and <a "
 "href=\"/integrations/ifttt\">IFTTT</a>."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3662,7 +3122,7 @@ msgid ""
 "emails with your email domain."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3670,7 +3130,7 @@ msgid ""
 "disposable email addresses."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3678,24 +3138,24 @@ msgid ""
 "emails that contain \"+\"."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3703,7 +3163,7 @@ msgid ""
 "%(support_email)s\">contact Zulip support</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3711,89 +3171,89 @@ msgid ""
 "%(support_email)s\">contact this Zulip server's administrators</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
 "management for your Zulip server."
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr ""
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr ""
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr ""
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "യൂസർനെയിം"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr ""
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr ""
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr ""
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> because all Zulip Cloud licenses are in use."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -3802,42 +3262,40 @@ msgid ""
 "or misconfiguration."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 msgid "Demo organizations disabled"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -3845,22 +3303,21 @@ msgid ""
 "organization for more information."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -3868,46 +3325,44 @@ msgid ""
 "Zulip support</a> for assistance in resolving this issue."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
 "a> like Firefox, Chrome, and Edge."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Deactivated organization"
 msgid "Finalize organization import"
 msgstr "നിഷ്ക്രീയമാക്കിയ സംഘടന"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 msgid "Organization import completed!"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -3915,54 +3370,53 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 msgid "Select your account"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create a new organization"
 msgid "Create new account"
 msgstr "ഒരു പുതിയ ഓർഗനൈസേഷൻ സൃഷ്ടിക്കുക"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr ""
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr "അടുത്തത്"
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -3970,81 +3424,81 @@ msgid ""
 "have one yet."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 msgid "Self-hosting Zulip?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">log in to manage plans and billing.</a>"
 msgstr ""
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr "രഹസ്യവാക്ക് പുനഃക്രമീകരിക്കുക"
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
 msgstr ""
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "രഹസ്യവാക്ക് ഉറപ്പിക"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr ""
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr ""
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr ""
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr ""
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr ""
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4052,7 +3506,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4061,57 +3515,57 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr ""
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4119,7 +3573,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4127,40 +3581,40 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4168,300 +3622,294 @@ msgid ""
 "away!"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
 "href=\"%(realm_url)s/#settings/notifications\">notification settings</a>."
 msgstr ""
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr ""
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr ""
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr ""
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr ""
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr ""
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr ""
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr ""
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 msgid "Cannot reactivate a deleted user"
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr ""
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr ""
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr ""
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr ""
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
 msgstr ""
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
 msgstr ""
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr ""
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr ""
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr ""
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr ""
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr ""
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr ""
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr ""
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr ""
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr ""
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr ""
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
 "{new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
 "{user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to resolve topics in this channel."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr ""
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr ""
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr ""
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr ""
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr ""
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
 "but there is no channel with that ID."
 msgstr ""
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4469,36 +3917,36 @@ msgid ""
 "it."
 msgstr ""
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
 "The channel exists but does not have any subscribers."
 msgstr ""
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr ""
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr ""
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr ""
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4506,107 +3954,105 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
 "authentication method."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr ""
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 msgid "Reminder could not be sent."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
 "the following error:"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr ""
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr ""
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr ""
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr ""
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr ""
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
 "**{old_policy}** to **{new_policy}**."
 msgstr ""
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -4615,51 +4061,49 @@ msgid ""
 "* **New**: {new_setting_description}\n"
 msgstr ""
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr ""
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr ""
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr ""
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr ""
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr ""
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr ""
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 msgstr ""
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr ""
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -4670,283 +4114,269 @@ msgid ""
 "{summary_line}"
 msgstr ""
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr ""
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr ""
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr ""
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr ""
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr ""
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr ""
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr ""
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr ""
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr ""
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr ""
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr ""
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
 "organization administrator to reactivate it."
 msgstr ""
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr ""
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr ""
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr ""
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr ""
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr ""
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr ""
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr ""
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
 "to register for accounts in this organization."
 msgstr ""
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr ""
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 msgid "Challenges are not enabled."
 msgstr ""
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "പുതിയ രഹസ്യവാക്ക്"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr ""
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "You're making too many attempts to sign in. Try again in "
 "{retry_after_string} or contact your organization administrator for help."
 msgstr ""
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
 msgstr ""
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr ""
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr ""
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr ""
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr ""
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr ""
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr ""
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr ""
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr ""
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr ""
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr ""
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr ""
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name can't be empty."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 msgid "Invalid channel folder ID"
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 msgid "Configure owner account email address."
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4955,69 +4385,69 @@ msgid ""
 "organization]({convert_demo}).\n"
 msgstr ""
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, python-brace-format
 msgid "{var_name} is not Base64 encoded"
 msgstr ""
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 msgid "Invalid `device_id`"
 msgstr ""
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr ""
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr ""
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr ""
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr ""
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr ""
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr ""
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr ""
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr ""
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr ""
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr ""
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5025,607 +4455,605 @@ msgid ""
 "{error_message}"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr ""
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr ""
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr ""
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr ""
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr ""
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr ""
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr ""
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr ""
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr ""
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr ""
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr ""
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr ""
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr ""
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
 msgstr ""
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr ""
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr ""
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr ""
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr ""
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr ""
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr ""
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr ""
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr ""
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 msgid "Must be a bot user"
 msgstr ""
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr ""
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr ""
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr ""
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
 "webhook; ignoring"
 msgstr ""
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr ""
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr ""
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr ""
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr ""
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} most recent messages in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr ""
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr ""
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
 msgstr ""
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr ""
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr ""
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr ""
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr ""
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr ""
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Find accounts"
 msgid "Atlassian account ID"
 msgstr "അക്കൗണ്ടുകൾ കണ്ടെത്തുക"
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 msgid "Behance username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 msgid "Bitbucket username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 msgid "Codeberg username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 msgid "Dribbble username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 msgid "Facebook username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "GitLab username"
 msgstr "യൂസർനെയിം"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 msgid "Instagram username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 msgid "Mastodon profile"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "Medium username"
 msgstr "യൂസർനെയിം"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 msgid "Pinterest username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "Reddit username"
 msgstr "യൂസർനെയിം"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 msgid "Snapchat username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 msgid "Threads username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "TikTok username"
 msgstr "യൂസർനെയിം"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "Twitch username"
 msgstr "യൂസർനെയിം"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "യൂസർനെയിം"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr ""
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr ""
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 msgid "Video calling"
 msgstr ""
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr ""
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr ""
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr ""
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr ""
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr ""
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr ""
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr ""
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr ""
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr ""
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr ""
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr ""
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr ""
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr ""
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr ""
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "{fullname} moderation"
 msgstr ""
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr ""
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr ""
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor_date' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr ""
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 msgid "Navigation view does not exist."
 msgstr ""
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5633,7 +5061,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5641,7 +5069,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5649,7 +5077,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5657,7 +5085,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5667,14 +5095,14 @@ msgid ""
 "a permanent organization]({convert_demo_organization_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
 "them in your [Inbox](/#inbox).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5682,7 +5110,7 @@ msgid ""
 "({navigation_tour_video_url}) for a quick app overview.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5697,14 +5125,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -5712,7 +5140,7 @@ msgid ""
 "and edit your [profile information](/help/edit-your-profile).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -5723,7 +5151,7 @@ msgid ""
 "experience in your [Preferences](#settings/preferences).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5734,7 +5162,7 @@ msgid ""
 "[Browse and subscribe to channels]({settings_link}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -5751,7 +5179,7 @@ msgid ""
 "discussed.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -5760,7 +5188,7 @@ msgid ""
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -5772,7 +5200,7 @@ msgid ""
 "times, and more.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5782,7 +5210,7 @@ msgid ""
 "or browse the [help center](/help/) to learn more!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5790,7 +5218,7 @@ msgid ""
 "get help, try one of the following messages: {bot_commands}\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5802,13 +5230,13 @@ msgid ""
 "({move_content_another_channel_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5822,12 +5250,11 @@ msgid ""
 "and above.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr ""
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -5835,14 +5262,14 @@ msgid ""
 "no matter how many other conversations are going on.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
 "conversations with unread messages.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -5850,7 +5277,7 @@ msgid ""
 "the `+` button next to its name.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -5858,13 +5285,13 @@ msgid ""
 "can we chat about…?”\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5872,7 +5299,7 @@ msgid ""
 "({format_message_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5892,1322 +5319,1299 @@ msgid ""
 "```\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
 "teammates.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
 "conversation.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr ""
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr ""
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr ""
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr ""
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 msgid "Invalid `push_key`"
 msgstr ""
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr ""
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr ""
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr ""
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 msgid "Reminder does not exist"
 msgstr ""
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr ""
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr ""
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr ""
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr ""
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr ""
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr ""
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr ""
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr ""
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 msgid "You do not have permission to create new topics in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr ""
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr ""
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr ""
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr ""
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr ""
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr ""
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} does not have the expected format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr ""
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr ""
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr ""
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {user_group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr ""
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr ""
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr ""
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr ""
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr ""
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 msgid "Name must not be empty!"
 msgstr ""
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr ""
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr ""
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr ""
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr ""
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr ""
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr ""
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr ""
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr ""
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr ""
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr ""
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr ""
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr ""
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr ""
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr ""
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr ""
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr ""
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr ""
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr ""
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr ""
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr ""
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr ""
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr ""
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr ""
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr ""
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr ""
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr ""
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr ""
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr ""
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr ""
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr ""
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr ""
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr ""
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr ""
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr ""
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr ""
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr ""
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr ""
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: empty field name."
 msgstr ""
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr ""
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr ""
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 msgid "Example input does not match the linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in alternative URL template is not present in linkifier "
 "pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in linkifier pattern is not present in alternative URL "
 "template."
 msgstr ""
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr ""
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "നിങ്ങൾക്ക് വേണ്ട ഇമോജി"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr ""
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr ""
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr ""
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr ""
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr ""
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr ""
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr ""
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr ""
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr ""
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr ""
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr ""
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr ""
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr ""
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr ""
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr ""
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr ""
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr ""
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr ""
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr ""
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr ""
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr ""
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr ""
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr ""
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr ""
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr ""
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr ""
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr ""
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 msgid "Failed to generate challenge"
 msgstr ""
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr ""
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr ""
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr ""
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr ""
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr ""
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr ""
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for use for user matching."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr ""
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr ""
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr ""
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr ""
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr ""
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr ""
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr ""
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr ""
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 msgid "Invitation already used or deactivated."
 msgstr ""
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr ""
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr ""
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr ""
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
 msgstr ""
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr ""
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr ""
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr ""
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr ""
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr ""
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr ""
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr ""
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr ""
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 msgid "Message reporting is not enabled in this organization."
 msgstr ""
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr ""
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr ""
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr ""
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr ""
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr ""
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr ""
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr ""
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr ""
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr ""
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 msgid "Navigation view already exists."
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7215,557 +6619,555 @@ msgid ""
 "later. Is this a good time?\n"
 msgstr ""
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr ""
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr ""
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 msgid "You do not have permission to manage plans and billing."
 msgstr ""
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr ""
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr ""
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr ""
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr ""
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr ""
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr ""
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr ""
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr ""
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr ""
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr ""
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr ""
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr ""
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr ""
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr ""
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr ""
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr ""
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr ""
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr ""
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr ""
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Invalid character in language: {character}"
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Language '{language}' is not allowed."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr ""
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr ""
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 msgid "Importing messages…"
 msgstr ""
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 msgid "Your name"
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr ""
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr ""
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr ""
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr ""
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr ""
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr ""
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr ""
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr ""
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr ""
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr ""
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr ""
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr ""
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr ""
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
 "**"
 msgstr ""
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr ""
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr ""
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr ""
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr ""
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr ""
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr ""
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr ""
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr ""
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr ""
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr ""
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr ""
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr ""
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr ""
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 msgstr ""
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr ""
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr ""
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
 "subgroups."
 msgstr ""
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr ""
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr ""
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr ""
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr ""
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr ""
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr ""
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr ""
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr ""
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr ""
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr ""
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 msgid "User is not allowed to delete other user's messages."
 msgstr ""
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr ""
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr ""
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "No analytics data available. Please contact your server administrator."
@@ -7775,302 +7177,302 @@ msgid ""
 msgstr ""
 "അനലിറ്റിക്സ് ഡാറ്റയൊന്നും ലഭ്യമല്ല. ദയവായി നിങ്ങളുടെ സെർവർ അഡ്മിനിസ്ട്രേറ്ററെ ബന്ധപ്പെടുക."
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 #, fuzzy
 #| msgid "Email address"
 msgid "Email address already in use"
 msgstr "ഈമെയിൽ വിലാസം"
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr ""
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr ""
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr ""
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 msgstr ""
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr ""
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr ""
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr ""
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr ""
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr ""
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} access token"
 msgstr ""
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} call"
 msgstr ""
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} credentials have not been configured"
 msgstr ""
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} credentials"
 msgstr ""
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr ""
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error authenticating to the {provider_name} server"
 msgstr ""
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr ""
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} session identifier"
 msgstr ""
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr ""
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} public room."
 msgstr ""
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr ""
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{full_name}'s Zulip room"
 msgstr ""
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr ""
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr ""
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr ""
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr ""
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr ""
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr ""
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr ""
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr ""
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr ""
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
 "({export_settings_link})."
 msgstr ""
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr ""
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr ""
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr ""
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr ""
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr ""
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr ""
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr ""
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr ""
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr ""
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr ""
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr ""
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr ""
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
 "try again later or reach out to {support_email} for assistance."
 msgstr ""
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr ""
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr ""
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr ""
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr ""
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
 "server: {reason}"
 msgstr ""
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr ""
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr ""
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr ""
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr ""
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr ""
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr ""
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr ""
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr ""
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 msgid "Missing idp param"
 msgstr ""
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr ""
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr ""

--- a/locale/mn/LC_MESSAGES/django.po
+++ b/locale/mn/LC_MESSAGES/django.po
@@ -18,7 +18,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 19:42+0000\n"
 "Last-Translator: Alex Vandiver <alexmv@zulip.com>\n"
 "Language-Team: Mongolian <https://hosted.weblate.org/projects/zulip/django/"
@@ -30,51 +30,51 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "Зочин хэрэглэгчдэд зөвшөөрөгдөөгүй"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "Буруу бүлэг"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr ""
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr ""
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr "Хувийн чат"
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr "Групп хувийн чат"
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr ""
 "Эхлэх цаг дуусах хугацаанаас хожуу байна. Эхлэх: {start}, Дуусах: {end}"
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr "Аналитик мэдээлэл байхгүй. Серверийн админтайгаа холбогдоно уу."
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -86,7 +86,7 @@ msgstr ""
 "эсвэл [идэвхгүй хэрэглэгчээ хасаж]({deactivate_user_help_page_link}) шинэ "
 "хэрэглэгч үүсгэх эрхээ нээнэ үү."
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -97,7 +97,7 @@ msgstr ""
 "({billing_page_link}) эсвэл [идэвхгүй хэрэглэгчээ хасаж ]"
 "({deactivate_user_help_page_link}) шинэ хэрэглэгч нэмэх эрхээ нээнэ үү."
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -108,7 +108,7 @@ msgstr ""
 "({billing_page_link}) эсвэл [идэвхгүй хэрэглэгчээ хасаж ]"
 "({deactivate_user_help_page_link}) шинэ хэрэглэгч нэмэх эрхээ нээнэ үү."
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -119,7 +119,7 @@ msgstr ""
 "({billing_page_link}) эсвэл [идэвхгүй хэрэглэгчээ хасаж ]"
 "({deactivate_user_help_page_link}) шинэ хэрэглэгч нэмэх эрхээ нээнэ үү."
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -128,77 +128,76 @@ msgid ""
 "({billing_page_link}) is greater than the current number of users."
 msgstr ""
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr ""
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr ""
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
 "(minimum {min_licenses})."
 msgstr ""
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
 "page. To complete the upgrade, please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr ""
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr "{brand} төгсгөл нь {last4}"
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr "Тодорхойгүй төлбөрийн хэлбэр байна. {email} холбогдоно уу."
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr "Алдаа гарлаа. {email} холбогдоно уу."
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "Алдаа гарлаа. Хуудсаа дахин уншуулна уу."
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr "Алдаа гарлаа. Хэсэг хугацаанд хүлээж байгаад дахин оролдоно уу."
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr ""
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
@@ -206,16 +205,16 @@ msgstr ""
 "Үйлчилгээний ангилал шинэчлэх боломжгүй. Хугацаа нь дууссаны дараа шинэ "
 "ангилал идэвхжүүлэх боломжтой."
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr "Үйлчилгээний ангилал шинэчлэх боломжгүй. Хугацаа нь дууссан байна."
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
@@ -223,23 +222,23 @@ msgstr ""
 "Лицензүүдийг гараар шинэчлэх боломжгүй. Таны план автомат лицензийн "
 "менежмент дээр байна."
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr "Таны үйлчилгээ {licenses} лицензээр сунгагдах боломжтой."
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr "Та одоогийн төлбөрийн хугацаандаа лицензийг бууруулах боломжгүй."
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
 msgstr ""
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
@@ -248,34 +247,34 @@ msgstr ""
 "Таны үйлчилгээ {licenses_at_next_renewal}  лицензээр автомат сунгалт "
 "хийгдэхээр байна."
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
 "billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr "Өөрчлөх зүйл алга."
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr "Энэ байгууллагад үйлчлүүлэгч байхгүй!"
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr "Холболт салсан"
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr "Төлбөрийн зориулалт олдсонгүй"
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr ""
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -290,100 +289,97 @@ msgstr ""
 "Хэрэв та {begin_link}Оффис чат-ийг вэбсайтдаа байршуулвал{end_link} бид "
 "талархах болно!"
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
 "{support_email}"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr ""
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "Алдаа"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr "Тухайн хуудас олдсонгүй. (404)"
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
 "%(support_email)s\">contact support</a>."
 msgstr ""
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr ""
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
 msgstr ""
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr ""
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
 msgstr ""
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr "Энэ аргыг зөвшөөрөөгүй (405)"
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr "Сервер дээрх алдаа"
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
 msgstr ""
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -391,13 +387,13 @@ msgid ""
 "a> with any questions."
 msgstr ""
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, fuzzy, python-format
 #| msgid ""
 #| "If you have any questions, please contact this Zulip server's "
@@ -409,143 +405,141 @@ msgstr ""
 "Хэрвээ таньд асуух зүйл байвал Оффис чат техникийн албатай %(support_email)s "
 "хаягаар холбогдоно уу."
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
 "href=\"%(troubleshooting_url)s\">Zulip server troubleshooting guide</a>."
 msgstr ""
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr "%(target_name)sшинжлэх | Оффис чат"
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr "Байгууллагыг үүсгэснээс хойш 24 цагийн дараа аналитик бүрэн боломжтой."
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr "%(target_name)s-д зориулсан Zulip аналитик"
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr "Бүлгийн нэмэлт"
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr "Нийт хэрэглэгчид"
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr "Сүүлийн 15 өдөр идэвхтэй байгаа хэрэглэгчид"
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr "Харилцагчдийн тоо"
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr "Нийт бичсэн чатын тоо"
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr "Сүүлийн 30 өдөр бичсэн нийт чатын тоо"
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr "Баримтын багтаамжын хэрэглээ"
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "Идэвхтэй хэрэглэгчид"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr "Өдөр тутмын идэвхтэй үйл ажиллагаа"
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr "15 хоногийн идэвхтэй"
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr "Бүх хэрэглэгчид"
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "Хэрэглэгчид"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr "Хүлээн авагчийн төрлөөр илгээсэн зурвасууд"
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "Би"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "Хүн бүр"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "Сүүлийн долоо хоног"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "Сүүлийн сар"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "Сүүлийн жил"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "Бүх цаг"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr "Цаг хугацааны явцад илгээсэн мессежүүд"
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "Өдөр бүр"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "Долоо хоног бүр"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr "Нэгдсэн"
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "Humans"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "Ботууд"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr "Мессежүүд цаг хугацааны явцад уншина"
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr "Хэрэглэгчээс илгээгдсэн мессежүүд"
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr "Сүүлийн шинэчлэл"
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
@@ -553,15 +547,15 @@ msgstr ""
 "Бүх графикуудын бүрэн шинэчлэлт өдөрт нэг удаа хийгддэг. \"Цаг хугацааны "
 "туршид илгээсэн мессеж\" графикийг цагт нэг удаа шинэчилдэг."
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr "Имэйл өөрчлөгдсөн"
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr "Имэйл өөрчлөгдсөн!"
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
@@ -570,50 +564,50 @@ msgstr ""
 "Энэ нь таны Zulip аккаунтын имэйл хаяг %(old_email_html_tag)s-аас "
 "%(new_email_html_tag)s болж өөрчлөгдсөнийг мэдэгдэж байна"
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr "Имэйл хаягыг баталгаажуулж байна"
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr "Баталгаажуулах холбоос байхгүй байна"
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr "Бид таны баталгаажуулах линкийг энэхүү систем дээрээс олсонгүй."
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr ""
 "Энэхүү баталгаажуулах линкийн хугацаа дууссан эсвэл идэвхгүй болсон байна"
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr ""
 "Энэхүү баталгаажуулах линкийн хугацаа дууссан эсвэл идэвхгүй болсон байна."
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr "Шинэ линк авахын тул байгууллагын админтай холбогдоно уу."
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr "Энэхүү баталгаажуулах линк эвдэрсэн байна"
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr "Энэхүү баталгаажуулах линк эвдэрсэн байна."
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
@@ -622,72 +616,55 @@ msgstr ""
 "хуудастай тулгарсан хэвээр байгаа бол энэ нь бидний буруу байж магадгүй юм. "
 "Биднийг уучлаарай."
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr "Төлбөр"
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr "Модалыг хаах"
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "Цуцлах"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr "Баталгаажуулалт"
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr ""
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr "Төлбөрийн мэдээлэл"
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -698,19 +675,19 @@ msgid ""
 "server."
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -718,736 +695,246 @@ msgid ""
 "%(support_email)s'>contact support</a> with any questions."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr "Тогтоосон лимит хэтэрсэн байна"
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr "Тогтоосон лимит хэтэрсэн байна."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, fuzzy, python-format
 #| msgid "You can try again in %(retry_after)s seconds."
 msgid "You can try again in %(retry_after_string)s."
 msgstr "%(retry_after)s секунтын дараа дахин оролдох боломжтой."
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr "Багц дээшлүүлэх"
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr ""
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr "Олон нийтийн лавлахыг нээх"
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr "Ангилалаар нь шүүх"
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "Бүгд"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr "Ангиллууд"
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr ""
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr "Zulip хөгжүүлэлт"
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr "Хэрэглэгчээр нэгдэх"
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr "Self-hoster-оор нэгдэх"
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr "Contributor-оор нэгдэх"
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "Байгууллага үүсгэх"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr ""
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr "Бидний Оффис чат"
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr "Ивээн тэтгэгч болох хүсэлт илгээх"
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr "Сургалтын үнэ"
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr "Үнэ харах"
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr "Бизнесд зориулсан Zulip"
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Zulip guide for open-source projects"
 msgid "Zulip for open source"
 msgstr "Open-source төсөлд зориулсан Оффис чатын гарын авлага"
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Create your Zulip organization"
 msgid "Screenshot of Zulip conversation"
 msgstr "Зулип групп үүсгэ"
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Messages sent over time"
 msgid "Message with code"
 msgstr "Цаг хугацааны явцад илгээсэн мессежүүд"
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr "Холбоос"
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr "Тусламж авах"
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr "Хэнээс"
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr "Байгууллага"
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr "Гарчиг"
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr "Мэссэж"
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr "Илгээх"
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr "Бидэнтэй холбогдсонд баярлалаа"
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr "Бидэнтэй холбогдсонд баярлалаа!"
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr "Бид удахгүй таньтай холбогдох болно."
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
@@ -1455,13 +942,13 @@ msgstr ""
 "Та байнга асуудаг асуултуудын хариултыг дараах хэсгээс олох боломжтой <a "
 "href=\"/help/\">Оффис чат тусламжийн төв</a>."
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 #, fuzzy
 #| msgid "Getting started"
 msgid "Get started"
 msgstr "Эхлэх"
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
@@ -1471,49 +958,48 @@ msgstr ""
 "Үргэлжлүүлэхийн тулд <a href=\"https://zulip.com/policies/terms\">Zulip "
 "үйлчилгээний нөхцөлийг</a> хүлээн зөвшөөрнө үү."
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr "Эсвэл нөөц утасныхаа аль нэгийг ашиглана уу:"
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr "Та нөөц токен ашиглаж болно:"
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr "Нөөц токен ашиглах"
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr "Үйлчилгээний нөхцөлийг зөвшөөрөх"
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr "Zulip-т тавтай морил"
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "Имэйл"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr "Zulip-ийн мэдээллийн санд бүртгүүлээрэй (жилд цөөхөн имэйл илгээдэг)."
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr "Үргэлжлүүлэх"
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr "Имэйл хаягаа баталгаажуулна уу"
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1521,78 +1007,77 @@ msgid ""
 "from Zulip."
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
 msgstr ""
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr ""
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr ""
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr ""
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr ""
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr "Видео дуудлага дууссан"
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr "Та энэ цонхыг хааж болно."
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr "Тохиргооны алдаа"
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
 msgstr ""
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1600,199 +1085,192 @@ msgid ""
 "href=\"%(doc_url)s\">documentation</a>."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr "Хаяг олдсонгүй"
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr "Zulip аккаунт олдсонгүй."
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, fuzzy, python-format
 #| msgid "Your account email: %(email)s"
 msgid "No account found for %(email)s."
 msgstr "Таны бүртгэлтэй имэйл: %(email)s"
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr "Өөр бүртгэлээр нэвтрэх"
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr "Бүртгэлээ үргэлжлүүлнэ үү"
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Must be a demo organization."
 msgid "Try Zulip in a demo organization"
 msgstr "Нэг тест бүлэг байх ёстой."
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Try Zulip now"
 msgid "Try Zulip"
 msgstr "Оффис чатыг туршаарай"
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "Шинэ бүлэг үүсгэх"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr "Шинэ Zulip байгууллагыг үүсгэ"
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr "Имэйл хаягаа оруулна уу"
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr "Таны имэйл"
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr "Группын төрөл"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 #, fuzzy
 #| msgid "Private, shared history"
 msgid "Import chat history?"
 msgstr "Хувийн, хуваалцсан түүх"
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr "Байгууллагын нэр"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "Бүлгийн холбоос"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr "%(external_host)s ашиглана уу"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "OR"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "Бүртгүүлэх"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "Zulip-д бүртгүүлнэ үү"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr "Энэ группд элсэхийн тулд танд урилга хэрэгтэй."
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr "%(identity_provider)s-аар нэвтрэх"
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "Нэвтрэх"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr "Имэйл хаягыг нууцлалыг тохируулна уу"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
@@ -1800,7 +1278,7 @@ msgstr ""
 "Та Оффис чат ашиглан ямар хэрэглэгчид имэйл хаягуудыг харах боломжтой үгүйг "
 "тохируулж болно."
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
@@ -1808,11 +1286,11 @@ msgstr ""
 "Та энэ бүлгийн үндсэн тохиргооноос имэйлийнхээ нууцлалын тохиргоог "
 "өөрчлөхийг хүсэж байна уу?"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr "Таны имэйл хаяг руу хэн хандах боломжтой"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1823,14 +1301,14 @@ msgstr ""
 "target=\"_blank\" rel=\"noopener noreferrer\">нэвтэрсний дараа</a> энэхүү "
 "тохиргоог өөрчлөх боломжтой."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 "Энэ Оффис чат бүлгийн админууд энэ имэйл хаягийг харах боломжтой болно."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
@@ -1838,12 +1316,12 @@ msgstr ""
 "Энэхүү Оффис чат бүлгийн администраторууд болон модераторууд энэ имэйл "
 "хаягийг харах боломжтой болно."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr "Энэ Оффис чат бүлгийн хэн ч энэ имэйл хаягийг харах боломжгүй."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
@@ -1851,80 +1329,79 @@ msgstr ""
 "Энэ Оффис чат бүлгийн бусад хэрэглэгчид энэ имэйл хаягийг харах боломжтой "
 "болно."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "Өөрчлөа"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr "Бүртгэл"
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr "Өөрийн группээ үүсгэх"
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr "Өөрийн аккаунтаа үүсгэх"
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr "<p>Бүртгэлийг дуусгахын тулд аккаунтын мэдээллээ оруулна уу.</p>"
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr "Танай байгууллага"
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr "Таны аккаунт"
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr "Тохиргоог импортлохгүй"
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr "Одоо байгаа Zulip аккаунтаас тохиргоог импортлох"
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "Нэр"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "Нууц үг"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr "LDAP/Active Directory нууц үгээ оруулна уу."
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 "Үүнийг гар утасны програмууд болон нууц үг шаарддаг бусад хэрэгслүүдэд "
 "ашигладаг."
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr "Нууц үгний найдварта байдал"
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr "Та юу сонирхож байна вэ?"
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
@@ -1933,22 +1410,22 @@ msgstr ""
 "Би <a href=\"%(root_domain_url)s/policies/terms\" target=\"_blank\" "
 "rel=\"noopener noreferrer\">үйлчилгээний нөхцөл</a> зөвшөөрч байна."
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr "Идэвхгүй болсон байгууллага"
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr ""
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -1956,7 +1433,7 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid ""
@@ -1964,41 +1441,41 @@ msgid ""
 "deleted."
 msgstr "Энэ бүлэг идэвхгүй болсон"
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
 "inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
 "administrators</a> to inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid "This organization has been deactivated."
 msgstr "Энэ бүлэг идэвхгүй болсон"
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
 "%(support_email)s\">contact Zulip support</a> to reactivate it."
 msgstr ""
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, fuzzy, python-format
 #| msgid ""
 #| "If you have any questions, please contact this Zulip server's "
@@ -2011,15 +1488,15 @@ msgstr ""
 "Хэрвээ таньд асуух зүйл байвал Оффис чат техникийн албатай %(support_email)s "
 "хаягаар холбогдоно уу."
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr "Компьютер дээрх нэвтэрч дуусгана уу"
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr "Компьютер дээрх нэвтэрч дуусгана уу"
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
@@ -2027,93 +1504,92 @@ msgstr ""
 "Амжилттай нэвтрэхийн тулд вэб хөтчөө ашиглаад, энд буцаж ирээд нэвтрэх "
 "токеноо оруулна уу."
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr "Токеныг энд оруулна уу"
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr "Дуусах"
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr "Буруу токен."
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr "Токен зөвшөөрөгдлөө. Нэвтэрч байна…"
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr "Компьютерын зориулалтын программыг ашиглан нэвтрэх"
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 "Амжилттай нэвтрэхийн тулд энэ нэвтрэх токеныг хуулаад Zulip програм руугаа "
 "буцна уу:"
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "Хуулах"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr "Дараа нь та энэ цонхыг хааж болно."
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr "Эсвэл өөрийн интернэт хөтөч дээрээ үргэлжлүүлж болно."
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr "Үл таних хэрэглэгч"
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr "Эзэмшигчид"
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "Админ"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr "Модераторууд"
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr "Зочин хэрэглэгчид"
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "Энгийн хэрэглэгч"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "Хаах"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "Өөрчлөх"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr "Zulip"
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr "Боловсруулах"
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
@@ -2121,17 +1597,17 @@ msgid ""
 msgstr ""
 "Баяр хүргэе, та шинэ Оффис чат бүлэг үүсгэсэн байна <b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr "Zulip-т тавтай морил!"
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr "Та энэхүү Оффис чат бүлэгт орсон байна: <b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
@@ -2140,43 +1616,43 @@ msgstr ""
 "Та Оффис Чат вэб, <a href=\"%(apps_page_link)s\">гар утас болон ширээний "
 "программ</a> руу нэвтрэхийн тулд дараах мэдээллийг ашиглана:"
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr "Байгууллагын URL: %(organization_url)s"
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr "Таны Хэрэглэгчийн нэр: %(ldap_username)s"
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr "Нэвтрэхийн тул өөрийн LDAP аккаунтаа ашиглана уу"
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr "Таны бүртгэлтэй имэйл: %(email)s"
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr "Бүлэгрүү очих"
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
 "href=\"%(getting_user_started_link)s\">getting started guide</a>!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2184,36 +1660,36 @@ msgid ""
 "Zulip</a>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
 "to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr ""
 "Zulip дээрх %(realm_name)s: Таны шинэ байгууллагын дэлгэрэнгүй мэдээлэл"
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr "Zulip дээр %(realm_name)s: Таны шинэ аккаунтын мэдээллүүд"
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr "Та %(realm_name)s шинэ Zulip байгууллагыг үүсгэсэн."
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr "Та Zulip байгууллагад элссэн байна %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
@@ -2222,33 +1698,33 @@ msgstr ""
 "Та Оффис чат вэб, гар утас болон ширээний программ руу нэвтрэхийн тулд "
 "дараах мэдээллийг ашиглана (%(apps_page_link)s):"
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
 "(%(getting_user_started_link)s)!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
 "(%(getting_organization_started_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 "Асуул байна уу ? бидэнтэй холбогдоно уу %(support_email)s — бид танд "
 "туслахдаа таатай байна!"
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2257,17 +1733,17 @@ msgstr ""
 "Хэрвээ таньд асуух зүйл байвал Оффис чат техникийн албатай %(support_email)s "
 "хаягаар холбогдоно уу."
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr "Сайн уу,"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2275,12 +1751,12 @@ msgid ""
 "password for this account, please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2289,14 +1765,14 @@ msgstr ""
 "Хэрэв та энэ өөрчлөлтийг хийх хүсэлт явуулаагүй бол яаралтай "
 "%(support_email)s холбогдоно уу."
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 #, fuzzy
 #| msgid "Create your Zulip organization"
 msgid "Verify your email address for your Zulip demo organization"
 msgstr "Зулип групп үүсгэ"
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2305,8 +1781,8 @@ msgstr ""
 "Хэрэв та энэ өөрчлөлтийг хийх хүсэлт явуулаагүй бол яаралтай "
 "%(support_email)s холбогдоно уу."
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2314,65 +1790,65 @@ msgid ""
 "please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr "имэйл өөрчлөхийг баталгаажуулна уу"
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr "Та саяхан Zulip-д бүртгүүлсэн байна."
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr "Бүртгэлийг дуусгахын тулд доорх товчийг дарна уу."
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr "Бүртгэл хийгдэж дууслаа"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr "Зулип групп үүсгэ"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr "Zulip аккаунтаа идэвхжүүлнэ үү"
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr "Доорх холбоос дээр дарж бүртгэлээ дуусгана уу."
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
@@ -2381,48 +1857,48 @@ msgstr ""
 "Та биднээс ямар нэгэн асуух зүйл байвал %(support_email)s хаягаар "
 "холбогдоорой. —Бид танд туслахад таатай байх болно."
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr "Имэйлийн тохиргоог удирдах"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr "Маркетингийн имэйлийн бүртгэлийг цуцлах"
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
 "deactivated, and you will no longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr "Техникийн албанаас тухайн мэдээллийг илгээсэн:"
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr "Хаяг идэвхгүй болгох сануулга %(realm_name)s"
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr ""
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2430,22 +1906,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because your organization has "
@@ -2461,8 +1937,8 @@ msgstr ""
 "href=\"%(help_url)s\">имэйл мэдэгдэлд гарч ирэх мессежийн агуулгыг</a> "
 "идэвхгүй болгосон тул энэ имэйлд мессежийн агуулгыг оруулаагүй болно."
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because you have disabled <a "
@@ -2477,40 +1953,40 @@ msgstr ""
 "class=\"content_disabled_help_link\" href=\"%(alert_notif_url)s\">имэйлийн "
 "мэдэгдэлд гарч ирэх мессежийн агуулгыг</a> идэвхгүй болгосон байна."
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, fuzzy, python-format
 #| msgid "Click here to log in to Zulip and catch up."
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr "Zulip-д нэвтэрхийн тулп энд дарна уу."
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr "Мэдээллийн цахим шуудангийн бүртгэлийг цуцлах"
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr "%(realm_name)s-д зориулсан Zulip digest"
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2527,8 +2003,8 @@ msgstr ""
 "мэдэгдэлд гарч ирэх мессежийн агуулгыг идэвхгүй болгосон байна.\n"
 "Харах %(hide_content_url)s илүү дэлгэрэнгүйн.\n"
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2544,41 +2020,38 @@ msgstr ""
 "мэдэгдэлд гарч ирэх мессежийн агуулгыг идэвхгүй болгосон байна. \n"
 "Илүү дэлгэрэнгүйг %(alert_notif_url)s-с үзнэ үү.\n"
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, fuzzy, python-format
 #| msgid "Click here to log in to Zulip and catch up: %(organization_url)s."
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr "Оффис чат-д нэвтэрч орохын тулд энд дарна уу: %(organization_url)s"
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr "Имэйлийн тохиргоог удирдах:"
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr "Мэдээллийн цахим шуудангийн бүртгэлийг цуцлах:"
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr "Swimming fish"
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr "Таны хүсэлтэнд баярлалаа!"
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
 "organizations:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
@@ -2587,33 +2060,29 @@ msgstr ""
 "Таны %(email)s и-мэйл хаяг нь %(external_host)s-н зохион байгуулсан дараах "
 "Zulip группд бүртгэлтэй байна:"
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
 "href=\"%(help_reset_password_link)s\">reset your password</a>."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
 "%(external_host)s."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2621,38 +2090,35 @@ msgid ""
 "to find your account."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr "Таны Zulip аккаунтууд"
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
 "try another way to find your account (%(help_logging_in_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr "Сайн байна уу,"
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
@@ -2661,18 +2127,18 @@ msgstr ""
 "%(referrer_name)s таныг бүтээмжийг нэмэгдүүлэх зорилготой багийн харилцааны "
 "хэрэгсэл болох Zulip-аар дамжуулан тэдэнтэй нэгдэхийг хүсч байна."
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr "Доорх товч дээр дарж эхлэнэ үү."
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 "%(referrer_full_name)s таныг %(referrer_realm_name)s-д нэгдэхийг урьсан"
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
@@ -2681,17 +2147,17 @@ msgstr ""
 "%(referrer_full_name)s (%(referrer_email)s) таныг бүтээмжид зориулагдсан "
 "багийн харилцааны хэрэгсэл болох Zulip дээр тэдэнтэй нэгдэхийг хүсч байна."
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr "Доорх холбоос дээр дарж эхлэнэ үү."
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr "Сайн уу,"
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
@@ -2701,13 +2167,13 @@ msgstr ""
 "харилцааны хэрэгсэл болох Zulip дээр тэдэнтэй нэгдэхийг хүсч байгааг "
 "мэдэгдэж байна."
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr "Энэ бол таны урилгаар хүлээн авах сүүлчийн мэдэгдэл юм."
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
@@ -2716,12 +2182,12 @@ msgstr ""
 "Энэ урилгын хугацаа хоёр хоногийн дараа дуусна. Хэрэв урилгын хугацаа "
 "дуусвал та %(referrer_name)s-с өөр урилга авах хэрэгтэй болно."
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr "Сануулга: %(referrer_name)s руу %(referrer_realm_name)s-д нэгдээрэй"
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2732,72 +2198,70 @@ msgstr ""
 "нэмэгдүүлэхэд зориулагдсан багийн харилцааны хэрэгсэл болох Zulip дээр "
 "тэдэнтэй нэгдэхийг хүсч байгааг сануулж байна."
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at <a href=\"mailto:%(email)s\">%(email)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
 "%(email)s\">Contact us</a> — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr "Таныг хэн нэгэн дурьдсан тул таньд энэ мэдээлэл ирж байгаа."
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr "Таныг %(mentioned_user_group_name)s чат өрөөнд дурьдсан байна."
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
 "#%(channel_name)s > %(topic_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2808,7 +2272,7 @@ msgstr ""
 "%(realm_name)s үзэх</a> эсвэл<a href=\"%(notif_url)s\"> имэйлийн тохиргоог "
 "удирдах боломжтой</a>."
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
@@ -2817,7 +2281,7 @@ msgstr ""
 "<a href=\"%(narrow_url)s\">Оффис чат %(realm_name)s дээр харах, хариу бичих, "
 "</a>эсвэл <a href=\"%(notif_url)s\">имэйлийн тохиргоог удирдах боломжтой</a>."
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
@@ -2826,7 +2290,7 @@ msgstr ""
 "<a href=\"%(narrow_url)s\">Оффис чат %(realm_name)s хариу бичих</a> эсвэл <a "
 "href=\"%(notif_url)s\">имэйлийн тохиргоог удирдах</a>."
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
@@ -2835,43 +2299,43 @@ msgstr ""
 "Энэ имэйлд хариу бичих хэрэггүй. Энэ Zulip сервер нь ирж буй имэйлийг хүлээн "
 "авахаар тохируулагдаагүй байна ( <a href=\"%(url)s\">тусламж</a> )."
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr "Групп DM-үүд %(direct_message_group_display_name)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr "DM-үүд %(sender_str)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr "Шинэ мессежүүд"
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 "Энэ имэйл хаягруу шууд хариу бичих, эсвэл Оффис чат дээр харах "
 "%(realm_name)s:"
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr "Оффис чат унших, %(realm_name)s хэрэглэгчид хариу бичих :"
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr "Оффис чат дээр %(realm_name)s хэрэглэгчид хариу бичих:"
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
@@ -2879,7 +2343,7 @@ msgstr ""
 "Энэ имэйлд хариу бичих хэрэггүй. Энэ Zulip сервер нь ирж буй имэйлийг хүлээн "
 "авахаар тохируулагдаагүй байна. Тусламж:"
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2890,22 +2354,22 @@ msgstr ""
 "байна. Хэрэв та энэ өөрчлөлтийг хийгээгүй бол бидэнтэй яаралтай "
 "%(support_email)s утсаар холбогдоно уу."
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr "Best,"
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr "Zulip Бүлэг"
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr "Zulip имэйлийг %(realm_name)s гэж өөрчилсөн"
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2916,53 +2380,53 @@ msgstr ""
 "байна. Хэрэв та энэ өөрчлөлтийг хийгээгүй бол бидэнтэй шууд холбогдоно "
 "уу<%(support_email)s> ."
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 msgstr ""
 "Байгууллага: %(organization_url)s Цаг: %(login_time)s Имэйл: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr "Дараах Zulip бүртгэлд саяхан нэвтэрсэн байна."
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr "Байгууллага: %(organization_link)s"
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr "Имэйл: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr "Цаг: %(login_time)s"
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr "Төхөөрөмж: %(device_browser)s , %(device_os)s."
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr "IP хаяг: %(device_ip)s"
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr "Хэрэв энэ та байсан бол ямар нэгэн зүйл хийх шаардлагагүй."
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2973,31 +2437,31 @@ msgstr ""
 "href=\"%(reset_link)s\">байвал нууц үгээ шинэчилнэ</a> үү эсвэл "
 "%(support_email)s руу шууд холбогдоно уу."
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr "Баярлалаа,"
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr "Zulip аюулгүй байдал"
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr "Нэвтрэх мэдэгдлийн бүртгэлийг цуцлах"
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr "%(device_os)s дээр %(device_browser)s -ээс шинэ нэвтрэлт"
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr "Байгууллага: %(organization_url)s"
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3008,7 +2472,7 @@ msgstr ""
 "байвал %(reset_link)s хаягаар нууц үгээ шинэчилнэ үү эсвэл %(support_email)s "
 "дугаараар бидэнтэй шууд холбогдоно уу."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -3016,25 +2480,25 @@ msgid ""
 "Zulip</a> to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
 "with you and share their unique perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -3042,7 +2506,7 @@ msgid ""
 "experience how a new chat app will help your team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -3050,53 +2514,53 @@ msgid ""
 "action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr "Тавтай морилно уу имэйлийн бүртгэлийг цуцлах %(realm_name)s"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
 "team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
@@ -3107,71 +2571,71 @@ msgstr ""
 "байгууллагуудад зориулсан Оффс чат-ын гол онцлогуудын талаарх энэхүү гарын "
 "авлагыг үзээрэй!"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr "Бизнесд зориулсаг оффис чатын гарын авлага харах"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr "Open-source төсөлд зориулсан Оффис чатын гарын авлага харах"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr "Боловсролд зориулсан Оффис чатын гарын авлага харах"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr "Судалгаанд зориулсан Оффис чатын гарын авлага харах"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr "Арга хэмжээ болон хуралд зориулсан Оффис чатын гарын авлага харах"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr "Ашигын бус байгууллагуудад зориулсан Оффис чатын гарын авлага харах"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr "Харилцаа холбоонд зориулсан Оффис чатын гарын авлага харах"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr "Бизнесийн Zulip гарын авлага"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr "Open-source төсөлд зориулсан Оффис чатын гарын авлага"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr "Боловсролд зориулсан Оффис чатын гарын авлага"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr "Оффис чат заавар"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr "Арга хэмжээ болон хуралд зориулсан Оффис чатын гарын авлага"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr "Ашигын бус байгууллагад зориулсан Оффис чатын гарын авлага"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr "Харилцаа холбоонд зориулсан Оффис чатын гарын авлага"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
@@ -3179,14 +2643,14 @@ msgstr ""
 "Оффис чат дээрх харилцан яригаа санаануудыг ашиглан эмх цэгцтэй байлгах "
 "зарим зөвлөмжийг энд оруулав."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
@@ -3195,12 +2659,12 @@ msgstr ""
 "Хичнээн өөр хэлэлцүүлэг өрнөж байгаагаас үл хамааран та мессеж бүрийг "
 "контекстээр нь харах болно."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3208,11 +2672,11 @@ msgid ""
 "about…?”"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr "Богино сэдвүүдийн жишээ"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3221,23 +2685,23 @@ msgid ""
 "href=\"%(move_channels_link)s\">move a topic to a different channel</a>."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr "Zulip-руу орох"
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr "Хэлэлцэж байгаа санаануудаа эмх цэгцтэй байлгаарай"
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3246,23 +2710,23 @@ msgid ""
 "(%(move_channels_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
 "%(email)s on %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr "Нууц үгээ шинэчлэхийн тулд доорх товчийг дарна уу."
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr "Нууц үг шинэчлэх"
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3273,47 +2737,47 @@ msgstr ""
 "болгосон. Та <a href=\"%(help_link)s\">бүртгэлээ дахин идэвхжүүлэхийн</a> "
 "тулд байгууллагын админтай холбогдож болно."
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr "Тэр Zulip байгууллагад танд аккаунт байхгүй."
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr "Та дараах байгууллагад(s) идэвхтэй аккаунттай байна."
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
 msgstr ""
 "Та дээрх байгууллагад(s) нэвтэрч эсвэл нууц үгээ шинэчлэхийг оролдож болно."
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr "Хэрэв та энэ үйлдлийг хийгээгүй бол энэ имэйлийг үл устгаж болно."
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr "%(realm_name)s-н нууц үг сэргээх хүсэлт"
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr "Доорх холбоос дээр дарж нууц үгээ шинэчилнэ үү."
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
 "You can contact an organization administrator to reactivate your account."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3324,7 +2788,7 @@ msgstr ""
 "улмаас Zulip Cloud Free багц руу шилжсэн байна. Төлөгдөөгүй нэхэмжлэхүүд "
 "хүчингүй болсон."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
@@ -3333,7 +2797,7 @@ msgstr ""
 "Zulip Cloud стандарт төлөвлөгөөг үргэлжлүүлэхийн тулд %(upgrade_url)s руу "
 "орж дахин шинэчилнэ үү."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
@@ -3342,8 +2806,8 @@ msgstr ""
 "Хэрэв та үүнийг алдаа гэж бодож байгаа эсвэл илүү дэлгэрэнгүй мэдээлэл авах "
 "шаардлагатай бол %(support_email)s дугаараар бидэнтэй холбогдоно уу."
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid "You've joined the Zulip organization %(realm_name)s."
 msgid ""
@@ -3351,104 +2815,104 @@ msgid ""
 "%(localized_date)s."
 msgstr "Та Zulip байгууллагад элссэн байна %(realm_name)s."
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr "Эрхэм %(realm_name)s-ийн хуучин админууд аа,"
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip demo organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr "Байгууллагаа дахин идэвхжүүлэхийн тулд доорх товчийг дарна уу."
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr "Байгууллагыг дахин идэвхжүүлэх"
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
@@ -3456,372 +2920,372 @@ msgstr ""
 "Хэрэв хүсэлт алдаатай байсан бол та ямар ч арга хэмжээ авах боломжгүй бөгөөд "
 "энэ холбоос 24 цагийн дотор хүчингүй болно."
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Reactivate your Zulip organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "Zulip байгууллагыг дахин идэвхжүүлнэ үү"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr "Zulip байгууллагыг дахин идэвхжүүлнэ үү"
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr "Доорх холбоос дээр дарж байгууллагаа дахин идэвхжүүлнэ үү."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for <b>%(remote_server_hostname)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, fuzzy
 #| msgid "Click the button below to complete registration."
 msgid "Click the button below to log in."
 msgstr "Бүртгэлийг дуусгахын тулд доорх товчийг дарна уу."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for %(remote_server_hostname)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
 "management for <b>%(remote_realm_host)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
 "management for %(remote_realm_host)s."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the <a href=\"%(plans_link)s\">Zulip Community plan</a>."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
 "website</a>, we would really appreciate it!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
 msgstr ""
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr "Бүртгэлээ олоорой"
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr "Zulip аккаунтаа олоорой"
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
 "accounts for another email address</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr "Имэйл хаяг"
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "Хаяг хайх"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr "Бүтээгдэхүүн"
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr "Why Zulip"
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr "Онцлог зүйлс"
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr "План болон үнэ"
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Zulip"
 msgid "Zulip Cloud"
 msgstr "Zulip"
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr "Self-hosting"
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr "Аюулгүй байдал"
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "интеграц"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr "Десктоп & утасны апп"
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr "Шинэ байгууллага"
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr "Шийдлүүд"
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr "Бизнес"
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr "Боловсрол"
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr "Судалгаа"
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr "Ар хэмжээ болон хурал"
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr "Нээлттэй эхийн төслүүд"
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr "Нийгэмлэгүүд"
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr "Хэрэглэгчийн түүхүүд"
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr "Нийгэмлэгүүд"
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr "Өгөгдөлүүд"
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr "Эхлэх"
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr "Тусламжийн төв"
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr "Олон нийтийн чат"
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr ""
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr "Zulip серверийг суулгаж байна"
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr "Zulip серверийг шинэчилж байна"
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr "Оролцох"
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr "Туслах гарын авлага"
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr "Хөгжүүлэлтийн нийгэмлэг"
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr "Орчуулга"
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr "GitHub"
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr "Бидний тухай"
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr "Баг"
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "Ашиглалтийн түүх"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr "Үнэ цэнэ"
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr "Ажлууд"
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr "Блог"
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr "Zulip тусламж"
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr ""
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr ""
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Values"
 msgid "Bluesky"
 msgstr "Үнэ цэнэ"
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr "<a href=\"https://zulip.com\">Оффис чат</a>-аар хангагдсан"
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr "Үйлчилгээний нөхцөл"
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr "Нууцлалын дүрэм"
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr "Вэб сайтын аттрибутууд"
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr "%(integrations_count_display)s гаруй интеграци."
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 #, fuzzy
 #| msgid ""
 #| "And hundreds more through <a href=\"/integrations/doc/zapier\">Zapier</a> "
@@ -3833,51 +3297,47 @@ msgstr ""
 "Мөн өөр олон зуун <a href=\"/integrations/doc/zapier\">Zapier</a> болон <a "
 "href=\"/integrations/doc/ifttt\">IFTTT</a>."
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr "Хайлтын нэгтгэлүүд"
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr "Захиалгат интеграци"
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr "Хүсэлт илгээж буй webhooks"
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr "Интерактив ботууд"
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr "REST API"
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr "Буруу имэйл байна"
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr "Зөвшөөрөгдөөгүй имэйл"
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr "Таны нэвтрэх гэсэн имэйл хаяг хүчингүй байна."
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3885,7 +3345,7 @@ msgid ""
 "emails with your email domain."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3893,7 +3353,7 @@ msgid ""
 "disposable email addresses."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3901,24 +3361,24 @@ msgid ""
 "emails that contain \"+\"."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr "Хүчинтэй имэйл хаяг ашиглан бүртгүүлнэ үү."
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr "Зөвшөөрөгдсөн имэйл хаягийг ашиглан бүртгүүлнэ үү."
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3926,7 +3386,7 @@ msgid ""
 "%(support_email)s\">contact Zulip support</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3934,72 +3394,72 @@ msgid ""
 "%(support_email)s\">contact this Zulip server's administrators</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
 "management for your Zulip server."
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr "Буруу эсвэл хугацаа нь дууссан нэвтрэх session байна"
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr "Буруу эсвэл хугацаа нь дууссан нэвтрэх session байна."
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr "Zulip руу нэвтэрнэ үү"
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr "Та энэ имэйл хаягаар аль хэдийн бүртгүүлсэн байна. Доор нэвтэрнэ үү."
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr "Имэйл эсвэл нэвтрэх нэр"
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "Нэвтрэх нэр"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr "Нууц үгээ мартсан уу?"
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr "%(identity_provider)s-аар нэвтрэх"
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr "Бүртгэлгүйгээр үзэх"
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 "Та хараахан аккаунтгүй байна уу? Та энэ групп элсэх урилгатай байх ёстой."
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr "Үйлчилгээг дахин ашиглах эрхгүй байна"
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr "Энэ групп яг одоо шинэ гишүүдийг хүлээн авах боломжгүй"
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> because all Zulip Cloud licenses are in use."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
@@ -4007,19 +3467,19 @@ msgstr ""
 "Таныг урьсан хүнтэй холбогдож лицензийн тоог нэмэгдүүлэхийг хүсээд дахин "
 "оролдоно уу."
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr "Дэд домайн баталгаажуулалтын алдаа"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr "Дэд домайн баталгаажуулалт"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -4028,44 +3488,42 @@ msgid ""
 "or misconfiguration."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 #, fuzzy
 #| msgid "New organization"
 msgid "Demo organizations disabled"
 msgstr "Шинэ байгууллага"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr "Шинэчлэх шаардлагатай"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr "Хамгийн сүүлийн хувилбарыг татаж авна уу."
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr "Бүлэг үүсгэх холбоос шаардлагатай"
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -4073,22 +3531,21 @@ msgid ""
 "organization for more information."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr "Байгууллага үүсгэх холбоосын хугацаа дууссан эсвэл хүчингүй байна"
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -4096,49 +3553,47 @@ msgid ""
 "Zulip support</a> for assistance in resolving this issue."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr "Дэмждэггүй вэб хөтөч"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, fuzzy, python-format
 #| msgid "Presence is not supported for bot users."
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr "Бот хэрэглэгчидийн хувьд Presence дэмжигдэхгүй."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
 "a> like Firefox, Chrome, and Edge."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr "Бүртгэл идэвхгүй болсон"
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Invalid organization"
 msgid "Finalize organization import"
 msgstr "Буруу бүлэг"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Organization type"
 msgid "Organization import completed!"
 msgstr "Группын төрөл"
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -4146,58 +3601,57 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Select your account"
 msgstr "Өөрийн аккаунтаа үүсгэх"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Create new account"
 msgstr "Өөрийн аккаунтаа үүсгэх"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr "Танай группыг амжилттай дахин идэвхжүүллээ"
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr "Танай группыг амжилттай дахин идэвхжүүллээ."
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr ""
 "Группын дахин идэвхжүүлэх холбоосын хугацаа дууссан эсвэл хүчингүй байна"
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr ""
 "Группын дахин идэвхжүүлэх холбоосын хугацаа дууссан эсвэл хүчингүй байна."
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr "Группруу нэвтэрнэ үү"
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr "Та группынхээ URL хаягийг мэдэхгүй байна уу?"
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr "Группээ олоорой."
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr "Дараагийнх"
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4205,24 +3659,24 @@ msgid ""
 "have one yet."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 #, fuzzy
 #| msgid "Self-host Zulip"
 msgid "Self-hosting Zulip?"
 msgstr "Бидний Оффис чат"
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">log in to manage plans and billing.</a>"
 msgstr ""
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr "Нууц үгээ шинэчлэх"
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
@@ -4230,63 +3684,63 @@ msgstr ""
 "Нууц үгээ мартсан уу? Асуудалгүй, бид таны бүртгүүлсэн имэйл рүү нууц үгээ "
 "шинэчлэх холбоосыг илгээх болно."
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr "Шинэчлэх холбоос илгээх"
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr "Шинэ нууц үг оруулах"
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "Нууц үгээ баталгаажуулах"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr ""
 "Уучлаарай, таны оруулсан холбоос буруу эсвэл аль хэдийн ашиглагдсан байна."
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr "Шинэ нууц үгийг амжилттай тохирууллаа"
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr "Та шинэ нууц үг тохирууллаа!"
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr "Шинэ нууц үгээрээ <a href=\"%(login_url)s\">нэвтрэнэ үү</a>."
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr "Нууц үг шинэчлэхийг илгээв!"
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr "Нууц үг шинэчлэхийг илгээв!"
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr "Процессыг дуусгахын тулд хэдэн минутын дараа имэйлээ шалгана уу."
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 #, fuzzy
 #| msgid "Export still in progress"
 msgid "Import progress"
 msgstr "Экспорт хийгдэж байна"
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4294,7 +3748,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4303,60 +3757,60 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 #, fuzzy
 #| msgid ""
 #| "Nobody in this Zulip organization will be able to see this email address."
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr "Энэ Оффис чат бүлгийн хэн ч энэ имэйл хаягийг харах боломжгүй."
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4364,7 +3818,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4372,21 +3826,21 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr "Баталгаажуулах бүртгэлийг сонгоно уу"
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr "<h1 class=\"get-started\">Аккаунтаа сонгоно уу</h1>"
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 "Таны GitHub бүртгэлтэй холбоотой баталгаажуулаагүй имэйл хаягууд байна."
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
@@ -4395,15 +3849,15 @@ msgstr ""
 "href=\"https://github.com/settings/emails\">GitHub-ээр баталгаажуулах ёстой."
 "</a>"
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr "Алдаатай хаагдсан имэйл хаяг"
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr "Үл мэдэгдэх имэйлийн бүртгэл цуцлах хүсэлт"
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
@@ -4411,7 +3865,7 @@ msgstr ""
 "Сайн уу! Та ямар нэг зүйлийн бүртгэлийг цуцлахыг оролдсон бололтой, гэхдээ "
 "бид URL-г танихгүй байна."
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4422,132 +3876,129 @@ msgstr ""
 "href=\"mailto:%(support_email)s\"> имэйл илгээвэл</a> бид үүнийг арилгах "
 "болно!"
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr "Имэйлийн тохиргоо шинэчлэгдсэн"
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
 "href=\"%(realm_url)s/#settings/notifications\">notification settings</a>."
 msgstr ""
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr "Буруу захиалга."
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr ""
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr ""
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr ""
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr "Бүртгэл"
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr ""
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr "{user} таны Zulip-д нэгдэх хүсэлтийг хүлээн авлаа!"
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 #, fuzzy
 #| msgid "Cannot deactivate the only {entity}."
 msgid "Cannot reactivate a deleted user"
 msgstr "Зөвхөн {entity}-г идэвхгүй болгох боломжгүй."
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr "{id} олдсонгүй."
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr ""
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr ""
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr ""
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
@@ -4555,7 +4006,7 @@ msgstr ""
 "Zulip хэрэглэгчдийн аюулгүй байдыг хангахын тулд нэг өдрийн дотор илгээх "
 "урилгын тоог хязгаарладаг. Та хязгаарт хүрсэн тул урилга илгээгдээгүй байна."
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
@@ -4563,75 +4014,75 @@ msgstr ""
 "Та уг үйлдэлийг хийх эрхгүй байна. Админ хэрэглэгчтэй холбогдон шийдвэрлэнэ "
 "үү."
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr "Зарим имэйлийг баталгаажуулаагүй тул бид урилга илгээгээгүй."
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr "Бид хэнийг ч урих боломжгүй байсан."
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr "Өөрчлөх зүйл байхгүй"
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr ""
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr "Хэрэглэгч рүү шууд бичсэн чат сэдэв болгон нэрлэх боломжгүй."
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr "Санааны засваргүйгээр түгээх_горим буруу байна"
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr ""
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr "Виджетийг засах боломжгүй."
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr "Танай байгууллага мессеж засварлахыг эрхийг хаасан байна"
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr "Та энэ мессежийг засах эрхгүй байна"
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr "Энэ мессежийг засварлах хугацаа өнгөрсөн байна"
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr "{user} энэ topic-ыг шийдсэн гэж тэмдэглэсэн."
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr "{user} энэ topic-ыг шийдэгдээгүй гэж тэмдэглэсэн."
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr "Энэ topic-ыг {user} {new_location} руу зөөсөн."
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr "{user} энэ topic-оос мессежийг {new_location} руу зөөсөн."
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
@@ -4640,25 +4091,25 @@ msgstr ""
 "{changed_messages_count} мессежийг {user} энэ topic-оос {new_location} руу "
 "зөөсөн."
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr "Энэ topic-ыг {old_location}-с {user} энд зөөсөн."
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 msgstr "[A message]({message_link}) {old_location}-с {user}-р энэд нүүлгэсэн."
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
 "{user}."
 msgstr "{changed_messages_count} мессежийг {old_location}-с {user} энд зөөсөн."
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 #, fuzzy
 #| msgid "You don't have permission to delete this message"
 msgid "You don't have permission to resolve topics in this channel."
@@ -4666,70 +4117,67 @@ msgstr ""
 "Та энэ мессежийг устгах эрхгүй байна\n"
 " "
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr "Та энэ мессежийг зөөх эрхгүй байна"
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr ""
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr "Буруу мессеж(үүд)"
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr "Мессежийг үзүүлэх боломжгүй"
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr "Хүлээн авагчийн өгөгдлийн төрөл буруу байна"
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 "Хүлээн авагчийн лист дотор имэйл хаяг эсвэл хэрэглэгчийн ID байх боломжтой, "
 "хоёулаа байх боломжгүй."
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
 "but there is no channel with that ID."
 msgstr ""
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4737,36 +4185,36 @@ msgid ""
 "it."
 msgstr ""
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
 "The channel exists but does not have any subscribers."
 msgstr ""
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr ""
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr "Widgets: API программист хүчингүй JSON контент илгээсэн"
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr "Widgets: {error_msg}"
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4774,64 +4222,62 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr "Адил нэртэй эможи аль хэдийн нэмэгдсэн байна."
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
 "authentication method."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr ""
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr "Илгээхээр төлөвлөсөн мессежийг аль хэдийн илгээсэн байна"
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder could not be sent."
 msgstr "Токен үүсээгүй байна"
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr "Мессежийг товлосон цагт илгээж чадсангүй."
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
@@ -4840,45 +4286,45 @@ msgstr ""
 "Таны {delivery_datetime}-д товлосон мессежийг дараах алдааны улмаас "
 "илгээгээгүй:"
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr "[Илгээхээр төлөвлөсөн мессежүүдийг харах](#scheduled)"
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr ""
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr ""
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr ""
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr ""
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
 "**{old_policy}** to **{new_policy}**."
 msgstr ""
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -4887,51 +4333,49 @@ msgid ""
 "* **New**: {new_setting_description}\n"
 msgstr ""
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr "Тайлбар байхгүй."
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr ""
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr "Хуучин тайлбар"
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr "Шинэ тайлбар"
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr "Forever"
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr ""
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 msgstr ""
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr ""
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -4942,99 +4386,89 @@ msgid ""
 "{summary_line}"
 msgstr ""
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr "Та энэхүү мессежинд дэд мессеж хавсаргах боломжгүй байна."
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr ""
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr ""
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr "Зөвшөөрөл хангалтгүй"
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr "Энэ API нь ирж буй webhook ботуудад боломжгүй."
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr "Аккаунт энэ дэд домэйнтай холбоогүй байна"
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr "БОТ-оос илгээсэн хүсэлтийг тухайн хэрэглэгч зөвшөөрсөнгүй."
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr "Серверийн администратор байх ёстой"
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr "Энэ төгсгөлийнцэг нь HTTP үндсэн баталгаажуулалтыг шаарддаг."
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr "Үндсэн баталгаажуулалтын зөвшөөрлийн толгой хэсэг буруу"
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr "Үндсэн баталгаажуулалтын зөвшөөрлийн толгой хэсэг байхгүй байна"
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr "Webhook ботууд зөвхөн webhooks-рүү хандах боломжтой"
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr ""
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
@@ -5043,51 +4477,50 @@ msgstr ""
 "Таны {username} аккаунт идэвхгүй байна. Та аккаунтаа идэвхтэй болгохын тулд "
 "байгууллагын админтайгаа холбогдоно уу."
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr "Нууц үг нь хэт хялбар байна."
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr "Дэд домэйн нь 3 болон түүнээс их урттай байна."
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr "Дэд домэйн нь '-' аар эхлэж эсвэл төгсөж болохгүй."
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr "Дэд домэйн нь зөвхөн жижиг үсэг, тоо болон '-' агуулсан байна."
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr "Өөрийн жинхэнэ имэйл хаягаа ашиглана уу."
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr "Таны {email} ашиглан бүртгүүлэх гэж буй бүлэг байхгүй байна."
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr "Бүлгийн админаас {email}-д урилга илгээнэ үү."
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
@@ -5096,11 +4529,11 @@ msgstr ""
 "Таны {email} и-мэйл хаяг нь энэ бүлгийн бүртгэлд бүртгүүлэх боломжтой "
 "домайнуудын аль нэгэнд байхгүй байна."
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr "Энэ бүлэгт + агуулсан имэйл хаягийг хориглоно."
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
@@ -5110,41 +4543,40 @@ msgstr ""
 "боломжгүй. Таныг урьсан хүнтэй холбогдож лицензийн тоог нэмэгдүүлэхийг "
 "хүсээд дахин оролдоно уу."
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 #, fuzzy
 #| msgid "Embedded bots are not enabled."
 msgid "Challenges are not enabled."
 msgstr "Суулгасан ботуудыг идэвхжүүлээгүй байна."
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "Шинэ нууц үг"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr "Шинэ нууц үгээ баталгаажуулна уу"
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "You're making too many attempts to sign in. Try again in "
 "{retry_after_string} or contact your organization administrator for help."
 msgstr ""
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
@@ -5152,90 +4584,88 @@ msgstr ""
 "Таны нууц үг хэтэрхий хялбар учир идэвхгүй болсон. Шинэ нууц үг үүсгэхийн "
 "тулд нууц үгээ шинэчилнэ үү."
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr "Токен"
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr "Зөвлөмж: Та олон имэйл хаягийг хооронд нь таслалаар оруулж болно."
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr "Хамгийн ихдээ 10 имэйл оруулна уу."
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr "Бид тэрхүү Zulip бүлгийг олж чадсангүй."
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr ""
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr "Алга болсон topic"
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr ""
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr ""
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr "Мессеж нь хүлээн авагчтай байх ёстой"
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr "Буруу мессежийн төрөл"
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr "Буруу хавсралт"
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr "Хавсралтыг устгах явцад алдаа гарлаа. Дараа дахин оролдож үзнэ үү."
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr "Мессеж нь хүлээн авагчтай байх ёстой!"
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Content can't be empty"
 msgid "Channel folder name can't be empty."
 msgstr "Контент нь хоосон байж болохгүй"
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Invalid data export ID"
 msgid "Invalid channel folder ID"
 msgstr "Дата экспортын ID буруу байна"
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 #, fuzzy
 #| msgid "Confirm your email address"
 msgid "Configure owner account email address."
 msgstr "Имэйл хаягаа баталгаажуулна уу."
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| " Congratulations, you have created a new demo Zulip organization. Note "
@@ -5251,72 +4681,72 @@ msgstr ""
 "устах болно гэдгийг анхаарна уу. Демо группын талаар илүү ихийг эндээс авна "
 "уу: %(demo_organizations_help_link)s"
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a date"
 msgid "{var_name} is not Base64 encoded"
 msgstr "{var_name} нь огноо биш"
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 #, fuzzy
 #| msgid "Invalid emoji code."
 msgid "Invalid `device_id`"
 msgstr "Буруу эможи код."
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr ""
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr "Домэйн нь хоосон байж болохгүй."
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr "Домэйн ядаж нэг цэгтэй (.) байна"
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr "Домэйн нь хэт урт байна"
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr "Домэйн нь цэгээр (.) эхлэх эсвэл төгсөж болохгүй"
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr "Дараалсан цэгүүд '.' зөвшөөрөгдөхгүй."
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr "Дэд домэйн нь '-' аар эхлэж эсвэл төгсөж болохгүй."
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr "Домэйн нь зөвхөн үсэг, тоо, '-' болон '.' агуулсан байна."
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr "Цагийн тэмдэглэгээ сөрөг байж болохгүй."
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr "Topic нь хоосон байт агуулах ёсгүй"
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr "Хэрэглэгч ноорог синхрончлохыг идэвхгүй болгосон."
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr "Ноорог үүсээгүй байна"
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5324,86 +4754,86 @@ msgid ""
 "{error_message}"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr "Spoiler агуулгыг харахын тулд Zulip-г нээнэ үү"
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr ""
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr "Буруу хаяг."
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr "Таны домэйноос гадуур."
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr "+ агуулсан имэйл хаягийг зөвшөөрөхгүй."
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr "Системийн ботуудад зориулж нөөцлөгдсөн."
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr "{email} аль хэдийн аккаунт байна"
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr "Аль хэдийн аккаунттай байна."
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr "Аккаунт идэвхгүй болсон байна."
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr ""
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr "Буруу эможи."
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr "Буруу эможи нэр."
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr "Энэ эможи идэвхгүй болсон."
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr "Буруу эможи код."
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr "Эможи буруу нэр."
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr "Эможи буруу төрөл."
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr "Бүлгийн админ эсвэл эможи зохиогч байх ёстой"
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr "Эможи нэр нь үсэг эсвэл цифрээр төгссөн байх ёстой."
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
@@ -5411,178 +4841,176 @@ msgstr ""
 "Эможи нэр нь зөвхөн жижиг англи үсэг, цифр, хоосон зай, зураас, доогуур "
 "зураас агуулсан байх ёстой."
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr "Эможи нэр дутуу байна"
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr "Үйл явдлын дарааллыг хуваарилж чадсангүй"
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr ""
 "Та нэвтрээгүй байна: API нэвтрэлт болон Хэрэглэгчийн Session байх "
 "шаардлагатай"
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr ""
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr "Бүлгийн эзэн"
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr "хэрэглэгч"
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr "Зөвхөн {entity}-г идэвхгүй болгох боломжгүй."
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr "Буруу тэмдэглэгээ оруулсан мэдэгдэл: {include_statement}"
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr "Алдаатай JSON"
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr "Бүлгийн админ байх ёстой"
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr "Бүлгийн эзэн байх ёстой"
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Must be an organization owner"
 msgid "Must be a bot user"
 msgstr "Бүлгийн эзэн байх ёстой"
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr "Хэрэглэгчийн нэр эсвэл нууц үг буруу байна"
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr "Энэ бүлэг идэвхгүй болсон"
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr "Таны серверийн мобайл мэдэгдлийн үйлчилгээний бүртгэл идэвхгүй болсон"
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr "Энэ бүлэгт нууц үгийн баталгаажуулалтыг идэвхгүй болгосон"
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr "Таны нууц үг идэвхгүй болсон тул дахин тохируулах шаардлагатай"
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr "API key алдаатай байна"
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr "Алдаатай API түлхүүр"
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
 "webhook; ignoring"
 msgstr ""
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 "Тухайн хүсэлтийг шалгах боломжгүй байна. {webhook_name} уг хүсэлтийг "
 "илгээсэн үү?"
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr "дэд домайн буруу байна"
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr "Энэ бүлэгт хувийн чатыг идэвхгүй болгосон."
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr ""
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr "Хандах эрхгүй байна"
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
@@ -5592,375 +5020,375 @@ msgstr ""
 "{total_messages_allowed_to_move}/{total_messages_in_topic} мессежийг зөөх "
 "зөвшөөрөл байна."
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr "Үйлдэл хийгдсэн байна."
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr "Ямар ч хариу үйлдэл байхгүй."
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
 msgstr ""
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr ""
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr ""
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr ""
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr ""
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr "Төлөвлөсөн хүргэх хугацааг тохируулахгүй байх хэрэгтэй."
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Already has an account."
 msgid "Atlassian account ID"
 msgstr "Аль хэдийн аккаунттай байна."
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Behance username"
 msgstr "Нэр эсвэл хэрэглэгчийн нэр буруу байна"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Bitbucket username"
 msgstr "GitHub хэрэглэгчийн нэр"
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Codeberg username"
 msgstr "Twitter хэрэглэгчийн нэр"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Dribbble username"
 msgstr "GitHub хэрэглэгчийн нэр"
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Facebook username"
 msgstr "Нэр эсвэл хэрэглэгчийн нэр буруу байна"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr "GitHub хэрэглэгчийн нэр"
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "GitLab username"
 msgstr "GitHub хэрэглэгчийн нэр"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Instagram username"
 msgstr "Twitter хэрэглэгчийн нэр"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 msgid "Mastodon profile"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Medium username"
 msgstr "GitHub хэрэглэгчийн нэр"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Pinterest username"
 msgstr "Twitter хэрэглэгчийн нэр"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Reddit username"
 msgstr "GitHub хэрэглэгчийн нэр"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Snapchat username"
 msgstr "GitHub хэрэглэгчийн нэр"
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Threads username"
 msgstr "Twitter хэрэглэгчийн нэр"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "TikTok username"
 msgstr "Twitter хэрэглэгчийн нэр"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Twitch username"
 msgstr "Twitter хэрэглэгчийн нэр"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "Нэвтрэх нэр"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr "Буруу гадаад аккаунтын төрөл"
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr "Integration frameworks"
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 #, fuzzy
 #| msgid "Video call ended"
 msgid "Video calling"
 msgstr "Видео дуудлага дууссан"
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr "Тасралтгүй интеграци"
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr "Хэрэглэгчийн дэмжлэг"
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr "Байршил"
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr "Entertainment"
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr "Communication"
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr "Санхүү"
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr "Хүний нөөц"
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr "Mаркетинг"
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr "Бусад"
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr "Ажиглалт"
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr "Төслийн менежмент"
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr "Productivity"
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr "Хувилбарын хяналт"
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr "Мессеж хоосон байж болохгүй"
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr "Мессеж нь хоосон байт агуулах ёсгүй"
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{fullname} moderation"
 msgstr "{full_name} таныг дурдсан:"
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr "Буруу оператор: {desc}"
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr ""
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr ""
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr "'anchor' аргумент дутуу байна."
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 #, fuzzy
 #| msgid "Missing 'anchor' argument."
 msgid "Missing 'anchor_date' argument."
 msgstr "'anchor' аргумент дутуу байна."
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr "Хүчингүй anchor"
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr ""
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 #, fuzzy
 #| msgid "Confirmation link does not exist"
 msgid "Navigation view does not exist."
 msgstr "Баталгаажуулах холбоос байхгүй байна."
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5968,7 +5396,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5976,7 +5404,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5984,7 +5412,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5992,7 +5420,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| " Congratulations, you have created a new demo Zulip organization. Note "
@@ -6009,14 +5437,14 @@ msgstr ""
 "устах болно гэдгийг анхаарна уу. Демо группын талаар илүү ихийг эндээс авна "
 "уу: %(demo_organizations_help_link)s"
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
 "them in your [Inbox](/#inbox).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6024,7 +5452,7 @@ msgid ""
 "({navigation_tour_video_url}) for a quick app overview.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6039,14 +5467,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -6054,7 +5482,7 @@ msgid ""
 "and edit your [profile information](/help/edit-your-profile).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -6065,7 +5493,7 @@ msgid ""
 "experience in your [Preferences](#settings/preferences).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6076,7 +5504,7 @@ msgid ""
 "[Browse and subscribe to channels]({settings_link}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -6093,7 +5521,7 @@ msgid ""
 "discussed.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -6102,7 +5530,7 @@ msgid ""
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -6114,7 +5542,7 @@ msgid ""
 "times, and more.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6124,7 +5552,7 @@ msgid ""
 "or browse the [help center](/help/) to learn more!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6132,7 +5560,7 @@ msgid ""
 "get help, try one of the following messages: {bot_commands}\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6144,13 +5572,13 @@ msgid ""
 "({move_content_another_channel_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6164,12 +5592,11 @@ msgid ""
 "and above.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr ""
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -6177,14 +5604,14 @@ msgid ""
 "no matter how many other conversations are going on.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
 "conversations with unread messages.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -6192,7 +5619,7 @@ msgid ""
 "the `+` button next to its name.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -6200,13 +5627,13 @@ msgid ""
 "can we chat about…?”\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6214,7 +5641,7 @@ msgid ""
 "({format_message_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6234,273 +5661,271 @@ msgid ""
 "```\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
 "teammates.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
 "conversation.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr ""
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr ""
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr ""
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr "Ирсэн хариунд буруу JSON байна"
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr "Хариултын формат буруу байна"
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr "Хоосон эсвэл буруу урттай токен"
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr "Буруу APNS токен"
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr ""
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr "Токен үүсээгүй байна"
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr "@{user_group_name} группд {full_name} -ийг дурдсан байна:"
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr "{full_name} таныг дурдсан:"
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr "{full_name} хүн бүрийг дурдсан:"
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "Шинэ мессеж"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 #, fuzzy
 #| msgid "Invalid API key"
 msgid "Invalid `push_key`"
 msgstr "API key алдаатай байна"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr "Тухайн хэрэглэгч энэ үйлдэлийг хийх эрхгүй байна"
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr "'{email}' нь Zulip ашиглахаа больсон."
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr "Та бүлгээс гадуур шууд мессежүүд илгээх боломжгүй."
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr "{var_name} хэт урт байна (limit: {max_length} characters)"
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder does not exist"
 msgstr "Токен үүсээгүй байна"
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr ""
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr ""
 "'{var_name1}', '{var_name2}' тухайн утгуудаас аль нэгийг сонгох боломжгүй "
 "байна"
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr "'{var_name}' аргумент дутуу байна"
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr "Буруу утга байна '{var_name}': {bad_value}"
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr "Илгээхээр төлөвлөсөн мессеж байхгүй байна"
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr ""
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr ""
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr ""
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 #, fuzzy
 #| msgid "You don't have permission to delete this message"
 msgid "You do not have permission to create new topics in this channel."
@@ -6508,641 +5933,625 @@ msgstr ""
 "Та энэ мессежийг устгах эрхгүй байна\n"
 " "
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr ""
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr ""
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr ""
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr ""
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr ""
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr "Зургийн кодыг тайлж чадсангүй; Та зургийн файл оруулсан уу?"
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr "Зургийн хэмжээ их байна."
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr "{var_name} нь алдаатай хариулт байна"
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} does not have a length"
 msgid "{var_name} does not have the expected format"
 msgstr "{var_name} урт байхгүй"
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr "{var_name} нь огноо биш"
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr "{var_name} алдаатай үйлдэл байна"
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr "Буруу {var_name}"
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr "{var_name} нь бутархай тоо биш байна"
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr "{var_name} нь хэт бага байна"
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr "{var_name} нь бүхэл тоон утга биш байна"
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr "{var_name} нь хэт том байна"
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr "{var_name} нь лист биш байна"
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr "{var_name} хэт урт байна (limit: {max_length} characters)"
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr "{var_name} нь мөр биш"
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr "{var_name} хэт урт байна (limit: {max_length} characters)"
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr "{var_name} хэт урт байна (limit: {max_length} characters)"
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr "Буруу ачаалал"
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr "{var_name} hex өнгөний код биш байна"
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid {var_name}"
 msgid "Invalid {setting_name}"
 msgstr "Буруу {var_name}"
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr "Энэ бүлэгт нэмэх файлын хэмжээ хэтэрсэн байна."
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr ""
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr ""
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr "Буруу хэрэглэгчийн групп"
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid user group"
 msgid "Invalid user group ID: {user_group_id}"
 msgstr "Буруу хэрэглэгчийн групп"
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr ""
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr ""
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr ""
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr "Үйлчлүүлэгч ямар ч шинэ утгыг дамжуулаагүй."
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 "Үйлчлүүлэгч эможи код эсвэл хариу үйлдлийн төрлийг дамжуулсан тохиолдолд "
 "emoji_name-г оруулах ёстой."
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr "Нэр хэт урт байна!"
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 #, fuzzy
 #| msgid "Message must not be empty"
 msgid "Name must not be empty!"
 msgstr "Мессеж хоосон байж болохгүй"
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr "Нэрэнд буруу тэмдэгт байна!"
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr "Формат буруу байна!"
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr ""
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr ""
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr "Нэр эсвэл хэрэглэгчийн нэр буруу байна"
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr ""
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr ""
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr ""
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr "Буруу тохиргооны өгөгдөл!"
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr "Ботын төрөл буруу байна"
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr "Интерфэйсийн төрөл буруу байна"
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr ""
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr "Ийм бот байхгүй"
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr "Ийм хэрэглэгч байхгүй"
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr "Хэрэглэгч deactivated"
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr "{item} хоосон байж болохгүй."
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr "{var_name} буруу урттай {length}; байх ёстой урт {target_length}"
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a string"
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr "{var_name} нь мөр биш"
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr "{container} нь яг {length} ийм урттай байна"
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr "{var_name} - ээс {key_name} түлхүүр алга болсон байна"
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr ""
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr "{var_name} нь зөвшөөрөгдсөн_төрөл биш юм"
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr "{variable} != {expected_value} ({value} буруу)"
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr "{var_name} нь URL биш байна"
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr "URL загвар нь '%(username)s'-г агуулсан байх ёстой."
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr "'{item}' хоосон байж болохгүй."
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr "Талбарт давхардсан сонголт байх ёсгүй."
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr "'{value}' нь '{field_name}'-д тохирох сонголт биш байна."
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr "{var_name} нь мөр эсвэл бүхэл тооны жагсаалт биш"
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr "{var_name} нь мөр эсвэл бүхэл тоо биш"
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr "{var_name} урт байхгүй"
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr "{var_name} нь алга байна"
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr "'{header}' HTTP үйл явдлын толгой хэсэг дутуу байна"
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr "z командын урд налуу зураас байх ёстой."
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr ""
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr "CSRF алдаа: {reason}"
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr "Гадаад аккаунт"
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr "төлөөний үг"
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr "Nobody"
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr ""
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "Гишүүд"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr "Интернэт дэх хүн бүр"
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Invalid characters in emoji name"
 msgid "Invalid auto-conversion field: empty field name."
 msgstr "Эможи нэр дээрх буруу тэмдэгтүүд"
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr "URL загвар дахь %(name)r групп нь холбогч загварт байхгүй байна."
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr ""
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr "Үл мэдэгдэх алдаа байна"
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr "Буруу URL загвар байна."
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid "Example input does not match the linkifier pattern."
 msgstr "URL загвар дахь %(name)r групп нь холбогч загварт байхгүй байна."
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr "URL загвар дахь %(name)r групп нь холбогч загварт байхгүй байна."
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr "Холбогч загвар дахь %(name)r групп URL загварт байхгүй байна."
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid ""
@@ -7150,7 +6559,7 @@ msgid ""
 "pattern."
 msgstr "URL загвар дахь %(name)r групп нь холбогч загварт байхгүй байна."
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgid ""
@@ -7158,337 +6567,334 @@ msgid ""
 "template."
 msgstr "Холбогч загвар дахь %(name)r групп URL загварт байхгүй байна."
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr "Юникод эможи"
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "Тусгай эможи"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr "Zulip нэмэлт эможи"
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr "Эможи нэр дээрх буруу тэмдэгтүүд"
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr "Хүчингүй дүрүүд нь pygments программын хэл"
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr ""
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr ""
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr ""
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr ""
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr ""
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr ""
 "Zulip Cloud Standard дээр ашиглах боломжтой. Хандахын тулд шинэчилнэ үү."
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr "G үнэлгээтэй GIF-г зөвшөөрөх (Ерөнхий үзэгчид)"
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr "PG үнэлгээтэй GIF-г зөвшөөрөх (Эцэг эхийн зааварчилгаа)"
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 "PG-13 үнэлгээтэй GIF-г зөвшөөрөх (Эцэг эхийн удирдамж - 13-аас доош насны)"
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr "R үнэлгээтэй GIF-г зөвшөөрөх (Хязгаарлагдмал)"
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr "Web-public"
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "Олон нийтийн"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr "Хувийн, хуваалцсан түүх"
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr "Хувийн, хамгаалагдсан түүх"
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr "Админ, модератор, гишүүд болон зочид"
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr "Админ, модераторууд болон гишүүд"
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr "Админ болон модераторууд"
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr "Зөвхөн админууд"
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr ""
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr "Бүлгийн эзэн"
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr "Бүлгийн админ"
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr "Модератор"
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "Гишүүн"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "Зочин"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr "Үл мэдэгдэх IP хаяг"
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr "Үл мэдэгдэх үйлдлийн систем"
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr "Үл мэдэгдэх интернэт хөтөч"
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr "'queue_id' аргумент алга"
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr "'last_event_id' аргумент алга"
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr "{event_id}-с шинэ арга хэмжээг аль хэдийн хассан байна!"
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr "{event_id} үйл ажиллагаа нь тухайн дараалалд байхгүй байна"
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr "Үйл явдлын дарааллын ID буруу байна: {queue_id}"
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 #, fuzzy
 #| msgid "Failed to create Zoom call"
 msgid "Failed to generate challenge"
 msgstr "Zoom дуудлага үүсгэхэд алдаатай"
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr "JWT баталгаажуулалтыг энэ бүлэгт идэвхжүүлээгүй байна"
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr "Ямар ч JSON вэб токен хүсэлтийг дамжуулаагүй"
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr "Буруу JSON вэб токен"
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr "JSON вэб токен нэхэмжлэлд ямар ч имэйл заагаагүй байна"
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr "Дэд домэйн шаардлагатай"
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr "Нууц үг буруу байна."
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr "Хүсэлтэд хэрэглэгчийн_агентын толгой хэсэг алга"
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr "Шошго хоосон байж болохгүй."
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr "Талбар дор хаяж нэг сонголттой байх ёстой."
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr "Талбарын төрлийг профайлын хураангуй хэсэгт харуулах боломжгүй байна."
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 #, fuzzy
 #| msgid "Field type not supported for display in profile summary."
 msgid "Field type not supported for use for user matching."
 msgstr "Талбарын төрлийг профайлын хураангуй хэсэгт харуулах боломжгүй байна."
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr "Талбарын төрөл буруу."
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 "Профайлын хураангуй хэсэгт зөвхөн 2 хувийн профайлын талбарыг харуулах "
 "боломжтой."
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr "Ийм шошготой талбар аль хэдийн байна."
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr "Default custom талбарыг шинэчлэх боломжгүй."
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr "Сүүлчийн гол санааг үйлдвэрлэлд ашиглах боломжгүй."
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr "DevAuthBackend идэвхжээгүй."
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr ""
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr ""
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr ""
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr ""
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr ""
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr ""
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr "Тийм урилга байхгүй"
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 #, fuzzy
 #| msgid "Invitation has already been revoked"
 msgid "Invitation already used or deactivated."
 msgstr "Урилгыг аль хэдийн хүчингүй болгосон байна"
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr "Урилгыг аль хэдийн хүчингүй болгосон байна"
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr ""
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr "Та дор хаяж нэг имэйл хаягийг зааж өгөх ёстой."
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
@@ -7496,106 +6902,104 @@ msgstr ""
 "Тэдгээр хаягуудын зарим нь аль хэдийн Zulip-г ашиглаж байгаа тул бид тэдэнд "
 "урилга илгээгээгүй. Бид бусад хүмүүст урилга илгээсэн!"
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr "Энэ бүлэгт мессеж засварлах түүхийг идэвхгүй болгосон"
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr "Та энэ мессежийг устгах эрхгүй байна"
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr "Энэ мессежийг устгах хугацаа өнгөрсөн байна"
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr "Мессеж аль хэдийн устсан байна"
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr ""
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr "Anchor-ийг зөвхөн төгсгөлд нь хасч болно"
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr ""
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Organization creation link required"
 msgid "An explanation is required."
 msgstr "Бүлэг үүсгэх холбоос шаардлагатай"
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Zephyr mirroring is not allowed in this organization"
 msgid "Message reporting is not enabled in this organization."
 msgstr "Zephyr mirroring нь энэхүү бүлэг зөвшөөрөгдөөгүй байна."
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr "Илгээгч алга байна"
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr "Хүлээн авагчийн хэрэглэгчийн ID -г харахыг зөвшөөрөхгүй"
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr "Мессеж хуулбарлахад алдаа гарлаа"
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr ""
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr ""
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr ""
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr "Өөрийн дууг хааж чадахгүй"
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr "Хэрэглэгчийн дууг хаасан"
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr "Хэрэглэгчийн дуу нээлтэй"
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 #, fuzzy
 #| msgid "Reaction already exists."
 msgid "Navigation view already exists."
 msgstr "Үйлдэл хийгдсэн байна."
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7603,21 +7007,21 @@ msgid ""
 "later. Is this a good time?\n"
 msgstr ""
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr "Бот хэрэглэгчидийн хувьд Presence дэмжигдэхгүй."
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr "{user_id_or_email}-д байгаа мэдээлэл алга"
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 #, fuzzy
 #| msgid "You don't have permission to delete this message"
 msgid "You do not have permission to manage plans and billing."
@@ -7625,556 +7029,554 @@ msgstr ""
 "Та энэ мессежийг устгах эрхгүй байна\n"
 " "
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr ""
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr ""
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr ""
 "Дараах аргументуудын дор хаяж нэг нь байх ёстой: emoji_name, emoji_code"
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr "Энэ бүлэгт уншсан баримтыг идэвхгүй болгосон."
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr ""
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr "Дор хаяж нэг баталгаажуулалтын аргыг идэвхжүүлсэн байх ёстой."
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr ""
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr ""
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr "Нэг тест бүлэг байх ёстой."
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr ""
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr "{domain} домэйн аль хэдийн танай бүлгийн нэг хэсэг болсон."
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr "{domain} домэйн олдсонгүй."
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr "Та нэг файл оруулах боломжтой."
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr "Зөвхөн администраторууд үндсэн эможиг өөрчилж болно."
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr ""
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 #, fuzzy
 #| msgid "JWT authentication is not enabled for this organization"
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr "JWT баталгаажуулалтыг энэ бүлэгт идэвхжүүлээгүй байна"
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr "Хязгаараас хэтэрсэн байна."
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr "Дата экспортын ID буруу байна"
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr "Экспортыг аль хэдийн устгасан"
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr "Экспорт амжилтгүй болсон, устгах зүйл алга"
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr "Экспорт хийгдэж байна"
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr "Та яг нэг дүрс байршуулах ёстой."
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr "Холбогч олдсонгүй."
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr "Та нэг лого оруулах боломжтой."
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid characters in pygments language"
 msgid "Invalid character in language: {character}"
 msgstr "Хүчингүй дүрүүд нь pygments программын хэл"
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not an allowed_type"
 msgid "Language '{language}' is not allowed."
 msgstr "{var_name} нь зөвшөөрөгдсөн_төрөл биш юм"
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr "Invalid playground"
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr ""
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "Direct messages"
 msgid "Importing messages…"
 msgstr "Хувийн чат"
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "Your email"
 msgid "Your name"
 msgstr "Таны имэйл"
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr "Хүсэлтийн формат буруу байна"
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr "Буруу DSN"
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr ""
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr "Та \"new_description\" эсвэл \"new_group_name\" оруулах хэрэгтэй."
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr ""
 "\"op\"-ын утга буруу. \"add\" эсвэл \"remove\"-ын аль нэгийг зааж өгнө үү."
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr "Буруу параметрууд"
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr ""
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr ""
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr ""
 "Хийх зүйлгүй. \"Нэмэх\" эсвэл \"устгах\"-ын дор хаяж нэгийг зааж өгнө үү."
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, fuzzy, python-brace-format
 #| msgid "{user_full_name} added you to the group {group_name}."
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr "{user_full_name} таныг {group_name} группд нэмсэн."
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr ""
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr ""
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr ""
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
 "**"
 msgstr ""
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr ""
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr ""
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr ""
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr "Дэдмессежинд зориулсан json буруу байна"
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr ""
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr ""
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr "Лист жагсаалт хоосон"
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr "Хэрэглэгч хувийн чатны мэдэгдлийг идэвхгүй болгосон"
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr "<p>Танд энэ файлыг харах эрхгүй алга</p>"
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr "Буруу токен"
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr "Буруу файлын нэр"
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr "Та байршуулах файлаа зааж өгөх шаардлагатай"
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr "Тухайн цагт та нэг л файл оруулах боломжтой"
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr "Шинэ мэдээлэл өгөөгүй"
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 msgstr ""
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr "{user_full_name} таныг {group_name} группд нэмсэн."
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr "{user_full_name} таныг {group_name} группээс хассан."
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr "{user_id} хэрэглэгч аль хэдийн энэ группын гишүүн болсон байна"
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr ""
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr "{group_id} хэрэглэгчийн групп аль хэдийн энэ группын дэд групп байна."
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
 "subgroups."
 msgstr ""
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr "{group_id} хэрэглэгчийн групп нь энэ группын дэд групп биш."
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr "Энэ байгууллагад \"аватар\" -ын өөрчлөлтийг идэвхгүй болгосон."
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr "Энэ байгууллагад имэйл хаягийн өөрчлөлтийг идэвхгүй болгосон."
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr "Хүчингүй default_language"
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr ""
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr ""
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr "Таны Zulip нууц үгийг LDAP дээр удирддаг"
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr "Пассворд буруу!"
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, fuzzy, python-brace-format
 #| msgid "You can try again in %(retry_after)s seconds."
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr "%(retry_after)s секунтын дараа дахин оролдох боломжтой."
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr "Шинэ нууц үг хэтэрхий сул байна!"
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr "Та яг нэг дүрс байршуулах ёстой."
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr "Topic-ийн дууг хаагаагүй"
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr "Ганц бүлгийн эзэмшигчийг идэвхгүй болгох боломжгүй"
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Nobody in this Zulip organization will be able to see this email address."
 msgid "User is not allowed to delete other user's messages."
 msgstr "Энэ Оффис чат бүлгийн хэн ч энэ имэйл хаягийг харах боломжгүй."
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 #, fuzzy
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr "Бүлгийн админ"
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr ""
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr ""
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
@@ -8186,25 +7588,25 @@ msgstr ""
 "FAKE_EMAIL_DOMAIN зөв тохируулагдах хүртэл бот үүсгэх боломжгүй.\n"
 "Серверийн админтайгаа холбогдоно уу."
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 #, fuzzy
 #| msgid "Email address"
 msgid "Email address already in use"
 msgstr "Имэйл хаяг"
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr "Эзэмшигчийг сольж чадсангүй, хэрэглэгч байхгүй"
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr "Эзэмшигчийг сольж чадсангүй, хэрэглэгч идэвхгүй болсон"
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr "Эзэмшигчийг сольж чадсангүй, ботууд бусад ботуудыг эзэмших боломжгүй"
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
@@ -8212,294 +7614,294 @@ msgstr ""
 "FAKE_EMAIL_DOMAIN зөв тохируулагдах хүртэл бот үүсгэх боломжгүй.\n"
 "Серверийн админтайгаа холбогдоно уу."
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr "Суулгасан ботуудыг идэвхжүүлээгүй байна."
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr "Суулгасан ботын нэр буруу."
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr ""
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr "Энэ байгууллагад '{email}' имэйл илгээхийг хориглоно"
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr ""
 "Энэ байгууллагад нэг удаагийн цахим шуудангийн хаяг оруулахыг хориглоно"
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom access token"
 msgid "Invalid {provider_name} access token"
 msgstr "Zoom хандах токен буруу байна"
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} call"
 msgstr "Zoom дуудлага үүсгэхэд алдаатай"
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Zoom credentials have not been configured"
 msgid "{provider_name} credentials have not been configured"
 msgstr "Zoom -ийн итгэмжлэлийг идэвхжүүлээгүй байна"
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom credentials"
 msgid "Invalid {provider_name} credentials"
 msgstr "Хүчингүй Zoom -ын итгэмжлэл"
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error connecting to the BigBlueButton server."
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr "BigBlueButton-ийн сервертэй холбогдоход алдаа гарлаа."
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error authenticating to the BigBlueButton server."
 msgid "Error authenticating to the {provider_name} server"
 msgstr "BigBlueButton-ийн сервертэй баталгаажуулахад алдаа гарлаа."
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "BigBlueButton server returned an unexpected error."
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr "BigBlueButton сервер гэнэтийн алдаа гаргалаа."
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom session identifier"
 msgid "Invalid {provider_name} session identifier"
 msgstr "Invalid Zoom session identifier"
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr ""
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} public room."
 msgstr "Zoom дуудлага үүсгэхэд алдаатай"
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr "гарын үсэг буруу."
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{full_name}'s Zulip room"
 msgstr "{full_name} таныг дурдсан:"
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 "Энэ хувилбарын хяналтын системийн үйлчилгээ үзүүлэгчийн ашигладаг "
 "төлөвлөгөөг дэмжихгүй байна"
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr "Invalid payload"
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr "Тодорхойгүй webhook хүсэлт"
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr "Сэдэв хоосон байж болохгүй"
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr "Контент нь хоосон байж болохгүй"
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr ""
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr "Malformed JSON input"
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr "Үйл ажиллагааны түлхүүр payload-д байхгүй байна"
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr "Алдаа: 0 эсвэл 1-ээс өөр channels_map_to_topics параметр"
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr ""
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
 "({export_settings_link})."
 msgstr ""
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr ""
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr ""
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr ""
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr ""
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr "Дэд домэйн буруу байна"
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr "Хүчинтэй Zulip сервер API түлхүүрээр баталгаажуулах ёстой"
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr "UUID буруу"
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr "токен төрөл буруу байна"
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr ""
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr ""
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr ""
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr ""
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
 "try again later or reach out to {support_email} for assistance."
 msgstr ""
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr ""
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr ""
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr ""
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr "user_id эсвэл user_uuid алга байна"
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
 "server: {reason}"
 msgstr ""
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr ""
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr ""
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr ""
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr "Өгөгдөл ажиллахаа больсон."
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr ""
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr ""
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr "Та нууц үгээ солих хэрэгтэй."
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr "id_token параметр алга"
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 #, fuzzy
 #| msgid "Missing id_token parameter"
 msgid "Missing idp param"
 msgstr "id_token параметр алга"
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr "OTP буруу"
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr "mobile_flow_otp болон desktop_flow_otp -ийг хамт ашиглах боломжгүй."
 

--- a/locale/my/LC_MESSAGES/django.po
+++ b/locale/my/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 18:51+0000\n"
 "Last-Translator: Alex Vandiver <alexmv@zulip.com>\n"
 "Language-Team: Burmese <https://hosted.weblate.org/projects/zulip/django/my/"
@@ -19,50 +19,50 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "ဧည့်သည်အသုံးပြုသူများအတွက် ခွင့်မပြုပါ"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "မမှန်ကန်သောအဖွဲ့အစည်း"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr ""
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr ""
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr "စတင်ချိန်သည် ပြီးဆုံးချိန်ထက် နောက်ကျသည်။ စတင်- {start}၊ အဆုံး- {end}"
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr "ခွဲခြမ်းစိတ်ဖြာမှုဒေတာ မရရှိနိုင်ပါ။ သင့်ဆာဗာစီမံခန့်ခွဲသူကို ဆက်သွယ်ပါ။"
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -74,7 +74,7 @@ msgstr ""
 "[လိုင်စင်အရေအတွက်ကို တိုးပါ]({billing_page_link}) သို့မဟုတ် [မလှုပ်မရှားသောအသုံးပြုသူများကို ပိတ်ရန်]"
 "({deactivate_user_help_page_link}) အသုံးပြုသူအသစ်များကို ပါဝင်ခွင့်ပြုပါ။"
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -85,7 +85,7 @@ msgstr ""
 "[လိုင်စင်အရေအတွက်ကို တိုးမြင့်စေနိုင်သည်]({billing_page_link}) သို့မဟုတ် [မလှုပ်မရှားသောအသုံးပြုသူများကို "
 "ပိတ်ရန်]({deactivate_user_help_page_link}) ကို ပြုလုပ်နိုင်ပါသည်။"
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -96,7 +96,7 @@ msgstr ""
 "[လိုင်စင်အရေအတွက်ကို တိုးမြှင့်နိုင်သည်]({billing_page_link}) သို့မဟုတ် [မလှုပ်မရှားသောအသုံးပြုသူများကို "
 "ပိတ်ရန်]({deactivate_user_help_page_link}) ကို ပြုလုပ်နိုင်ပါသည်။"
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -107,7 +107,7 @@ msgstr ""
 "[လိုင်စင်အရေအတွက်ကို တိုးမြှင့်နိုင်သည်]({billing_page_link}) သို့မဟုတ် [မလှုပ်မရှားသောအသုံးပြုသူများကို "
 "ပိတ်ရန်]({deactivate_user_help_page_link}) ကို ပြုလုပ်နိုင်ပါသည်။"
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -116,148 +116,147 @@ msgid ""
 "({billing_page_link}) is greater than the current number of users."
 msgstr ""
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr ""
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr ""
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
 "(minimum {min_licenses})."
 msgstr ""
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
 "page. To complete the upgrade, please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr ""
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr ""
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr ""
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr ""
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr ""
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr ""
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
 msgstr ""
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
 msgstr ""
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
 "licenses."
 msgstr ""
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
 "billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr ""
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr ""
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr ""
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -267,100 +266,97 @@ msgid ""
 "we would really appreciate it!"
 msgstr ""
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
 "{support_email}"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr ""
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr ""
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr ""
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
 "%(support_email)s\">contact support</a>."
 msgstr ""
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr ""
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
 msgstr ""
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr ""
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
 msgstr ""
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr ""
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr ""
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
 msgstr ""
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -368,289 +364,270 @@ msgid ""
 "a> with any questions."
 msgstr ""
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
 "a> for support."
 msgstr ""
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
 "href=\"%(troubleshooting_url)s\">Zulip server troubleshooting guide</a>."
 msgstr ""
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr ""
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr ""
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr ""
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr ""
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr ""
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr ""
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr ""
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr ""
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr ""
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr ""
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr ""
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr ""
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr ""
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr ""
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr ""
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr ""
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr ""
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr ""
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr ""
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr ""
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr ""
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr ""
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr ""
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr ""
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr ""
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr ""
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr ""
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr ""
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr ""
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr ""
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
 "%(old_email_html_tag)s to %(new_email_html_tag)s"
 msgstr ""
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr ""
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
 msgstr ""
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr ""
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr ""
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -661,19 +638,19 @@ msgid ""
 "server."
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -681,788 +658,297 @@ msgid ""
 "%(support_email)s'>contact support</a> with any questions."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, python-format
 msgid "You can try again in %(retry_after_string)s."
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr ""
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr ""
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr ""
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr ""
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr ""
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr ""
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr ""
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr ""
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr ""
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr ""
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr ""
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr ""
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr ""
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr ""
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 msgid "Zulip for open source"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 msgid "Message with code"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
 msgstr ""
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 msgid "Get started"
 msgstr ""
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
 "continue."
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1470,78 +956,77 @@ msgid ""
 "from Zulip."
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
 msgstr ""
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr ""
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr ""
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr ""
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr ""
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr ""
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr ""
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr ""
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
 msgstr ""
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1549,210 +1034,203 @@ msgid ""
 "href=\"%(doc_url)s\">documentation</a>."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, python-format
 msgid "No account found for %(email)s."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Invalid organization"
 msgid "Try Zulip in a demo organization"
 msgstr "မမှန်ကန်သောအဖွဲ့အစည်း"
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 msgid "Try Zulip"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid "Import chat history?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1760,123 +1238,122 @@ msgid ""
 "noreferrer\">after you join</a>."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr ""
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">Terms of Service</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr ""
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr ""
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -1884,45 +1361,45 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 msgid ""
 "This organization has been deactivated, and all organization data has been "
 "deleted."
 msgstr ""
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
 "inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
 "administrators</a> to inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 msgid "This organization has been deactivated."
 msgstr ""
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
 "%(support_email)s\">contact Zulip support</a> to reactivate it."
 msgstr ""
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -1930,165 +1407,164 @@ msgid ""
 "reactivate it."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr ""
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr ""
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
 "<b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
 "href=\"%(apps_page_link)s\">mobile and desktop</a> apps:"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
 "href=\"%(getting_user_started_link)s\">getting started guide</a>!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2096,83 +1572,83 @@ msgid ""
 "Zulip</a>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
 "to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
 "desktop apps (%(apps_page_link)s):"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
 "(%(getting_user_started_link)s)!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
 "(%(getting_organization_started_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2180,32 +1656,32 @@ msgid ""
 "password for this account, please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "%(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 msgid "Verify your email address for your Zulip demo organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "<%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2213,113 +1689,113 @@ msgid ""
 "please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
 "— we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
 "deactivated, and you will no longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr ""
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2327,22 +1803,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because your organization <a "
@@ -2350,8 +1826,8 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to <a "
@@ -2359,39 +1835,39 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr ""
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because your organization hides "
@@ -2399,81 +1875,74 @@ msgid ""
 "details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to hide "
 "message content in email notifications. See %(help_url)s for more details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr ""
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
 "organizations:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
 "organizations hosted by %(external_host)s:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
 "href=\"%(help_reset_password_link)s\">reset your password</a>."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
 "%(external_host)s."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2481,97 +1950,94 @@ msgid ""
 "to find your account."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
 "try another way to find your account (%(help_logging_in_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
 "communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr ""
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
 "-- the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
 "Zulip &mdash; the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
 "to ask %(referrer_name)s for another one."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2579,72 +2045,70 @@ msgid ""
 "productivity."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at <a href=\"mailto:%(email)s\">%(email)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
 "%(email)s\">Contact us</a> — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
 "#%(channel_name)s > %(topic_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2652,68 +2116,68 @@ msgid ""
 "preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails (<a href=\"%(url)s\">help</a>)."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2721,22 +2185,22 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2744,52 +2208,52 @@ msgid ""
 "immediately at <%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2797,31 +2261,31 @@ msgid ""
 "contact us immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2829,7 +2293,7 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -2837,25 +2301,25 @@ msgid ""
 "Zulip</a> to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
 "with you and share their unique perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -2863,7 +2327,7 @@ msgid ""
 "experience how a new chat app will help your team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -2871,148 +2335,148 @@ msgid ""
 "action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
 "team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
 "organizations like yours!"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3020,11 +2484,11 @@ msgid ""
 "about…?”"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3033,23 +2497,23 @@ msgid ""
 "href=\"%(move_channels_link)s\">move a topic to a different channel</a>."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3058,23 +2522,23 @@ msgid ""
 "(%(move_channels_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
 "%(email)s on %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3082,46 +2546,46 @@ msgid ""
 "href=\"%(help_link)s\">reactivate your account</a>."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
 "You can contact an organization administrator to reactivate your account."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3129,541 +2593,537 @@ msgid ""
 "have been voided."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
 "to %(upgrade_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip demo organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip demo organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Invalid organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "မမှန်ကန်သောအဖွဲ့အစည်း"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for <b>%(remote_server_hostname)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 msgid "Click the button below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for %(remote_server_hostname)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
 "management for <b>%(remote_realm_host)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
 "management for %(remote_realm_host)s."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the <a href=\"%(plans_link)s\">Zulip Community plan</a>."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
 "website</a>, we would really appreciate it!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
 msgstr ""
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
 "accounts for another email address</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr ""
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr ""
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr ""
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr ""
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr ""
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 msgid "Zulip Cloud"
 msgstr ""
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr ""
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr ""
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr ""
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr ""
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr ""
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr ""
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr ""
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr ""
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr ""
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr ""
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr ""
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr ""
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr ""
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr ""
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr ""
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr ""
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr ""
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr ""
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr ""
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr ""
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr ""
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr ""
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr ""
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr ""
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr ""
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr ""
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr ""
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr ""
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr ""
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr ""
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr ""
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr ""
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 msgid "Bluesky"
 msgstr ""
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr ""
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr ""
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr ""
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 msgid ""
 "And hundreds more through <a href=\"/integrations/zapier\">Zapier</a> and <a "
 "href=\"/integrations/ifttt\">IFTTT</a>."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3671,7 +3131,7 @@ msgid ""
 "emails with your email domain."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3679,7 +3139,7 @@ msgid ""
 "disposable email addresses."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3687,24 +3147,24 @@ msgid ""
 "emails that contain \"+\"."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3712,7 +3172,7 @@ msgid ""
 "%(support_email)s\">contact Zulip support</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3720,89 +3180,89 @@ msgid ""
 "%(support_email)s\">contact this Zulip server's administrators</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
 "management for your Zulip server."
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr ""
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr ""
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr ""
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr ""
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr ""
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr ""
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr ""
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> because all Zulip Cloud licenses are in use."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -3811,42 +3271,40 @@ msgid ""
 "or misconfiguration."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 msgid "Demo organizations disabled"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -3854,22 +3312,21 @@ msgid ""
 "organization for more information."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -3877,46 +3334,44 @@ msgid ""
 "Zulip support</a> for assistance in resolving this issue."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
 "a> like Firefox, Chrome, and Edge."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Invalid organization"
 msgid "Finalize organization import"
 msgstr "မမှန်ကန်သောအဖွဲ့အစည်း"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 msgid "Organization import completed!"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -3924,52 +3379,51 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 msgid "Select your account"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 msgid "Create new account"
 msgstr ""
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr ""
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -3977,81 +3431,81 @@ msgid ""
 "have one yet."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 msgid "Self-hosting Zulip?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">log in to manage plans and billing.</a>"
 msgstr ""
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr ""
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
 msgstr ""
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr ""
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr ""
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr ""
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr ""
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr ""
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4059,7 +3513,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4068,57 +3522,57 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr ""
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4126,7 +3580,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4134,40 +3588,40 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4175,300 +3629,294 @@ msgid ""
 "away!"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
 "href=\"%(realm_url)s/#settings/notifications\">notification settings</a>."
 msgstr ""
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr ""
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr ""
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr ""
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr ""
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr ""
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr ""
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr ""
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 msgid "Cannot reactivate a deleted user"
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr ""
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr ""
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr ""
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr ""
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
 msgstr ""
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
 msgstr ""
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr ""
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr ""
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr ""
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr ""
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr ""
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr ""
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr ""
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr ""
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr ""
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr ""
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
 "{new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
 "{user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to resolve topics in this channel."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr ""
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr ""
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr ""
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr ""
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr ""
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
 "but there is no channel with that ID."
 msgstr ""
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4476,36 +3924,36 @@ msgid ""
 "it."
 msgstr ""
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
 "The channel exists but does not have any subscribers."
 msgstr ""
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr ""
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr ""
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr ""
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4513,107 +3961,105 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
 "authentication method."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr ""
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 msgid "Reminder could not be sent."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
 "the following error:"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr ""
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr ""
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr ""
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr ""
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr ""
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
 "**{old_policy}** to **{new_policy}**."
 msgstr ""
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -4622,51 +4068,49 @@ msgid ""
 "* **New**: {new_setting_description}\n"
 msgstr ""
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr ""
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr ""
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr ""
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr ""
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr ""
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr ""
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 msgstr ""
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr ""
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -4677,283 +4121,269 @@ msgid ""
 "{summary_line}"
 msgstr ""
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr ""
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr ""
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr ""
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr ""
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr ""
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr ""
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr ""
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr ""
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr ""
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr ""
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr ""
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
 "organization administrator to reactivate it."
 msgstr ""
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr ""
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr ""
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr ""
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr ""
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr ""
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr ""
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr ""
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
 "to register for accounts in this organization."
 msgstr ""
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr ""
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 msgid "Challenges are not enabled."
 msgstr ""
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr ""
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr ""
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "You're making too many attempts to sign in. Try again in "
 "{retry_after_string} or contact your organization administrator for help."
 msgstr ""
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
 msgstr ""
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr ""
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr ""
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr ""
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr ""
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr ""
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr ""
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr ""
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr ""
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr ""
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr ""
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr ""
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name can't be empty."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 msgid "Invalid channel folder ID"
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 msgid "Configure owner account email address."
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4962,69 +4392,69 @@ msgid ""
 "organization]({convert_demo}).\n"
 msgstr ""
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, python-brace-format
 msgid "{var_name} is not Base64 encoded"
 msgstr ""
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 msgid "Invalid `device_id`"
 msgstr ""
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr ""
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr ""
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr ""
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr ""
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr ""
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr ""
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr ""
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr ""
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr ""
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr ""
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5032,593 +4462,591 @@ msgid ""
 "{error_message}"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr ""
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr ""
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr ""
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr ""
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr ""
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr ""
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr ""
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr ""
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr ""
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr ""
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr ""
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr ""
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr ""
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
 msgstr ""
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr ""
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr ""
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr ""
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr ""
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr ""
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr ""
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr ""
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr ""
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 msgid "Must be a bot user"
 msgstr ""
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr ""
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr ""
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr ""
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
 "webhook; ignoring"
 msgstr ""
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr ""
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr ""
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr ""
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr ""
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} most recent messages in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr ""
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr ""
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
 msgstr ""
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr ""
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr ""
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr ""
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr ""
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr ""
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 msgid "Atlassian account ID"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 msgid "Behance username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 msgid "Bitbucket username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 msgid "Codeberg username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 msgid "Dribbble username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 msgid "Facebook username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 msgid "GitLab username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 msgid "Instagram username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 msgid "Mastodon profile"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 msgid "Medium username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 msgid "Pinterest username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 msgid "Reddit username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 msgid "Snapchat username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 msgid "Threads username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 msgid "TikTok username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 msgid "Twitch username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 msgid "X username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr ""
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr ""
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 msgid "Video calling"
 msgstr ""
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr ""
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr ""
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr ""
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr ""
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr ""
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr ""
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr ""
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr ""
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr ""
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr ""
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr ""
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr ""
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr ""
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr ""
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "{fullname} moderation"
 msgstr ""
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr ""
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr ""
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor_date' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr ""
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 msgid "Navigation view does not exist."
 msgstr ""
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5626,7 +5054,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5634,7 +5062,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5642,7 +5070,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5650,7 +5078,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5660,14 +5088,14 @@ msgid ""
 "a permanent organization]({convert_demo_organization_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
 "them in your [Inbox](/#inbox).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5675,7 +5103,7 @@ msgid ""
 "({navigation_tour_video_url}) for a quick app overview.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5690,14 +5118,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -5705,7 +5133,7 @@ msgid ""
 "and edit your [profile information](/help/edit-your-profile).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -5716,7 +5144,7 @@ msgid ""
 "experience in your [Preferences](#settings/preferences).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5727,7 +5155,7 @@ msgid ""
 "[Browse and subscribe to channels]({settings_link}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -5744,7 +5172,7 @@ msgid ""
 "discussed.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -5753,7 +5181,7 @@ msgid ""
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -5765,7 +5193,7 @@ msgid ""
 "times, and more.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5775,7 +5203,7 @@ msgid ""
 "or browse the [help center](/help/) to learn more!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5783,7 +5211,7 @@ msgid ""
 "get help, try one of the following messages: {bot_commands}\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5795,13 +5223,13 @@ msgid ""
 "({move_content_another_channel_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5815,12 +5243,11 @@ msgid ""
 "and above.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr ""
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -5828,14 +5255,14 @@ msgid ""
 "no matter how many other conversations are going on.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
 "conversations with unread messages.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -5843,7 +5270,7 @@ msgid ""
 "the `+` button next to its name.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -5851,13 +5278,13 @@ msgid ""
 "can we chat about…?”\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5865,7 +5292,7 @@ msgid ""
 "({format_message_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5885,1321 +5312,1298 @@ msgid ""
 "```\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
 "teammates.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
 "conversation.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr ""
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr ""
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr ""
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr ""
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 msgid "Invalid `push_key`"
 msgstr ""
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
 msgstr[0] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr ""
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr ""
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr ""
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 msgid "Reminder does not exist"
 msgstr ""
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr ""
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr ""
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr ""
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr ""
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr ""
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr ""
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr ""
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr ""
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 msgid "You do not have permission to create new topics in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr ""
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr ""
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr ""
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr ""
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr ""
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr ""
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} does not have the expected format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr ""
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr ""
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr ""
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {user_group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr ""
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr ""
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr ""
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr ""
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr ""
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 msgid "Name must not be empty!"
 msgstr ""
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr ""
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr ""
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr ""
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr ""
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr ""
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr ""
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr ""
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr ""
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr ""
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr ""
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr ""
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr ""
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr ""
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr ""
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr ""
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr ""
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr ""
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr ""
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr ""
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr ""
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr ""
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr ""
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr ""
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr ""
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr ""
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr ""
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr ""
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr ""
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr ""
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr ""
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr ""
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr ""
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr ""
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr ""
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr ""
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr ""
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr ""
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: empty field name."
 msgstr ""
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr ""
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr ""
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 msgid "Example input does not match the linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in alternative URL template is not present in linkifier "
 "pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in linkifier pattern is not present in alternative URL "
 "template."
 msgstr ""
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr ""
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr ""
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr ""
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr ""
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr ""
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr ""
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr ""
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr ""
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr ""
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr ""
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr ""
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr ""
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr ""
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr ""
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr ""
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr ""
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr ""
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr ""
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr ""
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr ""
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr ""
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr ""
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr ""
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr ""
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr ""
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr ""
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr ""
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr ""
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr ""
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 msgid "Failed to generate challenge"
 msgstr ""
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr ""
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr ""
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr ""
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr ""
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr ""
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr ""
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for use for user matching."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr ""
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr ""
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr ""
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr ""
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr ""
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr ""
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr ""
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr ""
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 msgid "Invitation already used or deactivated."
 msgstr ""
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr ""
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr ""
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr ""
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
 msgstr ""
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr ""
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr ""
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr ""
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr ""
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr ""
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr ""
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr ""
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr ""
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 msgid "Message reporting is not enabled in this organization."
 msgstr ""
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr ""
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr ""
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr ""
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr ""
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr ""
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr ""
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr ""
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr ""
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr ""
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 msgid "Navigation view already exists."
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7207,557 +6611,555 @@ msgid ""
 "later. Is this a good time?\n"
 msgstr ""
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr ""
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr ""
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 msgid "You do not have permission to manage plans and billing."
 msgstr ""
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr ""
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr ""
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr ""
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr ""
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr ""
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr ""
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr ""
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr ""
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr ""
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr ""
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr ""
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr ""
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr ""
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr ""
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr ""
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr ""
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr ""
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr ""
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr ""
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Invalid character in language: {character}"
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Language '{language}' is not allowed."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr ""
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr ""
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 msgid "Importing messages…"
 msgstr ""
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 msgid "Your name"
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr ""
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr ""
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr ""
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr ""
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr ""
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr "မမှန်ကန်သော အနားသတ်များ"
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr ""
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr ""
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr ""
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr ""
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr ""
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr ""
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr ""
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
 "**"
 msgstr ""
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr ""
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr ""
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr ""
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr ""
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr ""
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr ""
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr ""
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr ""
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr ""
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr ""
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr ""
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr ""
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr ""
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 msgstr ""
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr ""
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr ""
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
 "subgroups."
 msgstr ""
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr ""
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr ""
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr ""
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr ""
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr ""
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr ""
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr ""
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr ""
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr ""
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr ""
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 msgid "User is not allowed to delete other user's messages."
 msgstr ""
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr ""
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr ""
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "No analytics data available. Please contact your server administrator."
@@ -7766,302 +7168,302 @@ msgid ""
 "Please contact your server administrator."
 msgstr "ခွဲခြမ်းစိတ်ဖြာမှုဒေတာ မရရှိနိုင်ပါ။ သင့်ဆာဗာစီမံခန့်ခွဲသူကို ဆက်သွယ်ပါ။"
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 msgid "Email address already in use"
 msgstr ""
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr ""
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr ""
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr ""
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 msgstr ""
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr ""
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr ""
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr ""
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr ""
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr ""
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} access token"
 msgstr ""
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} call"
 msgstr ""
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} credentials have not been configured"
 msgstr ""
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} credentials"
 msgstr ""
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr ""
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error authenticating to the {provider_name} server"
 msgstr ""
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr ""
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} session identifier"
 msgstr ""
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr ""
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} public room."
 msgstr ""
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr ""
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{full_name}'s Zulip room"
 msgstr ""
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr ""
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr ""
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr ""
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr ""
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr ""
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr ""
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr ""
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr ""
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr ""
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
 "({export_settings_link})."
 msgstr ""
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr ""
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr ""
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr ""
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr ""
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr ""
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr ""
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr ""
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr ""
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr ""
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr ""
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr ""
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr ""
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
 "try again later or reach out to {support_email} for assistance."
 msgstr ""
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr ""
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr ""
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr ""
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr "user_id သို့မဟုတ် user_uuid ပျောက်နေသည်။"
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
 "server: {reason}"
 msgstr ""
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr ""
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr ""
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr ""
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr "ဒေတာတွေ ပျက်နေတယ်။"
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr ""
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr ""
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr "သင့်စကားဝှက်ကို ပြန်လည်သတ်မှတ်ရန် လိုအပ်သည်။"
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr "id_token ပါရာမီတာ ပျောက်နေပါသည်။"
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 #, fuzzy
 #| msgid "Missing id_token parameter"
 msgid "Missing idp param"
 msgstr "id_token ပါရာမီတာ ပျောက်နေပါသည်။"
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr "မမှန်ကန်သော OTP"
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr "mobile_flow_otp နှင့် desktop_flow_otp နှစ်ခုလုံးကို တွဲသုံး၍မရပါ။"

--- a/locale/nl/LC_MESSAGES/django.po
+++ b/locale/nl/LC_MESSAGES/django.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 19:49+0000\n"
 "Last-Translator: Sietse Planting <sietse@planting.nu>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/zulip/django/nl/>\n"
@@ -23,51 +23,51 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "Geen toegang voor gastgebruikers"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "Ongeldige organisatie"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr "Openbare kanalen"
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr "Privékanalen"
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr "Privéberichten"
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 #, fuzzy
 msgid "Group direct messages"
 msgstr "Groepsberichten"
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr "Ontbrekend kanaal voor tabel: {chart_name}"
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr "Starttiijd ligt na de eindtijd. Start: {start}, Eind: {end}"
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr "Geen statistieken beschikbaar. Pas dit aan bij de admin instellingen."
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -80,7 +80,7 @@ msgstr ""
 "({billing_page_link}) of [deactiveer inactieve gebruikers]"
 "({deactivate_user_help_page_link}) om nieuwe gebruikers toe te laten treden."
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -92,7 +92,7 @@ msgstr ""
 "gebruikers deactiveren]({deactivate_user_help_page_link}) om meer dan 1 "
 "nieuwe gebruiker toe te laten treden."
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -104,7 +104,7 @@ msgstr ""
 "gebruikers deactiveren]({deactivate_user_help_page_link}) om meer dan 2 "
 "nieuwe gebruiker toe te laten treden."
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -116,7 +116,7 @@ msgstr ""
 "gebruikers deactiveren]({deactivate_user_help_page_link}) om meer dan 3 "
 "nieuwe gebruiker toe te laten treden."
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -125,35 +125,34 @@ msgid ""
 "({billing_page_link}) is greater than the current number of users."
 msgstr ""
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr ""
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr ""
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
 "(minimum {min_licenses})."
 msgstr ""
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
@@ -162,116 +161,116 @@ msgstr ""
 "Aankopen met meer dan {max_licenses} kunnen niet verwerkt worden via deze "
 "pagina. Contacteer alsjeblieft {email} om de upgrade te voltooien."
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr ""
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr "{brand} eindigt over {last4}"
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr ""
 "Dit is een onbekende betaalmethode. Neem alsjeblieft contact op met {email}."
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr "Er is iets mis gegaan. Neem alsjeblieft contact op met {email}."
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "Er is iets mis gegaan. Herlaad alsjeblieft de pagina."
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr ""
 "Er is iets mis gegaan. Wacht alsjeblieft een paar seconden en probeer het "
 "opnieuw."
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr ""
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr ""
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
 msgstr ""
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
 msgstr ""
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
 "licenses."
 msgstr ""
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
 "billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr ""
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr ""
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr ""
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -286,100 +285,97 @@ msgstr ""
 "We zouden het ten zeerste op prijs stellen als je {begin_link} Zulip zou "
 "kunnen weergeven als sponsor op jouw website{end_link}!"
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
 "{support_email}"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr ""
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "Fout"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr ""
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
 "%(support_email)s\">contact support</a>."
 msgstr ""
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr ""
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
 msgstr ""
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr ""
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
 msgstr ""
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr ""
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr "Interne serverfout"
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
 msgstr ""
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -387,159 +383,157 @@ msgid ""
 "a> with any questions."
 msgstr ""
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
 "a> for support."
 msgstr ""
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
 "href=\"%(troubleshooting_url)s\">Zulip server troubleshooting guide</a>."
 msgstr ""
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, fuzzy, python-format
 #| msgid "Zulip analytics for %(target_name)s"
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr "Zulip statistieken voor %(target_name)s"
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 "Analysegegevens zijn volledig toegankelijk na de eerste 24 uur van de "
 "creatie van de organisatie."
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr "Zulip statistieken voor %(target_name)s"
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr ""
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr ""
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr ""
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr ""
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr ""
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr ""
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr ""
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "Actieve gebruikers"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr "Dagelijks actief"
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr "Actief per 15 dagen"
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr "Totaal aantal gebruikers"
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "Gebruikers"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr "Verstuurde berichten per type"
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "Ik"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "Iedereen"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "Afgelopen week"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "Afgelopen maand"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "Afgelopen jaar"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "Alle"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr "Berichten verstuurd"
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "Dagelijks"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "Wekelijks"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr "Cumulatief"
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "Mensen"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "Bots"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr "Berichten gelezen"
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr "Berichten door clients verstuurd"
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr "Laatste update"
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
@@ -547,15 +541,15 @@ msgstr ""
 "Een volledige update van de grafieken gebeurt eens per dag. De “verstuurde "
 "berichten” grafiek wordt elk uur bijgewerkt."
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr "E-mail gewijzigd"
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
@@ -564,119 +558,102 @@ msgstr ""
 "Dit bevestigt dat het e-mailadres voor jouw Zulip account is veranderd van "
 "%(old_email_html_tag)s naar %(new_email_html_tag)s"
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr ""
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
 msgstr ""
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr "Facturering"
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr "Bevestig"
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr ""
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr ""
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -687,19 +664,19 @@ msgid ""
 "server."
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -707,729 +684,239 @@ msgid ""
 "%(support_email)s'>contact support</a> with any questions."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, python-format
 msgid "You can try again in %(retry_after_string)s."
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr ""
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr ""
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr "Filteren op categorie"
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "Alle"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr "Categorieën"
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr ""
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr ""
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr ""
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr ""
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr ""
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "Organisatie aanmaken"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr "Demo aanvragen"
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr "Zulip self-hosten"
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr "Sponsoring aanvragen"
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr "Prijzen voor onderwijsinstellingen"
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr "Prijzen bekijken"
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr "Zulip voor ondernemingen"
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 msgid "Zulip for open source"
 msgstr "Zulip voor open-source"
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation"
 msgstr "Screenshot van een Zulip-gesprek"
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr "Screenshot van een Zulip-gesprek met een Sentry-bot"
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr "Screenshot van Zulip-inbox"
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr "Geopende laptop met een boek erin"
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr "Twee handen die een puzzel samenstellen"
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 msgid "Message with code"
 msgstr "Bericht met code"
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr "Bliksem"
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr "Link"
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr "Stuurwiel"
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr "Neem contact op met de klantenservice"
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr "Van"
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr "Organisatie"
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr "Onderwerp"
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr "Bericht"
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr "Versturen"
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr "Bedankt voor je bericht"
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr "Bedankt voor je bericht!"
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr "We zullen snel contact met je opnemen."
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
@@ -1437,60 +924,59 @@ msgstr ""
 "Je kan antwoorden voor veelgestelde vragen vinden in het <a href=\"/help/"
 "\">helpcentrup van Zulip</a>."
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 msgid "Get started"
 msgstr "Beginnen"
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
 "continue."
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr "Of gebruik een van je backup-telefoons:"
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr "De laatste mogelijkheid is om een backuptoken te gebruiken:"
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr "Gebruik backup-token"
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr "Gebruikersvoorwaarden accepteren"
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr "Welkom bij Zulip"
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "E-mail"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr "Meld je aan voor Zulip's nieuwsbrief (een paar e-mails per jaar)."
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr "Doorgaan"
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr "Bevestig je e-mailadres"
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1500,7 +986,7 @@ msgstr ""
 "Om je aanmelding te voltooien, check je e-mail (<span class=\"user_email "
 "semi-bold\">%(email)s</span>) voor een bevestigings-e-mail van Zulip."
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
@@ -1508,72 +994,71 @@ msgstr ""
 "Als je geen bevestigings-e-mail in je inbox or spammap ziet, kunnen we hem "
 "<a href=\"#\" id=\"resend_email_link\">opnieuw sturen</a>."
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr ""
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr ""
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr ""
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr ""
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr ""
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr ""
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr ""
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
 msgstr ""
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1581,212 +1066,205 @@ msgid ""
 "href=\"%(doc_url)s\">documentation</a>."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr "Zulip-account niet gevonden."
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, python-format
 msgid "No account found for %(email)s."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr "Log in met een ander account"
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr "Verder met registratie"
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Create a new Zulip organization"
 msgid "Try Zulip in a demo organization"
 msgstr "Maak een nieuwe Zulip-organisatie"
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Why Zulip"
 msgid "Try Zulip"
 msgstr "Waarom Zulip"
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "Maak een nieuwe organisatie"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr "Maak een nieuwe Zulip-organisatie"
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr "Geef e-mailadres op"
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid "Import chat history?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr "Organisatienaam"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "Organisatie-URL"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr "Gebruik%(external_host)s"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "OF"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "Aanmelden"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "Aanmelden voor Zulip"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr "Voor deze organisatie moet u worden uitgenodigd."
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr "Aanmelden met %(identity_provider)s"
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "Inloggen"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1794,125 +1272,124 @@ msgid ""
 "noreferrer\">after you join</a>."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "Wijzigen"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr "Je account"
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "Naam"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "Wachtwoord"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 "Dit wordt gebruikt voor mobiele apps en andere tools die een wachtwoord "
 "nodig hebben."
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr "Wachtwoordsterkte"
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr ""
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">Terms of Service</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr "Organisatie gedeactiveerd"
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr ""
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -1920,7 +1397,7 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid ""
@@ -1928,41 +1405,41 @@ msgid ""
 "deleted."
 msgstr "Deze organisatie is gedeactiveerd"
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
 "inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
 "administrators</a> to inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid "This organization has been deactivated."
 msgstr "Deze organisatie is gedeactiveerd"
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
 "%(support_email)s\">contact Zulip support</a> to reactivate it."
 msgstr ""
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -1970,165 +1447,164 @@ msgid ""
 "reactivate it."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr "Incorrect token."
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "Kopiëren"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "Beheerders"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr "Moderators"
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr "Guest gebruikers"
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "Gewone gebruikers"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "Sluiten"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "Bijwerken"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr "Zulip"
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
 "<b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr "Welkom bij Zulip!"
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
 "href=\"%(apps_page_link)s\">mobile and desktop</a> apps:"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr "Organisatie URL: %(organization_url)s"
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
 "href=\"%(getting_user_started_link)s\">getting started guide</a>!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2136,83 +1612,83 @@ msgid ""
 "Zulip</a>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
 "to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
 "desktop apps (%(apps_page_link)s):"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
 "(%(getting_user_started_link)s)!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
 "(%(getting_organization_started_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr "Hallo,"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2220,32 +1696,32 @@ msgid ""
 "password for this account, please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "%(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 msgid "Verify your email address for your Zulip demo organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "<%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2253,113 +1729,113 @@ msgid ""
 "please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr "Bevestig aanpassing e-mailadres"
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr "Je hebt je zojuist aangemeld voor Zulip. Super!"
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr "Aanmelding afronden"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
 "— we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
 "deactivated, and you will no longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr ""
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2367,22 +1843,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because your organization <a "
@@ -2390,8 +1866,8 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to <a "
@@ -2399,40 +1875,40 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, fuzzy, python-format
 #| msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr "Graag <a href=\"%(login_url)s\">inloggen</a> met je nieuwe wachtwoord."
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr ""
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because your organization hides "
@@ -2440,82 +1916,75 @@ msgid ""
 "details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to hide "
 "message content in email notifications. See %(help_url)s for more details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, fuzzy, python-format
 #| msgid "Organization: %(organization_url)s"
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr "Organisatie: %(organization_url)s"
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr ""
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
 "organizations:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
 "organizations hosted by %(external_host)s:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
 "href=\"%(help_reset_password_link)s\">reset your password</a>."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
 "%(external_host)s."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2523,97 +1992,94 @@ msgid ""
 "to find your account."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
 "try another way to find your account (%(help_logging_in_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr "Hoi,"
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
 "communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr ""
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
 "-- the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr "Nogmaals hallo,"
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
 "Zulip &mdash; the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
 "to ask %(referrer_name)s for another one."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2621,72 +2087,70 @@ msgid ""
 "productivity."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at <a href=\"mailto:%(email)s\">%(email)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
 "%(email)s\">Contact us</a> — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
 "#%(channel_name)s > %(topic_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2694,68 +2158,68 @@ msgid ""
 "preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails (<a href=\"%(url)s\">help</a>)."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr "Nieuwe berichten"
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2763,22 +2227,22 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr "Groet,"
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr "Het Zulip-team"
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2786,53 +2250,53 @@ msgid ""
 "immediately at <%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 msgstr ""
 "Organisatie: %(organization_url)s Tijd: %(login_time)s E-mail: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr "Organisatie: %(organization_link)s"
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr "E-mailadres: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr "Tijd: %(login_time)s"
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr "Toestel: %(device_browser)s op %(device_os)s."
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr "IP adres: %(device_ip)s"
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2840,31 +2304,31 @@ msgid ""
 "contact us immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr "Bedankt,"
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr "Zulip Security"
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr "Organisatie: %(organization_url)s"
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2872,7 +2336,7 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -2880,25 +2344,25 @@ msgid ""
 "Zulip</a> to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
 "with you and share their unique perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -2906,7 +2370,7 @@ msgid ""
 "experience how a new chat app will help your team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -2914,148 +2378,148 @@ msgid ""
 "action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
 "team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
 "organizations like yours!"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3063,11 +2527,11 @@ msgid ""
 "about…?”"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3076,23 +2540,23 @@ msgid ""
 "href=\"%(move_channels_link)s\">move a topic to a different channel</a>."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr "Naar Zulip"
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3101,23 +2565,23 @@ msgid ""
 "(%(move_channels_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
 "%(email)s on %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr "Wachtwoord herstellen"
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3125,46 +2589,46 @@ msgid ""
 "href=\"%(help_link)s\">reactivate your account</a>."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
 "You can contact an organization administrator to reactivate your account."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3172,543 +2636,539 @@ msgid ""
 "have been voided."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
 "to %(upgrade_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip demo organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip demo organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Deactivated organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "Organisatie gedeactiveerd"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for <b>%(remote_server_hostname)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 msgid "Click the button below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for %(remote_server_hostname)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
 "management for <b>%(remote_realm_host)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
 "management for %(remote_realm_host)s."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the <a href=\"%(plans_link)s\">Zulip Community plan</a>."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
 "website</a>, we would really appreciate it!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
 msgstr ""
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr "Zoek je Zulip accounts"
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
 "accounts for another email address</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr "E-mailadres"
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "Vind accounts"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr ""
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr "Waarom Zulip"
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr "Mogelijkheden"
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr ""
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Zulip"
 msgid "Zulip Cloud"
 msgstr "Zulip"
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr ""
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr ""
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "Integratie"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr "Desktop & mobiele apps"
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr "Nieuwe organisatie"
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr ""
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr ""
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr "Onderwijs"
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr ""
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr ""
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr ""
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr ""
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr ""
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr ""
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr ""
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr ""
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr "Helpcentrum"
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr "Community chat"
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr ""
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr ""
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr ""
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr ""
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr ""
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr ""
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr ""
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr "Team"
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "Geschiedenis"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr ""
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr ""
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr ""
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr ""
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr ""
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 msgid "Bluesky"
 msgstr ""
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr ""
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr "Gebruiksvoorwaarden"
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr "Veiligheid van uw gegevens"
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 msgid ""
 "And hundreds more through <a href=\"/integrations/zapier\">Zapier</a> and <a "
 "href=\"/integrations/ifttt\">IFTTT</a>."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr "Zoekintegraties"
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr "Maatwerkintegraties"
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr "Inkomende webhooks"
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr "Interactieve bots"
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr "REST API"
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3716,7 +3176,7 @@ msgid ""
 "emails with your email domain."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3724,7 +3184,7 @@ msgid ""
 "disposable email addresses."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3732,24 +3192,24 @@ msgid ""
 "emails that contain \"+\"."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3757,7 +3217,7 @@ msgid ""
 "%(support_email)s\">contact Zulip support</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3765,90 +3225,90 @@ msgid ""
 "%(support_email)s\">contact this Zulip server's administrators</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
 "management for your Zulip server."
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr ""
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr ""
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 "Je bent al geregistreerd met dit e-mailadres. Hieronder inloggen graag."
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr "E-mailadres of gebruikersnaam"
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "Gebruikersnaam"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr "Wachtwoord vergeten?"
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr ""
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr ""
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> because all Zulip Cloud licenses are in use."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -3857,44 +3317,42 @@ msgid ""
 "or misconfiguration."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 #, fuzzy
 #| msgid "New organization"
 msgid "Demo organizations disabled"
 msgstr "Nieuwe organisatie"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr "Update vereist"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -3902,22 +3360,21 @@ msgid ""
 "organization for more information."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -3925,49 +3382,47 @@ msgid ""
 "Zulip support</a> for assistance in resolving this issue."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, fuzzy, python-format
 #| msgid "Presence is not supported for bot users."
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr "Aanwezigheid wordt niet ondersteund voor botgebruikers."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
 "a> like Firefox, Chrome, and Edge."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr "Account is gedeactiveerd"
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Invalid organization"
 msgid "Finalize organization import"
 msgstr "Ongeldige organisatie"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Organization name"
 msgid "Organization import completed!"
 msgstr "Organisatienaam"
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -3975,56 +3430,55 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Your account"
 msgid "Select your account"
 msgstr "Je account"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create a new organization"
 msgid "Create new account"
 msgstr "Maak een nieuwe organisatie"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr ""
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr "Volgende"
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4032,81 +3486,81 @@ msgid ""
 "have one yet."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 msgid "Self-hosting Zulip?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">log in to manage plans and billing.</a>"
 msgstr ""
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr "Herstel je wachtwoord"
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
 msgstr ""
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "Wachtwoord bevestigen"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr "Sorry, de link die je opgaf is ongeldig of is al eerder gebruikt."
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr ""
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr ""
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr "Graag <a href=\"%(login_url)s\">inloggen</a> met je nieuwe wachtwoord."
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr "Wachtwoordherstel verstuurd!"
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr ""
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr ""
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4114,7 +3568,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4123,57 +3577,57 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr ""
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4181,7 +3635,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4189,40 +3643,40 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr "<h1 class=\"get-started\">Selecteer account</h1>"
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr "Onbekend e-mail uitschrijfverzoek"
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4230,304 +3684,298 @@ msgid ""
 "away!"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr "E-mailinstellingen bijgewerkt"
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
 "href=\"%(realm_url)s/#settings/notifications\">notification settings</a>."
 msgstr ""
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr ""
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr ""
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr ""
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr ""
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr ""
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr ""
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr ""
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 msgid "Cannot reactivate a deleted user"
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr "Veld id {id} niet gevonden."
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr ""
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr ""
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr ""
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
 msgstr ""
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
 msgstr ""
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 "Sommige e-mails zijn niet gevalideerd, dus we hebben geen uitnodigingen "
 "gestuurd."
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr "We konden niemand uitnodigen."
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr "Niets te wijzigen"
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr ""
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr ""
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr ""
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr ""
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr ""
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr "Je organisatie heeft het bewerken van berichten uitgeschakeld"
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr "Je bent niet bevoegd dit bericht te bewerken"
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr ""
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
 "{new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
 "{user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 #, fuzzy
 #| msgid "You don't have permission to edit this message"
 msgid "You don't have permission to resolve topics in this channel."
 msgstr "Je bent niet bevoegd dit bericht te bewerken"
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr ""
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr ""
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr "Ongeldig(e) bericht(en)"
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr "Kan bericht niet opmaken"
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr ""
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
 "but there is no channel with that ID."
 msgstr ""
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4535,36 +3983,36 @@ msgid ""
 "it."
 msgstr ""
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
 "The channel exists but does not have any subscribers."
 msgstr ""
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr ""
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr ""
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr "Widgets: {error_msg}"
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4572,109 +4020,107 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
 "authentication method."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr ""
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder could not be sent."
 msgstr "Token bestaat niet"
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
 "the following error:"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr ""
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr ""
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr ""
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr ""
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr ""
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
 "**{old_policy}** to **{new_policy}**."
 msgstr ""
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -4683,51 +4129,49 @@ msgid ""
 "* **New**: {new_setting_description}\n"
 msgstr ""
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr "Geen beschrijving."
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr ""
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr ""
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr ""
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr ""
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr ""
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 msgstr ""
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr ""
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -4738,151 +4182,140 @@ msgid ""
 "{summary_line}"
 msgstr ""
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr ""
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr ""
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr ""
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr "Onvoldoende rechten"
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr "Deze API is niet beschikbaar voor inkomende webhook-bots."
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr "Account is niet verbonden met dit subdomein"
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr "Dit eindpunt accepteert geen botverzoeken."
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr ""
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr "Dit endpoint vereist HTTP basic authenticatie."
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr "Ongeldige autorizatie header voor basic auth"
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr "Webhook-bots hebben alleen toegang tot webhooks"
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr ""
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
 "organization administrator to reactivate it."
 msgstr ""
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr ""
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr "Subdomein moet minimaal 3 tekens lang zijn."
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr "Subdomein kan niet beginnen of eindigen met een '-'."
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr "Subdomein mag alleen kleine letters, cijfers en '-en' bevatten."
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr "Gebruik je echte e-mailadres."
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr ""
 "De organisatie waar je bij wilt aansluiten met {email} bestaat hier niet."
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr "Vraag een uitnodiging voor {email} aan bij de organisatiebeheerder."
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
@@ -4891,137 +4324,134 @@ msgstr ""
 "Je e-mailadres, {email}, bevindt zich niet in een van de domeinen die zich "
 "mogen registreren voor accounts in deze organisatie."
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr ""
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 msgid "Challenges are not enabled."
 msgstr ""
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "Nieuw wachtwoord"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr ""
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "You're making too many attempts to sign in. Try again in "
 "{retry_after_string} or contact your organization administrator for help."
 msgstr ""
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
 msgstr ""
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr "Token"
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr "Geef maximaal 10 e-mailadressen op."
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr ""
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr ""
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr "Ontbrekend onderwerp"
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr ""
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr ""
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr "Bericht moet ontvangers hebben"
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr "Ongeldig berichttype"
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr "Ongeldige bijlage"
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr ""
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Content can't be empty"
 msgid "Channel folder name can't be empty."
 msgstr "Inhoud kan niet leeg zijn"
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 msgid "Invalid channel folder ID"
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 #, fuzzy
 #| msgid "Enter your email address"
 msgid "Configure owner account email address."
 msgstr "Geef e-mailadres op"
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5030,70 +4460,70 @@ msgid ""
 "organization]({convert_demo}).\n"
 msgstr ""
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a URL"
 msgid "{var_name} is not Base64 encoded"
 msgstr "{var_name} is geen URL"
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 msgid "Invalid `device_id`"
 msgstr ""
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr ""
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr "Domein kan niet leeg zijn."
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr "Domein moet minimaal één punt (.) hebben"
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr "Domein is te lang"
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr "Domein kan niet beginnen of eindigen met een punt (.)"
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr "Opeenvolgende \".\" niet toegestaan."
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr "Subdomeinen kunnen niet beginnen of eindigen met een '-'."
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr "Domein kan alleen bestaan uit letters, cijfers, \".\" en \"-\"S."
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr ""
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr ""
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5101,628 +4531,626 @@ msgid ""
 "{error_message}"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr ""
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr "Ongeldig adres."
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr "Buiten je domein."
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr ""
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr ""
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr ""
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr "Heeft al een account."
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr "Account is gedeactiveerd."
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr ""
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr ""
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr ""
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr ""
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr ""
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr ""
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
 msgstr ""
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr "Emoji-naam ontbreekt"
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr "Kan wachtrij voor gebeurtenissen niet toewijzen"
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr "Niet ingelogd: API-authenticatie of gebruikerssessie vereist"
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr ""
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr "organisatie-eigenaar"
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr "gebruiker"
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr ""
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr "Misvormde JSON"
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr ""
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 msgid "Must be a bot user"
 msgstr ""
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr ""
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr "Deze organisatie is gedeactiveerd"
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr ""
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr ""
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr "Ongeldige API key"
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr "Misvormde API key"
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
 "webhook; ignoring"
 msgstr ""
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr "Ongeldig subdomein"
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr ""
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr ""
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr "Verboden toegang"
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} most recent messages in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr ""
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr ""
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
 msgstr ""
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr ""
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr ""
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr ""
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr ""
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr ""
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Already has an account."
 msgid "Atlassian account ID"
 msgstr "Heeft al een account."
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Behance username"
 msgstr "Verkeerde naam of gebruikersnaam"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 msgid "Bitbucket username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Codeberg username"
 msgstr "Verkeerde naam of gebruikersnaam"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Dribbble username"
 msgstr "E-mailadres of gebruikersnaam"
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Facebook username"
 msgstr "Verkeerde naam of gebruikersnaam"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "GitLab username"
 msgstr "E-mailadres of gebruikersnaam"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Instagram username"
 msgstr "Verkeerde naam of gebruikersnaam"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 msgid "Mastodon profile"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Medium username"
 msgstr "Verkeerde naam of gebruikersnaam"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Pinterest username"
 msgstr "Verkeerde naam of gebruikersnaam"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Reddit username"
 msgstr "E-mailadres of gebruikersnaam"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 msgid "Snapchat username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Threads username"
 msgstr "Verkeerde naam of gebruikersnaam"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "TikTok username"
 msgstr "E-mailadres of gebruikersnaam"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Twitch username"
 msgstr "E-mailadres of gebruikersnaam"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "Gebruikersnaam"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr ""
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr "Integratieframeworks"
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 #, fuzzy
 #| msgid "Billing"
 msgid "Video calling"
 msgstr "Facturering"
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr "Continu integratie"
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr "Klantenondersteuning"
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr "Inzet"
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr ""
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr "Communicatie"
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr "Financieel"
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr ""
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr "Marketing"
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr "Diversen"
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr ""
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr "Projectmanagement"
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr "Productiviteit"
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr "Versiebeheersing"
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr "Bericht kan niet leeg zijn"
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr "Bericht kan geen 'null bytes' bevatten"
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{fullname} moderation"
 msgstr "{full_name} vermeldde jou:"
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr "Ongeldige smalle operator: {desc}"
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr ""
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr ""
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 #, fuzzy
 #| msgid "Missing '{var_name}' argument"
 msgid "Missing 'anchor_date' argument."
 msgstr "Ontbrekend '{var_name}' argument"
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr ""
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Navigation view does not exist."
 msgstr "Token bestaat niet"
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5730,7 +5158,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5738,7 +5166,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5746,7 +5174,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5754,7 +5182,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5764,14 +5192,14 @@ msgid ""
 "a permanent organization]({convert_demo_organization_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
 "them in your [Inbox](/#inbox).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5779,7 +5207,7 @@ msgid ""
 "({navigation_tour_video_url}) for a quick app overview.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5794,14 +5222,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -5809,7 +5237,7 @@ msgid ""
 "and edit your [profile information](/help/edit-your-profile).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -5820,7 +5248,7 @@ msgid ""
 "experience in your [Preferences](#settings/preferences).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5831,7 +5259,7 @@ msgid ""
 "[Browse and subscribe to channels]({settings_link}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -5848,7 +5276,7 @@ msgid ""
 "discussed.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -5857,7 +5285,7 @@ msgid ""
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -5869,7 +5297,7 @@ msgid ""
 "times, and more.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5879,7 +5307,7 @@ msgid ""
 "or browse the [help center](/help/) to learn more!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5887,7 +5315,7 @@ msgid ""
 "get help, try one of the following messages: {bot_commands}\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5899,13 +5327,13 @@ msgid ""
 "({move_content_another_channel_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5919,12 +5347,11 @@ msgid ""
 "and above.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr ""
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -5932,14 +5359,14 @@ msgid ""
 "no matter how many other conversations are going on.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
 "conversations with unread messages.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -5947,7 +5374,7 @@ msgid ""
 "the `+` button next to its name.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -5955,13 +5382,13 @@ msgid ""
 "can we chat about…?”\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5969,7 +5396,7 @@ msgid ""
 "({format_message_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5989,1238 +5416,1217 @@ msgid ""
 "```\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
 "teammates.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
 "conversation.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr ""
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr ""
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr ""
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr "Leeg token of onjuiste lengte"
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr "Ongeldige APNS token"
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr ""
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr "Token bestaat niet"
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr "{full_name} vermeldde jou:"
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr "{full_name} vermeldde iedereen:"
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "Nieuw bericht"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 #, fuzzy
 #| msgid "Invalid API key"
 msgid "Invalid `push_key`"
 msgstr "Ongeldige API key"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr "Gebruiker niet geautoriseerd voor deze opvraag"
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr ""
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr ""
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr ""
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder does not exist"
 msgstr "Token bestaat niet"
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr ""
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr ""
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr "Ontbrekend '{var_name}' argument"
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr "Slechte waarde voor '{var_name}': {bad_value}"
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr ""
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr ""
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr ""
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr ""
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 #, fuzzy
 #| msgid "You don't have permission to edit this message"
 msgid "You do not have permission to create new topics in this channel."
 msgstr "Je bent niet bevoegd dit bericht te bewerken"
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr ""
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr ""
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr ""
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr ""
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr ""
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr ""
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} does not have the expected format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid attachment"
 msgid "Invalid {setting_name}"
 msgstr "Ongeldige bijlage"
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr ""
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr ""
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr ""
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {user_group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr ""
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr ""
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr ""
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr ""
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr "Naam te lang!"
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 #, fuzzy
 #| msgid "Message must not be empty"
 msgid "Name must not be empty!"
 msgstr "Bericht kan niet leeg zijn"
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr "Ongeldige tekens in de naam!"
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr ""
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr ""
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr ""
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr "Verkeerde naam of gebruikersnaam"
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr ""
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr ""
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr ""
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr ""
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr "Ongeldig bottype"
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr "Ongeldig interfacetype"
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr ""
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr "Niet zo'n bot"
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr "Niet zo'n gebruiker"
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr ""
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr ""
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr ""
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr ""
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr ""
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr ""
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr ""
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr "{variable} != {expected_value} ({value} is onjuist)"
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr "{var_name} is geen URL"
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr ""
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr ""
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr ""
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr ""
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr ""
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr ""
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr ""
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr ""
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr "CSRF fout: {reason}"
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr ""
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr "Niemand"
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr ""
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "Leden"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr ""
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Invalid characters in emoji name"
 msgid "Invalid auto-conversion field: empty field name."
 msgstr "Ongeldigetekens in emoji-naam"
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr ""
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr ""
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 msgid "Example input does not match the linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in alternative URL template is not present in linkifier "
 "pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in linkifier pattern is not present in alternative URL "
 "template."
 msgstr ""
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr "Unicode emoji"
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "Aangepaste emoji"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr "Zulip extra emoji"
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr "Ongeldigetekens in emoji-naam"
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr ""
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr ""
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr ""
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr ""
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr ""
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr ""
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr ""
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr ""
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr ""
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "Publiek"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr ""
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr ""
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr "Beheerders, moderators, leden en gasten"
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr "Beheerders, moderators en leden"
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr "Beheerders en moderators"
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr "Alleen beheerders"
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr ""
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr "Organisatie-eigenaar"
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr "Organisatiebeheerder"
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr "Moderator"
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "Lid"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "Gast"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr ""
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr ""
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr "Ontbrekend 'queue_id' argument"
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr "Ontbrekend 'last_event_id' argument"
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr ""
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr ""
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 msgid "Failed to generate challenge"
 msgstr ""
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr ""
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr "Geen JSON-webtoken doorgegeven in verzoek"
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr "Fout JSON web token"
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr ""
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr "Subdomein vereist"
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr ""
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 #, fuzzy
 #| msgid "Presence is not supported for bot users."
 msgid "Field type not supported for use for user matching."
 msgstr "Aanwezigheid wordt niet ondersteund voor botgebruikers."
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr "Ongeldig veldtype."
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr ""
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr ""
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr ""
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr ""
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr ""
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr ""
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr ""
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr ""
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid "Invitation already used or deactivated."
 msgstr "Deze organisatie is gedeactiveerd"
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr ""
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr ""
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr "Je moet minimaal één e-mailadres opgeven."
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
@@ -7228,104 +6634,102 @@ msgstr ""
 "Sommige van die adressen gebruiken al Zulip, dus we hebben ze geen "
 "uitnodiging gestuurd. We hebben alle anderen wel uitnodigingen gestuurd!"
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr ""
 "Bewerkingsgeschiedenis van berichten is uitgeschakeld in deze organisatie"
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr ""
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr ""
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr ""
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr ""
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr ""
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr ""
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr ""
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Message edit history is disabled in this organization"
 msgid "Message reporting is not enabled in this organization."
 msgstr ""
 "Bewerkingsgeschiedenis van berichten is uitgeschakeld in deze organisatie"
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr "Ontbrekende afzender"
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr ""
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr "Ongeldig gespiegeld bericht"
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr ""
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr ""
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr ""
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr ""
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr ""
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr ""
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 msgid "Navigation view already exists."
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7333,147 +6737,147 @@ msgid ""
 "later. Is this a good time?\n"
 msgstr ""
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr "Aanwezigheid wordt niet ondersteund voor botgebruikers."
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr ""
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 #, fuzzy
 #| msgid "You don't have permission to edit this message"
 msgid "You do not have permission to manage plans and billing."
 msgstr "Je bent niet bevoegd dit bericht te bewerken"
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr ""
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr ""
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr ""
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr ""
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr ""
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr "Er moet minimaal één authenticatiemethode worden ingeschakeld."
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr ""
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr ""
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr ""
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr ""
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr "Je moet exact één bestand uploaden."
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr ""
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 #, fuzzy
 #| msgid "Message edit history is disabled in this organization"
 msgid ""
@@ -7481,416 +6885,414 @@ msgid ""
 msgstr ""
 "Bewerkingsgeschiedenis van berichten is uitgeschakeld in deze organisatie"
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr ""
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr ""
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr ""
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr ""
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr ""
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr "Je moet precies één pictogram uploaden."
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr ""
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr "Je moet precies één logo uploaden."
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid characters in name!"
 msgid "Invalid character in language: {character}"
 msgstr "Ongeldige tekens in de naam!"
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Language '{language}' is not allowed."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr ""
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr ""
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 msgid "Importing messages…"
 msgstr ""
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 msgid "Your name"
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr ""
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr ""
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr ""
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr ""
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr ""
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr "Ongeldige parameters"
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr ""
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr ""
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr ""
 "Niets te doen. Geef minimaal één op van \"toevoegen\" of \"verwijderen\"."
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr ""
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr ""
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr ""
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr ""
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
 "**"
 msgstr ""
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr ""
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr ""
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr ""
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr ""
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr ""
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr ""
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr ""
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr ""
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr "<p>Je bent niet geautoriseerd om dit bestand te zien.</p>"
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr ""
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr ""
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr "Je moet een te uploaden bestand opgeven"
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr "Je mag maar één bestand tegelijk uploaden"
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr "Geen nieuwe gegevens opgegeven"
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 msgstr ""
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr ""
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr ""
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
 "subgroups."
 msgstr ""
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr "E-mail adreswijzigingen uitgeschakeld in deze organisatie."
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr ""
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr ""
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr ""
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr ""
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr "Verkeerd wachtwoord!"
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr ""
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr ""
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr "Je moet precies één avatar uploaden."
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr ""
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr ""
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 msgid "User is not allowed to delete other user's messages."
 msgstr ""
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr ""
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr ""
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "No analytics data available. Please contact your server administrator."
@@ -7899,306 +7301,306 @@ msgid ""
 "Please contact your server administrator."
 msgstr "Geen statistieken beschikbaar. Pas dit aan bij de admin instellingen."
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 #, fuzzy
 #| msgid "Email address"
 msgid "Email address already in use"
 msgstr "E-mailadres"
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr ""
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr ""
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr ""
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 msgstr ""
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr ""
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr ""
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr ""
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr ""
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr ""
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} access token"
 msgstr ""
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} call"
 msgstr ""
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} credentials have not been configured"
 msgstr ""
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} credentials"
 msgstr ""
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr ""
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error authenticating to the {provider_name} server"
 msgstr ""
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr ""
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} session identifier"
 msgstr ""
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr ""
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} public room."
 msgstr ""
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr ""
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{full_name}'s Zulip room"
 msgstr "{full_name} vermeldde jou:"
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr ""
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr "Onbekend webhook-verzoek"
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr "Onderwerp kan niet leeg zijn"
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr "Inhoud kan niet leeg zijn"
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr ""
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr "Misvormde JSON input"
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr ""
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr "Fout: channels_map_to_topics parameter anders dan 0 of 1"
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr ""
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
 "({export_settings_link})."
 msgstr ""
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr ""
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr ""
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr ""
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr ""
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr ""
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr "Moet worden gevalideerd met een geldige Zulip-server-API-sleutel"
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr ""
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr "Ongeldig tokentype"
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr ""
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr ""
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr ""
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr ""
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
 "try again later or reach out to {support_email} for assistance."
 msgstr ""
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr ""
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr ""
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr ""
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr ""
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
 "server: {reason}"
 msgstr ""
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr ""
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr ""
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr ""
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr ""
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr ""
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr ""
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr ""
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr ""
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 #, fuzzy
 #| msgid "Missing sender"
 msgid "Missing idp param"
 msgstr "Ontbrekende afzender"
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr "Ongeldig OTP"
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr ""
 

--- a/locale/no/LC_MESSAGES/django.po
+++ b/locale/no/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 19:30+0000\n"
 "Last-Translator: Sjur N Moshagen <sjurnm@mac.com>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/zulip/"
@@ -19,50 +19,50 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr ""
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr ""
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr ""
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr ""
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr ""
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr ""
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -71,7 +71,7 @@ msgid ""
 "users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -79,7 +79,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than one user to join."
 msgstr ""
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -87,7 +87,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than two users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -95,7 +95,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than three users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -104,148 +104,147 @@ msgid ""
 "({billing_page_link}) is greater than the current number of users."
 msgstr ""
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr ""
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr ""
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
 "(minimum {min_licenses})."
 msgstr ""
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
 "page. To complete the upgrade, please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr ""
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr ""
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr ""
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr ""
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr ""
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr ""
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
 msgstr ""
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
 msgstr ""
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
 "licenses."
 msgstr ""
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
 "billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr ""
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr ""
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr ""
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -255,100 +254,97 @@ msgid ""
 "we would really appreciate it!"
 msgstr ""
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
 "{support_email}"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr ""
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr ""
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr ""
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
 "%(support_email)s\">contact support</a>."
 msgstr ""
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr ""
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
 msgstr ""
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr ""
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
 msgstr ""
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr ""
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr ""
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
 msgstr ""
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -356,289 +352,270 @@ msgid ""
 "a> with any questions."
 msgstr ""
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
 "a> for support."
 msgstr ""
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
 "href=\"%(troubleshooting_url)s\">Zulip server troubleshooting guide</a>."
 msgstr ""
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr ""
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr ""
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr ""
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr ""
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr ""
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr ""
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr ""
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr ""
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr ""
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr ""
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr ""
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr ""
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr ""
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr ""
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr ""
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr ""
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr ""
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr ""
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr ""
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr ""
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr ""
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr ""
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr ""
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr ""
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr ""
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr ""
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr ""
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr ""
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr ""
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr ""
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
 "%(old_email_html_tag)s to %(new_email_html_tag)s"
 msgstr ""
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr ""
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
 msgstr ""
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr ""
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr ""
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -649,19 +626,19 @@ msgid ""
 "server."
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -669,788 +646,297 @@ msgid ""
 "%(support_email)s'>contact support</a> with any questions."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, python-format
 msgid "You can try again in %(retry_after_string)s."
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr ""
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr ""
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr ""
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr ""
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr ""
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr ""
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr ""
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr ""
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr ""
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr ""
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr ""
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr ""
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr ""
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr ""
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 msgid "Zulip for open source"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 msgid "Message with code"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
 msgstr ""
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 msgid "Get started"
 msgstr ""
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
 "continue."
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1458,78 +944,77 @@ msgid ""
 "from Zulip."
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
 msgstr ""
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr ""
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr ""
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr ""
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr ""
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr ""
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr ""
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr ""
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
 msgstr ""
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1537,208 +1022,201 @@ msgid ""
 "href=\"%(doc_url)s\">documentation</a>."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, python-format
 msgid "No account found for %(email)s."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 msgid "Try Zulip in a demo organization"
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 msgid "Try Zulip"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid "Import chat history?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1746,123 +1224,122 @@ msgid ""
 "noreferrer\">after you join</a>."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr ""
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">Terms of Service</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr ""
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr ""
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -1870,45 +1347,45 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 msgid ""
 "This organization has been deactivated, and all organization data has been "
 "deleted."
 msgstr ""
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
 "inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
 "administrators</a> to inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 msgid "This organization has been deactivated."
 msgstr ""
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
 "%(support_email)s\">contact Zulip support</a> to reactivate it."
 msgstr ""
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -1916,165 +1393,164 @@ msgid ""
 "reactivate it."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr ""
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr ""
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
 "<b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
 "href=\"%(apps_page_link)s\">mobile and desktop</a> apps:"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
 "href=\"%(getting_user_started_link)s\">getting started guide</a>!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2082,83 +1558,83 @@ msgid ""
 "Zulip</a>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
 "to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
 "desktop apps (%(apps_page_link)s):"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
 "(%(getting_user_started_link)s)!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
 "(%(getting_organization_started_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2166,32 +1642,32 @@ msgid ""
 "password for this account, please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "%(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 msgid "Verify your email address for your Zulip demo organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "<%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2199,113 +1675,113 @@ msgid ""
 "please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
 "— we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
 "deactivated, and you will no longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr ""
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2313,22 +1789,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because your organization <a "
@@ -2336,8 +1812,8 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to <a "
@@ -2345,39 +1821,39 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr ""
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because your organization hides "
@@ -2385,81 +1861,74 @@ msgid ""
 "details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to hide "
 "message content in email notifications. See %(help_url)s for more details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr ""
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
 "organizations:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
 "organizations hosted by %(external_host)s:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
 "href=\"%(help_reset_password_link)s\">reset your password</a>."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
 "%(external_host)s."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2467,97 +1936,94 @@ msgid ""
 "to find your account."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
 "try another way to find your account (%(help_logging_in_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
 "communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr ""
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
 "-- the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
 "Zulip &mdash; the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
 "to ask %(referrer_name)s for another one."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2565,72 +2031,70 @@ msgid ""
 "productivity."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at <a href=\"mailto:%(email)s\">%(email)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
 "%(email)s\">Contact us</a> — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
 "#%(channel_name)s > %(topic_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2638,68 +2102,68 @@ msgid ""
 "preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails (<a href=\"%(url)s\">help</a>)."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2707,22 +2171,22 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2730,52 +2194,52 @@ msgid ""
 "immediately at <%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2783,31 +2247,31 @@ msgid ""
 "contact us immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2815,7 +2279,7 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -2823,25 +2287,25 @@ msgid ""
 "Zulip</a> to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
 "with you and share their unique perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -2849,7 +2313,7 @@ msgid ""
 "experience how a new chat app will help your team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -2857,148 +2321,148 @@ msgid ""
 "action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
 "team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
 "organizations like yours!"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3006,11 +2470,11 @@ msgid ""
 "about…?”"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3019,23 +2483,23 @@ msgid ""
 "href=\"%(move_channels_link)s\">move a topic to a different channel</a>."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3044,23 +2508,23 @@ msgid ""
 "(%(move_channels_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
 "%(email)s on %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3068,46 +2532,46 @@ msgid ""
 "href=\"%(help_link)s\">reactivate your account</a>."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
 "You can contact an organization administrator to reactivate your account."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3115,539 +2579,535 @@ msgid ""
 "have been voided."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
 "to %(upgrade_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip demo organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip demo organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip demo organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for <b>%(remote_server_hostname)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 msgid "Click the button below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for %(remote_server_hostname)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
 "management for <b>%(remote_realm_host)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
 "management for %(remote_realm_host)s."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the <a href=\"%(plans_link)s\">Zulip Community plan</a>."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
 "website</a>, we would really appreciate it!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
 msgstr ""
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
 "accounts for another email address</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr ""
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr ""
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr ""
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr ""
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr ""
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 msgid "Zulip Cloud"
 msgstr ""
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr ""
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr ""
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr ""
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr ""
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr ""
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr ""
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr ""
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr ""
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr ""
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr ""
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr ""
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr ""
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr ""
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr ""
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr ""
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr ""
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr ""
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr ""
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr ""
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr ""
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr ""
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr ""
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr ""
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr ""
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr ""
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr ""
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr ""
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr ""
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr ""
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr ""
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr "Mastodon"
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr ""
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 msgid "Bluesky"
 msgstr ""
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr ""
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr ""
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr ""
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 msgid ""
 "And hundreds more through <a href=\"/integrations/zapier\">Zapier</a> and <a "
 "href=\"/integrations/ifttt\">IFTTT</a>."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3655,7 +3115,7 @@ msgid ""
 "emails with your email domain."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3663,7 +3123,7 @@ msgid ""
 "disposable email addresses."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3671,24 +3131,24 @@ msgid ""
 "emails that contain \"+\"."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3696,7 +3156,7 @@ msgid ""
 "%(support_email)s\">contact Zulip support</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3704,89 +3164,89 @@ msgid ""
 "%(support_email)s\">contact this Zulip server's administrators</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
 "management for your Zulip server."
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr ""
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr ""
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr ""
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr ""
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr ""
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr ""
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr ""
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> because all Zulip Cloud licenses are in use."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -3795,42 +3255,40 @@ msgid ""
 "or misconfiguration."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 msgid "Demo organizations disabled"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -3838,22 +3296,21 @@ msgid ""
 "organization for more information."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -3861,44 +3318,42 @@ msgid ""
 "Zulip support</a> for assistance in resolving this issue."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
 "a> like Firefox, Chrome, and Edge."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 msgid "Finalize organization import"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 msgid "Organization import completed!"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -3906,52 +3361,51 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 msgid "Select your account"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 msgid "Create new account"
 msgstr ""
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr ""
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -3959,81 +3413,81 @@ msgid ""
 "have one yet."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 msgid "Self-hosting Zulip?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">log in to manage plans and billing.</a>"
 msgstr ""
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr ""
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
 msgstr ""
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr ""
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr ""
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr ""
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr ""
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr ""
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4041,7 +3495,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4050,57 +3504,57 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr ""
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4108,7 +3562,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4116,40 +3570,40 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4157,300 +3611,294 @@ msgid ""
 "away!"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
 "href=\"%(realm_url)s/#settings/notifications\">notification settings</a>."
 msgstr ""
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr ""
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr ""
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr ""
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr ""
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr ""
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr ""
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr ""
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 msgid "Cannot reactivate a deleted user"
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr ""
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr ""
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr ""
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr ""
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
 msgstr ""
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
 msgstr ""
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr ""
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr ""
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr ""
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr ""
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr ""
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr ""
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr ""
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr ""
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr ""
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr ""
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
 "{new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
 "{user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to resolve topics in this channel."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr ""
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr ""
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr ""
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr ""
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr ""
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
 "but there is no channel with that ID."
 msgstr ""
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4458,36 +3906,36 @@ msgid ""
 "it."
 msgstr ""
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
 "The channel exists but does not have any subscribers."
 msgstr ""
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr ""
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr ""
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr ""
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4495,107 +3943,105 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
 "authentication method."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr ""
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 msgid "Reminder could not be sent."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
 "the following error:"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr ""
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr ""
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr ""
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr ""
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr ""
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
 "**{old_policy}** to **{new_policy}**."
 msgstr ""
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -4604,51 +4050,49 @@ msgid ""
 "* **New**: {new_setting_description}\n"
 msgstr ""
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr ""
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr ""
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr ""
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr ""
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr ""
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr ""
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 msgstr ""
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr ""
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -4659,283 +4103,269 @@ msgid ""
 "{summary_line}"
 msgstr ""
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr ""
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr ""
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr ""
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr ""
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr ""
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr ""
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr ""
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr ""
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr ""
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr ""
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr ""
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
 "organization administrator to reactivate it."
 msgstr ""
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr ""
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr ""
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr ""
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr ""
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr ""
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr ""
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr ""
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
 "to register for accounts in this organization."
 msgstr ""
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr ""
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 msgid "Challenges are not enabled."
 msgstr ""
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr ""
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr ""
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "You're making too many attempts to sign in. Try again in "
 "{retry_after_string} or contact your organization administrator for help."
 msgstr ""
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
 msgstr ""
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr ""
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr ""
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr ""
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr ""
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr ""
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr ""
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr ""
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr ""
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr ""
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr ""
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr ""
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name can't be empty."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 msgid "Invalid channel folder ID"
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 msgid "Configure owner account email address."
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4944,69 +4374,69 @@ msgid ""
 "organization]({convert_demo}).\n"
 msgstr ""
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, python-brace-format
 msgid "{var_name} is not Base64 encoded"
 msgstr ""
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 msgid "Invalid `device_id`"
 msgstr ""
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr ""
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr ""
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr ""
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr ""
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr ""
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr ""
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr ""
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr ""
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr ""
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr ""
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5014,593 +4444,591 @@ msgid ""
 "{error_message}"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr ""
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr ""
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr ""
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr ""
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr ""
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr ""
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr ""
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr ""
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr ""
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr ""
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr ""
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr ""
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr ""
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
 msgstr ""
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr ""
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr ""
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr ""
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr ""
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr ""
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr ""
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr ""
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr ""
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 msgid "Must be a bot user"
 msgstr ""
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr ""
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr ""
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr ""
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
 "webhook; ignoring"
 msgstr ""
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr ""
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr ""
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr ""
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr ""
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} most recent messages in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr ""
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr ""
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
 msgstr ""
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr ""
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr ""
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr ""
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr ""
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr ""
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 msgid "Atlassian account ID"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 msgid "Behance username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 msgid "Bitbucket username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 msgid "Codeberg username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 msgid "Dribbble username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 msgid "Facebook username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 msgid "GitLab username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 msgid "Instagram username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 msgid "Mastodon profile"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 msgid "Medium username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 msgid "Pinterest username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 msgid "Reddit username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 msgid "Snapchat username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 msgid "Threads username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 msgid "TikTok username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 msgid "Twitch username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 msgid "X username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr ""
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr ""
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 msgid "Video calling"
 msgstr ""
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr ""
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr ""
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr ""
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr ""
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr ""
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr ""
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr ""
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr ""
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr ""
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr ""
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr ""
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr ""
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr ""
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr ""
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "{fullname} moderation"
 msgstr ""
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr ""
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr ""
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor_date' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr ""
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 msgid "Navigation view does not exist."
 msgstr ""
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5608,7 +5036,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5616,7 +5044,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5624,7 +5052,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5632,7 +5060,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5642,14 +5070,14 @@ msgid ""
 "a permanent organization]({convert_demo_organization_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
 "them in your [Inbox](/#inbox).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5657,7 +5085,7 @@ msgid ""
 "({navigation_tour_video_url}) for a quick app overview.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5672,14 +5100,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -5687,7 +5115,7 @@ msgid ""
 "and edit your [profile information](/help/edit-your-profile).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -5698,7 +5126,7 @@ msgid ""
 "experience in your [Preferences](#settings/preferences).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5709,7 +5137,7 @@ msgid ""
 "[Browse and subscribe to channels]({settings_link}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -5726,7 +5154,7 @@ msgid ""
 "discussed.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -5735,7 +5163,7 @@ msgid ""
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -5747,7 +5175,7 @@ msgid ""
 "times, and more.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5757,7 +5185,7 @@ msgid ""
 "or browse the [help center](/help/) to learn more!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5765,7 +5193,7 @@ msgid ""
 "get help, try one of the following messages: {bot_commands}\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5777,13 +5205,13 @@ msgid ""
 "({move_content_another_channel_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5797,12 +5225,11 @@ msgid ""
 "and above.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr ""
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -5810,14 +5237,14 @@ msgid ""
 "no matter how many other conversations are going on.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
 "conversations with unread messages.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -5825,7 +5252,7 @@ msgid ""
 "the `+` button next to its name.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -5833,13 +5260,13 @@ msgid ""
 "can we chat about…?”\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5847,7 +5274,7 @@ msgid ""
 "({format_message_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5867,1322 +5294,1299 @@ msgid ""
 "```\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
 "teammates.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
 "conversation.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr ""
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr ""
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr ""
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr ""
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 msgid "Invalid `push_key`"
 msgstr ""
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr ""
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr ""
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr ""
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 msgid "Reminder does not exist"
 msgstr ""
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr ""
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr ""
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr ""
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr ""
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr ""
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr ""
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr ""
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr ""
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 msgid "You do not have permission to create new topics in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr ""
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr ""
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr ""
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr ""
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr ""
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr ""
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} does not have the expected format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr ""
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr ""
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr ""
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {user_group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr ""
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr ""
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr ""
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr ""
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr ""
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 msgid "Name must not be empty!"
 msgstr ""
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr ""
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr ""
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr ""
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr ""
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr ""
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr ""
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr ""
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr ""
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr ""
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr ""
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr ""
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr ""
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr ""
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr ""
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr ""
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr ""
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr ""
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr ""
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr ""
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr ""
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr ""
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr ""
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr ""
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr ""
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr ""
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr ""
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr ""
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr ""
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr ""
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr ""
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr ""
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr ""
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr ""
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr ""
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr ""
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr ""
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr ""
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: empty field name."
 msgstr ""
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr ""
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr ""
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 msgid "Example input does not match the linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in alternative URL template is not present in linkifier "
 "pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in linkifier pattern is not present in alternative URL "
 "template."
 msgstr ""
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr ""
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr ""
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr ""
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr ""
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr ""
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr ""
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr ""
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr ""
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr ""
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr ""
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr ""
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr ""
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr ""
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr ""
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr ""
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr ""
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr ""
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr ""
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr ""
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr ""
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr ""
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr ""
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr ""
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr ""
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr ""
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr ""
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr ""
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr ""
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr ""
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 msgid "Failed to generate challenge"
 msgstr ""
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr ""
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr ""
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr ""
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr ""
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr ""
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr ""
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for use for user matching."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr ""
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr ""
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr ""
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr ""
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr ""
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr ""
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr ""
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr ""
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 msgid "Invitation already used or deactivated."
 msgstr ""
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr ""
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr ""
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr ""
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
 msgstr ""
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr ""
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr ""
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr ""
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr ""
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr ""
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr ""
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr ""
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr ""
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 msgid "Message reporting is not enabled in this organization."
 msgstr ""
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr ""
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr ""
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr ""
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr ""
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr ""
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr ""
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr ""
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr ""
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr ""
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 msgid "Navigation view already exists."
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7190,856 +6594,854 @@ msgid ""
 "later. Is this a good time?\n"
 msgstr ""
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr ""
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr ""
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 msgid "You do not have permission to manage plans and billing."
 msgstr ""
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr ""
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr ""
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr ""
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr ""
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr ""
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr ""
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr ""
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr ""
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr ""
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr ""
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr ""
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr ""
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr ""
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr ""
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr ""
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr ""
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr ""
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr ""
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr ""
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Invalid character in language: {character}"
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Language '{language}' is not allowed."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr ""
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr ""
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 msgid "Importing messages…"
 msgstr ""
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 msgid "Your name"
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr ""
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr ""
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr ""
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr ""
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr ""
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr ""
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr ""
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr ""
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr ""
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr ""
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr ""
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr ""
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr ""
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
 "**"
 msgstr ""
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr ""
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr ""
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr ""
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr ""
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr ""
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr ""
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr ""
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr ""
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr ""
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr ""
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr ""
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr ""
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr ""
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 msgstr ""
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr ""
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr ""
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
 "subgroups."
 msgstr ""
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr ""
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr ""
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr ""
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr ""
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr ""
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr ""
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr ""
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr ""
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr ""
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr ""
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 msgid "User is not allowed to delete other user's messages."
 msgstr ""
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr ""
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr ""
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 msgid ""
 "Can't change bot email until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 msgstr ""
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 msgid "Email address already in use"
 msgstr ""
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr ""
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr ""
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr ""
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 msgstr ""
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr ""
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr ""
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr ""
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr ""
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr ""
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} access token"
 msgstr ""
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} call"
 msgstr ""
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} credentials have not been configured"
 msgstr ""
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} credentials"
 msgstr ""
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr ""
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error authenticating to the {provider_name} server"
 msgstr ""
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr ""
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} session identifier"
 msgstr ""
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr ""
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} public room."
 msgstr ""
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr ""
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{full_name}'s Zulip room"
 msgstr ""
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr ""
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr ""
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr ""
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr ""
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr ""
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr ""
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr ""
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr ""
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr ""
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
 "({export_settings_link})."
 msgstr ""
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr ""
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr ""
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr ""
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr ""
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr ""
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr ""
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr ""
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr ""
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr ""
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr ""
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr ""
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr ""
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
 "try again later or reach out to {support_email} for assistance."
 msgstr ""
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr ""
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr ""
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr ""
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr ""
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
 "server: {reason}"
 msgstr ""
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr ""
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr ""
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr ""
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr ""
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr ""
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr ""
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr ""
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr ""
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 msgid "Missing idp param"
 msgstr ""
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr ""
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr ""

--- a/locale/pl/LC_MESSAGES/django.po
+++ b/locale/pl/LC_MESSAGES/django.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 19:36+0000\n"
 "Last-Translator: Arusekk <arek_koz@o2.pl>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/zulip/django/pl/"
@@ -38,53 +38,53 @@ msgstr ""
 "n%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "Brak dostępu dla gości"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "Nieprawidłowa organizacja"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr "Kanały publiczne"
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr "Kanały prywatne"
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr "Wiadomości bezpośrednie"
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr "Grupowe wiadomości bezpośrednie"
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr "Brakuje kanału dla wykresu: {chart_name}"
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr "Nieznana nazwa znaku: {chart_name}"
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr ""
 "Czas rozpoczęcia jest późniejszy niż zakończenia. Rozpoczęcie: {start}, "
 "Koniec: {end}"
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr ""
 "Dane analityczne niedostępne. Skontaktuj się z administratorem serwera."
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -97,7 +97,7 @@ msgstr ""
 "albo [odłącz nieaktywnych użytkowników]({deactivate_user_help_page_link}) "
 "aby dołączyć nowych użytkowników."
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -109,7 +109,7 @@ msgstr ""
 "użytkowników]({deactivate_user_help_page_link}) aby zezwolić więcej niż "
 "jednemu użytkownikowi na dołączenie."
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -121,7 +121,7 @@ msgstr ""
 "({deactivate_user_help_page_link}) aby zezwolić więcej niż dwóm użytkownikom "
 "na dołączenie."
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -133,7 +133,7 @@ msgstr ""
 "({deactivate_user_help_page_link}) aby zezwolić więcej niż trzem "
 "użytkownikom na dołączenie."
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -147,7 +147,7 @@ msgstr ""
 "billing period]({billing_page_link}) jest większa niż bieżąca liczba "
 "użytkowników."
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
@@ -155,7 +155,7 @@ msgstr ""
 "Twoja organizacja nie ma wystarczającej liczby licencji Zulip. Zaproszenia "
 "nie zostały wysłane."
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
@@ -163,16 +163,15 @@ msgstr ""
 "Twoja organizacja nie ma wystarczającej liczby licencji Zulip, aby zmienić "
 "rolę użytkownika-gościa."
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr "Rejestracja jest wyłączona"
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr "Wadliwy serwer zdalny."
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
@@ -181,7 +180,7 @@ msgstr ""
 "Należy zakupić licencje dla wszystkich aktywnych użytkowników w organizacji "
 "(minimum {min_licenses})."
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
@@ -191,61 +190,61 @@ msgstr ""
 "przetwarzane z tej strony. Aby dokończyć aktualizację, skontaktuj się z "
 "{email}."
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr "Brak zapisanej metody płatności."
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr "{brand} kończy się w {last4}"
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr "Nieznana metoda płatności. Proszę skontaktuj się z {email}."
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr "Coś poszło nie tak. Proszę skontaktuj się z {email}."
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "Coś poszło nie tak. Spróbuj odświeżyć stronę."
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr "Coś poszło nie tak. Poczekaj kilka sekund i spróbuj ponownie."
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 "Przed rozpoczęciem bezpłatnego okresu próbnego należy dodać kartę kredytową."
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr "Dodaj kartę kredytową, aby zaplanować aktualizację."
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
 msgstr ""
 "Nie można zaktualizować planu. Plan wygasł i został zastąpiony nowym planem."
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr "Nie dało rady zmienić oferty. Oferta wygasła."
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 "Nie można zaktualizować licencji w bieżącym okresie rozliczeniowym dla "
 "bezpłatnego planu próbnego."
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
@@ -253,7 +252,7 @@ msgstr ""
 "Nie można ręcznie zaktualizować licencji. Twój plan zakłada automatyczne "
 "zarządzanie licencjami."
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
@@ -261,12 +260,12 @@ msgstr ""
 "Twój plan jest już objęty {licenses} licencji w bieżącym okresie "
 "rozliczeniowym."
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr ""
 "Nie można zmniejszyć liczby licencji w bieżącym okresie rozliczeniowym."
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
@@ -274,7 +273,7 @@ msgstr ""
 "Nie można zmienić licencji na następny cykl rozliczeniowy dla planu, który "
 "został obniżony."
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
@@ -283,7 +282,7 @@ msgstr ""
 "Plan jest już zaplanowany do odnowienia z licencjami "
 "{licenses_at_next_renewal}."
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
@@ -292,27 +291,27 @@ msgstr ""
 "Zakupiono już licencje {licenses_at_next_renewal} na następny okres "
 "rozliczeniowy."
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr "Nic do zmiany."
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr "Brak konsumenta dla tej organizacji!"
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr "Nie odnaleziono sesji"
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr "Nie odnaleziono powodu płatności"
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr "Przekaż stripe_session_id lub stripe_invoice_id"
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -327,20 +326,19 @@ msgstr ""
 "Jeśli mógłbyś {begin_link}wymienić Zulip jako sponsora na swojej "
 "stronie{end_link}, bylibyśmy naprawdę wdzięczni!"
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr "Parametr 'confirmed' jest wymagany"
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr "Token dostępu do płatności wygasł."
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr "Błędny token dostępu do płatności."
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
@@ -349,38 +347,37 @@ msgstr ""
 "Nie można uzgodnić danych rozliczeniowych między serwerem a sferą. Prosimy o "
 "kontakt {support_email}"
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr "Póki co nie ma konta użytkownika."
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr "Aby kontynuować, należy zaakceptować Warunki świadczenia usług."
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr "Organizacja zulip_org_id nie jest wpisana do systemu rozliczeń Zulip."
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr "Błędny zulip_org_key dla tej zulip_org_id."
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr "Przyjmowanie rejestracji zostało wyłączone."
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "Błąd"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr "Strona nie została odnaleziona (404)"
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
@@ -389,11 +386,11 @@ msgstr ""
 "O ile błąd jest nieoczekiwany możesz <a href=\"mailto:"
 "%(support_email)s\">dać znać pomocy technicznej</a>."
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr "Odmowa dostępu (403)"
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
@@ -402,12 +399,12 @@ msgstr ""
 "poświadczeń wymaganych do uwierzytelnienia dostępu. Aby rozwiązać ten "
 "problem:"
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr ""
 "Upewnij się, że Twoja przeglądarka zezwala na pliki cookie dla tej witryny."
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
@@ -415,16 +412,15 @@ msgstr ""
 "Sprawdź ustawienia prywatności lub rozszerzenia przeglądarki które blokują "
 "nagłówki Referer i wyłącz je dla tej strony. tej witryny."
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr "Metoda nie jest dozwolona (405)"
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr "Wewnętrzny błąd serwera"
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
@@ -433,7 +429,7 @@ msgstr ""
 "pracujemy nad jego rozwiązaniem. Zulip uruchomi się z automatu kiedy już "
 "wszystko wróci do normy."
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -444,7 +440,7 @@ msgstr ""
 "dowiedzieć się więcej i <a href=\"mailto:%(support_email)s\">daj znać pomocy "
 "technicznej Zulip</a> o ile masz dodatkowe pytania."
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
@@ -452,7 +448,7 @@ msgstr ""
 "Coś poszło nie tak. Przepraszamy za to! Zulip uruchomi się z automatu kiedy "
 "wszystko wróci do normy."
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
@@ -461,7 +457,7 @@ msgstr ""
 "<a href=\"mailto:%(support_email)s\">Skontaktuj się z administratorami "
 "serwera</a> aby uzyskać pomoc."
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
@@ -471,137 +467,135 @@ msgstr ""
 "href=\"%(troubleshooting_url)s\">poradnik Zulip jak rozwiązać problemy na "
 "tym poziomie</a>."
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr "Statystyka dla %(target_name)s | Zulip"
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 "Analityka jest w pełni dostępna po 24 godzinach od utworzenia organizacji."
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr "Statystyki Zulipa dla %(target_name)s"
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr "Podsumowanie organizacji"
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr "Liczba użytkowników"
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr "Użytkownicy aktywni w ciągu ostatnich 15 dni"
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr "Liczba gości"
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr "Łączna liczba wiadomości"
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr "Liczba wpisów za ostatnie 30 dni"
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr "Wykorzystano na pliki"
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "Aktywni użytkownicy"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr "Dziennie"
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr "Aktywni ostatnie 15 dni"
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr "Wszyscy"
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "Użytkownicy"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr "Wiadomości wysłane do"
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "Ja"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "Wszyscy"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "Ostatni tydzień"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "Ostatni miesiąc"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "Ostatni rok"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "Od początku"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr "Historia wysłanych wiadomości"
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "Dzienny"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "Tygodniowo"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr "Zbiorczo"
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "Ludzie"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "Boty"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr "Jak dotąd przeczytane wpisy"
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr "Wiadomości wysłane poprzez"
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr "Ostatnia aktualizacja"
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
@@ -609,15 +603,15 @@ msgstr ""
 "Pełna aktualizacja wszystkich wykresów odbywa się raz dziennie. Wykres "
 "„wiadomości wysłane w czasie” jest aktualizowany raz na godzinę."
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr "Zmieniono email"
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr "Zmieniono email!"
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
@@ -626,21 +620,21 @@ msgstr ""
 "To jest potwierdzenie, że adres email przypisany do konta Zulip zmienił się "
 "z %(old_email_html_tag)s na %(new_email_html_tag)s"
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr "Potwierdzanie twojego adresu email"
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr "Odnośnik konfiguracyjny nie istnieje"
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr "Ups. Nie mogliśmy znaleźć odnośnika potwierdzającego w systemie."
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
@@ -649,28 +643,28 @@ msgstr ""
 "Tak czy siak daj znać na %(support_email_html_tag)s a zajmiemy się tym tak "
 "szybko jak się da."
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr "Odnośnik potwierdzający wygasł lub został dezaktywowany"
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr "Ups. Odnośnik potwierdzający wygasł lub został dezaktywowany."
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr ""
 "Aby uzyskać nowy odnośnik, skontaktuj się z administratorem organizacji."
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr "Odnośnik jest wadliwy"
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr "Ups. Odnośnik potwierdzający jest wadliwy."
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
@@ -678,72 +672,55 @@ msgstr ""
 "Upewnij się, że odnośnik został poprawnie skopiowany do przeglądarki. Jeśli "
 "nadal napotykasz tę stronę, prawdopodobnie jest to nasza wina. Przepraszamy."
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr "Rozliczenie"
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr "Zamknij modal"
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr "Mniejsza z tym"
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr "Przywróć"
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr "Potwierdź"
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr "Anuluj aktualizację"
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr "Status rozliczeń"
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr "Wyłączyć rejestrację serwera?"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr "Zarządzanie ofertami nie jest dostępne"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -759,7 +736,7 @@ msgstr ""
 "href=\"https://zulip.com/help/self-hosted-billing#log-in-to-billing-"
 "management\">zakładce z instrukcjami</a> aby zarządzać planami serwera Zulip."
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
@@ -767,7 +744,7 @@ msgstr ""
 "Aby przenieść plan z serwera do tej organizacji lub w przypadku innych "
 "pytań, <a href=\"mailto:{{ support_email }}\">skontaktuj się z nami</a>."
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
@@ -775,7 +752,7 @@ msgstr ""
 "Zarządzanie planami dla tego serwera nie jest dostępne, ponieważ co najmniej "
 "jedna organizacja hostowana na tym serwerze ma już aktywny plan."
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -787,737 +764,247 @@ msgstr ""
 "<a href='mailto:%(support_email)s'>skontaktuj się</a> aby rozwiać "
 "wątpliwości."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr "Przekroczono limit ruchu"
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr "Przekroczono limit ruchu."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 "Twój serwer przekroczył limit operacji przewidziany dla tego typu akcji."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, fuzzy, python-format
 #| msgid "You can try again in %(retry_after)s seconds."
 msgid "You can try again in %(retry_after_string)s."
 msgstr "Spróbuj ponownie za %(retry_after)s sekund."
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr "Zaktualizuj"
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr "Wyślij fakturę i rozpocznij darmowe testy"
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr "Wyślij fakturę"
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr "Otwórz listę społeczności"
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr "Filtruj po kategorii"
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "Wszystko"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr "Kategorie"
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr "10000 wiadomości"
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr "Bez limitu"
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr "Pliki do 10 MB"
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr "Pliki do 1 GB"
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr "Wspierane"
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr "Samodzielnie zarządzany"
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr "Dla organizacji z nie więcej niż 10. użytkownikami"
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr "minimum 25 użytkowników"
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr "Niedostępny"
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr "Społeczność tworzących Zulip"
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr "Dołącz jako użytkownik"
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr "Dołącz jako self-hoster"
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr "Dołącz jako wspierający"
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "Stwórz organizację"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr "Uzyskaj demo"
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr "Zulip na własnym serwerze"
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr "Poproś o sponsoring"
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr "Cennik dla edukacji"
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr "Zobacz cennik"
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr "Zulip dla biznesu"
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Zulip guide for open-source projects"
 msgid "Zulip for open source"
 msgstr "Zobacz przewodnik Zulip dla projektów open-source"
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "start a conversation"
 msgid "Screenshot of Zulip conversation"
 msgstr "rozpocznij dyskusję"
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Messages sent over time"
 msgid "Message with code"
 msgstr "Historia wysłanych wiadomości"
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr "Link"
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr "Skontaktuj się ze wsparciem"
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr "Od"
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr "Organizacja"
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr "Temat"
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr "Wiadomość"
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr "Dodaj"
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr "Dziękujemy za nawiązanie kontaktu"
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr "Dziękujemy za wiadomość!"
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr "Odezwiemy się do ciebie już wkrótce."
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
@@ -1525,13 +1012,13 @@ msgstr ""
 "Odpowiedzi na najcześciej zadawane pytania znajdziesz <a href=\"/help/\">w "
 "centrum pomocy Zulip</a>."
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 #, fuzzy
 #| msgid "Getting started"
 msgid "Get started"
 msgstr "Jak zacząć"
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
@@ -1541,50 +1028,49 @@ msgstr ""
 "href=\"https://zulip.com/policies/terms\">Warunków korzystania z usług "
 "Zulip</a> aby kontynuować."
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr "Lub, alternatywnie, użyj jednego z Twoich zapasowych telefonów:"
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr "Ostatecznie możesz użyć zapasowego tokena:"
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr "Użyj zapasowego tokena"
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr "Zaakceptuj warunki użytkowania"
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr "Witaj w Zulip"
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "Email"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr ""
 "Dopisz mnie do listy wysyłkowej newslettera Zulip (kilka maili na rok)."
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr "Kontynuuj"
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr "Potwierdź swój adres email"
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1594,7 +1080,7 @@ msgstr ""
 "Aby dokończyć rejestrację sprawdź skrzynkę email (<span class=\"user_email "
 "semi-bold\">%(email)s</span>) pod kątem potwierdzenia od Zulip."
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
@@ -1602,30 +1088,30 @@ msgstr ""
 "O ile nie ma maila z potwierdzeniem w odebranych lub w spamie można go <a "
 "href=\"#\" id=\"resend_email_link\">ponowić</a>."
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr "Widok publiczny {org_name} | czat zespołowy Zulip"
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr "Przeglądaj publicznie dostępne kanału w {org_name} bez logowania się."
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
@@ -1633,39 +1119,38 @@ msgstr ""
 "O ile ta wiadomość nie chce zniknąć, spróbuj <a class=\"reload-"
 "lnk\">przeładować</a> stronę."
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 "Błąd załadowania Zulip. Spróbuj <a class=\"reload-lnk\">przeładować</a> "
 "stronę."
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr "Nie ma dyskusji wpisujących się w filtry."
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr "Ten widok nadal ładuje wpisy."
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr "Pokaż więcej"
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr "Zakończono połączenie wideo"
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr "Możesz już zamknąć to okno."
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr "Błąd konfiguracji"
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
@@ -1674,7 +1159,7 @@ msgstr ""
 "organizacji. Proszę użyć EmailAuthBackend do utworzenia organizacji, a "
 "następnie spróbuj ponownie."
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1685,72 +1170,70 @@ msgstr ""
 "dotyczące sposobu konfiguracji powiadomień push, można znaleźć w sekcji <a "
 "href=\"%(doc_url)s\">dokumentacja</a>."
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr "Nie odnaleziono konta"
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr "Nie odnaleziono konta Zulip."
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, python-format
 msgid "No account found for %(email)s."
 msgstr "Brak konta dla %(email)s."
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr "Zaloguj za pomocą innego konta"
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr "Kontynuuj rejestrację"
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Must be a demo organization."
 msgid "Try Zulip in a demo organization"
 msgstr "Musi być organizacją demo."
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Try Zulip now"
 msgid "Try Zulip"
 msgstr "Wypróbuj Zulip"
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "Utwórz nową organizację"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr "Dodaj nową organizację"
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr "Podaj swój adres email"
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr "Twój email"
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
@@ -1760,11 +1243,11 @@ msgstr ""
 "help/import-from-mattermost\">Mattermost</a>, lub <a href=\"/help/import-"
 "from-rocketchat\">Rocket.Chat</a>."
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr "Jak po raz pierwszy usłuszałeś o Zulip?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
@@ -1772,42 +1255,41 @@ msgstr ""
 "Ta wartość jest używana tylko w przypadku zapisania się do planu, w którym "
 "to przypadku zostanie wysłana do zespołu Zulip."
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr "Wybierz opcję"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr "Proszę opisz"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr "Gdzie widziałeś reklamę?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr "Która organizacja?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr "Który?"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr "Wybierz jedno"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr "Rodzaj organizacji"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr "Język organizacji"
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
@@ -1817,72 +1299,68 @@ msgstr ""
 "mattermost\">Mattermost</a> lub <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid "Import chat history?"
 msgstr "Zaimportować historię czatów?"
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr "Nazwa organizacji"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "URL organizacji"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr "Użyj %(external_host)s"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "LUB"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "Zarejestruj"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "Zarejestruj się w Zulipie"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr "Potrzebujesz zaproszenia aby dołączyć do tej organizacji."
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr "Zarejestruj się przy pomocy %(identity_provider)s"
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr "Masz już konto?"
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "Zaloguj się"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr "Skonfiguruj prywatność adresu email"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
@@ -1890,7 +1368,7 @@ msgstr ""
 "Zulip pozwala kontrolować, które role w organizacji mogą wyświetlać Twój "
 "adres email."
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
@@ -1898,11 +1376,11 @@ msgstr ""
 "Czy chcesz zmienić ustawienia prywatności poczty email z domyślnej "
 "konfiguracji dla tej organizacji?"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr "Kto ma dostęp do twojego adresu email"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1913,14 +1391,14 @@ msgstr ""
 "email-visibility\" target=\"_blank\" rel=\"noopener noreferrer\">po "
 "dołączeniu</a>."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 "Administratorzy tej organizacji Zulip będą mogli zobaczyć ten adres email."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
@@ -1928,91 +1406,90 @@ msgstr ""
 "Administratorzy i moderatorzy tej organizacji Zulip będą mogli zobaczyć ten "
 "adres email."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 "Nikt w tej organizacji Zulip nie będzie mógł zobaczyć tego adresu email."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 "Inni użytkownicy w tej organizacji Zulip będą mogli zobaczyć ten adres email."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "Zmień"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr "Rejestracja"
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr "Stwórz swoją organizację"
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr "Utwórz swoje konto"
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr "<p>Uzupełnij dane dla swojego konta aby dokończyć rejestrację.</p>"
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr "Twoja organizacja"
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr "Twoje konto"
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr "Nie importuj ustawień"
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr "Zimportuj ustawienia z istniejącego konta"
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr "Twoje imię i nazwisko"
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "Nazwa"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr "W ten sposób konto jest wyświetlane w Zulip."
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "Hasło"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr "Podaj hasło LDAP/Active Directory."
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr "Używane dla aplikacji mobilnych i innych narzędzi wymagających hasła."
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr "Siła hasła"
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr "Cym się interesujesz?"
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
@@ -2021,15 +1498,15 @@ msgstr ""
 "Akceptuję <a href=\"%(root_domain_url)s/policies/terms\" target=\"_blank\" "
 "rel=\"noopener noreferrer\">Warunki korzystania z usług</a>."
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr "Dezaktywowana organizacja"
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr "Organizacja przeniesiona"
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
@@ -2038,7 +1515,7 @@ msgstr ""
 "Ta organizacja przeniosła się do <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -2049,13 +1526,13 @@ msgstr ""
 "id=\"deactivated-org-auto-redirect\">nowy URL</a> w <span id=\"deactivated-"
 "org-auto-redirect-countdown\">5</span> sekund."
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 msgid ""
 "This organization has been deactivated, and all organization data has been "
 "deleted."
 msgstr "Ta organizacja została wyłączona a dane organizacji skasowane."
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
@@ -2064,7 +1541,7 @@ msgstr ""
 "W międzyczasie możesz <a href=\"mailto:%(support_email)s\">odezwać się do "
 "pomocy Zulip</a>."
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
@@ -2073,11 +1550,11 @@ msgstr ""
 "Możesz <a href=\"mailto:%(support_email)s\">poprosić administratora serwera "
 "Zulip</a> o ponowne użycie tego adresu URL dla nowej organizacji."
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 msgid "This organization has been deactivated."
 msgstr "Ta organizacja została wyłączona."
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -2086,7 +1563,7 @@ msgstr ""
 "Jak jesteś właścicielem tej organizacji, to możesz <a href=\"mailto:"
 "%(support_email)s\">skontaktować się z zespołem Zulip</a> aby ją reaktywować."
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
@@ -2096,7 +1573,7 @@ msgstr ""
 "wyłączona, to proszę skontaktuj się bezpośrednio z administratorami "
 "organizacji."
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -2107,15 +1584,15 @@ msgstr ""
 "%(support_email)s\">skontaktować się z administracją serwera Zulip</a> aby "
 "ją reaktywować."
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr "Dokończ logowanie w apce na komputer"
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr "Zakończ logowanie"
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
@@ -2123,91 +1600,90 @@ msgstr ""
 "Użyj swojej przeglądarki internetowej aby zakończyć logowanie, następnie "
 "wróć tutaj i wklej swój login token."
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr "Wklej token tutaj"
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr "Zakończ"
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr "Niewłaściwy token."
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr "Token zaakceptowany. Logowanie…"
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr "Zaloguj do aplikacji na komputer"
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr "Skopiuj ten token i wróć do aplikacji Zulip aby zakończyć logowanie:"
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "Kopiuj"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr "Możesz teraz zamknąć to okno."
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr "Lub kontynuuj w przeglądarce."
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr "Anonimowy użytkownik"
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr "Właściciele"
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "Administratorzy"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr "Moderatorzy"
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr "Goście"
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "Zwykli użytkownicy"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr "Przekaż emaile na konto email"
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "Zamknij"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "Zaktualizuj"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr "Zulip"
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr "Periodyk"
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
@@ -2215,17 +1691,17 @@ msgid ""
 msgstr ""
 "Super, udało się utworzyć nową organizację Zulip: <b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr "Witaj w Zulipie!"
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr "Dołączyłeś do organizacji Zulip <b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
@@ -2234,36 +1710,36 @@ msgstr ""
 "Następujące dane posłużą do logowania do Zulip w przeglądarce, <a "
 "href=\"%(apps_page_link)s\">apek mobilnej i na komputer</a>:"
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr "URL organizacji: %(organization_url)s"
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr "Twoja nazwa uzytkownika: %(ldap_username)s"
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr "Użyj konta LDAP aby zalogować się"
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr "Email konta: %(email)s"
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr "Idź do organizacji"
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
@@ -2272,7 +1748,7 @@ msgstr ""
 "O ile nie masz doświadczenia z Zulip sprawdź <a "
 "href=\"%(getting_user_started_link)s\">poradnik dla początkujących</a>!"
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2282,7 +1758,7 @@ msgstr ""
 "Mamy też poradnik <a href=\"%(getting_organization_started_link)s\">jak "
 "przenieść organizację do Zulip</a>."
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
@@ -2291,28 +1767,28 @@ msgstr ""
 "Pytania? <a href=\"mailto:%(support_email)s\">Skontaktuj się z nami</a> — "
 "chętnie pomożemy!"
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr "%(realm_name)s na Zulip: szczegóły nowej organizacji"
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr "%(realm_name)s na Zulip: szczegóły nowego konta"
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr "Super, udało się utworzyć nową organizację Zulip: %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr "Dołączyłeś do organizacji Zulip %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
@@ -2321,7 +1797,7 @@ msgstr ""
 "Aby zalogować się do aplikacji internetowej, mobilnej i komputerowej Zulip, "
 "należy użyć następujących informacji (%(apps_page_link)s):"
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
@@ -2330,7 +1806,7 @@ msgstr ""
 "O ile stawiasz pierwsze kroki z Zulip warto zajrzeć do przewodnika "
 "(%(getting_user_started_link)s)!"
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
@@ -2339,17 +1815,17 @@ msgstr ""
 "Mamy też poradnik dla przenoszących organizację do Zulip "
 "(%(getting_organization_started_link)s)."
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr "Pytania? Skontaktuj się z nami %(support_email)s — chętnie pomożemy!"
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2358,17 +1834,17 @@ msgstr ""
 "O ile masz pytania istnieje możliwość kontaktu z administratorami tej "
 "instancji Zulip %(support_email)s."
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr "Cześć,"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2379,12 +1855,12 @@ msgstr ""
 "organizacji demo Zulip na %(realm_url)s. Aby potwierdzić zmianę i ustawić "
 "hasło dla tego konta kliknij poniżej:"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr "Potwierdź i ustaw hasło"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2393,14 +1869,14 @@ msgstr ""
 "Jeśli nie prosiłeś o tę zmianę, skontaktuj się z nami natychmiast pod "
 "adresem %(support_email)s."
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 #, fuzzy
 #| msgid "Verify your new email address for your demo Zulip organization"
 msgid "Verify your email address for your Zulip demo organization"
 msgstr "Zweryfikuj swój nowy adres email dla demonstracyjnej organizacji Zulip"
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2409,8 +1885,8 @@ msgstr ""
 "Jeśli nie prosiłeś o tę zmianę, skontaktuj się z nami natychmiast pod "
 "adresem <%(support_email)s>."
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2420,33 +1896,33 @@ msgstr ""
 "Otrzymaliśmy prośbę o zmianę adresu email dla konta Zulip w %(realm_url)s z "
 "%(old_email)s na %(new_email)s. Aby potwierdzić zmianę kliknij poniżej:"
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr "Potwierdź zmianę adresu email"
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr "Sprawdź nowy adres email dla %(organization_host)s"
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr "Poprosiłeś o nową organizację Zulip:"
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr "Typ organizacji: %(organization_type)s"
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr "Ostatnio zalogowałeś się do Zulipa. Wspaniale!"
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
@@ -2454,33 +1930,33 @@ msgstr ""
 "Kliknij poniższy przycisk, aby utworzyć organizację i zarejestrować konto. "
 "Jeśli chcesz, możesz zaktualizować powyższe informacje."
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr "Kliknij przycisk poniżej, aby zakończyć rejestrację."
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr "Zakończ rejestrację"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr "Utwórz organizację Zulip"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr "Aktywuj swoje konto"
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr "Skorzystaj z odnośnika poniżej aby dokończyć rejestrację."
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
@@ -2489,20 +1965,20 @@ msgstr ""
 "Masz pytania lub opinię, którą chesz się podzielić? Odezwij się do nas "
 "%(support_email)s — chętnie pomożemy!"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr "Zarządzaj preferencjami email"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr "Zrezygnuj z emaili marketingowych"
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
@@ -2511,17 +1987,17 @@ msgstr ""
 "Twoje konto Zulip na <a href=\"%(realm_url)s\">%(realm_url)s</a> zostało "
 "dezaktywowane i nie będzie można się na nie zalogować."
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr "Komentarz od administratorów brzmi:"
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr "Powiadomienie o dezaktywacji konta w %(realm_name)s"
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
@@ -2530,11 +2006,11 @@ msgstr ""
 "Twoje konto Zulip na %(realm_url)s zostało dezaktywowane i nie będzie można "
 "się na nie zalogować."
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr "Nowe kanały"
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2545,7 +2021,7 @@ msgstr ""
 "%(new_streams_count)s nowych kanałów w <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
@@ -2554,7 +2030,7 @@ msgstr ""
 "Masz %(new_messages_count)s nowych wiadomości w <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
@@ -2563,8 +2039,8 @@ msgstr ""
 "Utworzono %(new_streams_count)s nowych kanałów w <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because your organization <a "
@@ -2575,8 +2051,8 @@ msgstr ""
 "class=\"content_disabled_help_link\" href=\"%(help_url)s\">ukrywa treść "
 "wiadomości</a> w powiadomieniach email."
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to <a "
@@ -2587,21 +2063,21 @@ msgstr ""
 "class=\"content_disabled_help_link\" href=\"%(help_url)s\">w ustawieniach "
 "możliwych powiadomień</a> o emailach."
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr "<a href=\"%(realm_url)s\">Zaloguj się</a>do Zulip aby na bieżąco."
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr "Wypisz z listy mailingowej"
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr "Periodyk Zulip dla %(realm_name)s"
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2610,18 +2086,18 @@ msgstr ""
 "Masz %(new_messages_count)s nowych wiadomości i utworzono "
 "%(new_streams_count)s nowych kanałów w %(realm_name)s."
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr "Masz %(new_messages_count)s nowych wiadomości w %(realm_name)s."
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr "Utworzono %(new_streams_count)s nowych kanałów w %(realm_name)s."
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because your organization hides "
@@ -2632,8 +2108,8 @@ msgstr ""
 "wyświetlanie w powiadomieniach email. Zobacz %(hide_content_url)s aby "
 "dowiedzieć się więcej."
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to hide "
@@ -2643,32 +2119,30 @@ msgstr ""
 "wyłączyła ich wyświetlanie w powiadomieniach email. Sprawdź %(help_url)s a "
 "dowiesz się więcej."
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr "Zaloguj się do Zulip aby przypilnować spraw: %(organization_url)s."
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr "Zmień ustawienia emoji:"
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr "Odsubskrybuj periodyk na email:"
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr "Pływająca ryba"
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr "Dziękujemy za twoje zgłoszenie!"
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
@@ -2677,8 +2151,7 @@ msgstr ""
 "Twój adres email %(email)s jest powiązany z kontami następujących "
 "organizacji Zulip Cloud:"
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
@@ -2687,7 +2160,7 @@ msgstr ""
 "Twój adres email %(email)s jest powiązany z następującymi kontami Zulip w "
 "ramach %(external_host)s:"
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
@@ -2696,19 +2169,15 @@ msgstr ""
 "O ile masz problem z zalogowaniem, możesz <a "
 "href=\"%(help_reset_password_link)s\">zresetować swoje hasło</a>."
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr "Poprosiłeś o listę kont Zulip dla tego adresu email."
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr "Niestety, nie odnaleziono kont Zulip Cloud."
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
@@ -2716,7 +2185,7 @@ msgid ""
 msgstr ""
 "Niestety nie odnaleziono kont organizacji Zulip w ramach %(external_host)s."
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2727,28 +2196,25 @@ msgstr ""
 "adresy email lub <a href =\"%(help_logging_in_link)s\">użyj alternatywnego "
 "sposobu</a> aby namierzyć własne konto."
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 "Jeśli nie rozpoznajesz tego żądania, możesz bezpiecznie zignorować tę "
 "wiadomość email."
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr "Twoje konta Zulip"
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr "Nie odnaleziono kont Zulip"
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr "W razie problemów z logowaniem można zresetować hasło."
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
@@ -2758,12 +2224,12 @@ msgstr ""
 "skorzystać z alternatywnej metody odnalezienia konta "
 "(%(help_logging_in_link)s)."
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr "Witaj,"
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
@@ -2772,18 +2238,18 @@ msgstr ""
 "%(referrer_name)s chce abyś dołączył do Zulip &mdash; narzędzia do "
 "efektywnej komunikacji."
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr "Naciśnij poniższy przycisk, żeby rozpocząć."
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 "%(referrer_full_name)s zaprosił cię abyś dołączył %(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
@@ -2792,17 +2258,17 @@ msgstr ""
 "%(referrer_full_name)s (%(referrer_email)s) chce abyś dołączył do Zulip -- "
 "narzędzie do komunikacji w z zespole pomyślane o produktywności."
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr "Naciśnij poniższy link, aby zacząć."
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr "Witaj spowrotem,"
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
@@ -2811,14 +2277,14 @@ msgstr ""
 "To jest przypomnienie, że %(referrer_name)s chce abyś dołączył do Zulip "
 "&mdash; narzędzia służącego zespołom do efektywnej komunikacji."
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr ""
 "To ostatnie przypomnienie, jakie otrzymasz w związku z tym zaproszeniem."
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
@@ -2827,12 +2293,12 @@ msgstr ""
 "To zaproszenie wygasa za dwa dni. Jeśli zaproszenie wygaśnie, musisz zapytać "
 "%(referrer_name)s o kolejne."
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr "Przypomnienie: Dołacz %(referrer_name)s w %(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2842,7 +2308,7 @@ msgstr ""
 "Przypominamy, że %(referrer_name)s (%(referrer_email)s) widzi cię wśród "
 "użytkowników Zulip -- narzędzia do czatowania w zespole."
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2851,7 +2317,7 @@ msgstr ""
 "O ile masz jakieś pytania warto skierować je do administracji tej instancji "
 "serwera Zulip <a href=\"mailto:%(email)s\">%(email)s</a>."
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
@@ -2860,23 +2326,21 @@ msgstr ""
 "Masz pytania lub opinię, którą chesz się podzielić? <a href=\"mailto:"
 "%(email)s\">Skontaktuj się z nami</a> — chętnie pomożemy!"
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr "Otrzymujesz tę wiadomość, ponieważ zostałeś wymieniony osobiście."
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr ""
 "Otrzymałeś to ponieważ @%(mentioned_user_group_name)s została wymieniona."
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
@@ -2885,8 +2349,8 @@ msgstr ""
 "Otrzymałeś to powiadomienie, bo wszyscy uczestnicy dyskusji zostali "
 "przywołani w #%(channel_name)s > %(topic_name)s."
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
@@ -2894,16 +2358,16 @@ msgstr ""
 "Otrzymujesz to, ponieważ masz włączone powiadomienia o wzmiankach z "
 "symbolami wieloznacznymi dla tematów, które obserwujesz."
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 "Otrzymujesz to, ponieważ wszyscy zostali wymienieni w #%(channel_name)s."
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
@@ -2911,8 +2375,8 @@ msgstr ""
 "Otrzymujesz tę wiadomość, ponieważ masz włączone powiadomienia email dla "
 "tematów, które obserwujesz."
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
@@ -2921,7 +2385,7 @@ msgstr ""
 "Otrzymujesz tę wiadomość, ponieważ masz włączone powiadomienia email dla "
 "#%(channel_name)s."
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2932,7 +2396,7 @@ msgstr ""
 "%(realm_name)s Zulip</a>, bądź <a href=\"%(notif_url)s\">zmień ustawienia "
 "email</a>."
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
@@ -2941,7 +2405,7 @@ msgstr ""
 "<a href=\"%(narrow_url)s\">Zobacz lub odpowiedz w %(realm_name)s Zulip</a>, "
 "bądź <a href=\"%(notif_url)s\">zmień ustawienia email</a>."
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
@@ -2950,7 +2414,7 @@ msgstr ""
 "<a href=\"%(narrow_url)s\">Odpowiedz w %(realm_name)s Zulip</a>, bądź <a "
 "href=\"%(notif_url)s\">zmień ustawienia email</a>."
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
@@ -2960,42 +2424,42 @@ msgstr ""
 "skonfigurowany do przyjmowania przychodzących wiadomości email (<a "
 "href=\"%(url)s\">pomoc</a>)."
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr "Grupowe DM z %(direct_message_group_display_name)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr "DM z %(sender_str)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr "[rozwiązano] #%(channel_name)s > %(topic_name)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr "Nowe wiadomości"
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 "Odpowiedź na ten email bezpośrednio lub zobacz w Zulip - %(realm_name)s:"
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr "Zobacz lub odpowiedz w %(realm_name)s Zulip:"
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr "Odpowiedz w %(realm_name)s Zulip:"
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
@@ -3003,7 +2467,7 @@ msgstr ""
 "Nie odpowiadaj na tę wiadomość email. Ten serwer Zulip nie jest "
 "skonfigurowany do przyjmowania przychodzących wiadomości email. Pomoc:"
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -3014,22 +2478,22 @@ msgstr ""
 "%(new_email)s. O ile to problem skontaktuj się jak najszybciej z "
 "%(support_email)s."
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr "Pozdrawiam,"
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr "Zespół Zulipa"
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr "Email Zulip zmieniony dla %(realm_name)s"
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -3040,53 +2504,53 @@ msgstr ""
 "%(new_email)s. O ile nie było to twoją intencją skontaktuj się z nami "
 "<%(support_email)s>."
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 msgstr ""
 "Organizacja: %(organization_url)s Czas: %(login_time)s Email: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr "Zauważyliśmy, że ktoś zalogował się następującym kontem Zulip."
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr "Organizacja: %(organization_link)s"
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr "Email: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr "Czas: %(login_time)s"
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr "Urządzenie: %(device_browser)s na %(device_os)s."
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr "Adres IP: %(device_ip)s"
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr "Jeśli to byłeś Ty, super! Nie musisz nic więcej robić."
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3097,31 +2561,31 @@ msgstr ""
 "przejęte <a href=\"%(reset_link)s\">zresetuj hasło</a> lub daj znać na "
 "%(support_email)s."
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr "Dzięki,"
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr "Bezpieczeństwo Zulip"
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr "Zrezygnuj z powiadomień o logowaniu"
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr "Nowe logowanie z %(device_browser)s na %(device_os)s"
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr "Organizacja: %(organization_url)s"
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3132,7 +2596,7 @@ msgstr ""
 "przejęte, zresetuj hasło pod adresem %(reset_link)s lub skontaktuj się z "
 "%(support_email)s."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -3144,7 +2608,7 @@ msgstr ""
 "href=\"%(get_organization_started)s\">przewodnika dla przenoszących się do "
 "Zulip</a> aby zacząć."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
@@ -3152,7 +2616,7 @@ msgstr ""
 "W przeciwnym razie, oto kilka rad, które często słyszymy od klientów "
 "sprawdzających <i>wszelkie</i> czaty dla zespołów:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
@@ -3161,12 +2625,12 @@ msgstr ""
 "<a href=\"%(invite_users)s\"><b>Zaproś członków zespołu</b></a> aby "
 "przekonać się co o tym wszystkim myślą."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr "Użyj samej apki aby przekazać swoje wrażenia."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -3178,7 +2642,7 @@ msgstr ""
 "sposób, aby naprawdę przekonać się, jak nowa aplikacja do czatowania pomoże "
 "Twojemu zespołowi w komunikacji."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -3189,21 +2653,21 @@ msgstr ""
 "a>, więc mamy nadzieję, że podpowiedzi naszych pracowników przydadzą się i "
 "twojemu zespołowi."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr "Pomiń powitalne emaile dla %(realm_name)s"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr "Wybór apki do czatowania dla twojego zespołu"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
@@ -3212,7 +2676,7 @@ msgstr ""
 "witamy! Możesz skorzystać z naszego przewodnika dotyczącego przenoszenia się "
 "na Zulip, aby rozpocząć."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
@@ -3220,7 +2684,7 @@ msgstr ""
 "W przeciwnym razie, oto kilka rad, które często słyszymy od klientów w celu "
 "oceny dowolnego produktu do czatu zespołowego:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
@@ -3228,7 +2692,7 @@ msgstr ""
 "Zaproś kolegów z zespołu do wspólnego odkrywania i dzielenia się swoimi "
 "unikalnymi perspektywami."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
@@ -3238,7 +2702,7 @@ msgstr ""
 "do czatu. To jedyny sposób, aby naprawdę doświadczyć, jak nowa aplikacja do "
 "czatu pomoże zespołowi komunikować się."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
@@ -3246,8 +2710,8 @@ msgstr ""
 "Zulip został zaprojektowany, aby umożliwić wydajną komunikację i mamy "
 "nadzieję, że te wskazówki pomogą Twojemu zespołowi doświadczyć go w akcji."
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
@@ -3257,78 +2721,78 @@ msgstr ""
 "najlepiej działać dla Twoich potrzeb. Sprawdź ten przewodnik po kluczowych "
 "funkcjach Zulip dla organizacji takich jak Twoja!"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr "Zobacz przewodnik Zulip dla biznesu"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr "Zobacz przewodnik Zulip dla projektów open-source"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr "Zobacz przewodnik Zulip dla edukacji"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr "Zobacz przewodnik Zulip dla badań i rozwoju"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr "Zobacz przewodnik Zulip dla imprez i konferencji"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr "Zobacz przewodnik Zulip dla NGO"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr "Zobacz przewodnik Zulip dla społeczności"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr "Przewodnik Zulip dla biznesu"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr "Zobacz przewodnik Zulip dla projektów open-source"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr "Przewodnik Zulip dla sektora edukacji"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr "Przewodnik Zulip dla sektora badań"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr "Zobacz przewodnik Zulip dla imprez i konferencji"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr "Przewodnik Zulip dla NGO"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr "Przewodnik Zulip dla społeczności"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
 msgstr ""
 "Oto kilka wskazówek, jak uporządkować konwersacje w Zulip za pomocą tematów."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
@@ -3336,8 +2800,8 @@ msgstr ""
 "W Zulip <b>kanały</b> określają kto dostanie wiadomość. <b>Wątki</b> mówią "
 "co zawiera pierwszy wpis."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
@@ -3346,12 +2810,12 @@ msgstr ""
 "każdą wiadomość w kontekście, bez względu na to, ile różnych dyskusji się "
 "toczy."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr "Kanały i wątki w apce Zulip"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3363,11 +2827,11 @@ msgstr ""
 "dobrą nazwę tematu, pomyśl o zakończeniu zdania: „Hej, możemy porozmawiać "
 "o…?”"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr "Przykłady krótkich tematów"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3381,17 +2845,17 @@ msgstr ""
 "nawet <a href=\"%(move_channels_link)s\">przenieść wątek do innego kanału</"
 "a>."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr "Idź do Zulip"
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr "Spraw aby dyskusje były zorganizowane w wątki"
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
@@ -3399,7 +2863,7 @@ msgstr ""
 "W Zulip kanały określają, kto otrzyma wiadomość. Tematy określają, czego "
 "dotyczy wiadomość."
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3412,8 +2876,8 @@ msgstr ""
 "przemianować temat (%(rename_topics_link)s), czy przenieść wątek do innego "
 "kanału (%(move_channels_link)s)."
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
@@ -3422,15 +2886,15 @@ msgstr ""
 "Ktoś (pewnie Ty) poprosił o nowe hasło do konta Zulip %(email)s na "
 "%(realm_url)s."
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr "Kliknij poniższy przycisk, żeby zresetować hasło."
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr "Zresetuj hasło"
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3441,18 +2905,18 @@ msgstr ""
 "dezaktywowane. Skontaktuj się z administratorem organizacji aby <a "
 "href=\"%(help_link)s\">reaktywować konto</a>."
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr "Nie masz konta w tej organizacji."
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr "Nie masz aktywnych kont w tej organizacji(ach)."
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
@@ -3460,24 +2924,24 @@ msgstr ""
 "Możesz spróbować zalogować się lub zresetować hasło dla tej organizacji "
 "(powyżej)."
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 "Jeśli nie rozpoznajesz tej aktywności, możesz bezpiecznie zignorować tę "
 "wiadomość email."
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr "Żądanie zmiany hasła dla %(realm_name)s"
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr "Naciśnij poniższy link, aby zresetować swoje hasło."
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
@@ -3486,7 +2950,7 @@ msgstr ""
 "Poprzednio miałeś konto w ramach %(realm_url)s, które zostało wyłączone. "
 "Można je przywrócić do działania za pośrednictwem administratora organizacji."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3497,7 +2961,7 @@ msgstr ""
 "teraz korzysta z darmowego planu Zulip Cloud z racji nieopłaconych faktur. "
 "Zostały one anulowane."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
@@ -3506,7 +2970,7 @@ msgstr ""
 "Aby kontynować użytkowanie Zulip Cloud Standard proszę przejdź do "
 "%(upgrade_url)s."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
@@ -3515,8 +2979,8 @@ msgstr ""
 "Jeśli uważasz, że był to błąd lub potrzebujesz więcej szczegółów, skontaktuj "
 "się z nami pod adresem %(support_email)s."
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "You have deactivated your Zulip organization, %(realm_name)s, on "
@@ -3528,8 +2992,8 @@ msgstr ""
 "Zdezaktywowałeś swoją organizację Zulip %(realm_name)sdnia "
 "%(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "Your Zulip organization, %(realm_name)s, was deactivated by "
@@ -3541,8 +3005,8 @@ msgstr ""
 "Twoja organizacja Zulip, %(realm_name)s, została wyłączona przez "
 "%(deactivating_owner)s dnia %(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "Your Zulip organization, %(realm_name)s, was deactivated on "
@@ -3554,8 +3018,8 @@ msgstr ""
 "Twoja organizacja Zulip, %(realm_name)s, została wyłączona dnia "
 "%(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
@@ -3564,8 +3028,8 @@ msgstr ""
 "Zdezaktywowałeś swoją organizację Zulip %(realm_name)sdnia "
 "%(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
@@ -3574,8 +3038,8 @@ msgstr ""
 "Twoja organizacja Zulip, %(realm_name)s, została wyłączona przez "
 "%(deactivating_owner)s dnia %(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
@@ -3584,14 +3048,14 @@ msgstr ""
 "Twoja organizacja Zulip, %(realm_name)s, została wyłączona dnia "
 "%(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr "Wszystkie dane związane z tą organizacją zostały na dobre skasowane."
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
@@ -3600,8 +3064,8 @@ msgstr ""
 "Wszystkie dane powiązane z tą organizacją zostaną trwale usunięte dnia "
 "%(deletion_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
@@ -3609,19 +3073,19 @@ msgstr ""
 "W przypadku jakichkolwiek pytań lub wątpliwości prosimy o jak najszybszą "
 "odpowiedź na tę wiadomość email."
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr "Twoja organizacja Zulip %(realm_name)s została wyłączona"
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr "Drodzy byli administratorzy %(realm_name)s,"
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "One of your administrators requested reactivation of the previously "
@@ -3633,8 +3097,8 @@ msgstr ""
 "Jeden z administratorów poprosił o reaktywację wcześniej dezaktywowanej "
 "organizacji Zulip hostowanej pod adresem %(realm_url)s."
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
@@ -3643,16 +3107,16 @@ msgstr ""
 "Jeden z administratorów poprosił o reaktywację wcześniej dezaktywowanej "
 "organizacji Zulip hostowanej pod adresem %(realm_url)s."
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr "Kliknij poniższy przycisk, aby ponownie aktywować swoją organizacje."
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr "Ponownie aktywuj organizacje"
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
@@ -3660,21 +3124,21 @@ msgstr ""
 "Jeśli żądanie było błędne, nie można podjąć żadnych działań, a odnośnik "
 "wygaśnie za 24 godziny."
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Reactivate your Zulip organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "Reaktywuj swoją organizację Zulip"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr "Reaktywuj swoją organizację Zulip"
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr "Kliknij poniższy link, aby ponownie aktywować swoją organizacje."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3683,18 +3147,18 @@ msgstr ""
 "Użytkownik lub ktoś w jego imieniu poprosił o odnośnik do logowania w celu "
 "zarządzania planem Zulip dla <b>%(remote_server_hostname)s</b>."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 msgid "Click the button below to log in."
 msgstr "Skorzystaj z przycisku poniżej aby się zalogować."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr "Odnośnik wydasnie w ciągu %(validity_in_hours)s godzin."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
@@ -3703,11 +3167,11 @@ msgstr ""
 "Pytania? <a href=\"%(billing_help_link)s\">Dowiedz się więcej</a> lub napisz "
 "%(billing_contact_email)s."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr "Zaloguj do Zulip - zarządzanie ofertami"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3716,12 +3180,12 @@ msgstr ""
 "Użytkownik lub ktoś w jego imieniu poprosił o odnośnik do logowania w celu "
 "zarządzania planem Zulip dla %(remote_server_hostname)s."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr "Skorzystaj z odnośnika poniżej aby zalogować się."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
@@ -3730,7 +3194,7 @@ msgstr ""
 "Pytania? Dowiedz się więcej %(billing_help_link)s lub napisz "
 "%(billing_contact_email)s."
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
@@ -3739,16 +3203,16 @@ msgstr ""
 "Kliknij w przycisk poniżej aby potwierdzić email i zalogować się do "
 "decydowania o zakresie usług Zulip dla <b>%(remote_realm_host)s</b>."
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr "Potwierdź i zaloguj"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr "Potwierdź email na potrzeby Zulip - zarządzanie ofertami"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
@@ -3757,7 +3221,7 @@ msgstr ""
 "Kliknij w poniższy odnośnik, aby potwierdzić swój adres email i zalogować "
 "się do zarządzania planem Zulip dla %(remote_realm_host)s."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
@@ -3766,7 +3230,7 @@ msgstr ""
 "Twój wniosek o sponsoring przez Zulip został zatwierdzony! Twoja organizacja "
 "została przypisana do usługi <a href=\"%(plans_link)s\">Zulip Community</a>."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
@@ -3775,12 +3239,12 @@ msgstr ""
 "Gdybyś mógł <a href=\"%(link_to_zulip)s\">wspomnieć o Zulip jako sponsorze "
 "twojej witryny</a>, byłoby nam bardzo miło!"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr "Sponsoring społeczności został zaakceptowany dla %(billing_entity)s!"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
@@ -3788,7 +3252,7 @@ msgstr ""
 "Twoja prośba o sponsoring Zulip została zatwierdzona! Twoja organizacja "
 "została przeniesiona do planu Zulip Community."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
@@ -3796,20 +3260,20 @@ msgstr ""
 "Gdybyś mógł wymienić Zulip jako sponsora na swojej stronie internetowej, "
 "bylibyśmy naprawdę wdzięczni!"
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr "Odnajdź swoje konta"
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr "Znajdź swoje konta na Zulipie"
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr "Maile rozesłane! Poniżej lista adresów z poprzedniej strony:"
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
@@ -3818,7 +3282,7 @@ msgstr ""
 "O ile nie dostałeś żadnego emaila w tej sprawie to <a "
 "href=\"%(current_url)s\">można poszukać konta dla innego adresu email</a>."
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
@@ -3826,7 +3290,7 @@ msgstr ""
 "Wprowadź swój adres email, aby otrzymać wiadomość z adresami URL wszystkich "
 "organizacji Zulip Cloud, w których masz aktywne konta."
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
@@ -3834,7 +3298,7 @@ msgstr ""
 "Wprowadź swój adres email, aby otrzymać email z adresami URL wszystkich "
 "organizacji Zulip Cloud, w których masz aktywne konta."
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
@@ -3842,216 +3306,216 @@ msgstr ""
 "O ile zapomniałeś także hasła, może je <a href=\"/help/change-your-"
 "password\">zresetować</a>."
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr "Adres email"
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "Znajdź konta"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr "Produkt"
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr "Dlaczego Zulip"
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr "Funkcje"
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr "Oferta i cennik"
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Zulip Cloud status"
 msgid "Zulip Cloud"
 msgstr "Stan chmury Zulip"
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr "Własny serwer"
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr "Bezpieczeństwo"
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "Integracje"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr "Aplikacje komputerowe i mobilne"
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr "Nowa organizacja"
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr "Rozwiązania"
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr "Biznes"
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr "Edukacja"
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr "Badania"
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr "Wydarzenia i konferencje"
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr "Projekty open source"
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr "Społeczności"
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr "Pochwały klientów"
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr "Otwarte społeczności"
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr "Zasoby"
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr "Jak zacząć"
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr "Centrum pomocy"
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr "Czat społecznościowy"
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr "Wspólnicy"
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr "Stan chmury Zulip"
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr "Przenosiny na Zulip"
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr "Instalacja serwera Zulip"
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr "Aktualizacja serwera Zulip"
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr "Wspierający"
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr "Przewodnik jak wesprzeć"
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr "Społeczność deweloperów"
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr "Tłumaczenie"
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr "GitHub"
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr "O nas"
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr "Zespół"
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "Historia"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr "Wartości"
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr "Praca"
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr "Blog"
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr "Wesprzyj Zulip"
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr "Mastodon"
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Values"
 msgid "Bluesky"
 msgstr "Wartości"
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr "Oprogramowanie zapewnia <a href=\"https://zulip.com\">Zulip</a>"
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr "Warunki korzystania z usługi"
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr "Polityka prywatności"
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr "Atrybuty witryny"
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr "Ponad %(integrations_count_display)s natywnych integracji."
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 #, fuzzy
 #| msgid ""
 #| "And hundreds more through <a href=\"/integrations/doc/zapier\">Zapier</a> "
@@ -4063,51 +3527,47 @@ msgstr ""
 "A także setki innych za pośrednictwem <a href=\"/integrations/doc/"
 "zapier\">Zapier</a> oraz <a href=\"/integrations/doc/ifttt\">IFTTT</a>."
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr "Szukaj integracji"
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr "Niestandardowe integracje"
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr "Wadliwy webhooks"
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr "Interaktywne boty"
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr "REST API"
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr "Nieprawidłowy adres email"
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr "Email nie jest dozwolony"
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr "Adres email podany podczas próby rejestracji jest nieprawidłowy."
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4118,7 +3578,7 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>, nie przyjmuje rejestracji z domen "
 "email jak twoja."
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4129,7 +3589,7 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>, nie przyjmuje rejestracji przez "
 "tymczasowy adres email."
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4140,24 +3600,24 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>, nie zezwala na rejestracje z "
 "użyciem emaila zawierającego \"+\"."
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr "Proszę zarejestruj się z użyciem prawidłowego adresu email."
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr "Proszę zarejestruj się z użyciem dozwolonego adresu email."
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr "Nie odnaleziono organizacji"
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr "Brak organizacji Zulip w <b>%(current_url)s</b>."
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -4168,7 +3628,7 @@ msgstr ""
 "find/\">uzyskaj listę swoich kont Zulip Cloud </a>, bądź <a href=\"mailto:"
 "%(support_email)s\">uzyskaj pomoc Zulip</a>."
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -4179,7 +3639,7 @@ msgstr ""
 "\">uzyskaj listę swoich kont</a> na tym serwerze lub <a href=\"mailto:"
 "%(support_email)s\">skontaktuj się z administratorami tego serwera Zulip</a>."
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
@@ -4188,59 +3648,59 @@ msgstr ""
 "<a href=\"%(current_url)s/serverlogin/\">Kliknij tutaj</a> aby uzyskać "
 "dostęp do zarządzania planami serwera Zulip."
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr "Wadliwa lub wygasła sesja logowania"
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr "Wadliwa lub wygasła sesja logowania."
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr "Zaloguj się do Zulipa"
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr "Zarejetrowano już ten adres email. Zaloguj się poniżej."
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr "Adres email lub nazwa użytkownika"
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "Nazwa użytkownika"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr "Nie pamiętasz hasła?"
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr "Zaloguj się przy pomocy %(identity_provider)s"
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr "Wyświetl bez konta"
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 "Nie masz jeszcze konta? Potrzebujesz zaproszenia, żeby dołączyć do tej "
 "organizacji."
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr "Brak dostępnych licencji"
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr "Organizacja nie przyjmuje obecnie nowych członków"
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
@@ -4250,7 +3710,7 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a> ponieważ wykorzystano wszystkie "
 "licencje usługi Zulip Cloud."
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
@@ -4258,19 +3718,19 @@ msgstr ""
 "Skontaktuj się z osobą, która Cię zaprosiła i poproś o zwiększenie liczby "
 "licencji, a następnie spróbuj ponownie."
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr "Przejdź do głównej zawartości"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr "Błąd subdomeny uwierzytelniania"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr "Subdomena uwierzytelnienia"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -4284,25 +3744,24 @@ msgstr ""
 "Jeśli utknąłeś tutaj próbując się zalogować, najprawdopodobniej jest to błąd "
 "serwera lub błędna konfiguracja."
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 #, fuzzy
 #| msgid "No organization found"
 msgid "Demo organizations disabled"
 msgstr "Nie odnaleziono organizacji"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr "Wymagana aktualizacja"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 "Używasz starego wydania apki Zulip na komputer, która nie jest już wspierana."
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
@@ -4310,22 +3769,21 @@ msgstr ""
 "Funkcja automatycznej aktualizacji w tej starej wersji aplikacji desktopowej "
 "Zulip już nie działa."
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr "Pobierz najnowszą wersję."
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 "Przekroczyłeś limit operacji przewidziany dla wykonania tego typu akcji."
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr "Wymagany odnośnik tworzenia organizacji"
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -4337,12 +3795,11 @@ msgstr ""
 "stable/production/multiple-organizations.html\">dokumentację</a> jak "
 "utworzyć nową organizację po więcej informacji."
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr "Odnośnik tworzenia organizacji wygasł lub jest wadliwy"
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
@@ -4350,11 +3807,11 @@ msgstr ""
 "Niestety to nie jest prawidłowy odnośnik do utworzenia organizacji. Proszę "
 "<a href=\"/new/\">uzyskaj nowy odnośnik</a> i spróbuj ponownie."
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr "Nieoczekiwana rejestracja serwera Zulip"
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -4365,17 +3822,16 @@ msgstr ""
 "<a href=\"mailto:%(support_email)s\">daj znać zespołowi Zulip</a> o ile "
 "chcesz rozwiązać ten problem."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr "Niewspierana przeglądarka"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr "%(browser_name)s nie jest obsługiwana przez Zulip."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
@@ -4384,7 +3840,7 @@ msgstr ""
 "Zulip obsługuje <a href=\"%(supported_browsers_page_link)s\">nowoczesne "
 "przeglądarki</a> jak Firefox, Chrome czy Edge."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
@@ -4392,21 +3848,20 @@ msgstr ""
 "Możesz też skorzystać z <a href=\"%(apps_page_link)s\">apki Zulip na "
 "komputer</a>."
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr "Konto jest zdezaktywowane"
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 msgid "Finalize organization import"
 msgstr "Dokończ importowanie organizacji"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 msgid "Organization import completed!"
 msgstr "Import organizacji zakończony!"
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -4418,54 +3873,53 @@ msgstr ""
 "(<strong>%(verified_email)s</strong>). Wybierz konto, które ma zostać "
 "powiązane z Twoim adresem email."
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 msgid "Select your account"
 msgstr "Wybierz swoje konto"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Create new account"
 msgstr "Utwórz swoje konto"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr "Organizacja poprawnie reaktywowana"
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr "Twoja organizacja została ponownie aktywowana."
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr "Odnośnik reaktywujący organizację wygasł lub jest wadliwy"
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr "Odnośnik do reaktywacji organizacji wygasł lub jest nieważny."
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr "Zaloguj się do swojej organizacji"
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr "twoja-organizacja"
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr "Nie znasz adresu URL organizacji?"
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr "Znajdź swoją organizacje."
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr "Następny"
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4476,11 +3930,11 @@ msgstr ""
 "href=\"%(org_creation_link)s\">Utwórz nową organizację</a> o ile jeszcze "
 "tego nie zrobiłeś."
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 msgid "Self-hosting Zulip?"
 msgstr "Zulip na własnym serwerze?"
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4490,11 +3944,11 @@ msgstr ""
 "href=\"%(self_hosted_login_help)s\">zalogować się aby zarządzać planami i "
 "opłatami.</a>"
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr "Zresetuj hasło"
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
@@ -4502,60 +3956,60 @@ msgstr ""
 "Nie pamiętasz hasła? Nie ma problemu, wyślemy link do zresetowania hasła "
 "mailem przypisanym do Twojego konta."
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr "Wyślij email zmiany hasła"
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr "Ustaw nowe hasło"
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "Potwierdź hasło"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr "Niestety, podany link jest nieprawidłowy lub został już użyty."
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr "Udało się nadać nowe hasło"
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr "Ustawiłeś nowe hasło!"
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr "Proszę <a href=\"%(login_url)s\">zaloguj</a> przy użyciu nowego hasła."
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr "Email odzyskiwania hasła wysłany"
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr "Wysłano dane do nadania hasła!"
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr "Sprawdź pocztę email za kilka minut, aby zakończyć proces."
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr "Zaimportuj ze Slack"
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr "Postęp importu"
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr "Sprawdzanie stanu importu…"
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4563,7 +4017,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4576,15 +4030,15 @@ msgstr ""
 "rel=\"noopener noreferrer\" target=\"_blank\">wskazane instrukcje</a> aby "
 "uzyskać <strong>token OAuth dla bota użytkownika</strong>."
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr "Token OAuth bota użytkownika Slack"
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr "Przekaż plik eksportu Slack"
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
@@ -4594,17 +4048,17 @@ msgstr ""
 "slack-data\" target=\"_blank\" rel=\"noopener noreferrer\">z tymi "
 "instrukcjami</a> aby uzyskać historię wiadomości Slack w formie pliku."
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 #, fuzzy
 #| msgid "Start import"
 msgid "Start upload"
 msgstr "Rozpocznij import"
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr "Przekazany plik eksportu"
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 #, fuzzy
 #| msgid ""
 #| "Nobody in this Zulip organization will be able to see this email address."
@@ -4612,24 +4066,24 @@ msgid "Who will be allowed to see other users' email addresses?"
 msgstr ""
 "Nikt w tej organizacji Zulip nie będzie mógł zobaczyć tego adresu email."
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr "Rozpocznij import"
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
@@ -4637,7 +4091,7 @@ msgstr ""
 "Bądź <span id=\"cancel-slack-import\" tabindex=\"0\">utwórz organizację</"
 "span> bez importu danych."
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4645,7 +4099,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4653,22 +4107,22 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr "Wybierz konto do autentykacji"
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr "<h1 class=\"get-started\">Wybierz konto</h1>"
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 "Twoje konto GitHub jest powiązane z adresami email, które nie zostały "
 "zweryfikowane."
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
@@ -4676,15 +4130,15 @@ msgstr ""
 "Aby korzystać z jednego z nich w Zulip, musisz najpierw <a href=\"https://"
 "github.com/settings/emails\">zweryfikować go w GitHub.</a>"
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr "Błąd odsubskrybowania email"
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr "Nieznany adres w poleceniu odsubskrybowania"
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
@@ -4692,7 +4146,7 @@ msgstr ""
 "Cześć! Wygląda na to, że próbowałeś zrezygnować z subskrypcji, ale nie "
 "rozpoznajemy adresu URL."
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4702,12 +4156,11 @@ msgstr ""
 "Sprawdź dokładnie, czy masz pełny adres URL i spróbuj ponownie, lub <a "
 "href=\"mailto:%(support_email)s\">podrzuć nam email</a> a zajmiemy się tym!"
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr "Zmieniono ustawienia email"
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
@@ -4716,7 +4169,7 @@ msgstr ""
 "Udało się odsubskrybować mailing Zulip %(subscription_type)s dla <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
@@ -4725,51 +4178,50 @@ msgstr ""
 "Możesz cofnąć tę zmianę lub przejrzeć wybory w <a href=\"%(realm_url)s/"
 "#settings/notifications\">ustawieniach powiadomień</a>."
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr "Nieprawidłowe mapowanie kolejności."
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr "Pytania i dyskusja jak korzystać z Zulip."
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr "Sprawdź działanie Zulip tutaj. :test_tube:"
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr "Pod dyskusje w zespole"
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr "rejestracje"
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr "{user} dołączył do tej organizacji."
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr "{user} zaakceptował Twoje zaproszenie Zulip!"
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 "Nie można aktywować konta zastępczego; zamiast tego poproś użytkownika o "
 "zarejestrowanie się."
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 #, fuzzy
 #| msgid "Cannot deactivate user group in use."
 msgid "Cannot reactivate a deleted user"
 msgstr "Nie można wyłączyć grupy użytkowników będącej w użyciu."
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
@@ -4777,36 +4229,35 @@ msgstr ""
 "Nie możesz zmienić tego pola. Skontaktuj się z administratorem, aby je "
 "zaktualizować."
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr "Brak pola id {id}."
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr "Nieprawidłowa nazwa domyślnej grupy kanałów '{group_name}'"
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 "Domyślna nazwa grupy kanałów jest zbyt długa (limit: {max_length} znaków)"
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr "Domyślna nazwa grupy kanałów '{group_name}' zawiera znaki NULL (0x00)."
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr "Wadliwa domyślna grupa dla kanału {group_name}"
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
@@ -4814,12 +4265,12 @@ msgstr ""
 "'{channel_name}' jest domyślnym kanałem i nie może zostać przypisany do "
 "'{group_name}'"
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr "Domyślna grupa kanału '{group_name}' już istnieje"
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
@@ -4828,7 +4279,7 @@ msgstr ""
 "Kanał '{channel_name}' jest już obecny w domyślnej grupie kanałów "
 "'{group_name}'"
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
@@ -4837,12 +4288,12 @@ msgstr ""
 "Kanał '{channel_name}' nie jest obecny w domyślnej grupie kanałów "
 "'{group_name}'"
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr "Ten domyślny kanał grupy jest już przypisany do '{group_name}'"
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
@@ -4851,7 +4302,7 @@ msgstr ""
 "wysłać w ciągu jednego dnia. Ponieważ osiągnąłeś limit, żadne zaproszenia "
 "nie zostały wysłane."
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
@@ -4859,78 +4310,78 @@ msgstr ""
 "Twoje konto jest zbyt nowe aby wysyłać zaproszenia. Zapytaj administratora "
 "organizacji lub innego uzytkownika."
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 "Niektórych emaili nie udało się potwierdzić, więc nie wysłano żadnych "
 "zaproszeń."
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr "Nie mogliśmy nikogo zaprosić."
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr "Nie ma czego zmienić"
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr "Nie można przenosić wiadomości bezpośrednich do kanałów."
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr "Wiadomości bezpośrednie nie mają tytułów."
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr "Wadliwy propagate_mode bez zmiany wątku"
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr "Czatu ogólnego nie można oznaczyć jako rozwiązany"
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr "Nie można zmieniać zawartości wpisu przy zmianie kanału"
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr "Widżety nie mogą być modyfikowane."
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr "Twoja organizacja wyłączyła możliwość zmiany wiadomości"
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr "Nie masz pozwolenia na edycję tej wiadomości"
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr "Za nami okno czasowe na zmiany tego wpisu"
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr "{user} oznaczył ten wątek jako rozwiązany."
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr "{user} oznaczył ten wątek jako czekający na rozwiązanie."
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr "Ten wątek został przeniesiony do {new_location} przez {user}."
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr ""
 "Wiadomość została przeniesiona z tego tematu do {new_location} przez {user}."
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
@@ -4939,12 +4390,12 @@ msgstr ""
 "Wiadomości {changed_messages_count} zostały przeniesione z tego tematu do "
 "{new_location} przez {user}."
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr "Ten wątek został przeniesiony z {old_location} przez {user}."
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
@@ -4952,7 +4403,7 @@ msgstr ""
 "[Wpis]({message_link}) został przeniesiony tutaj z {old_location} przez "
 "{user}."
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
@@ -4961,67 +4412,64 @@ msgstr ""
 "{changed_messages_count} wiadomości zostało przeniesionych tu z "
 "{old_location} przez {user}."
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to resolve topics in this channel."
 msgstr "Nie masz uprawnień do oznaczania wątków jako rozwiązane na tym kanale."
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr "Skończyło się okno czasowe na zmianę tytułu tematu."
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr "Nie masz uprawnień do przeniesienia tego wpisu"
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr "Upłynął limit czasu zmiany wpisu w tym kanale"
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr "Wadliwa flaga: '{flag}'"
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr "Nie można zmienić flagi: '{flag}'"
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr "Zła flaga operacji na wpisach: '{operation}'"
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr "Nieprawidłowa wiadomość"
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr "Nie można pokazać wiadomości"
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr "Oczekuje dokładnie jednego kanału"
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr "Wadliwy typ danych dla kanału"
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr "Wadliwy typ danych dla odbiorców"
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 "Listy odbiorców mogą zawierać adresy email lub identyfikatory użytkowników, "
 "ale nie oba te elementy."
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
@@ -5030,7 +4478,7 @@ msgstr ""
 "Twój bot {bot_identity} próbował wysłać wiadomość do kanału o "
 "identyfikatorze {channel_id}, ale kanał o tym identyfikatorze nie istnieje."
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -5041,7 +4489,7 @@ msgstr ""
 "ale ten kanał nie istnieje. Kliknij [tutaj]({new_channel_link}), aby go "
 "utworzyć."
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
@@ -5050,30 +4498,30 @@ msgstr ""
 "Twój bot {bot_identity} próbował wysłać wiadomość do kanału {channel_name}. "
 "Kanał istnieje, ale nie ma żadnych subskrybentów."
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr "Nie masz uprawnień dostępu do niektórych odbiorców."
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr "Widżety: programista API wysłał wadliwą zawartość JSON"
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr "Widżety: {error_msg}"
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, fuzzy, python-brace-format
 #| msgid "{user_name} created the following channels: {new_channels}."
 msgid "{user} has made the following changes to your account."
 msgstr "{user_name} utworzył następujące kanały: {new_channels}."
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5081,26 +4529,24 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr "Istnieje już niestandardowa emoji o tej nazwie."
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr "Wadliwy format obrazu"
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr "Uporządkowana lista nie może zawierać zduplikowanych łączników"
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 "Uporządkowana lista musi wyliczać wszystkie istniejące łączniki dokładnie raz"
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
@@ -5109,39 +4555,39 @@ msgstr ""
 "Aby korzystać z tej metody uwierzytelniania, należy uaktualnić plan do "
 "wersji {required_upgrade_plan_name}."
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr "Wadliwa metoda autoryzacji: {name}. Dostępne metody to: {methods}"
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr "Metoda uwierzytelniania {name} nie jest dostępna w bieżącym planie."
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr "Kanał moderacji musi być prywatny."
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr "Zapisany fragment nie istnieje."
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr "Zaplanowany wpis został już zamieszczony"
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 #, fuzzy
 #| msgid "Reminder does not exist"
 msgid "Reminder could not be sent."
 msgstr "Przypomnienie nie istnieje"
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr "Wiadomość nie może zostać dodana we wskazanym czasie."
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
@@ -5150,38 +4596,38 @@ msgstr ""
 "Wiadomość zaplanowana na {delivery_datetime} nie została wysłana z powodu "
 "następującego błędu:"
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr "[Zobacz odłożone wiadomości](#scheduled)"
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr "Kanał jest już wyłączony"
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr "Kanał #**{channel_name}** został zarchiwizowany."
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr "Kanał nie jest obecnie wyłączony"
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr "Kanał o nazwie {channel_name} już istnieje"
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr "Kanał jest prywatny i nie ma subskrybujących"
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr "Kanał #**{channel_name}** został odrchiwizowany."
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
@@ -5190,7 +4636,7 @@ msgstr ""
 "{user} zmienił [prawa dostępu]({help_link}) dla tego kanału z **{old_policy}"
 "** na **{new_policy}**."
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -5203,41 +4649,39 @@ msgstr ""
 "* **Stare**: {old_setting_description}\n"
 "* **Nowe**: {new_setting_description}\n"
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 "{user_name} zmienił nazwę kanału {old_channel_name} na {new_channel_name}."
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr "Brak opisu."
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr "{user} zmienił opis tego kanału."
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr "Stary opis"
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr "Nowy opis"
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr "Na zawsze"
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr "{number_of_days} dni"
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
@@ -5246,11 +4690,11 @@ msgstr ""
 "Wiadomości w tym kanale będą teraz automatycznie usuwane {number_of_days} "
 "dni po ich wysłaniu."
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr "Wiadomości w tym kanale będą teraz przechowywane bezterminowo."
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -5266,26 +4710,26 @@ msgstr ""
 "\n"
 "{summary_line}"
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr "Automatycznie"
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr "*{empty_topic_display_name}* jest prawidłowym wątkiem"
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr "Brak *{empty_topic_display_name}* wątku"
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr "Tylko *{empty_topic_display_name}* jako właściwy wątek"
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
@@ -5294,73 +4738,63 @@ msgstr ""
 "{user_name} zmienił \"Uprawnienia do wpisywania się w wątku *ogólny czat*\" "
 "w formie zmiany nastawu z {old_topics_policy} na {new_topics_policy}."
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr "Nie możesz dodać podwpisu do tego wpisu."
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr "Błędne ID użytkownika {user_id}"
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr "Grupa użytkowników '{group_name}' już istnieje."
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr "Niewystarczające pozwolenie"
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr "To API nie jest dostępne dla botów z przychodzącymi webhookami."
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr "Konto nie jest powiązane z tą subdomeną"
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr "Ten punkt końcowy nie przyjmuje żądań od botów."
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr "Musisz być administratorem serwera"
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr "Ten punkt końcowy wymaga prostego uwierzytelnienia HTTP."
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr "Nieprawidłowy nagłówek autoryzacji dla basic auth"
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr "Brakuje nagłówka uwierzytalniającego dla basic auth"
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr "Boty typu webhook mają dostęp tyko do webhooków"
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr "Wadliwy email lub hasło."
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
@@ -5369,52 +4803,51 @@ msgstr ""
 "Twoje konto {username} zostało dezaktywowane. Prosimy o kontakt z "
 "administratorem organizacji w celu jego ponownej aktywacji."
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr "Hasło jest za słabe."
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr "Subdomena musi mieć 3 lub więcej znaków."
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr "Subdomena nie może zaczynać się ani kończyć znakiem \"-\"."
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr "Subdomena może składać się tylko z małych liter, cyfr i znaków \"-\"."
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr "Subdomena jest już w użyciu. Proszę wybierz inną."
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr "Subdomena zarezerwowana. Proszę wybierz inną."
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr "Użyj swojego prawdziwego adresu email."
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr ""
 "Organizacja, do której próbujesz dołączyć email'em {email}, nie istnieje."
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr "Poproś administratora organizacji o zaproszenie na email {email}."
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr "Nie można dołączyć do organizacji: uwierzytelnie hasłem wyłączone."
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
@@ -5423,11 +4856,11 @@ msgstr ""
 "Domena twojego adresu email {email}, jest na liście zakazanych dla tej "
 "organizacji."
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr "Adres email zawierające + nie są dozwolone w tej organizacji."
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
@@ -5437,32 +4870,31 @@ msgstr ""
 "licencje Zulip są w użyciu. Skontaktuj się z osobą, która Cię zaprosiła i "
 "poproś o zwiększenie liczby licencji, a następnie spróbuj ponownie."
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr "Weryfikacja, że jesteś człowiekiem!"
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr "Weryfikacja, że nie jesteś botem…"
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 msgid "Challenges are not enabled."
 msgstr "Wyzwania nie są włączone."
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr "Weryfikacja bez powodzenia, spróbuj jeszcze raz."
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "Nowe hasło"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr "Potwierdzenie nowego hasła"
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "You're making too many attempts to sign in. Try again in {seconds} "
@@ -5474,7 +4906,7 @@ msgstr ""
 "Podjęto zbyt wiele prób logowania. Spróbuj ponownie za {seconds} sekund lub "
 "skontaktuj się z administratorem organizacji w celu uzyskania pomocy."
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
@@ -5482,85 +4914,83 @@ msgstr ""
 "Twoje hasło zostało wyłączone, ponieważ jest zbyt słabe. Zresetuj hasło, aby "
 "utworzyć nowe."
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr "Token"
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 "Wskazówka: możesz wprowadzić wiele adresów email, oddzielając je przecinkami."
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr "Wprowadź maks. 10 adresów email."
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr "Nie udało się odnaleźć takiej organizacji Zulip."
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr "Wadliwy email '{email}'"
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr "Brak wątku"
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr "Nie można wysłać do wielu kanałów"
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr "Brakujący kanał"
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr "Wiadomość musi mieć odbiorcę"
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr "Nieprawidłowy typ wiadomości"
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr "Nieprawidłowy załącznik"
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr "Wystąpił błąd podczas usuwania załącznika. Spróbuj ponownie później."
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr "Wiadomość musi mieć odbiorców!"
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name can't be empty."
 msgstr "Nazwa folderu kanału nie może być pusta."
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr "Wadliwy znak w nazwie folderu kanału - w miejscu {position}."
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr "Nazwa folderu kanału już w użyciu"
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 msgid "Invalid channel folder ID"
 msgstr "Wadliwe ID folderu kanału"
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 msgid "Configure owner account email address."
 msgstr "Skonfiguruj adresy email właściciela konta."
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "\n"
@@ -5580,73 +5010,73 @@ msgstr ""
 "zostanie **z automatu skasowana** po 30 dniach, o ile [nie zostanie\n"
 "zmieniona w bezterminową]({convert_demo_organization_help_url}).\n"
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a date"
 msgid "{var_name} is not Base64 encoded"
 msgstr "{var_name} to nie date"
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 #, fuzzy
 #| msgid "Invalid emoji code."
 msgid "Invalid `device_id`"
 msgstr "Nieprawidłowy kod emoji."
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr "{service_name} periodyk"
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr "Należy podać domenę."
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr "Domena musi mieć przynajmniej jedną kropkę (.)"
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr "Domena jest za długa"
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr "Domena nie może zaczynać się ani kończyć kropką (.)"
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr "Wielokropki (..) nie są dozwolone."
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr "Subdomena nie może zaczynać się ani kończyć znakiem \"-\"."
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr "Domena może składać się tylko z małych liter, cyfr i znaków \"-\"."
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr "Znacznik czasowy nie może być ujemny."
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr "Temat nie może być pusty"
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 "Musi określać dokładnie 1 identyfikator kanału dla komunikatów kanałowych"
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr "Użytkownik wyłączył synchronizację szkiców."
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr "Taki szkic nie istnieje"
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5657,86 +5087,86 @@ msgstr ""
 "email:\n"
 "{error_message}"
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr "Email bez tematu"
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr "Otwórz Zulip aby zobaczyć zakrytą zawartość"
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr "powiadomienia {service_name}"
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr "Nieprawidłowy adres."
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr "Poza Twoją domeną."
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr "Adresy email zawierające + nie są dozwolone."
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr "Zarezerwowane dla botów systemowych."
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr "{email} posiada już konto"
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr "Posiada już konto."
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr "Konto zostało zdezaktywowane."
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr "Emoji '{emoji_name}' nie istnieje"
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr "Nieprawidłowa niestandardowa emoji."
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr "Nieprawidłowa nazwa niestandardowej emoji."
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr "Ta niestandardowa emoji została zdezaktywowana."
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr "Nieprawidłowy kod emoji."
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr "Wadliwa nazwa emoji."
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr "Nieprawidłowy rodzaj emoji."
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr "Musisz być administratorem organizacji lub twórcom emoji"
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr "Nazwy emoji muszą kończyć się literą lub cyfrą."
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
@@ -5744,97 +5174,96 @@ msgstr ""
 "Nazwy emoji mogą zawierać tylko małe litery angielskie, cyfry, spacje, "
 "myślniki i podkreślniki."
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr "Brakuje nazwy emoji"
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr "Nie można stworzyć kolejki zdarzeń"
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr ""
 "Nie jesteś zalogowany: wymagane uwierzytelnienie API lub sesja użytkownika"
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr "Kanał '{channel_name}' już istnieje"
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr "Kanał '{stream}' nie istnieje"
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr "Kanał o ID '{stream_id}' nie istnieje"
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr "Nieobsługiwana kombinacja parametrów: {parameters}"
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr "właściciel organizacji"
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr "użytkownik"
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr "Nie można wyłączyć jedynej {entity}."
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr "Nieprawidłowa instrukcja Markdown include: {include_statement}"
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr "Nieprawidłowy JSON"
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr "Musisz być administratorem organizacji"
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr "Musi być właścicielem organizacji"
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Must be an organization owner"
 msgid "Must be a bot user"
 msgstr "Musi być właścicielem organizacji"
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr "Nazwa użytkownika lub hasło są błędne"
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr "Ta organizacja została wyłączona"
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
@@ -5842,23 +5271,23 @@ msgstr ""
 "Rejestracja usługi mobilnych powiadomień push dla twojego serwera została "
 "wyłączona"
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr "Logowanie z użyciem hasła jest wyłączone w tej organizacji"
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr "Twoje hasło zostało wyłączone i wymaga zresetowania"
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr "Nieprawidłowy klucz API"
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr "Wadliwy klucz API"
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
@@ -5867,27 +5296,26 @@ msgstr ""
 "Typ '{event_type}' dla zdarzenia nie jest obecnie obsługiwany przez webhook "
 "{webhook_name} webhook; pomijam"
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 "Nie można przetworzyć żądania: czy {webhook_name} wygenerował to zdarzenie?"
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr "Użytkownik nie został uwierzytelniony"
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr "Nieprawidłowa subdomena"
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 "Nie masz uprawnień do inicjowania dyskusji przez wiadomości bezpośrednie."
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
@@ -5896,12 +5324,12 @@ msgstr ""
 "Dodawanie wiadomości do {empty_topic_display_name} nie jest dozwolone na tym "
 "kanale."
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr "Tylko {empty_topic_display_name} wątek jest dozwolony na tym kanale."
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
@@ -5911,20 +5339,20 @@ msgstr ""
 "{empty_topic_display_name} wątku. Rozważ przemianowanie lub skasowanie "
 "innych wątków."
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr "Wiadomości bezpośrednie są wyłączone dla tej organizacji."
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr ""
 "Ta konwersacja nie obejmuje żadnych użytkowników, którzy mogą ją autoryzować."
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr "Odmowa dostępu"
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
@@ -5933,15 +5361,15 @@ msgstr ""
 "Masz uprawnienia do przeniesienia {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} ostatnich wpisów w tym wątku."
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr "Ta reakcja już istnieje."
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr "Reakcja nie istnieje."
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
@@ -5949,272 +5377,272 @@ msgstr ""
 "Twoja organizacja jest zarejestrowana na innym serwerze Zulip. Skontaktuj "
 "się z pomocą techniczną Zulip, aby uzyskać pomoc w rozwiązaniu tego problemu."
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr "Organizacja nie jest zarejestrowana"
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr "Nie masz uprawnień do używania symboli wieloznacznych w tym kanale."
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr "Nie masz uprawnień do używania symboli wieloznacznych w tym temacie."
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr "Wartość '{field_name}' nie pasuje do oczekiwanej wartości."
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr "'{setting_name}' musi być systemową grupą użytkowników."
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr "Nie można wyłączyć grupy użytkowników będącej w użyciu."
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr "Nie masz uprawnień do administracji tym kanałem."
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr "Nie masz uprawnień do zmiany domyślnych ustawień kanału."
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr "Email jest już w użyciu."
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr "Czas planowego doręczenia musi być w przyszłości."
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr "Wadliwy bouncer_public_key"
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr "Wywołanie wygasło"
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr "Wadliwe encrypted_push_registration"
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr "Serwer nie jest skonfigurowany do obsługi powiadomień push."
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Already has an account."
 msgid "Atlassian account ID"
 msgstr "Posiada już konto."
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Behance username"
 msgstr "Niewłaściwa nazwa lub nazwa użytkownika"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Bitbucket username"
 msgstr "Nazwa z GitHub"
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Codeberg username"
 msgstr "Nazwa z Twitter"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Dribbble username"
 msgstr "Nazwa z GitHub"
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Facebook username"
 msgstr "Niewłaściwa nazwa lub nazwa użytkownika"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr "Nazwa z GitHub"
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "GitLab username"
 msgstr "Nazwa z GitHub"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Instagram username"
 msgstr "Nazwa z Twitter"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Mastodon"
 msgid "Mastodon profile"
 msgstr "Mastodon"
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Medium username"
 msgstr "Nazwa z GitHub"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Pinterest username"
 msgstr "Nazwa z Twitter"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Reddit username"
 msgstr "Nazwa z GitHub"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Snapchat username"
 msgstr "Nazwa z GitHub"
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Threads username"
 msgstr "Nazwa z Twitter"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "TikTok username"
 msgstr "Nazwa z Twitter"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Twitch username"
 msgstr "Nazwa z Twitter"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "Nazwa użytkownika"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr "Wadliwy typ konta zewnętrznego"
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr "Frameworki integracji"
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 msgid "Video calling"
 msgstr "Połączenie wideo"
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr "CI"
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr "Obsługa klienta"
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr "Wdrożenie"
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr "Rozrywka"
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr "Komunikacja"
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr "Finanse"
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr "Zasoby ludzkie"
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr "Marketing"
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr "Różne"
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr "Monitoring"
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr "Zarządzanie projektami"
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr "Produktywność"
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr "Kontrola wersji"
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr "Wiadomość musi mieć treść"
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr "Wiadomość nie może być pusta"
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 "Nie masz uprawnień aby wymienić grupy użytkowników '{user_group_name}'."
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "{reporting_user_mention} reported a DM sent by {reported_user_mention} to "
@@ -6226,7 +5654,7 @@ msgstr ""
 "{reporting_user_mention} zgłosił DM wysłaną przez {reported_user_mention} do "
 "{recipient_mentions} a także {last_user_mention}."
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "{reporting_user_mention} reported a DM sent by {reported_user_mention} to "
@@ -6238,7 +5666,7 @@ msgstr ""
 "{reporting_user_mention} zgłosił DM wysłaną przez {reported_user_mention} do "
 "{recipient_mentions} a także {last_user_mention}."
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "{reporting_user_mention} reported a DM sent by {reported_user_mention} to "
@@ -6250,74 +5678,74 @@ msgstr ""
 "{reporting_user_mention} zgłosił DM wysłaną przez {reported_user_mention} do "
 "{recipient_mentions} a także {last_user_mention}."
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid "{fullname}'s moderation requests"
 msgid "{fullname} moderation"
 msgstr "Zgłoszenia {fullname} wymagające uwagi"
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr "Wadliwy operator zawężenia: {desc}"
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr "Wadliwa kombinacja operatora zawężającego: {desc}"
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr "Duplikuj operatory 'with'."
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr "Wadliwy operator 'with'"
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr "Brakuje argumentu 'anchor'."
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 #, fuzzy
 #| msgid "Missing 'anchor' argument."
 msgid "Missing 'anchor_date' argument."
 msgstr "Brakuje argumentu 'anchor'."
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr "Wadliwe zakotwiczenie"
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr "Operator {operator} nie jest obsługiwany."
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr "Operand {operand} nie jest obsługiwany."
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 msgid "Navigation view does not exist."
 msgstr "Widok nawigacyjny nie istnieje."
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr "Notka od {admin_group_syntax}:"
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6328,7 +5756,7 @@ msgstr ""
 "Aby dowiedzieć się więcej zobacz jak [korzystać z Zulip w klasie]"
 "({getting_started_url})!\n"
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6339,7 +5767,7 @@ msgstr ""
 "Aby dowiedzieć się więcej skorzystaj z [poradnika jak zacząć]"
 "({getting_started_url})!\n"
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6350,7 +5778,7 @@ msgstr ""
 "Mamy też przewodnik jak [ustawić Zulip dla klasy]"
 "({organization_setup_url}).\n"
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6361,7 +5789,7 @@ msgstr ""
 "Mamy też przewodnik dla [przenoszących organizację do Zulip]"
 "({organization_setup_url}).\n"
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "\n"
@@ -6382,7 +5810,7 @@ msgstr ""
 "zostanie **z automatu skasowana** po 30 dniach, o ile [nie zostanie\n"
 "zmieniona w bezterminową]({convert_demo_organization_help_url}).\n"
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
@@ -6392,7 +5820,7 @@ msgstr ""
 "Rozpocząłem kilka rozmów, które pomogą ci zacząć. Można je znaleźć\n"
 "je w [Inbox](/#inbox).\n"
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6403,7 +5831,7 @@ msgstr ""
 "Zawsze możesz wrócić do filmiku [Witaj w Zulip]({navigation_tour_video_url}) "
 "aby zapoznać się z podstawami.\n"
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6427,7 +5855,7 @@ msgstr ""
 "{demo_organization_text}\n"
 "\n"
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
@@ -6437,7 +5865,7 @@ msgstr ""
 "Możesz [pobrać](/apps/) apki [mobilny i na komputer](/apps/).\n"
 "Zulip działa też świetnie w przeglądarce.\n"
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -6449,7 +5877,7 @@ msgstr ""
 "help/change-your-profile-picture)\n"
 "aby zmienić swój [profil](/help/edit-your-profile).\n"
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -6465,7 +5893,7 @@ msgstr ""
 "język interfejsu](/help/change-your-language), bądź dopasować Zulip\n"
 "w jeszcze inny sposób [w ustawieniach](#settings/preferences).\n"
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6482,7 +5910,7 @@ msgstr ""
 "\n"
 "[Przeglądaj i subskrybuj kanały]({settings_link}).\n"
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -6513,7 +5941,7 @@ msgstr ""
 "obecnie\n"
 "dyskutowane.\n"
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -6528,7 +5956,7 @@ msgstr ""
 "\n"
 "Naciśnij `?` a zobaczysz [ściągę](#keyboard-shortcuts).\n"
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -6547,7 +5975,7 @@ msgstr ""
 "czasie\n"
 "globalnym i nie tylko.\n"
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6562,7 +5990,7 @@ msgstr ""
 "Sprawdź [przewodnik jak zacząć](/help/getting-started-with-zulip),\n"
 "lub przejrzyj [centrum pomocy](/help/) aby dowiedzieć się więcej!\n"
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6573,7 +6001,7 @@ msgstr ""
 "Możesz czatować ze mną ile tylko chcesz! Aby\n"
 "uzyskać pomoc skorzystaj z następujących komend: {bot_commands}\n"
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6592,7 +6020,7 @@ msgstr ""
 "bądź przenieść temat [do innego kanału]"
 "({move_content_another_channel_help_url}).\n"
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
@@ -6600,7 +6028,7 @@ msgstr ""
 "\n"
 ":point_right: Spróbuj przenieść ten wpis do innego wątku i z powrotem.\n"
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6622,12 +6050,11 @@ msgstr ""
 "#**{zulip_discussion_channel_name}**, jak widać na lewym pasku bocznym\n"
 "i powyżej.\n"
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr "witaj w Zulip!"
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -6638,7 +6065,7 @@ msgstr ""
 "Możesz przeglądać jedną dyskusję Zulip na raz, widząc każdy wpis i kontekst\n"
 "bez względu jak wiele innych konwersacji akurat ma miejsce.\n"
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
@@ -6648,7 +6075,7 @@ msgstr ""
 ":point_right: W wolnej chwili zajrzyj do [odebranych](/#inbox) pod kątem\n"
 "innych nieprzeczytanych wiadomości.\n"
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -6660,7 +6087,7 @@ msgstr ""
 "stronie\n"
 "i skorzystaj z przycisku `+` obok jego nazwy.\n"
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -6671,7 +6098,7 @@ msgstr ""
 "Nadaj wątkowi charakter. To powinno być coś w rodzaju “Hej,\n"
 "czy możemy podyskutować o…?”\n"
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
@@ -6679,7 +6106,7 @@ msgstr ""
 "\n"
 ":point_right: Spróbuj rozpocząć nową dyskusję w tym kanale.\n"
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6690,7 +6117,7 @@ msgstr ""
 ":point_right:  Użyj tego wątku aby przetestować [możliwości Zulip jeśli "
 "idzie o wpisy]({format_message_help_url}).\n"
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6725,7 +6152,7 @@ msgstr ""
 "\n"
 "```\n"
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
@@ -6735,7 +6162,7 @@ msgstr ""
 "Ten **powitalny** wątek to dobre miejsce na dopisanie “hej” :wave: "
 "pozostałym.\n"
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
@@ -6745,102 +6172,102 @@ msgstr ""
 ":point_right: Kliknij na tą wiadomość aby rozpocząć wpisywanie odpowiedzi do "
 "dyskusji.\n"
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr "przenoszenie wiadomości"
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr "eksperymenty"
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr "rozpocznij dyskusję"
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr "pozdrowienia"
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr "Wadliwy JSON w odpowiedzi"
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr "Wadliwy format odpowiedzi"
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr "Pusty lub nieprawidłowy token długości"
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr "Nieprawidłowy token APNS"
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr "Nieprawidłowa opcja GCM dla bouncera: priorytet {priority!r}"
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr "Nieprawidłowe opcje GCM dla bouncera: {options}"
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr "Token nie istnieje"
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr "{full_name} wspomniał o @{user_group_name}:"
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr "{full_name} wspomniał o tobie:"
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr "{full_name} wywołał wszystkich:"
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "Nowa wiadomość"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr "Powiadomienie próbne"
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr "To jest powiadomienie próbne z {realm_name} ({realm_url})."
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr "Urządzenie nie zostało rozpoznane"
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr "Urządzenie nie zostało rozpoznane przez bramkę push"
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr "Brak dodanego urządzenia push"
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr "Błąd sieci przy próbie połączenia z usługą powiadomień push Zulip."
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 "Wewnętrzny błąd serwera usługi powiadomień push Zulip, spróbuj później."
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
@@ -6848,13 +6275,13 @@ msgstr ""
 "Problem z konfiguracją powiadomień push na serwerze, skontaktuj się z "
 "administratorem serwera lub spróbuj później."
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 #, fuzzy
 #| msgid "Invalid API key"
 msgid "Invalid `push_key`"
 msgstr "Nieprawidłowy klucz API"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
@@ -6863,32 +6290,30 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr "Zła data lub ID kanału"
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr "Użytkownik nie jest uprawniony do tego zapytania"
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr "'{email}' nie używa obecnie Zulip."
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr "Nie możesz wysyłać bezpośrednich wiadomości poza swoją organizację."
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr "Maksymalna długość notki przypomnienia: {max_length} znaków"
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "You requested a reminder for the following direct message. Note:\n"
@@ -6900,13 +6325,13 @@ msgstr ""
 "Ustawiono przypomnienie o następującej wiadomości bezpośredniej. Notka:\n"
 " > {note}"
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 #, fuzzy
 #| msgid "You requested a reminder for the following direct message."
 msgid "You requested a reminder for the following message."
 msgstr "Poproszono o przypomnienie o tej wiadomości bezpośredniej."
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
@@ -6915,11 +6340,11 @@ msgstr ""
 "Ustawiono przypomnienie o następującej wiadomości bezpośredniej. Notka:\n"
 " > {note}"
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr "Poproszono o przypomnienie o tej wiadomości bezpośredniej."
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{user_silent_mention} [sent]({conversation_url}) a todo list."
 msgid ""
@@ -6927,14 +6352,14 @@ msgid ""
 "{topic_pretty_link}."
 msgstr "{user_silent_mention} [dodał]({conversation_url}) listę todo."
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{user_silent_mention} [said]({conversation_url}):"
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr "{user_silent_mention} [wspomniał]({conversation_url}):"
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{user_silent_mention} [sent]({conversation_url}) a todo list."
 msgid ""
@@ -6942,7 +6367,7 @@ msgid ""
 "{list_of_recipient_mentions}."
 msgstr "{user_silent_mention} [dodał]({conversation_url}) listę todo."
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{user_silent_mention} [said]({conversation_url}):"
 msgid ""
@@ -6950,558 +6375,542 @@ msgid ""
 "{list_of_recipient_mentions}:"
 msgstr "{user_silent_mention} [wspomniał]({conversation_url}):"
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{user_silent_mention} [sent]({conversation_url}) a todo list."
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr "{user_silent_mention} [dodał]({conversation_url}) listę todo."
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{user_silent_mention} [sent]({conversation_url}) a todo list."
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr "{user_silent_mention} [dodał]({conversation_url}) listę todo."
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 msgid "Reminder does not exist"
 msgstr "Przypomnienie nie istnieje"
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr "Błąd odsyłacza powiadomień push: {error}"
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr "Nie można zdecydować czy '{var_name1}' bądź '{var_name2}'"
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr "Brakuje argumentu '{var_name}'"
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr "Zła wartość dla '{var_name}': {bad_value}"
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr "Zaplanowany wpis nie istnieje"
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr "{service_name} bezpieczeństwo konta"
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr "Domyślny kanał nie może być prywatny."
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr "Kanały ogólnodostępne nie są włączone."
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr "Nie masz uprawnień do publikowania wpisów na tym kanale."
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr "Brak uprawnień dla aktywności w '{channel_name}'"
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 #, fuzzy
 #| msgid "You don't have permission to resolve topics in this channel."
 msgid "You do not have permission to create new topics in this channel."
 msgstr "Nie masz uprawnień do oznaczania wątków jako rozwiązane na tym kanale."
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr "Wadliwe ID kanału"
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr "Wadliwa nazwa kanału '{channel_name}'"
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr "Kanał(y) ({channel_names}) nie istnieje"
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr "Domyślna grupa kanałów o identyfikatorze '{group_id}' nie istnieje."
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr "Nazwa kanału nie może być pusta."
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr "Nazwa kanału za długa (limit: {max_length} characters)."
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr "Wadliwy znak w nazwie kanału - w miejscu {position}."
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr "Wadliwy znak w tytule - w miejscu {position}!"
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr "Dane o subskrybentach nie są dostępne dla tego kanału"
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr "Nie można zobaczyć subrybujących prywatny kanał"
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr "Nie można zdekodować obrazu; czy przesłałeś plik obrazu?"
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr "Rozmiar obrazu przekracza limit."
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr "Obraz jest uszkodzony lub ucięty"
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr "{var_name} to nie boolean"
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} does not have the expected format"
 msgstr "{var_name} nie posiada oczekiwanego formatu"
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr "{var_name} to nie date"
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr "{var_name} to nie dict"
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr "Wadliwa {var_name}"
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr "Argument \"{argument}\" w {var_name} jest nieoczekiwany"
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr "{var_name} to nie float"
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr "{var_name} jest za mała"
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr "{var_name} to nie integer"
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr "{var_name} nie jest prawidłowym JSON"
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr "{var_name} jest za duża"
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr "{var_name} to nie list"
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr "{var_name} jest za długa (limit: {max_length} znaków)"
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr "{var_name} jest za krótka."
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr "{var_name} to nie string"
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr "{var_name} ma wadliwy format"
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr "{var_name} nie ma długości {length}"
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr "{var_name} jest za długa (limit: {max_length} znaków)"
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr "{var_name} jest za długa (limit: {max_length} znaków)"
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr "{var_name} nie może być pusta"
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr "Wadliwa {var_name}: {msg}"
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr "Brakuje pola {var_name}, więc: {msg}"
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr "Zdeformowany ładunek"
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr "Brak na liście możliwych wartości"
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr "To nie URL"
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr "Nie rozpoznano strefy czasowej"
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr "{var_name} to nie jest właściwy kod hex koloru"
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr "Wadliwa {setting_name}"
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr "Przesłane dane przekraczają limit twojej organizacji."
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr "Rozmiar obrazu przekracza limit"
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr "Grupa użytkowników wyłączona."
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr "Nieprawidłowa grupa"
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid user group ID: {group_id}"
 msgid "Invalid user group ID: {user_group_id}"
 msgstr "Wadliwy ID grupy użytkowników: {group_id}"
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr "Wadliwa nazwa grupy systemowej."
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr "Wadliwy ID grupy użytkowników: {group_id}"
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 "'{setting_name}' ustawienie nie można zostać ustawione dla grupy 'role:"
 "internet'."
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 "Ustawienia '{setting_name}' nie można przypisać do grupy 'role:nobody'."
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 "Ustawienia '{setting_name}' nie można przypisać do grupy 'role:everyone'."
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 "Ustawienia '{setting_name}' nie można przypisać do grupy '{group_name}'."
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr "Nazwa grupy użytkowników nie może być pusta!"
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr "Nazwa grupy użytkowników nie może przekraczać {max_length} znaków."
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr "Nazwa dla grupy użytkowników nie może rozpoczynać się od '{prefix}'."
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr "Klient nie przekazał żadnych nowych wartości."
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 "Klient musi przekazać emoji_name o ile przekazują emoji_code lub "
 "reaction_type."
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr "Nazwa jest zbyt długa!"
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 msgid "Name must not be empty!"
 msgstr "Nazwa nie może być pusta!"
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr "Nieprawidłowe znaki w nazwie!"
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr "Nieprawidłowy format!"
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr "W tej organizacji wymagane są niepowtarzalne nazwy."
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr "Nazwa już w użyciu."
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr "Niewłaściwa nazwa lub nazwa użytkownika"
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr "Wadliwa integracja '{integration_name}'."
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr "Brak skonfigurowanych parametrów: {keys}"
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr "Wadliwa {key} wartość {value} ({error})"
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr "Nieprawidłowa konfiguracja!"
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr "Nieprawidłowy rodzaj bota"
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr "Nieprawidłowy interfejs"
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr "Błędne ID użytkownika: {user_id}"
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr "Nie ma takiego bota"
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr "Nie ma takiego użytkownika"
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr "Użytkownik jest zdezaktywowany"
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr "{item} nie może być puste."
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr "{var_name} ma błędną długość {length}; powinno być {target_length}"
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a string"
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr "{var_name} to nie string"
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr "{container} powinien zawierać dokładnie {length} elementów"
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr "Brakuje klucza {key_name} z {var_name}"
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr "Nieoczekiwane argumenty: {keys}"
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr "{var_name} to nie allowed_type"
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr "{variable} != {expected_value} ({value} jest błędna)"
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr "{var_name} to nie URL"
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr "Szablon URL musi zawierać '%(username)s'."
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr "'{item}' nie może być puste."
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr "Pole nie może mieć zduplikowanych opcji."
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr "'{value}' nie jest właściwym wyborem dla '{field_name}'."
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr "{var_name} to nie string lub integer list"
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr "{var_name} to nie string lub integer"
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr "{var_name} nie posiada długości"
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr "Brakuje {var_name}"
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr "Nieznane 'PresetUrlOption': {config}"
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr "Brakuje nagłówka zdarzeń HTTP '{header}'"
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr "Algorytm '{algorithm}' nie jest obsługiwany."
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
@@ -7509,153 +6918,153 @@ msgstr ""
 "Brak sekretu dla webhook. Proszę ustaw webhook_secret w trakcie tworzenia "
 "URL."
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr "Weryfikacja sygnatury webhook bez powodzenia."
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr "W nazwie powinien znajdować się ukośnik zcommand."
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr "Brak komendy: {command}"
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr "`zulip_update_announcements_stream` jest niespodziewanie wyłączony."
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr "Błąd CSRF: {reason}"
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr "Błędna konfiguracja reverse proxy: {proxy_reason}"
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr "Wadliwe ID użytkownika: {invalid_ids}"
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr "Użytkownik z ID {user_id} jest dezaktywowany"
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr "Użytkownik o ID {user_id} to bot"
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr "Data"
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr "Zewnętrzne konto"
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr "Zaimki"
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr "Nikt"
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr "Pełni użytkownicy"
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "Członkowie"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr "Każdy w internecie"
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Invalid characters in emoji name"
 msgid "Invalid auto-conversion field: empty field name."
 msgstr "Nieprawidłowe znaki w nazwie emoji"
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr "Grupa %(name)r w szablonie URL nie występuje we wzorcu łącznika."
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr "Złe wyrażenie regularne: {regex}"
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr "Nieznany błąd wyrażenia regularnego"
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr "Wadliwy format URL."
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid "Example input does not match the linkifier pattern."
 msgstr "Grupa %(name)r w szablonie URL nie występuje we wzorcu łącznika."
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr "Grupa %(name)r w szablonie URL nie występuje we wzorcu łącznika."
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr "Grupa %(name)r w szablonie łącznika nie występuje w szablonie URL."
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid ""
@@ -7663,7 +7072,7 @@ msgid ""
 "pattern."
 msgstr "Grupa %(name)r w szablonie URL nie występuje we wzorcu łącznika."
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgid ""
@@ -7671,334 +7080,331 @@ msgid ""
 "template."
 msgstr "Grupa %(name)r w szablonie łącznika nie występuje w szablonie URL."
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr "Emoji unicode"
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "Spersonalizowane emoji"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr "Zulip ekstra emoji"
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr "Nieprawidłowe znaki w nazwie emoji"
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr "Nieprawidłowe znaki w przetwarzanym języku"
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr "Brak wymaganej zmiennej \"code\" w szablonie URL"
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr "Zmienna \"code\" powinna być jedyną obecną w szablonie URL"
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr "piaskownica"
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr "ogólne"
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr "wydarzenia kanału"
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr "Spam"
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr "Nękanie"
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr "Nieodpowiednia zawartość"
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr "Łamie normy społeczne"
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr "Inny powód"
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr "Aktualizacje Zulip"
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr "Dostępne w ramach Zulip Cloud Standard. Wykup aby uzyskać dostęp."
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr "Dostępne w ramach Zulip Cloud Plus. Ulepsz aby uzyskać dostęp."
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr "Zezwól na GIF z serii G (ogólna widownia)"
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr "Zezwól na GIF z serii PG (ochrona rodzicielska)"
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 "Zezwalaj na GIF-y z oceną PG-13 (kontrola rodzicielska - poniżej 13 lat)"
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr "Zezwól na GIF z serii R (ograniczone)"
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr "Ogólnodostępny"
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "Publiczny"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr "Prywatny, otwarta historia"
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr "Prywatny, zamknięta historia"
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr "Administratorzy, moderatorzy, członkowie i goście"
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr "Administratorzy, moderatorzy i członkowie"
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr "Administratorzy i moderatorzy"
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr "Tylko administratorzy"
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr "Nieznany użytkownik"
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr "Właściciel organizacji"
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr "Administrator organizacji"
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr "Moderator"
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "Członek"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "Gość"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr "Nieznany adres IP"
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr "nieznany system operacyjny"
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr "Nieznana przeglądarka"
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr "Brak argumentu 'queue_id'"
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr "Brak argumentu 'last_event_id'"
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr "Zdarzenie nowsze od {event_id} zostało już wyczyszczone!"
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr "Zdarzenia {event_id} nie było w tym zapytaniu"
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr "Zły ID kolejki zdarzeń: {queue_id}"
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 msgid "Failed to generate challenge"
 msgstr "Nie udało się wygenerować wyzwania"
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr "Autoryzacja JWT nie jest włączona dla tej organizacji"
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr "Nie przekazano: JSON web token"
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr "Niewłaściwy JSON web token"
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr "Nie określono adresu email w danych tokena JSON"
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr "Subdomena jest wymagana"
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr "Hasło nie jest poprawne."
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr "Aby uzyskać oczekiwany efekt musisz usunąć wszystkie kanały z folderu."
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr "Brakuje nagłówka User-Agent w żądaniu"
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr "Etykieta nie może być pusta."
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr "Pole musi oferować co najmniej jeden wybór."
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr "Typ pola nie może zostać wyświetlony w podsumowaniu profilu."
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 #, fuzzy
 #| msgid "Field type not supported for display in profile summary."
 msgid "Field type not supported for use for user matching."
 msgstr "Typ pola nie może zostać wyświetlony w podsumowaniu profilu."
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr "Nieprawidłowy typ pola."
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 "Tylko 2 niestandardowe pola profilu mogą być wyświetlane w podsumowaniu "
 "profilu."
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr "Tak opisane pole już istnieje."
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr "Domyślne dodatkowe pole nie może zostać zmienione."
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr "Punkt końcowy nie jest dostępny."
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr "Nie włączono DevAuthBackend."
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr "Wadliwy parametr '{key}' dla anonimowego zapytania"
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr "Baza danych jest pusta"
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr "Nie można połączyć z postgresql"
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr "Nie można połączyć z rabbitmq"
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr "Nie można połączyć z rabbitmq"
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr "Nie można połączyć z redis"
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr "Nie można zapisać do memcached"
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr "Nie można połączyć z memcached"
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr "Nie ma takiego zaproszenia"
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 #, fuzzy
 #| msgid "Invitation has already been revoked"
 msgid "Invitation already used or deactivated."
 msgstr "Zaproszenie zostało już odwołane"
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr "Zaproszenie zostało już odwołane"
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr "Wadliwy ID kanału {channel_id}. Nie wysłano zaproszeń."
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr "Nie masz uprawnień do subskrybowania kanałów innych użytkowników."
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr "Określ przynajmniej jeden adres email."
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
@@ -8006,100 +7412,98 @@ msgstr ""
 "Niektóre z tych adresów są już zarejestrowane w Zulipie, więc nie wysłaliśmy "
 "im zaproszeń. Wszystkie inne dostały zaproszenie!"
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr "Historia edycji wiadomości jest wyłączona w tej organizacji"
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr "Nie masz uprawnień by usunąć tą wiadomość"
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr "Za nami okno czasowe na skasowanie tego wpisu"
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr "Wiadomość została już usunięta"
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr "Zażądano zbyt wielu wiadomości (maksimum to {max_messages})."
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr "Kotwicę można wykluczyć tylko na końcu zakresu"
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr "Brak wątku '{topic}'"
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr "Wymagane jest wyjaśnienie."
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 msgid "Message reporting is not enabled in this organization."
 msgstr "Zgłaszanie wiadomości w tej organizacji nie jest włączone."
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr "Brak nadawcy"
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr "Mirroring nie jest dozwolony z identyfikatorami odbiorcy"
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr "nieprawdłowa wiadomość-mirror"
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr "Funkcje AI nie są włączone na tym serwerze."
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr "Wyczerpano limit żetonów do użycia AI."
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr "Brak wiadomości w dyskusji do podsumowania"
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr "Nie możesz wyciszyć siebie"
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr "Użytkownik jest już wyciszony"
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr "Użytkownik nie jest wyciszony"
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr "Domyślne widoki nie mogą nosić zmienionych nazw."
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr "Własne widoku muszą nosić prawidłową nazwę."
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 msgid "Navigation view already exists."
 msgstr "Widok nawigacyjny już istnieje."
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr "Nieznany etap wdrażania: {onboarding_step}"
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -8110,58 +7514,58 @@ msgstr ""
 "Poprosiłeś o odłożenie oglądania filmiku [Witaj w Zulip]"
 "({navigation_tour_video_url}) Czy teraz masz chwilę?\n"
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr "Obecność nie jest mierzona dla botów."
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr "Brak danych o obecności dla {user_id_or_email}"
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr "Wadliwy status: {status}"
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 #, fuzzy
 #| msgid "You do not have permission to change default channels."
 msgid "You do not have permission to manage plans and billing."
 msgstr "Nie masz uprawnień do zmiany domyślnych ustawień kanału."
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr "Serwer nie używa usługi powiadomień push"
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr "Błąd zwrócony przez bramkę: {result}"
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr "Sekret weryfikacyjny nie jest przygotowany"
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
@@ -8169,284 +7573,283 @@ msgstr ""
 "Musi być obecny co najmniej jeden z następujących argumentów: emoji_name, "
 "emoji_code"
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr "Pokwitowania odczytu są wyłączone w tej organizacji."
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr "Wadliwy język '{language}'"
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr "Należy włączyć przynajmniej jedną metodę uwierzytelniania."
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr "Wadliwy dostawca czatu wideo {video_chat_provider}"
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid giphy_rating {giphy_rating}"
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr "Wadliwy giphy_rating {giphy_rating}"
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr "Musi być organizacją demo."
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 "Termin usunięcia danych może sięgać do {max_allowed_days} dni w przyszłość."
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 "Termin usunięcia danych to nie mniej niż {min_allowed_days} dni przed nami."
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr "Wadliwa domena: {error}"
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr "Domena {domain} jest już częścią twojej organizacji."
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr "Brak wpisu dla domeny {domain}."
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr "Musisz przesłać dokładnie jeden plik."
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr "Tylko administratorzy mogą nadpisać domyślne emoji."
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr "Załadowany plik jest większy od dozwolonego limitu {max_size} MiB"
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 #, fuzzy
 #| msgid "JWT authentication is not enabled for this organization"
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr "Autoryzacja JWT nie jest włączona dla tej organizacji"
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr "Przekroczono limit ruchu."
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr "Wadliwe ID eksportu danych"
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr "Eksport został skasowany"
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr "Eksport bez powodzenia, nic do skasowania"
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr "Eksport nadal w realizacji"
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr "Prześlij dokładnie jedną ikonę."
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr "Nie odnaleziono łącznika."
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr "Musisz przesłać dokładnie jedno logo."
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid characters in pygments language"
 msgid "Invalid character in language: {character}"
 msgstr "Nieprawidłowe znaki w przetwarzanym języku"
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid language '{language}'"
 msgid "Language '{language}' is not allowed."
 msgstr "Wadliwy język '{language}'"
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr "Wadliwa piaskownica"
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr "Nie można anulować importu kiedy już ruszył."
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr "Nieuwierzytelniony"
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 msgid "Importing messages…"
 msgstr "Importowanie wiadomości…"
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr "Importowanie danych załączników…"
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr "Importowanie przetworzonych danych Slack…"
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr "Kończenie importu…"
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr "Gotowe!"
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr "Brak użytkowników z takim adresem email."
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "Your full name"
 msgid "Your name"
 msgstr "Twoje imię i nazwisko"
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr "Wymagany odbiorca dla tego typu odwlekanej wiadomości."
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 "Temat wymagany podczas aktualizacji zaplanowanego typu wiadomości do kanału."
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr "Wadliwy format żądania"
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr "Wadliwy DSN"
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr "Prywatne kanały nie mogą robić za domyślne."
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr "Musisz przekazać \"new_description\" lub \"new_group_name\"."
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr "Wadliwa wartość \"op\". Określ \"add\" lub \"remove\"."
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr "Nieprawidłowe parametry"
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr "Wymagana kontrola dostępu do kanału."
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr "Kanał ma już taką nazwę."
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr "Brak polecenia. Określ przynajmniej jedno \"dodaj\" lub \"skasuj\"."
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr "{user_full_name} dodał cię do śledzących {channel_name}."
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr "{user_full_name} dodał cię do śledzących następujące kanały:"
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr "Brak dostępu do kanału ({channel_name})."
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr "{user_name} utworzył następujące kanały: {new_channels}."
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr "{user_name} utworzył nowy kanał {new_channels}."
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr "nowe kanały"
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr "**Dostępny dla każdego** kanał utworzony przez {user_name}. **Opis:**"
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr "**Publiczny**kanał dodany przez {user_name}. **Opis:**"
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
@@ -8454,7 +7857,7 @@ msgstr ""
 "**Prywatny, udostępniona historia** kanał utworzony przez {user_name}. "
 "**Opis:**"
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
@@ -8462,26 +7865,26 @@ msgid ""
 msgstr ""
 "**Prywatny, chroniona historia** kanał utworzony przez {user_name}. **Opis:**"
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr "{property} to nie boolean"
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr "Nieznane właściwości subskrypcji: {property}"
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr "Nie zasubskrybowany do kanału ID {channel_id}"
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr "Wadliwy json dla podwiadomości"
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
@@ -8490,7 +7893,7 @@ msgstr ""
 "Plik jest większy niż maksymalny rozmiar przesyłania ({max_size} MiB) "
 "dozwolony w planie organizacji."
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
@@ -8499,7 +7902,7 @@ msgstr ""
 "Plik jest większy niż maksymalny rozmiar przesyłania skonfigurowany na tym "
 "serwerze ({max_size} MiB)."
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
@@ -8508,55 +7911,54 @@ msgstr ""
 "Przekazany plik przekracza dozwolony limit dla plików importu "
 "{max_file_size} MiB."
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 "Użytkownik wyłączył powiadamianie o tym, że akurat wpisuje coś do kanału"
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr "Brakuje argumentu 'to'"
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr "Pusta lista 'do'"
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr ""
 "Użytkownik wyłączył powiadomienia o tym, że akurat dodaje wiadomość "
 "bezpośrednią"
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr "<p>Taki plik nie istnieje lub został skasowany.</p>"
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr "<p>Nie jesteś uprawniony do przeglądania tego pliku.</p>"
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr "Wadliwy token"
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr "Nieprawidłowa nazwa pliku"
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr "Określ plik do przesłania"
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr "Możesz przesyłać tylko pojedyncze pliki"
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr "Nie podano nowych danych"
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
@@ -8564,32 +7966,32 @@ msgstr ""
 "Nic do roboty. Określ co najmniej jedno z \"add\", \"delete\", "
 "\"add_subgroups\" lub \"delete_subgroups\"."
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr "{user_full_name} dodał cię do grupy {group_name}."
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr "{user_full_name} usunął cię z grupy {group_name}."
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr "Użytkownik {user_id} jest już członkiem tej grupy"
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr "Brak użytkownika '{user_id}' w tej grupie użytkowników"
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr "Grupa użytkowników {group_id} jest już podgrupą tej grupy."
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
@@ -8598,78 +8000,78 @@ msgstr ""
 "Grupa użytkowników {user_group_id} jest już podgrupą jednej z podanych "
 "podgrup."
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr "Grupa użytkowników {group_id} nie jest podgrupą tej grupy."
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr "Zmiany awatatara są wyłączone dla tej organizacji."
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr "Zmiany adresu email są wyłączone w tej organizacji."
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr "Wadliwy domyślny język"
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr "Wadliwy dźwięk powiadomienia '{notification_sound}'"
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr "Wadliwa wartość okresu wysyłki serii emaii: {seconds} sekund"
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr "Twoje hasło Zulip jest obsługiwane przez LDAP"
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr "Niewłaściwe hasło!"
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, fuzzy, python-brace-format
 #| msgid "You're making too many attempts! Try again in {seconds} seconds."
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr "Podejmujesz zbyt wiele prób! Spróbuj ponownie za {seconds} sekund."
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr "Nowe hasło jest za słabe!"
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr "Prześlij dokładnie jeden awatar."
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr "Temat nie jest wyciszony"
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr "Nie można dezaktywować jedynego właściciela organizacji"
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Nobody in this Zulip organization will be able to see this email address."
@@ -8677,27 +8079,27 @@ msgid "User is not allowed to delete other user's messages."
 msgstr ""
 "Nikt w tej organizacji Zulip nie będzie mógł zobaczyć tego adresu email."
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr "Użytkownik nie ma uprawnień do zmiany emaili użytkowników"
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 "Uprawnienie właściciela nie może zostać usunięte z jedynego właściciela "
 "organizacji."
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr "Wadliwy nowy adres email."
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr "Błąd w nowym email: {message}"
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
@@ -8710,25 +8112,25 @@ msgstr ""
 "skonfigurowany.\n"
 "Skontaktuj się z administratorem serwera."
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 #, fuzzy
 #| msgid "Email is already in use."
 msgid "Email address already in use"
 msgstr "Email jest już w użyciu."
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr "Błąd przy zmianie właściciela, brak użytkownika"
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr "Błąd przy zmianie właściciela, nieaktywny użytkownik"
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr "Nie udało się zmienić właściciela - bot nie może pilnować innego bota"
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
@@ -8737,140 +8139,140 @@ msgstr ""
 "skonfigurowany.\n"
 "Skontaktuj się z administratorem serwera."
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr "Wbudowane boty nie są włączone."
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr "Wadliwa nazwa wbudowanego bota."
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr "Użytkownik nie może dodawać użytkowników"
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr "Email '{email}' nie jest dozwolony w tej organizacji"
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr "Tymczasowe adresy email nie są dozwolone w tej organizacji"
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom access token"
 msgid "Invalid {provider_name} access token"
 msgstr "Wadliwy token dostępu Zoom"
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} call"
 msgstr "Nie udało się zestawić połączenia Zoom"
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Zoom credentials have not been configured"
 msgid "{provider_name} credentials have not been configured"
 msgstr "Poświadczenia Zoom nie zostały skonfigurowane"
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom credentials"
 msgid "Invalid {provider_name} credentials"
 msgstr "Wadliwe dane Zoom"
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error connecting to the BigBlueButton server."
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr "Błąd połączenia z serwerem BigBlueButton."
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error authenticating to the BigBlueButton server."
 msgid "Error authenticating to the {provider_name} server"
 msgstr "Błąd autoryzacji do serwera BigBlueButton."
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "BigBlueButton server returned an unexpected error."
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr "Serwer BigBlueButton zwrócił niespodziewany błąd."
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom session identifier"
 msgid "Invalid {provider_name} session identifier"
 msgstr "Wadliwy identyfikator sesji Zoom"
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr "Nieznany email użytkownika Zoom"
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} public room."
 msgstr "Nie udało się zestawić połączenia Zoom"
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr "Wadliwa sygnaturka."
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{full_name}'s Zulip room"
 msgstr "{full_name} wspomniał o tobie:"
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 "Projekty korzystające z tego dostawcy systemu kontroli wersji nie są "
 "obsługiwane"
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr "Wadliwy ładunek"
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr "Nieznany webhook request"
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr "Należy określić wątek"
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr "Treść nie może być pusta"
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr "Nie można obsłużyć współpracy z Jotform"
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr "Zła forma: JSON input"
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr "Brakuje klucza zdarzeń w ładunku"
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr "Błąd: parametr channels_map_to_topics inny od 0 lub 1"
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr "Nieznana akcja webhooka WordPress: {hook}"
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
@@ -8879,76 +8281,76 @@ msgstr ""
 "Eksport danych zakończony. [View and download exports]"
 "({export_settings_link})."
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr "Sekret weryfikacji wygasł"
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr "Sekret weryfikacji jest wadliwy"
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr "Sekret weryfikacji jest zdeformowany"
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr "Sekret weryfikacji przynależy do innego hosta"
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr "Nieprawidłowa subdomena dla bouncera powiadomień push"
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr "Należy zweryfikować poprawnym kluczem API serwera Zulp"
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr "Wadliwy UUID"
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr "Nieprawidłowy typ tokenu"
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 "{hostname} zawiera błędne komponenty (jak ścieżka, zapytanie, fragment)."
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr "{hostname} nie jest poprawnym hostname"
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr "Jeszcze nie zarejestrowano {hostname}"
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr "Wadliwy adres email administratora serwera: {email_reason}"
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr "example.com to nie jest właściwa domena email."
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr "{domain} jest nieprawidłowa, ponieważ nie ma żadnych rekordów MX"
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr "{domain} nie istnieje"
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
@@ -8957,29 +8359,29 @@ msgstr ""
 "Wyczerpano limit przewidziany dla tego punktu końcowego. Proszę spróbuj "
 "ponownie później lub skontaktuj się z {support_email} aby uzyskać pomoc."
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr "Nie odnaleziono rejestracji dla tego hosta"
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr "Host nie ma przydzielonego sekretu weryfikacji."
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, fuzzy, python-brace-format
 #| msgid "Error response received from the host: {status_code}"
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr "Napotkano na błąd hosta: {status_code}"
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr "Brakuje ios_app_id"
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr "Brakuje user_id lub user_uuid"
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
@@ -8988,50 +8390,50 @@ msgstr ""
 "Twój plan nie zezwala na wysyłanie powiadomień push. Powód podany przez "
 "serwer: {reason}"
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr "Twój plan nie przewiduje wysyłki powiadomień push."
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr "Wadliwa wartość {property}"
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr "Wadliwy typ wydarzenia."
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr "Dane są w złym porządku."
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr "Wykryto wielokrotną rejestrację."
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr "Wadliwe dane dziennika operacji"
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr "Musisz zmienić swoje hasło."
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr "Brakuje parametru id_token"
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 #, fuzzy
 #| msgid "Missing id_token parameter"
 msgid "Missing idp param"
 msgstr "Brakuje parametru id_token"
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr "Nieprawidłowy OTP"
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr "Nie można użyć mobile_flow_otp i desktop_flow_otp za jednym razem."
 

--- a/locale/pt/LC_MESSAGES/django.po
+++ b/locale/pt/LC_MESSAGES/django.po
@@ -20,7 +20,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 18:56+0000\n"
 "Last-Translator: Alex Vandiver <alexmv@zulip.com>\n"
 "Language-Team: Portuguese <https://hosted.weblate.org/projects/zulip/django/"
@@ -33,52 +33,52 @@ msgstr ""
 "1000000 == 0 ? 1 : 2;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "Não permitido para usuários convidados"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "Organização inválida"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr "Canais público"
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr "Canais privados"
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr "Mensagens diretas"
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr "Mensagens diretas em grupo"
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr "Canal ausente para o gráfico: {chart_name}"
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr "Nome do gráfico desconhecido: {chart_name}"
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr "Data de início é depois da data de fim. Início: {start}, Fim: {end}"
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr ""
 "Nenhuma dado analítico disponível. Por favor contate o administrador do "
 "servidor."
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -91,7 +91,7 @@ msgstr ""
 "({billing_page_link}) ou [desativar usuários inativos]"
 "({deactivate_user_help_page_link}) para permitir novos usuários juntar-se."
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -103,7 +103,7 @@ msgstr ""
 "inativos]({deactivate_user_help_page_link}) para permitir que mais de um "
 "usuário juntar-se."
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -115,7 +115,7 @@ msgstr ""
 "inativos]({deactivate_user_help_page_link}) para permitir que mais de dois "
 "usuários a juntar-se."
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -127,7 +127,7 @@ msgstr ""
 "inativos]({deactivate_user_help_page_link}) para permitir que mais de três "
 "usuários a juntar-se."
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -140,7 +140,7 @@ msgstr ""
 "certificar-se que o [número de licenças no período de faturação atual]"
 "({billing_page_link}) é superior ao atual número de usuários."
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
@@ -148,7 +148,7 @@ msgstr ""
 "Sua organização não tem licenças Zulip suficiente. Os convites não foram "
 "enviados."
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
@@ -156,16 +156,15 @@ msgstr ""
 "A sua organização não tem licenças Zulip suficiente para alterar a função de "
 "um usuário visitante."
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr "O cadastro está desativado"
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr "Servidor remoto inválido."
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
@@ -174,7 +173,7 @@ msgstr ""
 "Você deve comprar licenças para todos os usuários ativos em sua organização "
 "(minimum {min_licenses})."
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
@@ -183,43 +182,43 @@ msgstr ""
 "Faturas com mais de {max_licenses} licenças não podem ser processadas desta "
 "página. Para completar a atualização, por favor entre em contato com {email}."
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr "Sem método de pagamento no arquivo."
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr "{brand} terminado em {last4}"
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr "Método de pagamento desconhecido. Por favor contacte {email}."
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr "Erro inesperado. Por favor contacte {email}."
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "Algo deu errado. Por favor, recarregue a página."
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr "Algo deu errado. Por favor, aguarde alguns segundos e tente novamente."
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 "Por favor adicionar um cartão de crédito antes de começar seu teste gratuito."
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr "Por favor, adicionar um cartão de crédito para agendar a atualização."
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
@@ -227,18 +226,18 @@ msgstr ""
 "Incapaz de atualizar o plano. O plano expirou e foi substituído com um novo "
 "plano."
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr "Incapaz de atualizar o plano. O plano foi encerrado."
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 "Não pode atualizar licenças no período de cobrança atual para o plano de "
 "teste gratuito."
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
@@ -246,17 +245,17 @@ msgstr ""
 "Incapaz de atualizar as licenças manualmente. Seu plano está em "
 "gerenciamento automático de licenças."
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr "Seu plano já possui {licenses} licenças no atual período de pagamento."
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr "Você não pode reduzir as licenças no atual período de pagamento."
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
@@ -264,7 +263,7 @@ msgstr ""
 "Não pode alterar as licenças para o próximo ciclo de cobrança para um plano "
 "que está sendo rebaixado."
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
@@ -273,7 +272,7 @@ msgstr ""
 "Seu plano já está programado para renovar com {licenses_at_next_renewal} "
 "licenças."
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
@@ -282,27 +281,27 @@ msgstr ""
 "Você já adquiriu {licenses_at_next_renewal} licenças para o próximo período "
 "de pagamento."
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr "Nada para alterar."
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr "Não tem cliente para esta organização!"
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr "Sessão não encontrada"
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr "Intenção de pagamento não encontrada"
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr "Passar stripe_session_id ou stripe_invoice_id"
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -317,20 +316,19 @@ msgstr ""
 "Se você puder {begin_link} listar o Zulip como patrocinador em seu site "
 "{end_link}, nós ficariamos muito agradecidos!"
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr "Parâmetro 'confirmed' é obrigatório"
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr "O token de acesso à cobrança expirou."
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr "Token de acesso à cobrança inválido."
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
@@ -339,40 +337,39 @@ msgstr ""
 "Não é possível reconciliar a informação de faturação entre o servidor e o "
 "domínio. Por favor contacte o suporte {support_email}"
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr "A conta do usuário ainda não existe."
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr "Você deve aceitar os Termos de Serviço para prosseguir."
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 "Este zulip_org_id não está registrado com o sistema de gestão de cobrança do "
 "Zulip."
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr "Chave zulip_org_key inválida para esta zulip_org_id."
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr "O registro do seu servidor foi desativado."
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "Erro"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr "Página não encontrada (404)"
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
@@ -381,11 +378,11 @@ msgstr ""
 "Se esse erro é inesperado, você pode <a href=\"mailto:"
 "%(support_email)s\">entrar em contato com o suporte</a>."
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr "Acesso negado (403)"
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
@@ -394,11 +391,11 @@ msgstr ""
 "credenciais obrigatórias para autenticar seu acesso. Para resolver esse "
 "problema:"
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr "Certificar-se que seu navegador permite cookies para este site."
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
@@ -406,22 +403,21 @@ msgstr ""
 "Marcar qualquer configurações de privacidade para navegador ou extensões que "
 "bloqueiam cabeçalhos Referer, e as desative para esse site."
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr "Método não permitido (405)"
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr "Erro interno do servidor"
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
 msgstr ""
 
-#: templates/500.html:27
+#: templates/500.html
 #, fuzzy, python-format
 #| msgid ""
 #| "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -436,13 +432,13 @@ msgstr ""
 "find/\">obter uma lista da sua conta Zulip Cloud</a>, ou <a href=\"mailto:"
 "%(support_email)s\">entre em contato com o suporte Zulip</a>."
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -460,7 +456,7 @@ msgstr ""
 "a> para suporte.\n"
 "                            "
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
@@ -470,138 +466,136 @@ msgstr ""
 "href=\"%(troubleshooting_url)s\">Guia de resolução de problemas do servidor "
 "Zulip</a>."
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr "Análise de dados para %(target_name)s | Zulip"
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 "As análises estarão totalmente disponíveis 24 horas após a criação da "
 "organização."
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr "Análise do Zulip para %(target_name)s"
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr "Resumo da organização"
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr "Número de usuários"
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr "Usuários ativos durante os últimos 15 dias"
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr "Número de convidados"
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr "Número total de mensagens"
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr "Número de mensagens nos últimos 30 dias"
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr "Armazenamento de arquivos em uso"
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "Usuários ativos"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr "Diários ativos"
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr "15 dias ativos"
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr "Total de usuários"
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "Usuários"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr "Mensagens enviadas pelo tipo de destinatário"
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "Eu"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "Todos"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "Semana anterior"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "Mês anterior"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "Ano anterior"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "Período integral"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr "Mensagens enviadas ao longo do tempo"
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "Diário"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "Semanal"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr "Acumulado"
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "Pessoas"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "Bots"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr "Mensagens lidas ao longo do tempo"
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr "Mensagens enviadas pelo cliente"
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr "Última atualização"
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
@@ -609,15 +603,15 @@ msgstr ""
 "Uma atualização completa de todos os gráficos acontece uma vez por dia. O "
 "gráfico de “mensagens enviadas por período” é atualizado a cada hora."
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr "E-mail alterado"
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr "Email alterado!"
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
@@ -626,21 +620,21 @@ msgstr ""
 "Isso confirma que o endereço de e-mail para sua conta Zulip foi alterado de "
 "%(old_email_html_tag)s para %(new_email_html_tag)s"
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr "Confirmando seu endereço de e-mail"
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr "O link de confirmação não existe"
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr "Ops. Não foi possível encontrar seu link de confirmação no sistema."
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
@@ -649,29 +643,29 @@ msgstr ""
 "De qualquer forma, envie-nos uma mensagem em %(support_email_html_tag)s e "
 "resolveremos isso em breve."
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr "Link de confirmação expirado ou inativo"
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr "Ops. O link de confirmação expirou ou foi desativado."
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr ""
 "Entre em contato com o administrador da sua organização para obter um novo "
 "link."
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr "Link de confirmação incorreto"
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr "Ops. O link de confirmação está incorreto."
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
@@ -680,72 +674,55 @@ msgstr ""
 "ainda está encontrando esta página, provavelmente a culpa é nossa. Nós "
 "lamentamos."
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr "Faturamento"
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr "Fechar modal"
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr "Não se preocupe"
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr "Rebaixar"
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr "Confirmar"
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr "Cancelar a atualização"
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr "Status de cobrança"
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr "Desativar registro do servidor?"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr "Gerenciamento de plano não disponível"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -762,7 +739,7 @@ msgstr ""
 "in-to-billing-management\">Instruções de log</a> para administrar seu plano "
 "Servidor Zulip."
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
@@ -770,7 +747,7 @@ msgstr ""
 "Para mover o plano do servidor para esta organização, ou para mais dúvidas "
 "<a href=\"mailto:{{ support_email }}\">entre em contato com o suporte</a>."
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
@@ -778,7 +755,7 @@ msgstr ""
 "O gerenciamento de plano para este servidor não está disponível porque ao "
 "menos uma organização hospedada nesse servidor já tem um plano ativo."
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -790,737 +767,247 @@ msgstr ""
 "href='mailto:%(support_email)s'>contato com o suporte</a> se tiver qualquer "
 "dúvida."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr "Limite de taxa excedido"
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr "Limite de taxa excedido."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 "Seu servidor excedeu o limite de quantas vezes essa ação pode ser executada."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, fuzzy, python-format
 #| msgid "You can try again in %(retry_after)s seconds."
 msgid "You can try again in %(retry_after_string)s."
 msgstr "Você pode tentar de novo em %(retry_after)s segundos."
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr "Atualizar"
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr "Enviar fatura e começar o teste gratuito"
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr "Enviar fatura"
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr "Abrir diretório de comunidades"
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr "Filtrar por categoria"
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "Todos"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr "Categorias"
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr "10,000 mensagens"
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr "Ilimitado"
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr "Arquivos de até 10 MB"
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr "Arquivos de até 1 GB"
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr "Suportado"
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr "Autogerenciado"
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr "Para organizações com até 10 usuários"
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr "Mínimo de 25 usuários"
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr "Indisponível"
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr "A comunidade de desenvolvimento do Zulip"
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr "Ingressar como usuário"
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr "Ingressar como um auto-hospedador"
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr "Ingressar como contribuidor"
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "Criar organização"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr "Obtenha uma demonstração"
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr "Autohospedar Zulip"
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr "Solicitar patrocínio"
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr "Preços para educação"
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr "Ver os preços"
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr "Zulip para empresas"
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Zulip guide for open-source projects"
 msgid "Zulip for open source"
 msgstr "Guia Zulip para projetos de código aberto"
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "start a conversation"
 msgid "Screenshot of Zulip conversation"
 msgstr "Começar uma conversa"
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Messages sent over time"
 msgid "Message with code"
 msgstr "Mensagens enviadas ao longo do tempo"
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr "Link"
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr "Contatar o suporte"
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr "De"
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr "Organização"
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr "Assunto"
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr "Mensagem"
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr "Enviar"
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr "Obrigado por entrar em contato conosco"
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr "Obrigado por entrar em contato conosco!"
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr "Entraremos em contato em breve."
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
@@ -1528,13 +1015,13 @@ msgstr ""
 "Você pode encontrar respostas para perguntas frequentes no <a href=\"/help/"
 "\">centro de ajuda do Zulip</a>."
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 #, fuzzy
 #| msgid "Getting started"
 msgid "Get started"
 msgstr "Primeiros passos"
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
@@ -1544,51 +1031,50 @@ msgstr ""
 "aceite os <a href=\"https://zulip.com/policies/terms\">Termos de Serviço do "
 "Zulip</a> para continuar."
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr "Ou, alternativamente, utilize um dos seus telefones de backup:"
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr "Como um último recurso, você pode utilizar um token de backup:"
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr "Utilizar token de backup"
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr "Aceite os Termos de Serviço"
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr "Bem-vindo ao Zulip"
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "Email"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr ""
 "Inscreva-me no boletim informativo de baixo tráfego do Zulip (alguns e-mails "
 "por ano)."
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr "Continuar"
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr "Confirme seu endereço de e-mail"
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1599,7 +1085,7 @@ msgstr ""
 "class=\"user_email semi-bold\">%(email)s</span>) para um e-mail de "
 "confirmação do Zulip."
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
@@ -1608,31 +1094,31 @@ msgstr ""
 "pasta de Spam, podemos <a href=\"#\" id=\"resend_email_link\"> reenviá-lo</"
 "a>."
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr "Visão pública das conversas Time Zulip de {org_name}"
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 "Explore os canais publicamente acessíveis de {org_name} sem iniciar sessão."
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
@@ -1640,39 +1126,38 @@ msgstr ""
 "Se esta mensagem não desaparecer, tente <a class=\"reload-lnk\">recarregar </"
 "a> a página."
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 "Erro ao carregar o Zulip. Tente <a class=\"reload-lnk\">recarregar</a> a "
 "página."
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr "Nenhuma conversa corresponde aos seus filtros."
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr "Essa visualização ainda está carregando as mensagens."
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr "Carregar mais"
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr "Chamada de vídeo encerrada"
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr "Você pode fechar essa janela agora."
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr "Erro de configuração"
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
@@ -1681,7 +1166,7 @@ msgstr ""
 "primeiro. Por favor use EmailAuthBackend para criar sua organização e então "
 "tente novamente."
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1692,73 +1177,71 @@ msgstr ""
 "instruções de como configurar notificações push, por favor veja a <a "
 "href=\"%(doc_url)s\">documentação</a>."
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr "Conta não encontrada"
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr "Conta Zulip não encontrada."
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, fuzzy, python-format
 #| msgid "Your account email: %(email)s"
 msgid "No account found for %(email)s."
 msgstr "Sua conta de e-mail: %(email)s"
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr "Entrar com outra conta"
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr "Continuar com registro"
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Must be a demo organization."
 msgid "Try Zulip in a demo organization"
 msgstr "Deve ser uma organização de demonstração."
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Try Zulip now"
 msgid "Try Zulip"
 msgstr "Experimente o Zulip agora"
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "Crie uma nova organização"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr "Criar uma nova organização Zulip"
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr "Insira seu endereço de email"
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr "Seu e-mail"
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
@@ -1768,11 +1251,11 @@ msgstr ""
 "import-from-mattermost\">Mattermost</a>, ou <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr "Como você ouviu falar do Zulip pela primeira vez?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
@@ -1780,42 +1263,41 @@ msgstr ""
 "Este valor será utilizado somente se você assinar um plano, neste caso será "
 "enviado para a equipe Zulip."
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr "Selecione uma opção"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr "Por favor descreva"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr "Onde você viu o anúncio?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr "Qual organização?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr "Qual deles?"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr "Selecionar uma"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr "Tipo de organização"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr "Idioma da organização"
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 #, fuzzy
 #| msgid ""
 #| "\n"
@@ -1838,74 +1320,70 @@ msgstr ""
 "a>.\n"
 "                "
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 #, fuzzy
 #| msgid "Private, shared history"
 msgid "Import chat history?"
 msgstr "Histórico privado e compartilhado"
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr "Nome da organização"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "URL da organização"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr "Utilizar %(external_host)s"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "OU"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "Cadastrar"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "Inscreva-se no Zulip"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr "Você precisa de um convite para ingressar nesta organização."
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr "Inscrever-se com %(identity_provider)s"
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr "Já tem uma conta?"
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "Entrar"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr "Configurar a privacidade do endereço de e-mail"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
@@ -1913,7 +1391,7 @@ msgstr ""
 "O Zulip permite que você controle quais cargos na organização podem ver seu "
 "endereço de e-mail."
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
@@ -1921,11 +1399,11 @@ msgstr ""
 "Você deseja alterar a configuração de privacidade do seu e-mail da "
 "configuração padrão desta organização?"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr "Quem pode acessar seu endereço de e-mail"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1936,14 +1414,14 @@ msgstr ""
 "help/configure-email-visibility\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">depois de ingressar</a>."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 "Administradores desta organização Zulip poderão ver este endereço de email."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
@@ -1951,94 +1429,93 @@ msgstr ""
 "Administradores e moderadores desta organização Zulip poderão ver este "
 "endereço de email."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 "Ninguém nessa organização do Zulip conseguirá visualizar esse endereço de e-"
 "mail."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 "Outros usuários nesta organização Zulip poderão ver este endereço de e-mail."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "Alteração"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr "Registro"
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr "Crie sua organização"
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr "Crie sua conta"
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr "<p>Insira os detalhes da sua conta para concluir o registro.</p>"
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr "Sua organização"
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr "Sua conta"
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr "Não importe configurações"
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr "Importar configurações de conta Zulip existente"
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr "Seu nome completo"
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "Nome"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr "É assim que sua conta é exibida no Zulip."
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "Senha"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr "Entre sua senha LDAP/Active Directory."
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 "Isto é utilizado para aplicações móveis e outras ferramentas que exigem uma "
 "senha."
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr "Força da senha"
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr "Em quê você está interessado?"
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
@@ -2047,15 +1524,15 @@ msgstr ""
 "Eu concordo com os <a href=\"%(root_domain_url)s/policies/terms\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">Termos de Serviço</a>."
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr "Organização desativada"
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr "Organização movida"
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
@@ -2064,7 +1541,7 @@ msgstr ""
 "Essa organização foi movida para <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -2072,7 +1549,7 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid ""
@@ -2080,7 +1557,7 @@ msgid ""
 "deleted."
 msgstr "Esta organização foi desativada"
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2097,7 +1574,7 @@ msgstr ""
 "Zulip</a>.\n"
 "                            "
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2115,13 +1592,13 @@ msgstr ""
 "a> para suporte.\n"
 "                            "
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid "This organization has been deactivated."
 msgstr "Esta organização foi desativada"
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -2131,14 +1608,14 @@ msgstr ""
 "%(support_email)s\">entrar em contato com o suporte do Zulip</a> para "
 "reativá-la."
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -2149,15 +1626,15 @@ msgstr ""
 "%(support_email)s\">entrar em contato com os administradores desse servidor "
 "Zulip</a> para reativá-lo."
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr "Concluir o login do aplicativo de desktop"
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr "Concluir login na área de trabalho"
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
@@ -2165,93 +1642,92 @@ msgstr ""
 "Use seu navegador web para concluir o login, depois volte aqui para colar "
 "seu token de login."
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr "Cole o token aqui"
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr "Finalizar"
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr "Token incorreto."
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr "Token aceito. Fazendo login…"
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr "Faça login no aplicativo de desktop"
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 "Copie este token de login e retorne ao seu aplicativo Zulip para concluir o "
 "login:"
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "Copiar"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr "Você pode então fechar esta janela."
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr "Ou continue no seu navegador."
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr "Usuário anônimo"
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr "Proprietários"
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "Administradores"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr "Moderadores"
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr "Usuários convidados"
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "Usuários padrão"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr "Encaminhar e-mails para uma conta de e-mail"
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "Fechar"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "Atualizar"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr "Zulip"
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr "Resumo"
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
@@ -2259,17 +1735,17 @@ msgid ""
 msgstr ""
 "Parabéns, você criou uma nova organização Zulip: <b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr "Bem-vindo ao Zulip!"
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr "Você entrou na organização Zulip <b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
@@ -2278,36 +1754,36 @@ msgstr ""
 "Você usará as seguintes informações para fazer login nos aplicativos Zulip "
 "para web, <a href=\"%(apps_page_link)s\">dispositivo móvel e desktop</a> :"
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr "URL da organização: %(organization_url)s"
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr "Seu nome de usuário: %(ldap_username)s"
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr "Usar sua conta LDAP para entrar"
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr "Sua conta de e-mail: %(email)s"
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr "Ir para a organização"
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
@@ -2316,7 +1792,7 @@ msgstr ""
 "Se você é novo para Zulip, confira nosso <a "
 "href=\"%(getting_user_started_link)s\">Guia de primeiros passos</a>!"
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2327,7 +1803,7 @@ msgstr ""
 "href=\"%(getting_organization_started_link)s\">Configurar sua organização</"
 "a>."
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
@@ -2336,28 +1812,28 @@ msgstr ""
 "Perguntas? <a href=\"mailto:%(support_email)s\">Entre em contato</a> — "
 "adoraríamos ajudar!"
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr "%(realm_name)s no Zulip: Detalhes da sua nova organização"
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr "%(realm_name)s no Zulip: Detalhes de sua nova conta"
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr "Parabéns, você criou uma nova organização Zulip: %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr "Você ingressou na organização Zulip %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
@@ -2366,7 +1842,7 @@ msgstr ""
 "Você vai usar as seguintes informações para fazer login nos aplicativos web, "
 "de dispositivos móveis e de desktop (%(apps_page_link)s):"
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
@@ -2375,7 +1851,7 @@ msgstr ""
 "Se você é um usuário novo para Zulip, confira nosso guia inicial "
 "(%(getting_user_started_link)s)?"
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
@@ -2384,19 +1860,19 @@ msgstr ""
 "Também temos um guia para mudar sua organização para Zulip "
 "(%(getting_organization_started_link)s)."
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 "Perguntas? Entre em contato conosco em %(support_email)s — adoraríamos "
 "ajudar!"
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2405,17 +1881,17 @@ msgstr ""
 "Se você tiver alguma dúvida, entre em contato com os administradores deste "
 "servidor Zulip em %(support_email)s."
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr "Oi,"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2427,12 +1903,12 @@ msgstr ""
 "%(realm_url)s. Para confirmar essa atualização e definir uma senha para essa "
 "conta, por favor clique abaixo:"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr "Confirme e defina a senha"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2441,7 +1917,7 @@ msgstr ""
 "Se você não solicitou esta alteração, por favor entre em contato conosco "
 "imediatamente em %(support_email)s."
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 #, fuzzy
 #| msgid "Verify your new email address for your demo Zulip organization"
 msgid "Verify your email address for your Zulip demo organization"
@@ -2449,8 +1925,8 @@ msgstr ""
 "Verifique seu novo endereço de e-mail para sua organização Zulip de "
 "demonstração"
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2459,8 +1935,8 @@ msgstr ""
 "Se você não requisitou esta modificação. por favor contacte-nos "
 "imediatamente em <%(support_email)s>."
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2471,33 +1947,33 @@ msgstr ""
 "Zulip em %(realm_url)s de %(old_email)s para %(new_email)s. Para confirmar "
 "essa alteração, por favor clique abaixo:"
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr "Confirmar alteração de e-mail"
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr "Verifique seu novo endereço de e-mail para %(organization_host)s"
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr "Você solicitou uma nova organização Zulip:"
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr "Tipo da organização: %(organization_type)s"
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr "Você recentemente se inscreveu no Zulip. Incrível!"
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
@@ -2505,33 +1981,33 @@ msgstr ""
 "Clique no botão abaixo para criar a organização e registrar sua conta. Você "
 "será capaz de atualizar a informação acima se preferir."
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr "Clique no botão abaixo para concluir o registro."
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr "Completar registro"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr "Criar a sua organização Zulip"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr "Ativar sua conta Zulip"
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr "Clique no link abaixo para completar o registro."
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
@@ -2540,20 +2016,20 @@ msgstr ""
 "Você tem perguntas ou feedback para compartilhar? Entre em contato conosco "
 "em%(support_email)s — adoraríamos ajudar!"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr "Gerenciar preferências de e-mail"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr "Desinscrever de e-mails de marketing"
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
@@ -2562,17 +2038,17 @@ msgstr ""
 "Sua conta do Zulip em <a href=\"%(realm_url)s\">%(realm_url)s</a> foi "
 "desativada, e você não poderá mais fazer log in."
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr "Os administradores disponibilizaram o seguinte comentário:"
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr "Notificação de desativação de conta em %(realm_name)s"
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
@@ -2581,11 +2057,11 @@ msgstr ""
 "Sua conta do Zulip em %(realm_url)s foi desativada e você não poderá mais "
 "fazer login."
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr "Novos canais"
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2593,22 +2069,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because your organization has "
@@ -2624,8 +2100,8 @@ msgstr ""
 "desativou a <a class=\"content_disabled_help_link\" "
 "href=\"%(help_url)s\">exibição de conteúdo nas notificações de e-mail</a>."
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because you have disabled <a "
@@ -2640,40 +2116,40 @@ msgstr ""
 "class=\"content_disabled_help_link\" href=\"%(alert_notif_url)s\">exibição "
 "de conteúdo nas notificações de e-mail</a>."
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, fuzzy, python-format
 #| msgid "Click here to log in to Zulip and catch up."
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr "Clique aqui para fazer login no Zulip e se atualizar."
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr "Cancelar inscrição de resumos de e-mails"
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr "Resumo do Zulip para %(realm_name)s"
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2690,8 +2166,8 @@ msgstr ""
 "desativou a exibição do conteúdo da mensagem em notificações por e-mail.\n"
 "Veja %(hide_content_url)s para mais detalhes.\n"
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2707,34 +2183,32 @@ msgstr ""
 "exibição do conteúdo da mensagem em notificações por e-mail.\n"
 "Veja %(alert_notif_url)s para mais detalhes.\n"
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, fuzzy, python-format
 #| msgid "Click here to log in to Zulip and catch up: %(organization_url)s."
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr ""
 "Clique aqui para fazer login no Zulip e se atualizar: %(organization_url)s."
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr "Gerenciar preferências de e-mail:"
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr "Cancelar inscrição de e-mails de resumo:"
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr "Peixe nadando"
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr "Obrigado pelo seu pedido!"
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
@@ -2743,8 +2217,7 @@ msgstr ""
 "Seu endereço de e-mail %(email)s tem contas com as seguintes organizações no "
 "Zulip Cloud:"
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
@@ -2753,7 +2226,7 @@ msgstr ""
 "Seu endereço de e-mail %(email)s tem contas nas seguintes organizações do "
 "Zulip hospedadas por%(external_host)s:"
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
@@ -2762,20 +2235,16 @@ msgstr ""
 "Se tiver problema ao fazer log in, você pode <a "
 "href=\"%(help_reset_password_link)s\">redefinir sua senha</a>."
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 "Você solicitou uma lista de contas do Zulip para este endereço de e-mail."
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr "Infelizmente, nenhuma conta Zulip Cloud foi encontrada."
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
@@ -2784,7 +2253,7 @@ msgstr ""
 "Infelizmente, nenhuma conta foi encontrada em organizações do Zulip "
 "hospedadas por%(external_host)s."
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2795,28 +2264,25 @@ msgstr ""
 "outro e-mail ou <a href =\"%(help_logging_in_link)s\">tentar outra maneira</"
 "a> de encontrar sua conta."
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 "Se você não reconhecer esta solicitação, pode ignorar este e-mail com "
 "segurança."
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr "Suas contas Zulip"
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr "Nenhuma conta do Zulip encontrada"
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr "Se tiver problema ao fazer log in, você pode redefinir sua senha."
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
@@ -2825,12 +2291,12 @@ msgstr ""
 "Você pode verificar contas com outro e-mail (%(find_accounts_link)s ), ou "
 "tentar outra maneira de encontrar sua conta (%(help_logging_in_link)s )."
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr "Olá,"
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
@@ -2839,19 +2305,19 @@ msgstr ""
 "%(referrer_name)s quer que você se junte a eles no Zulip &mdash; a "
 "ferramenta de comunicação em equipe projetada para a produtividade."
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr "Para começar, clique no botão abaixo."
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 "%(referrer_full_name)s convidou você para ingressar em "
 "%(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
@@ -2861,17 +2327,17 @@ msgstr ""
 "Zulip -- a ferramenta de comunicação corporativa projetada para "
 "produtividade."
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr "Para começar, clique no link abaixo."
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr "Olá novamente,"
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
@@ -2881,13 +2347,13 @@ msgstr ""
 "eles no Zulip &mdash; a ferramenta de comunicação corporativa projetada para "
 "produtividade."
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr "Este é o último lembrete que você receberá para este convite."
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
@@ -2896,12 +2362,12 @@ msgstr ""
 "Este convite expira em dois dias. Se o convite expirar, você precisará pedir "
 "outro a%(referrer_name)s."
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr "Lembrete: Ingresse %(referrer_name)s em %(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2912,7 +2378,7 @@ msgstr ""
 "que você se junte a eles no Zulip &mdash; a ferramenta de comunicação "
 "corporativa projetada para produtividade."
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2922,7 +2388,7 @@ msgstr ""
 "administradores deste servidor Zulip em <a href=\"mailto:"
 "%(email)s\">%(email)s</a>."
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
@@ -2931,13 +2397,13 @@ msgstr ""
 "Você tem perguntas ou feedback para compartilhar? <a href=\"mailto:"
 "%(email)s\">Entre em contato conosco</a> — adoraríamos ajudar!"
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr "Você está recebendo isto porque foi mencionado pessoalmente."
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
@@ -2945,10 +2411,8 @@ msgstr ""
 "Você está recebendo isso porque @%(mentioned_user_group_name)s foi "
 "mencionado."
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
@@ -2957,8 +2421,8 @@ msgstr ""
 "Você está recebendo isto porque todos os participantes do tópico foram "
 "mencionados em #%(channel_name)s > %(topic_name)s."
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
@@ -2966,16 +2430,16 @@ msgstr ""
 "Você está recebendo isto porque você ativou notificações de menção global "
 "para tópicos que você segue."
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 "Você está recebendo isso porque todos foram mencionados em #%(channel_name)s."
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
@@ -2983,8 +2447,8 @@ msgstr ""
 "Você está recebendo isso porque você tem notificações de e-mail habilitadas "
 "para tópicos que você segue."
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
@@ -2993,7 +2457,7 @@ msgstr ""
 "Você está recebendo isto porque você ativou notificações por e-mail para "
 "#%(channel_name)s."
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -3004,7 +2468,7 @@ msgstr ""
 "%(realm_name)s </a>, ou <a href=\"%(notif_url)s\">gerencie suas preferências "
 "de e-mail</a>."
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
@@ -3013,7 +2477,7 @@ msgstr ""
 "<a href=\"%(narrow_url)s\">Veja ou responda no Zulip %(realm_name)s </a>, ou "
 "<a href=\"%(notif_url)s\">gerencie suas preferências de e-mail</a>."
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
@@ -3022,7 +2486,7 @@ msgstr ""
 "<a href=\"%(narrow_url)s\">Responder em %(realm_name)s Zulip</a>, ou <a "
 "href=\"%(notif_url)s\">gerenciar preferências de email </a>."
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
@@ -3031,42 +2495,42 @@ msgstr ""
 "Não responda a este e-mail. Este servidor Zulip não está configurado para "
 "aceitar e-mails recebidos. (<a href=\"%(url)s\">ajuda</a>)."
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr "DMs de grupo com %(direct_message_group_display_name)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr "DMs com %(sender_str)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr "[solucionado] #%(channel_name)s > %(topic_name)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr "Novas mensagens"
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 "Responda a este e-mail diretamente ou visualize-o em %(realm_name)s Zulip:"
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr "Ver ou responder em %(realm_name)s Zulip:"
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr "Responder em %(realm_name)s Zulip:"
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
@@ -3074,7 +2538,7 @@ msgstr ""
 "Não responda esse e-mail. Este servidor Zulip não esta configurado para "
 "receber e-mails. Ajuda:"
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -3085,22 +2549,22 @@ msgstr ""
 "%(new_email)s. Se você não solicitou essa alteração, entre em contato "
 "conosco imediatamente em %(support_email)s."
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr "Melhor,"
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr "Equipe Zulip"
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr "E-mail do Zulip alterado para %(realm_name)s"
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -3111,7 +2575,7 @@ msgstr ""
 "%(new_email)s. Se você não solicitou essa alteração, por favor, contacte-nos "
 "imediatamente em <%(support_email)s>."
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
@@ -3119,46 +2583,46 @@ msgstr ""
 "Organização: %(organization_url)s Horário: %(login_time)s E-mail: "
 "%(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr "Observamos uma entrada recente para a seguinte conta Zulip."
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr "Organização: %(organization_link)s"
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr "E-mail: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr "Horário: %(login_time)s"
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr "Dispositivo: %(device_browser)s em %(device_os)s."
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr "Endereço IP: %(device_ip)s"
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr "Se isto foi você, ótimo! Não há mais nada que você precise fazer."
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3169,31 +2633,31 @@ msgstr ""
 "comprometida, por favor <a href=\"%(reset_link)s\">redefina sua senha</a> ou "
 "entre em contato conosco imediatamente em %(support_email)s."
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr "Obrigado,"
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr "Segurança do Zulip"
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr "Desinscrever de notificações de entrada"
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr "Nova entrada de %(device_browser)s em %(device_os)s"
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr "Organização: %(organization_url)s"
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3204,7 +2668,7 @@ msgstr ""
 "comprometida, por favor redefina sua senha em %(reset_link)s ou entre em "
 "contato conosco imediatamente em %(support_email)s."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -3215,7 +2679,7 @@ msgstr ""
 "usar o <a href=\"%(get_organization_started)s\">guia para mudar para Zulip</"
 "a> para começar."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
@@ -3223,7 +2687,7 @@ msgstr ""
 "De qualquer modo, aqui estão alguns conselhos de clientes para "
 "avaliar<i>qualquer</i> produto de conversas em equipe:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
@@ -3232,12 +2696,12 @@ msgstr ""
 "<a href=\"%(invite_users)s\"><b>Convidar seus colegas</b></a> para explorar "
 "com você e partilhar perspectivas únicas."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr "Use o próprio aplicativo para conversar sobre suas impressões."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -3249,7 +2713,7 @@ msgstr ""
 "Somente esta é a única forma para experienciar como é que a nova aplicação "
 "de conversas poderá ajudar a sua equipe."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -3260,21 +2724,21 @@ msgstr ""
 "eficiente</a>, e nós esperamos que essas dicas ajudem sua equipe a vivenciar "
 "isso em ação prática."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr "Desinscrever de e-mails de boas vindas para %(realm_name)s"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr "Escolhendo o aplicativo de chat para sua equipe"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
@@ -3282,7 +2746,7 @@ msgstr ""
 "Se você já decidiu usar o Zulip para sua organização, bem-vindo! Você pode "
 "usar nosso guia para mudar para o Zulip para começar."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
@@ -3290,7 +2754,7 @@ msgstr ""
 "Caso contrário, aqui estão alguns conselhos que ouvimos frequentemente dos "
 "clientes para avaliar qualquer produto de chat em equipe:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
@@ -3298,7 +2762,7 @@ msgstr ""
 "Convide seus colegas de equipe para explorar com você e compartilhar suas "
 "perspectivas únicas."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
@@ -3308,7 +2772,7 @@ msgstr ""
 "ferramenta de chat. Esta é a única maneira de realmente experimentar como um "
 "novo aplicativo de bate-papo ajudará sua equipe a se comunicar."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
@@ -3316,8 +2780,8 @@ msgstr ""
 "O Zulip foi projetado para permitir uma comunicação eficiente e esperamos "
 "que essas dicas ajudem sua equipe a vivenciar isso em ação."
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
@@ -3327,71 +2791,71 @@ msgstr ""
 "como ele pode funcionar melhor para suas necessidades. Confira este guia "
 "sobre os principais recursos do Zulip para organizações como a sua!"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr "Veja o guia Zulip para empresas"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr "Veja o guia Zulip para projetos de código aberto"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr "Veja o guia Zulip para educação"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr "Veja o guia Zulip para pesquisa"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr "Veja o guia Zulip para eventos e conferências"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr "Veja o guia Zulip para organizações sem fins lucrativos"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr "Veja o guia Zulip para comunidades"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr "Guia Zulip para empresas"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr "Guia Zulip para projetos de código aberto"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr "Guia Zulip para educação"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr "Guia Zulip para pesquisa"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr "Guia do Zulip para eventos e conferências"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr "Guia Zulip para organizações sem fins lucrativos"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr "Zulip para comunidades"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
@@ -3399,7 +2863,7 @@ msgstr ""
 "Aqui estão algumas dicas para manter suas conversas do Zulip organizadas com "
 "tópicos."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
@@ -3407,8 +2871,8 @@ msgstr ""
 "No Zulip, <b>canais</b> determinam quem recebe uma mensagem. <b>Tópicos</b> "
 "dizem sobre o que é a mensagem."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
@@ -3417,12 +2881,12 @@ msgstr ""
 "cada mensagem em seu contexto, não importa quantas discussões diferentes "
 "estejam ocorrendo."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr "Canais e tópicos no aplicativo Zulip"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3434,11 +2898,11 @@ msgstr ""
 "discussões em andamento. Para um bom nome de tópico, pense em como terminar "
 "a frase: “Oi, podemos conversar sobre...?”"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr "Exemplos de tópicos curtos"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3452,17 +2916,17 @@ msgstr ""
 "até<a href=\"%(move_channels_link)s\">mover o tópico para um canal "
 "diferente</a>."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr "Vá para Zulip"
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr "Mantenha suas conversas organizadas com tópicos"
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
@@ -3470,7 +2934,7 @@ msgstr ""
 "No Zulip, canais determinam quem recebe uma mensagem. Tópicos dizem sobre o "
 "que é a mensagem."
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3483,8 +2947,8 @@ msgstr ""
 "renomear tópicos (%(rename_topics_link)s), ou até mover o tópico para um "
 "canal diferente (%(move_channels_link)s)."
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
@@ -3493,15 +2957,15 @@ msgstr ""
 "Alguém (possivelmente você) pediu uma nova senha para a conta Zulip%(email)s "
 "em%(realm_url)s."
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr "Clique no botão abaixo para redefinir sua senha."
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr "Redefinir senha"
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3512,41 +2976,41 @@ msgstr ""
 "contactar o administrador da organização para <a "
 "href=\"%(help_link)s\">reativar a sua conta</a>."
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr "Você não tem uma conta nessa organização Zulip."
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr "Você tem contas ativas nas seguintes organizações."
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
 msgstr "Você pode tentar entrar ou redefinir sua senha nas organizações acima."
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 "Se você não reconhece esta atividade, você pode ignorar com segurança este e-"
 "mail."
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr "Requisição de redefinição de senha para %(realm_name)s"
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr "Clique no link abaixo para redefinir sua senha."
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
@@ -3555,7 +3019,7 @@ msgstr ""
 "Já teve uma conta em %(realm_url)s mas foi desativada. Você pode contactar o "
 "administrador da organização para reativar a sua conta."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3566,7 +3030,7 @@ msgstr ""
 "Cloud Zulip para o Plano gratuito devido a falha no pagamento de faturas. As "
 "faturas não pagas foram anuladas."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
@@ -3575,7 +3039,7 @@ msgstr ""
 "Para continuar no Plano standard da Cloud Zulip, por favor faça upgrade "
 "novamente em %(upgrade_url)s."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
@@ -3584,8 +3048,8 @@ msgstr ""
 "Se você achar que esse foi um erro ou necessitar de mais informações, por "
 "favor contacte-nos em %(support_email)s."
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "You have deactivated your Zulip organization, %(realm_name)s, on "
@@ -3596,8 +3060,8 @@ msgid ""
 msgstr ""
 "Você desativou sua organização Zulip, %(realm_name)s, a%(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "Your Zulip organization, %(realm_name)s, was deactivated by "
@@ -3609,8 +3073,8 @@ msgstr ""
 "A sua organização Zulip, %(realm_name)s, foi desativada "
 "por%(deactivating_owner)s a %(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "Your Zulip organization, %(realm_name)s, was deactivated on "
@@ -3622,8 +3086,8 @@ msgstr ""
 "A sua organização Zulip, %(realm_name)s, foi desativada em "
 "%(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
@@ -3631,8 +3095,8 @@ msgid ""
 msgstr ""
 "Você desativou sua organização Zulip, %(realm_name)s, a%(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
@@ -3641,8 +3105,8 @@ msgstr ""
 "A sua organização Zulip, %(realm_name)s, foi desativada "
 "por%(deactivating_owner)s a %(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
@@ -3651,15 +3115,15 @@ msgstr ""
 "A sua organização Zulip, %(realm_name)s, foi desativada em "
 "%(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 "Todos os dados associados com esta organização foram apagado permanentemente."
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
@@ -3668,8 +3132,8 @@ msgstr ""
 "Todos os dados associados com esta organização foram apagado permanentemente "
 "em %(deletion_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
@@ -3677,19 +3141,19 @@ msgstr ""
 "Se você tiver alguma dúvida ou preocupação, por favor, responda a este e-"
 "mail o mais rápido possível."
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr "Sua organização Zulip %(realm_name)s foi desativada"
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr "Caros antigos administradores de %(realm_name)s,"
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "One of your administrators requested reactivation of the previously "
@@ -3701,8 +3165,8 @@ msgstr ""
 "Um dos seus administradores solicitou a reativação da organização Zulip "
 "previamente desativada, hospedada em %(realm_url)s."
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
@@ -3711,16 +3175,16 @@ msgstr ""
 "Um dos seus administradores solicitou a reativação da organização Zulip "
 "previamente desativada, hospedada em %(realm_url)s."
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr "Clique no botão abaixo para reativar sua organização."
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr "Reativar organização"
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
@@ -3728,21 +3192,21 @@ msgstr ""
 "Se na requisição tiver ocorrido um erro, você não poderá fazer nada e esse "
 "link expirará em 24 horas."
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Reactivate your Zulip organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "Reative sua organização no Zulip"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr "Reative sua organização no Zulip"
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr "Clique no link abaixo para reativar sua organização."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3751,20 +3215,20 @@ msgstr ""
 "Você, ou alguém em seu nome, solicitou um link de login para gerenciar o "
 "plano Zulip para <b>%(remote_server_hostname)s</b>."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, fuzzy
 #| msgid "Click the link below to log in."
 msgid "Click the button below to log in."
 msgstr "Clique no link abaixo para fazer log in."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr "Esse link vai expirar em %(validity_in_hours)s horas."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
@@ -3773,11 +3237,11 @@ msgstr ""
 "Perguntas? <a href=\"%(billing_help_link)s\">Saiba mais</a> ou entre em "
 "contato com %(billing_contact_email)s."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr "Faça login no gerenciamento do plano Zulip"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3786,12 +3250,12 @@ msgstr ""
 "Você, ou alguém em seu nome, solicitou um link de login para gerenciar o "
 "plano Zulip para %(remote_server_hostname)s."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr "Clique no link abaixo para fazer log in."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
@@ -3800,7 +3264,7 @@ msgstr ""
 "Perguntas? Saiba mais em %(billing_help_link)s ou entre em contato com "
 "%(billing_contact_email)s."
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
@@ -3809,16 +3273,16 @@ msgstr ""
 "Clique no botão abaixo para confirmar o seu email e iniciar sessão na gestão "
 "de planos Zulip para <b>%(remote_realm_host)s</b>."
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr "Confirme e faça login"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr "Confirme email para gerenciamento do plano Zulip"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
@@ -3827,7 +3291,7 @@ msgstr ""
 "Clique na link abaixo para confirmar o seu email e iniciar sessão na gestão "
 "de plano Zulip para %(remote_realm_host)s."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
@@ -3836,7 +3300,7 @@ msgstr ""
 "O seu pedido de patrocínio Zulip foi aprovado! A sua organização recebeu um "
 "upgrade para o <a href=\"%(plans_link)s\">plano comunitário Zulip</a>."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
@@ -3845,12 +3309,12 @@ msgstr ""
 "Se você puder <a href=\"%(link_to_zulip)s\">listar o Zulip como patrocinador "
 "no seu site</a>, seria imensamente apreciado!"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr "Patrocínio de plano comunitário aprovado para %(billing_entity)s!"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
@@ -3858,7 +3322,7 @@ msgstr ""
 "Seu pedido de patrocínio Zulip foi aprovado! Sua organização foi atualizada "
 "para o plano Zulip Community."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
@@ -3866,22 +3330,22 @@ msgstr ""
 "Se você pudesse listar a Zulip como patrocinadora em seu site, ficaríamos "
 "muito gratos!"
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr "Encontre suas contas"
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr "Encontre suas contas Zulip"
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 "Emails enviado! Os endereços introduzidos na página anterior estão listados "
 "abaixo:"
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
@@ -3890,7 +3354,7 @@ msgstr ""
 "Se não receber um email, poderá, você pode <a "
 "href=\"%(current_url)s\">encontrar contas para outro endereço de email</a>."
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
@@ -3898,7 +3362,7 @@ msgstr ""
 "Digitar seu endereço de email para receber um email com os URLs de todas as "
 "organizações do Zulip Cloud nas quais você tem contas ativas."
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
@@ -3906,7 +3370,7 @@ msgstr ""
 "Digitar seu endereço de email para receber um email com os URLs de todas as "
 "organizações Zulip neste servidor nas quais você tem contas ativas."
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
@@ -3914,216 +3378,216 @@ msgstr ""
 "Se você esqueceu sua senha, você pode <a href=\"/help/change-your-"
 "password\">redefini-la</a>."
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr "Endereço de e-mail"
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "Encontrar contas"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr "Produto"
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr "Por que o Zulip"
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr "Recursos"
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr "Planos e preços"
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Zulip Cloud status"
 msgid "Zulip Cloud"
 msgstr "Status do Zulip Cloud"
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr "Auto-hospedagem"
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr "Segurança"
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "Integrações"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr "Aplicativos móveis e para desktop"
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr "Nova organização"
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr "Soluções"
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr "Negócios"
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr "Educação"
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr "Pesquisar"
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr "Eventos e conferências"
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr "Projetos de código-aberto"
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr "Comunidades"
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr "Relatos de clientes"
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr "Comunidades abertas"
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr "Recursos"
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr "Primeiros passos"
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr "Centro de ajuda"
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr "Chat da comunidade"
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr "Status do Zulip Cloud"
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr "Mudando para o Zulip"
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr "Instalando um servidor Zulip"
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr "Atualizando um servidor Zulip"
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr "Contribuindo"
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr "Guia de contribuição"
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr "Comunidade de desenvolvimento"
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr "Tradução"
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr "GitHub"
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr "Sobre nós"
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr "Time"
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "Histórico"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr "Valores"
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr "Carreiras"
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr "Blog"
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr "Apoiar a Zulip"
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr "Mastodonte"
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Values"
 msgid "Bluesky"
 msgstr "Valores"
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr "Desenvolvido por <a href=\"https://zulip.com\">Zulip</a>"
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr "Termos de serviço"
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr "Política de privacidade"
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr "Atribuições do site"
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr "Mais de %(integrations_count_display)s integrações nativas."
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 #, fuzzy
 #| msgid ""
 #| "And hundreds more through <a href=\"/integrations/doc/zapier\">Zapier</a> "
@@ -4135,53 +3599,49 @@ msgstr ""
 "E centenas mais através do <a href=\"/integrations/doc/zapier\">Zapier</a> e "
 "<a href=\"/integrations/doc/ifttt\">IFTTT</a>."
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr "Pesquisar integrações"
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr "Integrações personalizadas"
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr "Webhooks de entrada"
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr "Bots interativos"
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr "API REST"
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr "E-mail inválido"
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr "E-mail não permitido"
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr ""
 "O endereço de e-mail que você está tentando usar para se inscrever não é "
 "válido."
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4192,7 +3652,7 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>, não permite inscrições usando "
 "emails com seu domínio de email."
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4203,7 +3663,7 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>, não permite inscrições usando "
 "endereços de email temporários."
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4214,24 +3674,24 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>, não permite inscrições usando "
 "emails que contenham o símbolo \"+\"."
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr "Por favor, inscreva-se usando um endereço de e-mail válido."
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr "Por favor, inscreva-se usando um endereço de e-mail permitido."
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr "Nenhuma organização encontrada"
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr "Não há organização Zulip em <b>%(current_url)s</b>."
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -4242,7 +3702,7 @@ msgstr ""
 "find/\">obter uma lista da sua conta Zulip Cloud</a>, ou <a href=\"mailto:"
 "%(support_email)s\">entre em contato com o suporte Zulip</a>."
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -4254,7 +3714,7 @@ msgstr ""
 "href=\"mailto:%(support_email)s\">entre em contato com os administradores do "
 "servidor</a>."
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
@@ -4263,61 +3723,61 @@ msgstr ""
 "<a href=\"%(current_url)s/serverlogin/\">Clique aqui</a> para acessar o "
 "gerenciamento do plano para seu servidor Zulip."
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr "Sessão de login inválida ou expirada"
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr "Sessão de login inválida ou expirada."
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr "Entrar no Zulip"
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 "Você já se registrou com este endereço de e-mail. Por favor, faça o login "
 "abaixo."
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr "E-mail ou nome de usuário"
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "Nome de usuário"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr "Esqueceu sua senha?"
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr "Entrar com %(identity_provider)s"
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr "Ver sem uma conta"
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 "Não tem uma conta ainda? Você precisa ser convidado para ingressar nesta "
 "organização."
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr "Nenhuma licença disponível"
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr "A organização não pode aceitar novos membros neste momento"
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
@@ -4327,7 +3787,7 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a> porque todas licenças Zulip Cloud "
 "estão em uso."
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
@@ -4335,19 +3795,19 @@ msgstr ""
 "Por favor, entre em contato com a pessoa que te convidou e peça para "
 "aumentar o número de licenças. Depois, tente novamente."
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr "Pular para conteúdo principal"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr "Erro no subdomínio de autenticação"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr "Subdomínio de autenticação"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -4361,18 +3821,17 @@ msgstr ""
 "endereço. Se você ficou preso aqui enquanto tentava fazer login, isso "
 "provavelmente é um bug do servidor ou uma configuração incorreta."
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 #, fuzzy
 #| msgid "No organization found"
 msgid "Demo organizations disabled"
 msgstr "Nenhuma organização encontrada"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr "Atualização necessária"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
@@ -4380,7 +3839,7 @@ msgstr ""
 "Você está usando uma versão antiga do aplicativo Zulip Desktop que já não é "
 "suportada."
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
@@ -4388,23 +3847,22 @@ msgstr ""
 "A funcionalidade de atualização automática nesta versão antiga neste "
 "aplicativo Zuliip Desktop já não funciona."
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr "Baixe a versão mais recente."
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 "Você excedeu o limite da frequência com que um usuário pode executar esta "
 "ação."
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr "Link de criação de organização necessário"
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -4416,12 +3874,11 @@ msgstr ""
 "en/stable/production/multiple-organizations.html\">documentação</a> sobre "
 "como criar uma nova organização para mais informações."
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr "O link de criação da organização expirou ou é inválido"
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
@@ -4429,11 +3886,11 @@ msgstr ""
 "Infelizmente este não é um link válido para a criação de uma organização. "
 "Por favor <a href=\"/new/\">obtenha uma novo link</a> e tente novamente."
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr "Registro inesperado do servidor Zulip"
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -4445,17 +3902,16 @@ msgstr ""
 "%(support_email)s\">contacte o suporte Zulip </a> para assistência na "
 "resolução deste problema."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr "Navegador não suportado"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr "%(browser_name)s não é suportado por Zulip."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
@@ -4464,7 +3920,7 @@ msgstr ""
 "O Zulip suporta<a href=\"%(supported_browsers_page_link)s\">navegadores "
 "modernos</a> tais como o Firefox, Chrome, e Edge."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
@@ -4472,25 +3928,24 @@ msgstr ""
 "Você pode também utilizar o <a href=\"%(apps_page_link)s\">aplicativo Zulip "
 "Desktop</a>."
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr "Conta está desativada"
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Invalid organization"
 msgid "Finalize organization import"
 msgstr "Organização inválida"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Organization moved"
 msgid "Organization import completed!"
 msgstr "Organização movida"
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -4498,56 +3953,55 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Select your account"
 msgstr "Crie sua conta"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Create new account"
 msgstr "Crie sua conta"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr "A organização foi reativada com sucesso"
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr "Sua organização foi reativada com sucesso."
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr "Link de reativação da organização expirado ou inválido"
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr "O link de reativação da organização expirou ou não é válido."
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr "Entre em sua organização"
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr "sua-organização"
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr "Não sabe a URL da sua organização?"
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr "Encontre sua organização."
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr "Próximo"
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4558,13 +4012,13 @@ msgstr ""
 "href=\"%(org_creation_link)s\">Criar uma nova organização</a> Se você ainda "
 "não tem uma."
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 #, fuzzy
 #| msgid "Self-host Zulip"
 msgid "Self-hosting Zulip?"
 msgstr "Autohospedar Zulip"
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, fuzzy, python-format
 #| msgid ""
 #| "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4578,11 +4032,11 @@ msgstr ""
 "href=\"%(org_creation_link)s\">Criar uma nova organização</a> Se você ainda "
 "não tem uma."
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr "Redefinir sua senha"
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
@@ -4590,62 +4044,62 @@ msgstr ""
 "Esqueceu sua senha? Não tem problema, enviaremos um link para redefinir sua "
 "senha para o e-mail com o qual você se inscreveu."
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr "Enviar link de redefinição"
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr "Defina uma nova senha"
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "Confirme a senha"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr "Sinto muito, o link que você forneceu é inválido ou já foi utilizado."
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr "Nova senha definida com sucesso"
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr "Você definiu uma nova senha!"
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr "Por favor, <a href=\"%(login_url)s\">entre</a> com sua nova senha."
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr "E-mail de redefinição de senha enviado"
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr "Redefinição de senha enviada!"
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr "Verifique seu e-mail em alguns minutos para concluir o processo."
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 #, fuzzy
 #| msgid "Export still in progress"
 msgid "Import progress"
 msgstr "Exportação ainda em andamento"
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4653,7 +4107,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4662,30 +4116,30 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 #, fuzzy
 #| msgid ""
 #| "Nobody in this Zulip organization will be able to see this email address."
@@ -4694,30 +4148,30 @@ msgstr ""
 "Ninguém nessa organização do Zulip conseguirá visualizar esse endereço de e-"
 "mail."
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4725,7 +4179,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4733,22 +4187,22 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr "Selecione a conta para autenticação"
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr "<h1 class=\"get-started\">Selecionar conta</h1>"
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 "A sua conta GitHub também tem endereços de email não verificados associados "
 "a ela."
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
@@ -4757,15 +4211,15 @@ msgstr ""
 "href=\"https://github.com/settings/emails\">verificá-los com GitHub</a> "
 "primeiro."
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr "Erro ao desinscrever e-mail"
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr "Requisição para desinscrever email desconhecido"
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
@@ -4773,7 +4227,7 @@ msgstr ""
 "Olá! Parece que você tentou cancelar a inscrição de algo, mas não "
 "reconhecemos o URL."
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4783,12 +4237,11 @@ msgstr ""
 "Por favor verificar se você tem a URL completa e tente novamente, ou<a "
 "href=\"mailto:%(support_email)s\"> contacte-nos </a> e vamos resolver isso!"
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr "Configurações de e-mail atualizadas"
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
@@ -4797,7 +4250,7 @@ msgstr ""
 "Você desinscreveu seus emails com sucesso de Zulip %(subscription_type)s "
 "para <a href=\"%(realm_url)s\">%(realm_name)s</a>."
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
@@ -4807,51 +4260,50 @@ msgstr ""
 "href=\"%(realm_url)s/#settings/notifications\">preferências de notificação</"
 "a>."
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr "Mapeamento de pedidos inválido."
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr "Perguntas e discussões sobre o uso do Zulip."
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr "Experimente o Zulip aqui. :test_tube:"
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr "Para conversas com toda a equipe"
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr "inscrições"
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr "{user} ingressou nessa organização."
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr "{user} aceitou seu convite para participar do Zulip!"
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 "Não é possível ativar uma conta de espaço reservado; peça ao usuário para se "
 "inscrever."
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 #, fuzzy
 #| msgid "Cannot deactivate user group in use."
 msgid "Cannot reactivate a deleted user"
 msgstr "Não pode desativar grupo de usuários em uso."
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
@@ -4859,26 +4311,25 @@ msgstr ""
 "Você não está permitido para alterar este campo. Entre em contato com um "
 "administrador para atualiza-lo."
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr "Campo id {id} não encontrado."
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr "Nome de grupo de canais padrão inválido '{group_name}'"
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 "O nome do grupo de canal padrão é muito longo. (limite: {max_length} "
 "caracteres)"
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
@@ -4886,24 +4337,24 @@ msgstr ""
 "Nome padrão de grupo de canal '{group_name}' contém caracteres nulos NULL "
 "(0x00)."
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr "Grupo de canais padrão inválido {group_name}"
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 "'{channel_name}' é um canal padrão e não pode ser adicionado a '{group_name}'"
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr "O grupo de canais padrão '{group_name}' já existe"
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
@@ -4912,7 +4363,7 @@ msgstr ""
 "O canal '{channel_name}' já está presente no grupo de canais padrão "
 "'{group_name}'"
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
@@ -4921,12 +4372,12 @@ msgstr ""
 "O canal '{channel_name}' não está presente no grupo de canais padrão "
 "'{group_name}'"
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr "Este grupo de canais padrão já se chama '{group_name}'"
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
@@ -4934,7 +4385,7 @@ msgstr ""
 "Para proteger os usuários, o Zulip limita o número de convites que você pode "
 "enviar em um dia. Como você alcançou o limite, nenhum convite foi enviado."
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
@@ -4942,76 +4393,76 @@ msgstr ""
 "Sua conta é muito nova para enviar convites para esta organização. Pergunte "
 "a um administrador da organização ou a um usuário mais experiente."
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 "Alguns e-mails não foram validados, por isso não enviamos nenhum convite."
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr "Não fomos capazes de convidar ninguém."
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr "Nada para alterar"
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr "Mensagens diretas não podem ser movidas para canais."
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr "Mensagens diretas não podem ter tópicos."
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr "propagate_mode inválido sem edição de tópico"
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr "Bate-papo geral não pode ser marcado como resolvido"
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr "Não é possível alterar o conteúdo da mensagem ao mudar de canal"
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr "Os widgets não podem ser editados."
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr "Sua organização desligou a edição de mensagem"
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr "Você não tem permissão para editar esta mensagem"
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr "O limite de tempo para editar esta mensagem passou"
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr "{user} marcou esse tópico como solucionado."
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr "{user} marcou esse tópico como não solucionado."
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr "Esse tópico foi movido para {new_location} pelo {user}."
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr "Uma mensagem foi movida desse tópico para {new_location} por {user}."
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
@@ -5020,12 +4471,12 @@ msgstr ""
 "{changed_messages_count} mensagens foram movidas desse tópico para "
 "{new_location} por {user}."
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr "Esse tópico foi movido para cá de {old_location} por {user}."
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
@@ -5033,7 +4484,7 @@ msgstr ""
 "[Uma mensagem]({message_link}) foi movida de {old_location} para cá por "
 "{user}."
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
@@ -5042,69 +4493,66 @@ msgstr ""
 "{changed_messages_count} mensagens foram movidas de {old_location} para cá "
 "por {user}."
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 #, fuzzy
 #| msgid "You do not have permission to post in this channel."
 msgid "You don't have permission to resolve topics in this channel."
 msgstr "Você não tem permissão para publicar nesse canal"
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr "O limite de tempo para editar o tópico desta mensagem expirou."
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr "Você não tem permissão para mover esta mensagem"
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr "O prazo para editar o canal desta mensagem expirou"
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr "Sinalizador inválido: '{flag}'"
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr "Sinalizador não editável: '{flag}'"
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr "Operação de sinalização de mensagem inválida: '{operation}'"
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr "Mensagem inválida"
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr "Não é possível processar a mensagem"
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr "Esperava exatamente um canal"
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr "Tipo de dados inválido para canal"
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr "Tipo de dados inválido para destinatários"
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 "As listas de destinatários podem conter e-mails ou IDs de usuário, mas não "
 "ambos."
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
@@ -5113,7 +4561,7 @@ msgstr ""
 "Seu bot {bot_identity} tentou enviar uma mensagem para o ID do canal "
 "{channel_id}, mas não há nenhum canal com esse ID."
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -5124,7 +4572,7 @@ msgstr ""
 "{channel_name}, mas o canal não existe. Clique [aqui]({new_channel_link}) "
 "para o criar."
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
@@ -5133,30 +4581,30 @@ msgstr ""
 "O seu bot {bot_identity} tentou enviar uma mensagem para o canal "
 "{channel_name}. O canal existe mas não tem nenhum subscritor."
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr "Você não tem permissão para acessar alguns dos destinatários."
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr "Widgets: o programador da API enviou conteúdo JSON inválido"
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr "Widgets: {error_msg}"
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, fuzzy, python-brace-format
 #| msgid "{user_name} created the following channels: {new_channels}."
 msgid "{user} has made the following changes to your account."
 msgstr "{user_name} criou os seguintes canais: {new_channels}."
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5164,27 +4612,25 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr "Um emoji personalizado com este nome já existe."
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr "Formato de imagem inválido"
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr "Uma lista ordenada não pode conter criadores de ligações em duplicado"
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 "Uma lista ordenada tem de enumerar todas os criadores de ligações exatamente "
 "uma vez"
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
@@ -5193,41 +4639,41 @@ msgstr ""
 "Você precisa atualizar para o plano {required_upgrade_plan_name} para usar "
 "este método de autenticação."
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 "Método de autenticação inválido: {name}. Os métodos válidos são: {methods}"
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 "O método de autenticação {name} não está disponível no seu plano atual."
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr "O canal de solicitação de moderação deve ser privado."
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr "Frase pronta salva não existe. \"Snippet\""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr "A mensagem agendada já foi enviada"
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder could not be sent."
 msgstr "Token não existe"
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr "A mensagem não pôde ser enviada no horário agendado."
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
@@ -5236,40 +4682,40 @@ msgstr ""
 "A mensagem que você agendou para entrega a {delivery_datetime} não foi "
 "enviada devido ao seguinte erro:"
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr "[Ver mensagens agendadas](#scheduled)"
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr "O canal já está desativado"
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, fuzzy, python-brace-format
 #| msgid "Channel {channel_name} has been archived."
 msgid "Channel #**{channel_name}** has been archived."
 msgstr "Canal {channel_name} foi arquivado."
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr "O canal não está desativado atualmente"
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr "O canal com nome {channel_name} já existe"
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr "Canal é privado e não tem inscritos"
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, fuzzy, python-brace-format
 #| msgid "Channel {channel_name} has been archived."
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr "Canal {channel_name} foi arquivado."
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
@@ -5278,7 +4724,7 @@ msgstr ""
 "{user} alterou as [permissões de acesso]({help_link}) para esse canal de "
 "**{old_policy}** para **{new_policy}**."
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -5291,41 +4737,39 @@ msgstr ""
 "* **Antigo**: {old_setting_description}\n"
 "* **Novo**: {new_setting_description}\n"
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 "{user_name} renomeou o canal {old_channel_name} para {new_channel_name}."
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr "Nenhuma descrição."
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr "{user} mudou a descrição para esse canal."
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr "Descrição antiga"
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr "Nova descrição"
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr "Para sempre"
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr "{number_of_days} dias"
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
@@ -5334,11 +4778,11 @@ msgstr ""
 "A mensagens agora neste canal serão automaticamente apagadas "
 "{number_of_days} dias depois de serem enviadas."
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr "As mensagens neste canal serão mantidas para sempre."
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -5354,99 +4798,89 @@ msgstr ""
 "\n"
 "{summary_line}"
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr "Você não pode anexar uma submensagem a esta mensagem."
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr "ID de usuário inválido: {user_id}"
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr "Grupo de usuários '{group_name}' já existe."
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr "Permissão insuficiente"
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr "Esta API não está disponível para bots de webhooks de entrada."
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr "Conta não está associada a este subdomínio"
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr "Este ponto de acesso não aceita requisições de bot."
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr "Deve ser um administrador do servidor"
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr "Este endpoint requer autenticação HTTP basic authentication."
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr "Cabeçalho de autorização inválido para autenticação básica"
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr "Cabeçalho de autorização ausente para autenticação básica"
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr "Bots webhooks podem apenas acessar webhooks"
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr "Email ou Senha incorretos."
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
@@ -5455,53 +4889,52 @@ msgstr ""
 "Sua conta {username} foi desativada. Por favor entre em contato com o "
 "administrador da sua organização para reativá-lo."
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr "A senha é muito fraca."
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr "Subdomínio precisa ter comprimento 3 ou maior."
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr "Subdomínio não pode iniciar ou terminar com um '-'."
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr "Subdomínio pode apenas ter letras minúsculas, números e '-'s."
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr "Subdomínio já em uso. Por favor, escolha outro."
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr "Subdomínio reservado. Por favor, escolha outro."
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr "Por favor, utilize seu endereço de e-mail real."
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr ""
 "A organização que você está tentando ingressar utilizando {email} não existe."
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr ""
 "Por favor, solicite um convite para {email} do administrador da organização."
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
@@ -5510,11 +4943,11 @@ msgstr ""
 "Seu endereço de e-mail {email} não está em um dos domínios com permissão "
 "para se inscrever em contas dessa organização."
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr "Endereços de e-mail contendo + não são permitidos nesta organização."
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
@@ -5524,34 +4957,33 @@ msgstr ""
 "do Zulip estão em uso. Por favor, entre em contato com a pessoa que o "
 "convidou e peça para aumentar o número de licenças, depois tente novamente."
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 #, fuzzy
 #| msgid "Embedded bots are not enabled."
 msgid "Challenges are not enabled."
 msgstr "Bots incorporados não estão habilitado."
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "Nova senha"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr "Nova confirmação de senha"
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "You're making too many attempts to sign in. Try again in {seconds} "
@@ -5564,7 +4996,7 @@ msgstr ""
 "segundos ou entre em contato com o administrador da sua organização para "
 "obter ajuda."
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
@@ -5572,96 +5004,94 @@ msgstr ""
 "Sua senha foi desativada porque está muito fraca. Redefina sua senha para "
 "criar uma nova."
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr "Token"
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 "Dica: Você pode inserir múltiplos endereços de e-mail com vírgulas entre "
 "eles."
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr "Por favor, insira no máximo 10 e-mails."
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr "Não conseguimos encontrar essa organização Zulip."
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr "E´mail '{email}' inválido"
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr "Tópico ausente"
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr "Não é possível enviar para múltiplos canais"
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr "Canal não encontrado"
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr "Mensagem deve ter destinatários"
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr "Tipo de mensagem inválido"
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr "Anexo inválido"
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr ""
 "Ocorreu um erro ao excluir o anexo. Por favor, tente novamente mais tarde."
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr "Mensagem deve ter destinatários!"
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Channel name can't be empty."
 msgid "Channel folder name can't be empty."
 msgstr "O nome do canal não pode estar vazio!"
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid character in channel name, at position {position}."
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr "Caractere inválido no nome do canal, na posição {position}."
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Channel name is already in use."
 msgid "Channel folder name already in use"
 msgstr "O nome do canal já se encontra em uso.."
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Invalid channel ID"
 msgid "Invalid channel folder ID"
 msgstr "ID de canal inválido"
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 #, fuzzy
 #| msgid "Confirm your email address"
 msgid "Configure owner account email address."
 msgstr "Confirme seu endereço de e-mail"
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "\n"
@@ -5679,72 +5109,72 @@ msgstr ""
 "({demo_organization_help_url}) e\n"
 "será **eliminada automaticamente** ao fim de 30 dias.\n"
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a date"
 msgid "{var_name} is not Base64 encoded"
 msgstr "{var_name} não é uma data"
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 #, fuzzy
 #| msgid "Invalid emoji code."
 msgid "Invalid `device_id`"
 msgstr "Código de emoji inválido."
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr "Resumo de {service_name}"
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr "Domínio não pode estar vazio."
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr "Domínio deve ter pelo menos um ponto (.)"
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr "Domínio é muito longo"
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr "Domínio não pode iniciar ou terminar com um ponto (.)"
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr "'.' consecutivos não são permitidos."
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr "Subdomínios não podem iniciar ou terminar com um '-'."
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr "Domínio pode apenas ter letras, números, '.' e '-'s."
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr "O carimbo de data/hora não deve ser negativo."
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr "O tópico não deve conter bytes nulos"
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr "Deve especificar exatamente 1 ID de canal para mensagens de canal"
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr "O usuário desabilitou a sincronização de rascunhos."
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr "Rascunho não existe"
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5755,86 +5185,86 @@ msgstr ""
 "notificação:\n"
 "{error_message}"
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr "E-mail sem assunto"
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr "Abra o Zulip para ver o conteúdo do spoiler"
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr "notificações do {service_name}"
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr "Endereço inválido."
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr "Fora de seu domínio."
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr "Endereços de e-mail contendo + não são permitidos."
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr "Reservado para bots de sistema."
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr "{email} já tem uma conta"
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr "Já tem uma conta."
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr "A conta foi desativada."
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr "O emoji '{emoji_name}' não existe"
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr "Emoji personalizado inválido."
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr "Nome de emoji personalizado inválido."
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr "Este emoji personalizado foi desativado."
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr "Código de emoji inválido."
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr "Nome do emoji inválido."
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr "Tipo de emoji inválido."
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr "Deve ser um administrador da organização ou autor do emoji"
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr "Nomes de emojis devem terminar com uma letra ou dígito."
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
@@ -5842,97 +5272,96 @@ msgstr ""
 "Nomes de emojis devem conter apenas letras minúsculas em inglês, dígitos, "
 "espaços, hifens e sublinhados."
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr "O nome do emoji está ausente"
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr "Não foi possível alocar a fila de eventos"
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr "Não entrou: autenticação da API ou sessão de usuário requerida"
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, fuzzy, python-brace-format
 #| msgid "Channel named {channel_name} already exists"
 msgid "Channel '{channel_name}' already exists"
 msgstr "O canal com nome {channel_name} já existe"
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr "Canal '{stream}' não existe"
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr "Canal com ID '{stream_id}' não existe"
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr "Combinação de parâmetros não suportada: {parameters}"
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr "proprietário da organização"
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr "usuário"
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr "Não é possível desativar a única {entity}."
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr "Declaração de inclusão de Markdown inválida: {include_statement}"
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr "JSON mal formado"
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr "Deve ser um administrador da organização"
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr "Deve ser o proprietário de uma organização"
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Must be an organization owner"
 msgid "Must be a bot user"
 msgstr "Deve ser o proprietário de uma organização"
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr "O nome de usuário ou a senha estão incorretos"
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr "Esta organização foi desativada"
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
@@ -5940,23 +5369,23 @@ msgstr ""
 "O registro do serviço de notificação push móvel para o seu servidor foi "
 "desativado"
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr "A autenticação por senha está desativada nesta organização"
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr "Sua senha foi desativada e precisa ser redefinida"
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr "Chave API inválida"
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr "Chave de API malformada"
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
@@ -5965,56 +5394,55 @@ msgstr ""
 "O evento '{event_type}' não é suportado atualmente por webhook "
 "{webhook_name}; ignorando"
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr "Incapaz de processar o pedido: {webhook_name} gerou este evento?"
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr "Usuário não autenticado"
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr "Subdomínio inválido"
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr "Você não tem permissão para iniciar conversas por mensagens diretas."
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr "Mensagens diretas estão desabilitadas nesta organização."
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr "Esta conversa não inclui nenhum usuário que possa autorizá-la."
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr "Acesso negado"
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
@@ -6023,15 +5451,15 @@ msgstr ""
 "Você somente tem permissão para mover as {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} mensagens mais recente neste tópico."
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr "Reação já existe."
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr "Reação não existe."
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
@@ -6039,370 +5467,370 @@ msgstr ""
 "A sua organização está registada para outro servidor Zulip. Por favor "
 "contacte o suporte Zulip para assistência na resolução deste problema."
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr "Organização não registrada"
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 "Você não tem permissão para utilizar menções genéricas de canal neste canal."
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 "Você não tem permissão para utilizar menções genéricas de tópico neste "
 "tópico."
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr "'{field_name}' valor não corresponde ao valor esperado."
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr "'{setting_name}' deverá ser do grupo de usuários de sistema."
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr "Não pode desativar grupo de usuários em uso."
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr "Você não tem permissão para administrar este canal."
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr "Você não tem permissão para alterar o padrão dos canais."
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr "Email já está em uso."
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr "O prazo de entrega programado deve ser no futuro."
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Server doesn't use the push notification service"
 msgid "Server is not configured to use push notification service."
 msgstr "O servidor não utiliza serviço de notificação push"
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Already has an account."
 msgid "Atlassian account ID"
 msgstr "Já tem uma conta."
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Behance username"
 msgstr "Nome ou nome de usuário incorreto"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Bitbucket username"
 msgstr "Nome de usuário do GitHub"
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Codeberg username"
 msgstr "Nome de usuário do Twitter"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Dribbble username"
 msgstr "Nome de usuário do GitHub"
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Facebook username"
 msgstr "Nome ou nome de usuário incorreto"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr "Nome de usuário do GitHub"
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "GitLab username"
 msgstr "Nome de usuário do GitHub"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Instagram username"
 msgstr "Nome de usuário do Twitter"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Mastodon"
 msgid "Mastodon profile"
 msgstr "Mastodonte"
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Medium username"
 msgstr "Nome de usuário do GitHub"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Pinterest username"
 msgstr "Nome de usuário do Twitter"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Reddit username"
 msgstr "Nome de usuário do GitHub"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Snapchat username"
 msgstr "Nome de usuário do GitHub"
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Threads username"
 msgstr "Nome de usuário do Twitter"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "TikTok username"
 msgstr "Nome de usuário do Twitter"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Twitch username"
 msgstr "Nome de usuário do Twitter"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "Nome de usuário"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr "Tipo de conta externa inválido"
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr "Estruturas de Integração"
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 #, fuzzy
 #| msgid "Video call ended"
 msgid "Video calling"
 msgstr "Chamada de vídeo encerrada"
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr "Integração contínua"
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr "Suporte ao cliente"
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr "Implantação"
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr "Entretenimento"
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr "Comunicação"
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr "Financeiro"
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr "Recursos humanos"
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr "Marketing"
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr "Diversos"
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr "Monitoramento"
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr "Gerenciamento de projeto"
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr "Produtividade"
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr "Controle de versão"
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr "Mensagem não deve ser vazia"
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr "Mensagem não deve conter bytes nulos"
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 "Você não está permitido para fazer menção no grupo de usuários "
 "'{user_group_name}'."
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{fullname} moderation"
 msgstr "{full_name} mencionou você:"
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr "Operador de limite inválido: {desc}"
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr "Combinação inválida de operadores estreito: {desc}"
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr "Operadores 'com' duplicados."
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr "Operador 'com' inválido"
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr "Argumento 'ancora' em falta."
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 #, fuzzy
 #| msgid "Missing 'anchor' argument."
 msgid "Missing 'anchor_date' argument."
 msgstr "Argumento 'ancora' em falta."
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr "Âncora inválida"
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr "Operador {operator} não suportado."
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr "Operando {operand} não suportado."
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 #, fuzzy
 #| msgid "Confirmation link does not exist"
 msgid "Navigation view does not exist."
 msgstr "O link de confirmação não existe"
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6413,7 +5841,7 @@ msgstr ""
 "Para saber mais, confira nosso [Usando o Zulip para um guia de aula]"
 "({getting_started_url})!\n"
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6424,7 +5852,7 @@ msgstr ""
 "Para saber mais, confira nosso [Guia primeiros passos]"
 "({getting_started_url})!\n"
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6435,7 +5863,7 @@ msgstr ""
 "Também temos um guia para [Configuração Zulip para a aula]"
 "({organization_setup_url}).\n"
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6446,7 +5874,7 @@ msgstr ""
 "Também temos um guia para [moving your organization to Zulip]"
 "({organization_setup_url}).\n"
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "\n"
@@ -6465,7 +5893,7 @@ msgstr ""
 "({demo_organization_help_url}) e\n"
 "será **eliminada automaticamente** ao fim de 30 dias.\n"
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
@@ -6475,7 +5903,7 @@ msgstr ""
 "Iniciei algumas conversas para ajudar você a começar. Você pode encontrar\n"
 "em sua [Caixa de Entrada](/#inbox).\n"
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6486,7 +5914,7 @@ msgstr ""
 "Você pode sempre voltar para o [Vídeo de boas-vindas no Zulip]"
 "({navigation_tour_video_url}) para uma rápida visão geral do aplicativo.\n"
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6511,7 +5939,7 @@ msgstr ""
 "{demo_organization_text}\n"
 "\n"
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
@@ -6522,7 +5950,7 @@ msgstr ""
 "desktop](/apps/).\n"
 "Zulip também funciona muito bem em um navegador.\n"
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -6534,7 +5962,7 @@ msgstr ""
 "do perfil](/help/change-your-profile-photo)\n"
 "e edite suas [informações de perfil](/help/edit-your-profile).\n"
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -6553,7 +5981,7 @@ msgstr ""
 "Zulip nas suas\n"
 "[Preferências](#settings/preferences).\n"
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6569,7 +5997,7 @@ msgstr ""
 "\n"
 "[Navegue e inscreva-se em canais]({settings_link}).\n"
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -6599,7 +6027,7 @@ msgstr ""
 "estão sendo\n"
 "discutido.\n"
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -6615,7 +6043,7 @@ msgstr ""
 "Pressione `?` a qualquer momento para ver uma [folha de dicas](#keyboard-"
 "shortcuts).\n"
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -6635,7 +6063,7 @@ msgstr ""
 "escondidos, \n"
 "fusos horários, entre outros. \n"
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "\n"
@@ -6656,7 +6084,7 @@ msgstr ""
 "Confira nosso [Guia de primeiros passos](/help/getting-started-with-zulip),\n"
 "ou navegue até ao [Centro de ajuda](/help/) para saber mais!\n"
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6667,7 +6095,7 @@ msgstr ""
 "Você pode conversar comigo o quanto quiser! Para\n"
 "obter ajuda, tente uma das seguintes mensagens: {bot_commands}\n"
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6686,7 +6114,7 @@ msgstr ""
 " tópicos ou até mover o tópico [para outro canal]"
 "({move_content_another_channel_help_url}).\n"
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
@@ -6695,7 +6123,7 @@ msgstr ""
 ":point_right: Tente mover esta mensagem para outro tópico e voltar "
 "novamente.\n"
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6717,12 +6145,11 @@ msgstr ""
 "#**{zulip_discussion_channel_name}**, como você pode ver através da\n"
 "barra lateral esquerda e em cima.\n"
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr "Bem-vindo ao Zulip!"
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -6734,7 +6161,7 @@ msgstr ""
 "dentro de um contexto, não importa quantas outras conversas estejam em "
 "curso..\n"
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
@@ -6745,7 +6172,7 @@ msgstr ""
 "#inbox) para outras\n"
 "conversas com mensagens não lidas.\n"
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -6757,7 +6184,7 @@ msgstr ""
 "clique\n"
 "no botão `+` ao lado do nome.\n"
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -6768,7 +6195,7 @@ msgstr ""
 "Rotule sua conversa com um tópico. Pense em terminar a frase: “Ei,\n"
 "podemos conversar sobre…?”\n"
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
@@ -6776,7 +6203,7 @@ msgstr ""
 "\n"
 ":point_right: Tente iniciar uma nova conversa neste canal.\n"
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6787,7 +6214,7 @@ msgstr ""
 ":point_right: Usar este tópico para experimentar [as funcionalidades de "
 "mensagens do Zulip]({format_message_help_url}).\n"
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6822,7 +6249,7 @@ msgstr ""
 "\n"
 "``` \n"
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
@@ -6832,7 +6259,7 @@ msgstr ""
 "Este tópico de **saudações** é um ótimo lugar para dizer “oi” :wave: para "
 "seus colegas de equipe.\n"
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
@@ -6842,117 +6269,117 @@ msgstr ""
 ":point_right: Clique nesta mensagem para iniciar uma nova mensagem na mesma "
 "conversa.\n"
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr "mensagens movidas"
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr "experimentos"
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr "Começar uma conversa"
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr "saudações"
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr "JSON inválido na resposta"
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr "Formato de resposta inválido"
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr "Token de comprimento vazio ou inválido"
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr "Token APNS inválido"
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr "Opção GCM inválida para bouncer: prioridade {priority!r}"
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr "Opções GCM inválidas para bouncer: {options}"
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr "Token não existe"
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr "{full_name} mencionado/a @{user_group_name}:"
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr "{full_name} mencionou você:"
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr "{full_name} mencionou a todos:"
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "Nova mensagem"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr "Notificação de teste"
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr "Isso é uma notificação de teste de {realm_name} ({realm_url})."
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr "Dispositivo não reconhecido"
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr "Dispositivo não reconhecido pelo serviço de notificações"
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 #, fuzzy
 #| msgid "Server doesn't use the push notification service"
 msgid "Network error while connecting to Zulip push notification service."
 msgstr "O servidor não utiliza serviço de notificação push"
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 #, fuzzy
 #| msgid "Server doesn't use the push notification service"
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr "O servidor não utiliza serviço de notificação push"
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 #, fuzzy
 #| msgid "Invalid API key"
 msgid "Invalid `push_key`"
 msgstr "Chave API inválida"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
@@ -6960,745 +6387,727 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr "Tipo de dados para ID de canal inválido"
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr "Usuário não autorizado para esta consulta"
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr "'{email}' não está mais usando o Zulip."
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr "Você não pode enviar mensagens diretas para fora da sua organização."
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "Channel name too long (limit: {max_length} characters)."
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr "O nome do canal é muito longo (limite: {max_length} caracteres)."
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder does not exist"
 msgstr "Token não existe"
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr "Erro de retorno de notificações push: {error}"
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr ""
 "Não é possível decidir entre os argumentos '{var_name1}' e '{var_name2}'"
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr "Argumento '{var_name}' ausente"
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr "Valor incorreto para '{var_name}': {bad_value}"
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr "A mensagem agendada não existe"
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr "Segurança da conta {service_name}"
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr "O canal padrão não pode ser privado."
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr "Os canais públicos web não estão habilitado."
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr "Você não tem permissão para publicar nesse canal."
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr "Não autorizado para enviar para o canal '{channel_name}'"
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 #, fuzzy
 #| msgid "You do not have permission to post in this channel."
 msgid "You do not have permission to create new topics in this channel."
 msgstr "Você não tem permissão para publicar nesse canal"
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr "ID de canal inválido"
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr "Nome de canal inválido '{channel_name}'"
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr "O/os canal(ais) ({channel_names}) não existe/em"
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr "O canal de grupo padrão com o id '{group_id}' não existe."
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr "O nome do canal não pode estar vazio."
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr "O nome do canal é muito longo (limite: {max_length} caracteres)."
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr "Caractere inválido no nome do canal, na posição {position}."
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr "Caractere inválido no tópico, na posição {position}!"
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr "Os dados de inscrito não estão disponíveis para este canal"
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr "Não foi possível recuperar inscritos no canal privado"
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr ""
 "Não foi possível decodificar a imagem; você enviou um arquivo de imagem?"
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr "Tamanho da imagem excede limite."
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr "A imagem está corrompida ou truncada"
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr "{var_name} não é booleano"
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} does not have a length"
 msgid "{var_name} does not have the expected format"
 msgstr "{var_name} não tem um comprimento"
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr "{var_name} não é uma data"
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr "{var_name} não é um dicionário"
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr "{var_name} inválido"
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr "O argumento \"{argument}\"em {var_name} é inesperado"
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr "{var_name} não é um float"
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr "{var_name} é muito pequeno"
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr "{var_name} não é um número inteiro"
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr "{var_name} não é um JSON válido"
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr "{var_name} é muito grande"
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr "{var_name} não é uma lista"
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr "{var_name} é muito longa (limite: {max_length} caracteres)"
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr "{var_name} é muito curto."
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr "{var_name} não é uma string"
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr "{var_name} tem um formato inválido"
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr "{var_name} não possui o comprimento de {length}"
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr "{var_name} é muito longa (limite: {max_length} caracteres)"
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr "{var_name} é muito longa (limite: {max_length} caracteres)"
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr "{var_name} não pode estar em branco"
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr "{var_name} inválido: {msg}"
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr "Campo {var_name} está faltando: {msg}"
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr "Payload incorreto"
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr "Não está na lista de valores possíveis"
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr "Não é uma URL"
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr "Não é um fuso horário reconhecido"
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr "{var_name} não é um código de cor hexadecimal válido"
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr "{setting_name} inválido"
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr "Envio excederia a cota de envio da organização."
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr "O tamanho da imagem excede o limite"
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr "Grupo de usuários está desativado."
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr "Grupo de usuário inválido"
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid user group ID: {group_id}"
 msgid "Invalid user group ID: {user_group_id}"
 msgstr "ID de grupo de usuários inválido: {group_id}"
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr "Nome de grupo de sistema inválido."
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr "ID de grupo de usuários inválido: {group_id}"
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 "A configuração '{setting_name}' não pode ser definida para o grupo 'role:"
 "internet'."
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 "A configuração '{setting_name}' não pode ser definida para o grupo 'role:"
 "nobody."
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 "A configuração '{setting_name}' não pode ser definida para o grupo 'role:"
 "everyone'."
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 "A configuração '{setting_name}' não pode ser definida para o grupo "
 "'{group_name}'."
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr "O nome do grupo não pode estar vazio!"
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr "O nome do grupo de usuários não pode exceder {max_length} caracteres."
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr "O nome do grupo de usuários não pode começar com '{prefix}'."
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr "Cliente não passou nenhum novo valor."
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 "Cliente deve passar emoji_name se ele passar emoji_code ou reaction_type."
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr "Nome muito longo!"
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 #, fuzzy
 #| msgid "Message must not be empty"
 msgid "Name must not be empty!"
 msgstr "Mensagem não deve ser vazia"
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr "Caracteres inválidos no nome!"
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr "Formato Inválido!"
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr "Nomes exclusivos são necessários nesta organização."
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr "O nome já está em uso."
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr "Nome ou nome de usuário incorreto"
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr "Integração inválida '{integration_name}'."
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr "Parâmetros de configuração ausente: {keys}"
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr "Valor {value} da chave {key} inválido ({error})"
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr "Dados de configuração inválidos"
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr "Tipo do bot inválido"
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr "Tipo de interface inválido"
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr "ID de usuário inválido: {user_id}"
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr "Bot inexistente"
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr "Usuário não existe"
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr "Usuário está desativado"
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr "{item} não pode estar em branco."
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr "{var_name} tem tamanho incorreto {length}; deve ser {target_length}"
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a string"
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr "{var_name} não é uma string"
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr "{container} deve conter exatamente {length} itens"
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr "Chave {key_name} está em falta de {var_name}"
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr "Argumentos inesperados: {keys}"
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr "{var_name} não é um allowed_type"
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr "{variable} != {expected_value} ({value} está errado)"
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr "{var_name} não é uma URL"
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr "O padrão de URL deve conter '%(username)s'."
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr "'{item}' não pode estar em branco."
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr "O campo não deve ter escolhas duplicadas."
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr "'{value}' não é uma opção válida para '{field_name}'."
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr "{var_name} não é uma string ou uma lista de inteiros"
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr "{var_name} não é uma string ou inteiro"
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr "{var_name} não tem um comprimento"
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr "{var_name} está ausente"
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr "O cabeçalho de evento HTTP '{header}' ausente"
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, fuzzy, python-brace-format
 #| msgid "Operator {operator} not supported."
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr "Operador {operator} não suportado."
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr "Deve haver uma barra no início do comando zcommand."
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr "Comando inexistente: {command}"
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr "`zulip_update_announcements_stream` é desativado inesperadamente."
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr "Erro CSRF: {reason}"
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr "Configuração incorreta do proxy reverso: {proxy_reason}"
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr "IDs de usuário inválido: {invalid_ids}"
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr "O usuário com o ID {user_id} está desativado"
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr "O usuário com o ID {user_id} é um bot"
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr "Data"
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr "Conta externa"
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr "Pronomes"
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr "Ninguém"
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr "Membros plenos"
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "Membros"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr "Qualquer um na internet"
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Invalid characters in emoji name"
 msgid "Invalid auto-conversion field: empty field name."
 msgstr "Caracteres inválidos no nome do emoji"
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid ""
@@ -7707,20 +7116,20 @@ msgstr ""
 "Grupo %(name)r no modelo de URL não está presente no padrão criadores de "
 "ligações."
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr "Expressão regular inválida: {regex}"
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr "Erro de expressão regular desconhecido"
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr "Modelo de URL inválido."
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid "Example input does not match the linkifier pattern."
@@ -7728,33 +7137,33 @@ msgstr ""
 "Grupo %(name)r no modelo de URL não está presente no padrão criadores de "
 "ligações."
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 "Grupo %(name)r no modelo de URL não está presente no padrão criadores de "
 "ligações."
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 "Grupo %(name)r no padrão de criadores de ligações não está presente no "
 "modelo de URL."
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid ""
@@ -7764,7 +7173,7 @@ msgstr ""
 "Grupo %(name)r no modelo de URL não está presente no padrão criadores de "
 "ligações."
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgid ""
@@ -7774,337 +7183,334 @@ msgstr ""
 "Grupo %(name)r no padrão de criadores de ligações não está presente no "
 "modelo de URL."
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr "Emoji unicode"
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "Emoji personalizado"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr "Emoji extra do Zulip"
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr "Caracteres inválidos no nome do emoji"
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr "Caracteres inválidos na linguagem pygments"
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr "Variável \"code\" requerido no modelo de URL encontra-se em falta"
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr "\"code\" deve ser somente a única variável no modelo de URL"
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr "sandbox"
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr "geral"
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr "Eventos de canal"
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr "Atualizações do Zulip"
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr "Disponível no Zulip Cloud Standard. Atualize para acessar."
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr "Disponível no Zulip Cloud Plus. Atualize para acessar."
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr "Permitir GIFs classificados como G (Público geral)"
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr "Permitir GIFs classificados como PG (Supervisão dos pais)"
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 "Permitir GIFs classificados como PG-13 (Supervisão dos pais - menores de 13 "
 "anos)"
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr "Permitir GIFs classificados como R (Restrito)"
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr "Público na Web"
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "Público"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr "Histórico privado e compartilhado"
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr "Histórico privado e protegido"
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr "Admins, moderadores, membros e visitantes"
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr "Administradores, moderadores e membros"
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr "Administradores e moderadores"
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr "Apenas administradores"
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr "Usuário desconhecido"
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr "Dono da organização"
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr "Administrador da organização"
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr "Moderador"
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "Membro"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "Convidado"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr "Endereço IP desconhecido"
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr "um sistema operacional desconhecido"
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr "Um navegador desconhecido"
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr "Argumento 'queue_id' ausente"
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr "Argumento 'last_event_id' ausente"
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr "Um evento mais recente {event_id} já foi removido!"
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr "O evento {event_id} não estava nesta fila"
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr "ID evento de fila inválido: {queue_id}"
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 #, fuzzy
 #| msgid "Failed to create Zoom call"
 msgid "Failed to generate challenge"
 msgstr "Zoom: Falha ao criar uma chamada"
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr "A autenticação JWT não está habilitado para esta organização"
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr "Nenhum token JSON na web foi aprovado na requisição"
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr "Token JSON na web incorreto"
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr "Não foi especificado nenhum email na reivindicação de token web JSON"
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr "Subdomínio requerido"
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr "A senha está incorreta."
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr "Cabeçalho User-Agent ausente da requisição"
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr "O rótulo não pode ficar em branco."
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr "Campo deve ter pelo menos uma escolha."
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr "Tipo de campo não suportado para exibição no resumo do perfil."
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 #, fuzzy
 #| msgid "Field type not supported for display in profile summary."
 msgid "Field type not supported for use for user matching."
 msgstr "Tipo de campo não suportado para exibição no resumo do perfil."
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr "Tipo de campo inválido."
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 "Apenas 2 campos de perfil personalizados podem ser exibidos no cartão do "
 "usuário."
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr "Um campo com esse rótulo já existe."
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr "O campo personalizado padrão não pode ser atualizado."
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr "Endpoint não disponível em produção."
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr "DevAuthBackend não habilitado."
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr "Parâmetro '{key}' inválido para pedido anónimo"
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr "A base de dados está vazia"
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr "Não é possível consultar o PostgreSQL"
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr "Não é possível conectar-se ao RabbitMQ"
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr "Não é possível consultar o RabbitMQ"
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr "Não é possível consultar o Redis"
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr "Não é possível gravar no memcached"
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr "Não é possível consultar o memcached"
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr "Nenhum convite"
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 #, fuzzy
 #| msgid "Invitation has already been revoked"
 msgid "Invitation already used or deactivated."
 msgstr "O convite já foi revogado"
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr "O convite já foi revogado"
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr "ID de canal inválido {channel_id}. Não foi enviado nenhum convite."
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr "Você não tem permissão de inscrever outros usuários a canais."
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr "Você deve especificar pelo menos um endereço de e-mail."
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
@@ -8112,108 +7518,106 @@ msgstr ""
 "Alguns desses endereços já estão usando o Zulip, então não enviamos um "
 "convite. Nós enviamos convites para todos os outros!"
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr "Histórico de edição de mensagem está desabilitado nesta organização"
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr "Você não tem permissão para excluir esta mensagem"
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr "O limite de tempo para excluir esta mensagem passou"
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr "Mensagem já deletada"
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr "Muitas mensagens solicitadas (máximo {max_messages})."
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr "A âncora somente pode ser excluída no fim da faixa"
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr "Nenhum tópico '{topic}'"
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Channel content access is required."
 msgid "An explanation is required."
 msgstr "É obrigatório acesso ao conteúdo do canal."
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Zephyr mirroring is not allowed in this organization"
 msgid "Message reporting is not enabled in this organization."
 msgstr "Espelhamento do Zephyr não é permitido nesta organização"
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr "Remetente ausente"
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr "Espelhamento não permitido com IDs de usuário do destinatário"
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr "Mensagem espelhada inválida"
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr "Funcionalidades de AI não estão habilitado neste servidor."
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr "Atingiu o limite de créditos mensal da AI."
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr "Sem mensagens na conversa para resumir"
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr "Não pode se silenciar"
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr "Usuário já está silenciado"
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr "Usuário não está silenciado"
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 #, fuzzy
 #| msgid "{hostname} is not a valid hostname"
 msgid "Custom views must have a valid name."
 msgstr "{hostname} não é um nome de host válido"
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 #, fuzzy
 #| msgid "Reaction already exists."
 msgid "Navigation view already exists."
 msgstr "Reação já existe."
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr "Etapa de integração desconhecida: {onboarding_step}"
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -8224,58 +7628,58 @@ msgstr ""
 "Você pediu para assistir ao [vídeo de boas-vindas ao Zulip]"
 "({navigation_tour_video_url}) depois. Esse é um bom momento?\n"
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr "Presença não é suportado para usuários bot."
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr "Não tem dados de presença para {user_id_or_email}"
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr "Status inválido: {status}"
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 #, fuzzy
 #| msgid "You do not have permission to change default channels."
 msgid "You do not have permission to manage plans and billing."
 msgstr "Você não tem permissão para alterar o padrão dos canais."
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr "O servidor não utiliza serviço de notificação push"
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr "Erro retornado por segurança: {result}"
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr "Segredo de verificação não preparado"
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
@@ -8283,50 +7687,50 @@ msgstr ""
 "Pelo menos um dos seguintes argumentos deve estar presente: emoji_name, "
 "emoji_code"
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr "Recibo de leitura estão desabilitado nesta organização."
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr "Idioma inválido '{language}'"
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr "Pelo menos um método de autenticação deve estar habilitado."
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr "Provedor de chat de vídeo inválido {video_chat_provider}"
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid giphy_rating {giphy_rating}"
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr "giphy_rating inválido {giphy_rating}"
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr "Deve ser uma organização de demonstração."
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
@@ -8334,7 +7738,7 @@ msgstr ""
 "O tempo de exclusão de dados deve ser no máximo {max_allowed_days} dias no "
 "futuro."
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
@@ -8342,241 +7746,240 @@ msgstr ""
 "O tempo de exclusão de dados deve ser de pelo menos {min_allowed_days} dias "
 "no futuro."
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr "Domínio inválido: {error}"
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr "O domínio {domain} já é parte da sua organização."
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr "Não foi encontrado nenhum registo para o domínio {domain}."
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr "Você deve enviar exatamente um arquivo."
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr "Apenas administradores podem substituir emojis padrão."
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr "O arquivo enviado é maior que o limite permitido de {max_size} MiB"
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 #, fuzzy
 #| msgid "JWT authentication is not enabled for this organization"
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr "A autenticação JWT não está habilitado para esta organização"
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr "Uso da API excedeu a taxa limite."
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr "ID de exportação de dados inválido"
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr "Exportação já apagada"
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr "Exportação falhou, nada para apagar"
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr "Exportação ainda em andamento"
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr "Você deve enviar exatamente um ícone."
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr "Link modificador não encontrado."
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr "Você deve enviar exatamente um logotipo."
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid characters in pygments language"
 msgid "Invalid character in language: {character}"
 msgstr "Caracteres inválidos na linguagem pygments"
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid language '{language}'"
 msgid "Language '{language}' is not allowed."
 msgstr "Idioma inválido '{language}'"
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr "Playground inválido"
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "User not authenticated"
 msgid "Unauthenticated"
 msgstr "Usuário não autenticado"
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "moving messages"
 msgid "Importing messages…"
 msgstr "mensagens movidas"
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "Your full name"
 msgid "Your name"
 msgstr "Seu nome completo"
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr "Destinatário obrigatório ao atualizar o tipo de mensagem agendada."
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 "Tópico obrigatório ao atualizar o tipo de mensagem agendada para o canal."
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr "Formato de solicitação inválido"
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr "DNS Inválido"
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr "Canais privados não podem ser definidos como padrão."
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr "Você deve passar \"new_description\" ou \"new_group_name\"."
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr "Valor inválido para \"op\". Especifique \"adicionar\" ou \"remover\"."
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr "Parâmetros inválidos"
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr "É obrigatório acesso ao conteúdo do canal."
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr "O canal já tem esse nome."
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr "Nada para fazer. Especifique pelo menos \"adicionar\" ou \"excluir\"."
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, fuzzy, python-brace-format
 #| msgid "{user_full_name} subscribed you to the channel {channel_name}."
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr "{user_full_name} inscreveu você no canal {channel_name}."
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr "{user_full_name} inscreveu você nos seguintes canais:"
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr "Incapaz de acessar o canal ({channel_name})."
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr "{user_name} criou os seguintes canais: {new_channels}."
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr "{user_name} criou um novo canal {new_channels}."
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr "Novos canais"
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, fuzzy, python-brace-format
 #| msgid "**{policy}** channel created by {user_name}. **Description:**"
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr "**{policy}** canal criado por {user_name}. **Descrição:**"
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, fuzzy, python-brace-format
 #| msgid "**{policy}** channel created by {user_name}. **Description:**"
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr "**{policy}** canal criado por {user_name}. **Descrição:**"
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, fuzzy, python-brace-format
 #| msgid "**{policy}** channel created by {user_name}. **Description:**"
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr "**{policy}** canal criado por {user_name}. **Descrição:**"
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, fuzzy, python-brace-format
 #| msgid "**{policy}** channel created by {user_name}. **Description:**"
 msgid ""
@@ -8584,26 +7987,26 @@ msgid ""
 "**"
 msgstr "**{policy}** canal criado por {user_name}. **Descrição:**"
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr "{property} não é um booleano"
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr "Propriedade de inscrição desconhecida: {property}"
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr "Não inscrito para o canal ID {channel_id}"
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr "Json inválido para sub-mensagem"
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
@@ -8612,7 +8015,7 @@ msgstr ""
 "O arquivo é maior que o tamanho máximo para enviar ({max_size} MiB) "
 "permitido pelo plano da sua organização."
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
@@ -8621,7 +8024,7 @@ msgstr ""
 "O arquivo é maior que o tamanho máximo para enviar configurado neste "
 "servidor ({max_size} MiB)."
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "Uploaded file is larger than the allowed limit of {max_file_size} MiB"
@@ -8631,54 +8034,53 @@ msgid ""
 msgstr ""
 "O arquivo enviado é maior que o limite permitido de {max_file_size} MiB"
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 "O usuário desativou as notificações de digitação para mensagens de canal"
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr "Faltando o argumento 'para'"
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr "Lista vazia 'para'"
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr ""
 "O usuário desativou as notificações de digitação para mensagens diretas"
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr "<p>Esse arquivo não existe ou foi apagado.</p>"
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr "<p>Você não está autorizado a visualizar este arquivo.</p>"
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr "Token inválido"
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr "Nome de arquivo inválido"
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr "Você deve escolher um arquivo para enviar"
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr "Você pode enviar somente um arquivo por vez"
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr "Nenhum novo dado fornecido"
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
@@ -8686,32 +8088,32 @@ msgstr ""
 "Nada a fazer. Especifique pelo menos um de \"Adicionar\", \"Apagar\", "
 "\"Adicionar Sub-Grupo\" ou \"Apagar Sub-Grupo\"."
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr "{user_full_name} te adicionou ao grupo {group_name}."
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr "{user_full_name} removeu você do grupo {group_name}."
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr "O usuário {user_id} já é um membro desse grupo"
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr "Não há membro '{user_id}' nesse grupo de usuários"
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr "Grupo de usuários {group_id} já é um subgrupo desse grupo."
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
@@ -8720,79 +8122,79 @@ msgstr ""
 "O grupo de usuários {user_group_id} já é um subgrupo de um dos subgrupos "
 "fornecidos."
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr "O grupo de usuários {group_id} não é um subgrupo desse grupo."
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr "Mudanças na imagem de perfil estão desativadas nesta organização."
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr "Alteração de endereço de email está desabilitada neste organização."
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr "default_language inválida"
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr "Som de notificação inválido '{notification_sound}'"
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr "Período de envio de email inválido: {seconds} segundos"
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr "Sua senha do Zulip é gerenciada no LDAP"
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr "Senha incorreta!"
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, fuzzy, python-brace-format
 #| msgid "You're making too many attempts! Try again in {seconds} seconds."
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr ""
 "Você está fazendo muitas tentativas! Tente de novo em {seconds} segundos."
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr "A nova senha está muito fraca!"
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr "Você deve enviar apenas um avatar."
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr "Tópico não está silenciado"
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr "Não é possível desativar o único proprietário da organização"
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Nobody in this Zulip organization will be able to see this email address."
@@ -8801,27 +8203,27 @@ msgstr ""
 "Ninguém nessa organização do Zulip conseguirá visualizar esse endereço de e-"
 "mail."
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr "Usuário não autorizado para alterar emails de usuário"
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 "A permissão de proprietário não pode ser removida do único proprietário da "
 "organização."
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr "Novo endereço de email inválido."
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr "Novo valor de email erro: {message}"
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
@@ -8834,25 +8236,25 @@ msgstr ""
 "configurado.\n"
 "Por favor entre em contato com o administrador do seu servidor."
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 #, fuzzy
 #| msgid "Email is already in use."
 msgid "Email address already in use"
 msgstr "Email já está em uso."
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr "Falha ao alterar proprietário, usuário inexistente"
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr "Falha ao alterar proprietário, usuário está desativado"
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr "Falha ao alterar proprietário, bots não podem ter outros bots"
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
@@ -8861,140 +8263,140 @@ msgstr ""
 "configurado.\n"
 "Por favor entre em contato com o administrador do seu servidor."
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr "Bots incorporados não estão habilitado."
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr "Nome do bot incorporado inválido."
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr "Usuário não autorizado a criar usuários"
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr "E-mail '{email}' não permitido nessa organização"
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr "Endereços de e-mail descartáveis não são permitidos nesta organização"
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom access token"
 msgid "Invalid {provider_name} access token"
 msgstr "Zoom: Token de acesso inválido"
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} call"
 msgstr "Zoom: Falha ao criar uma chamada"
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Zoom credentials have not been configured"
 msgid "{provider_name} credentials have not been configured"
 msgstr "Zoom: As credenciais de acesso não foram configuradas"
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom credentials"
 msgid "Invalid {provider_name} credentials"
 msgstr "Zoom: Credenciais inválidas"
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error connecting to the BigBlueButton server."
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr "Erro ao conectar ao servidor BigBlueButton."
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error authenticating to the BigBlueButton server."
 msgid "Error authenticating to the {provider_name} server"
 msgstr "Erro ao autenticar ao servidor BigBlueButton."
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "BigBlueButton server returned an unexpected error."
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr "O servidor BigBlueButton retornou um erro inesperado."
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom session identifier"
 msgid "Invalid {provider_name} session identifier"
 msgstr "Zoom: Identificador de sessão de inválido"
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr "Email desconhecido do usuário Zoom"
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} public room."
 msgstr "Zoom: Falha ao criar uma chamada"
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr "Assinatura inválida."
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{full_name}'s Zulip room"
 msgstr "{full_name} mencionou você:"
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 "Projetos que estão usando este provedor de sistema de controle de versão não "
 "são suportado"
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr "Carga útil inválida"
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr "Requisição webhook desconhecida"
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr "Tópico não pode ser vazio"
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr "Conteúdo não pode ser vazio"
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr "Incapaz de manipular a carga útil do Jotform"
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr "Entrada JSON mal-formada"
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr "A chave de eventos está faltando na carga útil"
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr "Erro: parâmetro channels_map_to_topics diferente de 0 ou 1"
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr "Ação desconhecida do webhook do WordPress: {hook}"
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
@@ -9003,77 +8405,77 @@ msgstr ""
 "Sua exportação de dados foi concluída. [Ver e baixar exportações]"
 "({export_settings_link})."
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr "O segredo de verificação expirou"
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr "O segredo de verificação é inválido"
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr "O segredo de verificação está malformado"
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr "O segredo de verificação é para um nome de host diferente"
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr "Subdomínio inválido para retorno de notificações via push"
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr "Deve validar com chave API válida do servidor Zulip"
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr "UUID inválido"
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr "Tipo de token inválido"
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 "{hostname} contém componentes inválidos (por exemplo, caminho, consulta , "
 "fragmento)."
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr "{hostname} não é um nome de host válido"
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr "{hostname} ainda não registrado"
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr "{domain} é inválido porque não tem nenhum registro MX"
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr "{domain} não existe"
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
@@ -9083,29 +8485,29 @@ msgstr ""
 "novamente depois ou entre em contato com {support_email} para obter "
 "assistência."
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr "Registro não encontrado para este nome de host"
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr "O host relatou que não tem segredo de verificação."
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, fuzzy, python-brace-format
 #| msgid "Error response received from the host: {status_code}"
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr "Resposta de erro recebida do host: {status_code}"
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr "Faltando ios_app_id"
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr "Falta user_id ou user_uuid"
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
@@ -9114,50 +8516,50 @@ msgstr ""
 "Seu plano não permite o envio de notificações push. Motivo fornecido pelo "
 "servidor: {reason}"
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr "Seu plano não permite o envio de notificações push."
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr "Propriedade inválida {property}"
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr "Tipo de evento inválido."
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr "Dados estão fora de ordem."
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr "Registro duplicado detectado."
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr "Dados de log de auditoria com formato incorreto"
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr "Você precisa redefinir sua senha."
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr "Faltando parâmetro id_token"
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 #, fuzzy
 #| msgid "Missing id_token parameter"
 msgid "Missing idp param"
 msgstr "Faltando parâmetro id_token"
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr "OTP inválido"
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr "Não pode usar mobile_flow_otp e desktop_flow_otp juntos."
 

--- a/locale/pt_PT/LC_MESSAGES/django.po
+++ b/locale/pt_PT/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 19:27+0000\n"
 "Last-Translator: Manuela Silva <mmsrs@sky.com>\n"
 "Language-Team: Portuguese (Portugal) <https://hosted.weblate.org/projects/"
@@ -26,53 +26,53 @@ msgstr ""
 "1000000 == 0 ? 1 : 2;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "Não permitido a visitantes"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "Organização inválida"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr "Canais públicos"
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr "Canais privados"
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr "Mensagens privadas"
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr "Mensagens privadas de grupo"
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr "Canal em falta para o gráfico: {chart_name}"
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr "Gráfico desconhecido: {chart_name}"
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr ""
 "A hora de início é posterior à hora de fim. Início: {start}, Fim: {end}"
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr ""
 "Sem dados analíticos disponíveis. Por favor contacte o administrador do "
 "servidor."
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -86,7 +86,7 @@ msgstr ""
 "({deactivate_user_help_page_link}) para permitir a entrada de novos "
 "utilizadores."
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -98,7 +98,7 @@ msgstr ""
 "inativos]({deactivate_user_help_page_link}) para permitir a entrada a mais "
 "que um novo utilizador."
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -110,7 +110,7 @@ msgstr ""
 "utilizadores inativos]({deactivate_user_help_page_link}) para permitir a "
 "entrada a mais que dois novos utilizadores."
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -122,7 +122,7 @@ msgstr ""
 "utilizadores inativos]({deactivate_user_help_page_link}) para permitir a "
 "entrada a mais que três novos utilizadores."
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -135,7 +135,7 @@ msgstr ""
 "certifique-se que o [número de licenças no período de faturação atual]"
 "({billing_page_link}) é superior ao número de utilizadores."
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
@@ -143,7 +143,7 @@ msgstr ""
 "A sua organização Zulip não tem licenças suficientes. Os convites não foram "
 "enviados."
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
@@ -151,16 +151,15 @@ msgstr ""
 "A sua organização Zulip não tem licenças suficientes para alterar a função "
 "de um visitante."
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr "O registo está desativado"
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr "Servidor remoto inválido."
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
@@ -169,7 +168,7 @@ msgstr ""
 "Deverá comprar licenças para todos os utilizadores ativos na sua "
 "organização, (mínimo {min_licenses})."
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
@@ -178,44 +177,44 @@ msgstr ""
 "Faturas com mais de {max_licenses} licenças não podem ser processadas "
 "através desta página. Para finalizar o upgrade, por favor contacte {email}."
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr "Sem método de pagamento guardado."
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr "{brand} acaba com {last4}"
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr "Método de pagamento desconhecido. Por favor contacte {email}."
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr "Algo correu mal. Por favor contacte {email}."
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "Algo correu mal. Por favor recarregue a página."
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr "Algo correu mal. Por favor aguarde alguns segundos e volte a tentar."
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 "Por favor adicione um cartão de crédito antes de começar o período "
 "experimental gratuito."
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr "Por favor adicione um cartão de crédito para agendar um upgrade."
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
@@ -223,18 +222,18 @@ msgstr ""
 "Não foi possível atualizar o plano. O plano expirou e foi substituído por um "
 "novo plano."
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr "Não foi possível atualizar o plano. O plano terminou."
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 "Não é possível atualizar licenças no período de faturação atual "
 "correspondente ao período experimental gratuito."
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
@@ -242,7 +241,7 @@ msgstr ""
 "Não foi possível atualizar as licenças manualmente. O seu plano está sob "
 "gestão de licenciamento automática."
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
@@ -250,11 +249,11 @@ msgstr ""
 "O seu plano já corresponde a {licenses} licenças no período de faturação "
 "atual."
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr "Não pode diminuir o número de licenças no período de faturação atual."
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
@@ -262,7 +261,7 @@ msgstr ""
 "Não pode alterar o número de licenças para o próximo período de faturação "
 "dado estar em processo de downgrade."
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
@@ -271,7 +270,7 @@ msgstr ""
 "O seu plano já está agendado para renovação com {licenses_at_next_renewal} "
 "licenças."
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
@@ -280,27 +279,27 @@ msgstr ""
 "Já comprou {licenses_at_next_renewal} licenças para o próximo período de "
 "faturação."
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr "Nada a alterar."
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr "Sem clientes para esta organização!"
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr "Não foi encontrada uma sessão"
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr "Não foi encontrada intenção de pagamento"
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr "Passar stripe_session_id ou stripe_invoice_id"
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -316,20 +315,19 @@ msgstr ""
 "Se puder {begin_link}listar o Zulip como patrocinador no seu site{end_link}, "
 "nós apreciaríamos imenso!"
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr "Parâmetro 'confirmado' é obrigatório"
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr "Código de acesso à faturação expirou."
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr "Código de acesso à faturação inválido."
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
@@ -338,39 +336,38 @@ msgstr ""
 "Não é possível reconciliar a informação de faturação entre o servidor e o "
 "domínio. Por favor contacte o suporte {support_email}"
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr "A conta de utilizador ainda não existe."
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr "Tem de aceitar os Termos de serviço para continuar."
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 "Esta zulip_org_id não está registada no sistema de gestão de faturação Zulip."
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr "zulip_org_key inválida para esta zulip_org_id."
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr "O servidor de registo foi desativado."
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "Erro"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr "Página não encontrada (404)"
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
@@ -379,11 +376,11 @@ msgstr ""
 "Se este erro é inesperado, poderá <a href=\"mailto:"
 "%(support_email)s\">contactar o suporte</a>."
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr "Acesso proibido (403)"
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
@@ -392,12 +389,12 @@ msgstr ""
 "credenciais de acesso necessárias para autenticar o seu acesso. Para "
 "resolver este problema:"
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr ""
 "Certifique-se que o seu navegador permite os ''cookies'' para este ''site''."
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
@@ -405,22 +402,21 @@ msgstr ""
 "Verifique as definições de privacidade ou extensões do navegador que possam "
 "bloquear os cabeçalhos 'Referer', e desative-os para este ''site''."
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr "Método não permitido (405)"
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr "Erro interno do servidor"
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
 msgstr ""
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -428,13 +424,13 @@ msgid ""
 "a> with any questions."
 msgstr ""
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
@@ -443,7 +439,7 @@ msgstr ""
 "<a href=\"mailto:%(support_email)s\">Contacte estes administradores de "
 "servidor</a> para apoio."
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
@@ -453,138 +449,136 @@ msgstr ""
 "href=\"%(troubleshooting_url)s\">guia da resolução de problemas do servidor "
 "do Zulip</a>."
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr "Analítica para %(target_name)s | Zulip"
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 "A analítica está completamente disponível 24 horas depois da criação da "
 "organização."
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr "Analítica do Zulip para %(target_name)s"
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr "Resumo da organização"
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr "Número de utilizadores"
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr "Utilizadores ativos nos últimos 15 dias"
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr "Número de visitantes"
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr "Número total de mensagens"
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr "Número de mensagens nos últimos 30 dias"
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr "Armazenamento de ficheiros em utilização"
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "Utilizadores ativos"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr "Ativos diários"
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr "Ativos em 15 dias"
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr "Total de utilizadores"
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "Utilizadores"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr "Mensagens enviadas por tipo de destinatário"
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "Eu"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "Todos"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "Última semana"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "Último mês"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "Último ano"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "Desde sempre"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr "Mensagens enviadas ao longo do tempo"
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "Diariamente"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "Semanalmente"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr "Cumulativo"
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "Humanos"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "Robôs"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr "Mensagens lidas ao longo do tempo"
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr "Mensagens enviadas por cliente"
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr "Última atualização"
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
@@ -593,15 +587,15 @@ msgstr ""
 "gráfico de “mensagens enviadas ao longo do tempo” é atualizado uma vez por "
 "hora."
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr "E-mail alterado"
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr "E-mail alterado!"
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
@@ -610,22 +604,22 @@ msgstr ""
 "Isto confirma que o endereço de correio eletrónico para a sua conta Zulip "
 "foi alterado de %(old_email_html_tag)s para %(new_email_html_tag)s"
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr "Confirmar o seu endereço de correio eletrónico"
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr "A hiperligação da confirmação não existe"
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr ""
 "Ups! Não foi possível encontrar a sua hiperligação de confirmação no sistema."
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
@@ -634,29 +628,29 @@ msgstr ""
 "De qualquer modo, envie-nos uma mensagem para %(support_email_html_tag)s e "
 "nós iremos resolver isto rapidamente."
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr "Hiperligação de confirmação expirada ou desativada"
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr "Ups! A hiperligação de confirmação expirou ou foi desativada."
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr ""
 "Por favor, contacte o administrador da sua organização para receber uma nova "
 "hiperligação."
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr "Hiperligação de confirmação incorreta"
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr "Ups. A hiperligação de confirmação está incorreta."
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
@@ -665,72 +659,55 @@ msgstr ""
 "Se ainda assim chegar esta página, será provavelmente um problema do nosso "
 "lado. Nós pedimos desculpa."
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr "Faturação"
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr "Fechar modal"
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr "Não lembrar"
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr "Reverter Versão"
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr "Confirmar"
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr "Cancelar atualização"
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr "Estado da faturação"
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr "Desativar registo do servidor?"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr "Gestão de planos indisponível"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -741,7 +718,7 @@ msgid ""
 "server."
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
@@ -749,7 +726,7 @@ msgstr ""
 "Mover o plano do servidor para esta organização, ou para outras questões, <a "
 "href=\"mailto:{{ support_email }}\">contacte o suporte</a>."
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
@@ -757,7 +734,7 @@ msgstr ""
 "A gestão de planos para este servidor não está disponível pois pelo menos "
 "uma organização alojada neste servidor já tem um plano ativo."
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -768,17 +745,17 @@ msgstr ""
 "a> para planear a gestão da sua organização, ou <a href='mailto:"
 "%(support_email)s'>contacte o suporte</a> para quaisquer questões."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr "Excedeu o limite da frequência de pedidos"
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr "Excedeu o limite da frequência de pedidos."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
@@ -786,720 +763,230 @@ msgstr ""
 "O seu servidor excedeu o limite do quão frequentemente esta ação pode ser "
 "executada."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, fuzzy, python-format
 #| msgid "You can try again in %(retry_after)s seconds."
 msgid "You can try again in %(retry_after_string)s."
 msgstr "Pode tentar novamente dentro de %(retry_after)s segundos."
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr "Atualização"
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr "Enviar a fatura e dar início ao período de avaliação gratuita"
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr "Enviar fatura"
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr "Abrir diretoria das comunidades"
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr "Filtrar por categoria"
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "Tudo"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr "Categorias"
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr "10,000 mensagens"
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr "Ilimitado"
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr "Ficheiros até 10 MB"
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr "Ficheiros até 1 GB"
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr "Suportado"
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr "Gestão própria"
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr "Para organizações até 10 utilizadores"
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr "mínimo de 25 utilizadores"
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr "Indisponível"
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr "A comunidade de desenvolvimento do Zulip"
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr "Aderir como utilizador"
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr "Aderir como alojador"
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr "Aderir como contribuidor"
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "Criar organização"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr "Obter uma demonstração"
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr "Alojar o Zulip"
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr "Pedir patrocínio"
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr "Preços educação"
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr "Ver preços"
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr "Zulip para negócios"
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Zulip guide for open-source projects"
 msgid "Zulip for open source"
 msgstr "Guia Zulip para projetos open-source"
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "start a conversation"
 msgid "Screenshot of Zulip conversation"
 msgstr "iniciar uma conversa"
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Messages sent over time"
 msgid "Message with code"
 msgstr "Mensagens enviadas ao longo do tempo"
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr "Ligação"
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr "Contactar o suporte"
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr "De"
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr "Organização"
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr "Assunto"
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr "Mensagem"
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr "Submeter"
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr "Agradecemos o seu contacto"
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr "Agradecemos o seu contacto!"
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr "Entraremos em contacto brevemente."
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
@@ -1507,13 +994,13 @@ msgstr ""
 "Poderá encontrar respostas para perguntas frequentes no <a href=\"/help/"
 "\">Centro de ajuda Zulip</a>."
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 #, fuzzy
 #| msgid "Getting started"
 msgid "Get started"
 msgstr "Primeiros passos"
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
@@ -1523,51 +1010,50 @@ msgstr ""
 "<a href=\"https://zulip.com/policies/terms\">Termos de serviço Zulip</a> "
 "para continuar."
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr "Ou, alternativamente, use um dos seus telefones de backup:"
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr "Em última instância, pode usar um código de backup:"
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr "Utilizar um código de backup"
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr "Aceitar os Termos de serviço"
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr "Bem-vindo/a ao Zulip"
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "Email"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr ""
 "Subscreva-me à newsletter do Zulip de baixo-tráfego (apenas algumas "
 "mensagens por ano)."
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr "Continuar"
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr "Confirme o seu endereço de email"
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1578,7 +1064,7 @@ msgstr ""
 "class=\"user_email semi-bold\">%(email)s</span>) com a mensagem de "
 "confirmação do Zulip.."
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
@@ -1587,31 +1073,31 @@ msgstr ""
 "entrada ou no spam/lixo, poderá pedir o <a href=\"#\" "
 "id=\"resend_email_link\">reenvio da mensagem</a>."
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr "Vista pública do Zulip de {org_name}"
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 "Explore os canais publicamente acessíveis de {org_name} sem iniciar sessão."
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
@@ -1619,39 +1105,38 @@ msgstr ""
 "Se esta mensagem não desaparecer, tente<a class=\"reload-lnk\">recarregar</"
 "a> a página."
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 "Erro ao carregar o Zulip. Por favor <a class=\"reload-lnk\">recarregue</a> a "
 "página."
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr "Não existe nenhuma conversação correspondente aos filtros escolhidos."
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr "Esta vista ainda está a carregar as mensagens."
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr "Carregar mais"
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr "A videochamada terminou"
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr "Já pode fechar esta janela."
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr "Erro de configuração"
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
@@ -1660,7 +1145,7 @@ msgstr ""
 "primeiro uma organização. Por favor utilize EmailAuthBackend para criar a "
 "sua organização e tente novamente."
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1671,73 +1156,71 @@ msgstr ""
 "instruções em como configurar as notificações push, por favor veja a <a "
 "href=\"%(doc_url)s\">documentação</a>."
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr "Conta não encontrada"
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr "Conta Zulip não encontrada."
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, fuzzy, python-format
 #| msgid "Your account email: %(email)s"
 msgid "No account found for %(email)s."
 msgstr "O endereço de email da sua conta: %(email)s"
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr "Iniciar sessão com outra conta"
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr "Continuar para o registo"
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Must be a demo organization."
 msgid "Try Zulip in a demo organization"
 msgstr "Deve ser uma organização de demonstração."
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Try Zulip now"
 msgid "Try Zulip"
 msgstr "Experimente o Zulip agora"
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "Criar uma organização"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr "Criar uma organização Zulip"
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr "Introduza o seu endereço de e-mail"
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr "O seu email"
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
@@ -1747,11 +1230,11 @@ msgstr ""
 "import-from-mattermost\">Mattermost</a>, ou<a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr "Como é que ouviu acerca do Zulip pela primeira vez?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
@@ -1759,42 +1242,41 @@ msgstr ""
 "Este valor apenas será utilizado se subscrever um plano, nesse caso será "
 "enviado para a equipa Zulip."
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr "Selecione uma opção"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr "Por favor descreva"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr "Onde é que viu o anúncio?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr "Qual organização?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr "Tipo de organização"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr "Idioma da organização"
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 #, fuzzy
 #| msgid ""
 #| "\n"
@@ -1816,74 +1298,70 @@ msgstr ""
 "                ou<a href=\"/help/import-from-rocketchat\">Rocket.Chat</a>.\n"
 "                "
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 #, fuzzy
 #| msgid "Private, shared history"
 msgid "Import chat history?"
 msgstr "Privado, histórico partilhado"
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr "Nome da organização"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "URL da Organização"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr "Usar %(external_host)s"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "OU"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "Registar-se"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "Registe-se no Zulip"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr "Precisa de um convite para aderir a esta organização."
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr "Inscrever-se com %(identity_provider)s"
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr "Já tem uma conta?"
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "Iniciar Sessão"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr "Configurar privacidade do endereço de email"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
@@ -1891,7 +1369,7 @@ msgstr ""
 "O Zulip permite que controle quais os perfis dentro da organização que podem "
 "visualizar o seu endereço de email."
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
@@ -1899,11 +1377,11 @@ msgstr ""
 "Pretende alterar a definição de privacidade do seu email para algo diferente "
 "do pré-definido nesta organização?"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr "Quem poderá ver o seu endereço de email"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1914,14 +1392,14 @@ msgstr ""
 "email-visibility\" target=\"_blank\" rel=\"noopener noreferrer\">depois de "
 "aderir</a>."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 "Administradores desta organização Zulip poderão ver este endereço de email."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
@@ -1929,92 +1407,91 @@ msgstr ""
 "Administradores e moderadores desta organização Zulip poderão ver este "
 "endereço de email."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr "Ninguém nesta organização Zulip poderá ver este endereço de email."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr "Outros utilizadores poderão ver este endereço de email."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "Alterar"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr "Registo"
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr "Crie a sua organização"
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr "Crie a sua conta"
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr ""
 "<p>Introduza as suas informações de conta para finalizar o registo.</p>"
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr "A sua organização"
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr "A sua conta"
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr "Não importar definições"
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr "Importar definições de uma conta Zulip existente"
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr "O seu nome completo"
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "Nome"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr "Isto é como a sua conta será vista no Zulip."
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "Palavra-passe"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr "Introduza a sua palavra-passe LDAP/Active Directory."
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 "Isto é utilizado para aplicações móveis e outras ferramentas que exijam uma "
 "palavra-passe."
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr "Força da palavra-passe"
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr "Quais são os seus interesses?"
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
@@ -2023,15 +1500,15 @@ msgstr ""
 "Aceito os <a href=\"%(root_domain_url)s/policies/terms\" target=\"_blank\" "
 "rel=\"noopener noreferrer\">Termos de serviço</a>."
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr "Organização desativada"
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr "Organização movida"
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
@@ -2040,7 +1517,7 @@ msgstr ""
 "Esta organização foi movida para <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -2048,7 +1525,7 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid ""
@@ -2056,7 +1533,7 @@ msgid ""
 "deleted."
 msgstr "Esta organização foi desativada"
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
@@ -2065,7 +1542,7 @@ msgstr ""
 "Pode <a href=\"mailto:%(support_email)s\">contactar o apoio do Zulip</a> "
 "para perguntar sobre a reutilização deste URL para uma nova organização."
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
@@ -2075,13 +1552,13 @@ msgstr ""
 "servidor do Zulip </a> para perguntar sobre a reutilização deste URL para "
 "uma nova organização."
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid "This organization has been deactivated."
 msgstr "Esta organização foi desativada"
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -2090,14 +1567,14 @@ msgstr ""
 "Se for o proprietário desta organização, poderá <a href=\"mailto:"
 "%(support_email)s\">contactar o suporte Zulip</a> para a reativar."
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -2108,15 +1585,15 @@ msgstr ""
 "%(support_email)s\">contactar os administradores deste servidor Zulip</a> "
 "para a reativar."
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr "Finalizar início de sessão da aplicação de ambiente de trabalho"
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr "Finalizar início de sessão de ambiente de trabalho"
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
@@ -2124,110 +1601,109 @@ msgstr ""
 "Utilize o seu navegador para finalizar o início de sessão, depois volte aqui "
 "para colar o código de início de sessão."
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr "Colar código aqui"
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr "Finalizar"
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr "Código incorreto."
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr "Código aceite. A iniciar sessão…"
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr "Iniciar sessão na aplicação de ambiente de trabalho"
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 "Copie este código de início de sessão e volte à sua aplicação Zulip para "
 "finalizar o início de sessão:"
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "Copiar"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr "Já pode fechar esta janela."
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr "Ou, continue no seu navegador."
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr "Utilizador anónimo"
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr "Proprietários"
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "Administradores"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr "Moderadores"
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr "Visitantes"
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "Utilizadores regulares"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr "Encaminhar emails para conta de email"
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "Fechar"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "Atualizar"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr "Zulip"
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr "Resumo"
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
 "<b>%(realm_name)s</b>."
 msgstr "Parabéns, criou uma nova organização Zulip: <b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr "Bem-vindo/a ao Zulip!"
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr "Aderiu à organização Zulip <b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
@@ -2236,43 +1712,43 @@ msgstr ""
 "Irá utilizar a seguinte informação para iniciar a sessão do Zulip na Web, "
 "nas aplicações para <a href=\"%(apps_page_link)s\">PC e móvel </a>:"
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr "URL da organização: %(organization_url)s"
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr "O seu nome de utilizador: %(ldap_username)s"
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr "Utilize a sua conta LDAP para iniciar sessão"
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr "O endereço de email da sua conta: %(email)s"
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr "Ir para organização"
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
 "href=\"%(getting_user_started_link)s\">getting started guide</a>!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2280,7 +1756,7 @@ msgid ""
 "Zulip</a>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
@@ -2289,28 +1765,28 @@ msgstr ""
 "Questões? <a href=\"mailto:%(support_email)s\">Contacte-nos</a> — "
 "gostaríamos de o/a ajudar!"
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr "%(realm_name)s no Zulip: Detalhes da sua organização"
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr "%(realm_name)s no Zulip: Detalhes da sua conta"
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr "Parabéns, criou uma nova organização Zulip: %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr "Aderiu à organização Zulip%(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
@@ -2319,31 +1795,31 @@ msgstr ""
 "Irá utilizar a seguinte informação para iniciar a sessão no Zulip na Web, "
 "para as aplicações de PC e móvel (%(apps_page_link)s):"
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
 "(%(getting_user_started_link)s)!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
 "(%(getting_organization_started_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr "Questões? Contacte-nos %(support_email)s — gostaríamos de o/a ajudar!"
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2352,17 +1828,17 @@ msgstr ""
 "Para quaisquer questões, por favor contacte os administradores deste "
 "servidor Zulip em %(support_email)s."
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr "Olá,"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2374,12 +1850,12 @@ msgstr ""
 "esta alteração e definir uma palavra-passe para esta conta, confirme "
 "clicando abaixo:"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr "Confirmar e definir uma palavra-passe"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2388,7 +1864,7 @@ msgstr ""
 "Se não pediu esta alteração, por favor contacte-nos imediatamente em "
 "%(support_email)s."
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 #, fuzzy
 #| msgid "Verify your new email address for your demo Zulip organization"
 msgid "Verify your email address for your Zulip demo organization"
@@ -2396,8 +1872,8 @@ msgstr ""
 "Verifique o seu novo endereço de email da sua organização de demonstração "
 "Zulip"
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2406,8 +1882,8 @@ msgstr ""
 "Se não pediu esta alteração, por favor contacte-nos imediatamente em "
 "<%(support_email)s>."
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2418,33 +1894,33 @@ msgstr ""
 "%(realm_url)s de%(old_email)s para%(new_email)s. Para confirmar esta "
 "alteração, por favor clique abaixo:"
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr "Confirmar alteração de email"
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr "Verifique o seu novo endereço de email para%(organization_host)s"
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr "Pediu uma nova organização Zulip:"
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr "Tipo de organização: %(organization_type)s"
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr "Registou-se recentemente no Zulip. Excelente!"
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
@@ -2452,33 +1928,33 @@ msgstr ""
 "Clique no botão abaixo para criar uma organização e registar a sua conta. "
 "Pode atualizar a informação acima se pretender."
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr "Clique no botão abaixo para finalizar o registo."
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr "Finalizar o registo"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr "Criar a sua organização Zulip"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr "Ativar a sua conta Zulip"
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr "Clique na ligação abaixo para finalizar o registo."
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
@@ -2487,20 +1963,20 @@ msgstr ""
 "Tem questões ou sugestões que gostaria de partilhar connosco? Contacte-nos "
 "em%(support_email)s — gostaríamos de o/a ajudar!"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr "Gerir preferências de email"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr "Cancelar subscrição de emails de marketing"
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
@@ -2509,17 +1985,17 @@ msgstr ""
 "A sua conta Zulip em <a href=\"%(realm_url)s\">%(realm_url)s</a> foi "
 "desativada, e não será possível iniciar sessão."
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr "Os administradores deixaram o seguinte comentário:"
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr "Notificação de desativação de conta em %(realm_name)s"
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
@@ -2528,11 +2004,11 @@ msgstr ""
 "A sua conta Zulip em %(realm_url)s foi desativada, e não será possível "
 "iniciar sessão."
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr "Novos canais"
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2540,22 +2016,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because your organization has "
@@ -2572,8 +2048,8 @@ msgstr ""
 "href=\"%(help_url)s\">conteúdo das mensagens aparecer nas notificações por "
 "email</a>."
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because you have disabled <a "
@@ -2588,22 +2064,22 @@ msgstr ""
 "class=\"content_disabled_help_link\" href=\"%(alert_notif_url)s\">conteúdo "
 "das mensagens de aparecer nas notificações por email</a>."
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, fuzzy, python-format
 #| msgid "Click here to log in to Zulip and catch up."
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr "Clique aqui para iniciar sessão e acompanhe as novidades."
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr "Cancelar subscrição das mensagens de resumo"
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr "Resumo do Zulip para %(realm_name)s"
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2612,18 +2088,18 @@ msgstr ""
 "Tem %(new_messages_count)s novas mensagens, e existem %(new_streams_count)s "
 "novos canais em %(realm_name)s."
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr "Tem %(new_messages_count)s novas mensagens em %(realm_name)s."
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr "Existem %(new_streams_count)s novos canais em %(realm_name)s."
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because your organization hides "
@@ -2634,8 +2110,8 @@ msgstr ""
 "oculta o conteúdo da mensagem nas notificações por correio eletrónico. "
 "Consulte %(hide_content_url)s para mais detalhes."
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to hide "
@@ -2645,33 +2121,31 @@ msgstr ""
 "o conteúdo da mensagem nas notificações por correio eletrónico. Consulte "
 "%(help_url)s para mais detalhes."
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr ""
 "Inicie a sessão no Zulip para acompanhar as novidades: %(organization_url)s."
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr "Gerir preferências do correio eletrónico:"
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr "Cancelar subscrição das mensagens de resumo:"
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr "Peixe a nadar"
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr "Obrigado pelo seu pedido!"
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
@@ -2680,8 +2154,7 @@ msgstr ""
 "O seu endereço de correio eletrónico %(email)s tem contas com as seguintes "
 "organizações de Zulip Cloud:"
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
@@ -2690,7 +2163,7 @@ msgstr ""
 "O seu endereço de correio eletrónico %(email)s tem contas com as seguintes "
 "organizações do Zulip alojadas por %(external_host)s:"
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
@@ -2699,21 +2172,17 @@ msgstr ""
 "Ser estiver com dificuldades para iniciar a sessão, pode <a "
 "href=\"%(help_reset_password_link)s\">redefinir a sua palavra-passe</a>."
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 "Você solicitou uma lista de contas do Zulip para este endereço de correio "
 "eletrónico."
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr "Infelizmente não foram encontradas contas de Zulip Cloud."
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
@@ -2722,7 +2191,7 @@ msgstr ""
 "Infelizmente, não foram encontradas contas nas organizações do Zulip "
 "alojadas por %(external_host)s."
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2734,29 +2203,26 @@ msgstr ""
 "=\"%(help_logging_in_link)s\">tentar outro método</a> para encontrar a sua "
 "conta."
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 "Se não reconhece este pedido, poderá ignorar esta mensagem com segurança."
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr "As suas contas do Zulip"
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr "Não foram encontradas contas do Zulip"
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 "Se estiver com dificuldades para iniciar a sessão, pode redefinir a sua "
 "palavra-passe."
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
@@ -2766,12 +2232,12 @@ msgstr ""
 "eletrónico (%(find_accounts_link)s), ou tentar outro método para encontrar a "
 "sua conta (%(help_logging_in_link)s)."
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr "Olá,"
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
@@ -2780,18 +2246,18 @@ msgstr ""
 "%(referrer_name)s quer que se junte ao Zulip &mdash; a ferramenta de "
 "comunicação criada para a produtividade."
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr "Para começar, clique no botão em baixo."
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 "%(referrer_full_name)s convidou-o(a) para aderir a %(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
@@ -2800,17 +2266,17 @@ msgstr ""
 "%(referrer_full_name)s (%(referrer_email)s) quer que se junte ao Zulip -- a "
 "ferramenta de comunicação criada para a produtividade."
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr "Para começar, clique na hiperligação em baixo."
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr "Olá novamente,"
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
@@ -2819,13 +2285,13 @@ msgstr ""
 "Isto é um lembrete amigável de %(referrer_name)s que quer que se junte ao "
 "Zulip &mdash; a ferramenta de comunicação criada para a produtividade."
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr "Este é o último lembrete que irá receber sobre este convite."
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
@@ -2834,12 +2300,12 @@ msgstr ""
 "Este convite expira dentro em dois dias. Se o convite expirar, terá de "
 "solicitar um novo convite a %(referrer_name)s."
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr "Lembrete: Junte-se a %(referrer_name)s em%(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2850,7 +2316,7 @@ msgstr ""
 "quer que se junte ao Zulip -- a ferramenta de comunicação criada para a "
 "produtividade."
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2859,7 +2325,7 @@ msgstr ""
 "Se tiver quaisquer questões, por favor, contacte os administradores do "
 "servidor do Zulip em <a href=\"mailto:%(email)s\">%(email)s</a>."
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
@@ -2868,14 +2334,14 @@ msgstr ""
 "Tem questões ou sugestões que gostaria de partilhar? <a href=\"mailto:"
 "%(email)s\">Contacte-nos</a> — nós gostaríamos de o(a) ajudar!"
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr ""
 "Está a receber esta notificação porque você foi mencionado(a) pessoalmente."
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
@@ -2883,10 +2349,8 @@ msgstr ""
 "Está a receber esta notificação porque @%(mentioned_user_group_name)s foi "
 "mencionado(a)."
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
@@ -2895,8 +2359,8 @@ msgstr ""
 "Está a receber esta notificação porque todos os participantes do tópico "
 "foram mencionados em #%(channel_name)s > %(topic_name)s."
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
@@ -2904,8 +2368,8 @@ msgstr ""
 "Está a receber esta notificação porque tem as notificações de menção "
 "ativadas para os tópicos que segue."
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
@@ -2913,8 +2377,8 @@ msgstr ""
 "Está a receber esta notificação porque todos foram mencionados em "
 "#%(channel_name)s."
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
@@ -2922,8 +2386,8 @@ msgstr ""
 "Está a receber esta notificação porque tem as notificações por correio "
 "eletrónico ativadas para os tópicos que segue."
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
@@ -2932,7 +2396,7 @@ msgstr ""
 "Está a receber esta notificação porque tem as notificações por correio "
 "eletrónico ativadas para #%(channel_name)s."
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2943,7 +2407,7 @@ msgstr ""
 "%(realm_name)s </a>, ou<a href=\"%(notif_url)s\">gira as preferências do "
 "correio eletrónico</a>."
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
@@ -2952,7 +2416,7 @@ msgstr ""
 "<a href=\"%(narrow_url)s\">Veja ou responda em %(realm_name)s </a>, ou<a "
 "href=\"%(notif_url)s\">gira as preferências do correio eletrónico</a>."
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
@@ -2961,7 +2425,7 @@ msgstr ""
 "<a href=\"%(narrow_url)s\">Responda em %(realm_name)s </a>, ou<a "
 "href=\"%(notif_url)s\">gira as preferências do correio eletrónico</a>."
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
@@ -2970,41 +2434,41 @@ msgstr ""
 "Não responda a esta mensagem. Este servidor do Zulip não está configurado "
 "para receber mensagens (<a href=\"%(url)s\">ajuda</a>)."
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr "Mensagens privadas de grupo com %(direct_message_group_display_name)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr "Mensagens privadas com %(sender_str)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr "[resolvido] #%(channel_name)s > %(topic_name)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr "Novas mensagens"
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr "Responda a esta mensagem diretamente, ou veja-a em %(realm_name)s :"
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr "Veja ou responda em %(realm_name)s :"
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr "Responda em %(realm_name)s :"
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
@@ -3012,7 +2476,7 @@ msgstr ""
 "Não responda a esta mensagem. Este servidor do Zulip não está configurado "
 "para aceitar mensagens. Ajuda:"
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -3023,22 +2487,22 @@ msgstr ""
 "recentemente para %(new_email)s. Se não solicitou esta alteração, por favor, "
 "contacte-nos de imediato em %(support_email)s."
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr "Com os melhores cumprimentos,"
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr "Equipa Zulip"
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr "Endereço de correio eletrónico do Zulip alterado para %(realm_name)s"
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -3049,7 +2513,7 @@ msgstr ""
 "recentemente para %(new_email)s. Se não solicitou esta alteração, por favor, "
 "contacte-nos de imediato em <%(support_email)s>."
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
@@ -3057,47 +2521,47 @@ msgstr ""
 "Organização: %(organization_url)s Data/hora: %(login_time)s E-mail: "
 "%(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr ""
 "Nós detetamos um início de sessão recente com a seguinte conta do Zulip."
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr "Organização: %(organization_link)s"
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr "E-mail: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr "Data/hora: %(login_time)s"
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr "Dispositivo: %(device_browser)s no %(device_os)s."
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr "Endereço de IP: %(device_ip)s"
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr "Se foi você, excelente! Não há mais nada a fazer."
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3108,31 +2572,31 @@ msgstr ""
 "sido comprometida, por favor, <a href=\"%(reset_link)s\">redefina a sua "
 "palavra-passe</a> ou contacte-nos de imediato em %(support_email)s."
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr "Obrigado,"
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr "Segurança do Zulip"
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr "Cancelar subscrição das notificações de autenticação"
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr "Novo início de sessão em %(device_browser)s no %(device_os)s"
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr "Organização: %(organization_url)s"
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3143,7 +2607,7 @@ msgstr ""
 "sido comprometida, por favor, redefina a sua palavra-passe em %(reset_link)s "
 "ou contacte-nos de imediato em %(support_email)s."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -3151,7 +2615,7 @@ msgid ""
 "Zulip</a> to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
@@ -3159,7 +2623,7 @@ msgstr ""
 "De qualquer modo, aqui estão alguns conselhos de clientes para "
 "avaliar<i>qualquer</i> produto de comunicação para equipas:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
@@ -3168,12 +2632,12 @@ msgstr ""
 "<a href=\"%(invite_users)s\"><b>Convide os seus colegas</b></a> para "
 "explorar e partilhar perspetivas e ideias únicas."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr "Utilize a própria aplicação para partilhar as suas impressões."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -3185,7 +2649,7 @@ msgstr ""
 "comunicação. Esta é a única forma de experienciar como é que a nova "
 "aplicação poderá ajudar a sua equipa."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -3196,27 +2660,27 @@ msgstr ""
 "eficientes</a>, e esperamos que estas dicas ajudem a sua equipa a "
 "experienciá-las em ação."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr "Cancelar subscrição de mensagens de boas-vindas para %(realm_name)s"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr "Escolher uma aplicação de comunicação para a sua equipa"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
@@ -3224,7 +2688,7 @@ msgstr ""
 "De qualquer modo, aqui estão alguns conselhos que recebemos frequentemente "
 "de clientes a testar um qualquer produto de comunicação para equipas:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
@@ -3232,7 +2696,7 @@ msgstr ""
 "Convide os seus colegas para explorar e partilhar as suas ideias e "
 "perspetivas."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
@@ -3243,7 +2707,7 @@ msgstr ""
 "Este é o único método de garantir que vai experienciar as formas como a nova "
 "aplicação de comunicação vai ajudar a sua equipa."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
@@ -3251,8 +2715,8 @@ msgstr ""
 "O Zulip é pensado para a comunicação eficiente, e esperamos que estas dicas "
 "ajudem a sua equipa a experienciá-la em ação."
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
@@ -3263,71 +2727,71 @@ msgstr ""
 "necessidades. Veja este guia das funcionalidades chave do Zulip para "
 "organizações como a sua!"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr "Veja o guia Zulip para negócios"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr "Veja o guia Zulip para projetos open-source"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr "Veja o guia Zulip para educação"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr "Veja o guia Zulip para investigação"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr "Veja o guia Zulip para eventos e conferências"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr "Veja o guia Zulip para organizações sem fins lucrativos"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr "Veja o guia Zulip para comunidades"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr "Guia Zulip para negócios"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr "Guia Zulip para projetos open-source"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr "Guia Zulip para educação"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr "Guia Zulip para investigação"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr "Guia Zulip para eventos e conferências"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr "Guia Zulip para organizações sem fins lucrativos"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr "Guia Zulip para comunidades"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
@@ -3335,7 +2799,7 @@ msgstr ""
 "Aqui estão algumas dicas para manter as suas conversas Zulip organizadas por "
 "tópicos."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
@@ -3343,8 +2807,8 @@ msgstr ""
 "No Zulip, os<b>canais</b> determinam quem recebe a mensagem. Os<b>Tópicos</"
 "b> dizem qual o tema da mensagem."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
@@ -3353,12 +2817,12 @@ msgstr ""
 "mensagem em contexto, independentemente de quantas discussões se encontrarem "
 "em curso."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr "Canais e tópicos na aplicação Zulip"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3370,11 +2834,11 @@ msgstr ""
 "curso. Para escolher um bom nome para o tópico, pense em como terminar a "
 "seguinte frase: “Olá, podemos falar sobre…?”"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr "Exemplos de tópicos curtos"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3388,17 +2852,17 @@ msgstr ""
 "a>, ou até<a href=\"%(move_channels_link)s\">mover o tópico para um canal "
 "diferente</a>."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr "Ir para o Zulip"
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr "Mantenha as conversações organizadas por tópicos"
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
@@ -3406,7 +2870,7 @@ msgstr ""
 "No Zulip, os canais determinam quem recebe a mensagem. Os tópicos referem o "
 "assunto da mensagem."
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3419,8 +2883,8 @@ msgstr ""
 "alterar o nome do tópico (%(rename_topics_link)s), ou até mover o tópico "
 "para um canal diferente (%(move_channels_link)s)."
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
@@ -3429,15 +2893,15 @@ msgstr ""
 "Alguém (possivelmente você) pediu uma nova palavra-passe para a conta "
 "Zulip%(email)s em%(realm_url)s."
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr "Clique no botão abaixo para repor a sua palavra-passe."
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr "Repor a palavra-passe"
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3448,18 +2912,18 @@ msgstr ""
 "contactar o administrador da organização para<a "
 "href=\"%(help_link)s\">reativar a sua conta</a>."
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr "Não tem uma conta nessa organização Zulip."
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr "Tem contas ativas na/s seguinte/s organização(ões)."
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
@@ -3467,22 +2931,22 @@ msgstr ""
 "Poderá tentar iniciar sessão ou repor a sua palavra-passe na/s "
 "organização(ões) acima."
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr "Se não reconhece esta atividade, pode ignorar este e-mail."
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr "Pedido de reposição de palavra-passe para%(realm_name)s"
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr "Clique na ligação abaixo para repor a sua palavra-passe."
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
@@ -3491,7 +2955,7 @@ msgstr ""
 "Já teve uma conta em %(realm_url)s mas foi desativada. Poderá contactar o "
 "administrador da organização para reativar a sua conta."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3502,7 +2966,7 @@ msgstr ""
 "Cloud Zulip para o Plano gratuito devido a falha no pagamento de faturas. As "
 "faturas não pagas foram anuladas."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
@@ -3511,7 +2975,7 @@ msgstr ""
 "Para continuar no Plano standard da Cloud Zulip, por favor faça upgrade "
 "novamente em %(upgrade_url)s."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
@@ -3520,8 +2984,8 @@ msgstr ""
 "Se achar que isto foi um erro ou necessitar de mais informações, por favor "
 "contacte-nos em %(support_email)s."
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "You have deactivated your Zulip organization, %(realm_name)s, on "
@@ -3532,8 +2996,8 @@ msgid ""
 msgstr ""
 "Desativou a sua organização Zulip, %(realm_name)s, a%(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "Your Zulip organization, %(realm_name)s, was deactivated by "
@@ -3545,8 +3009,8 @@ msgstr ""
 "A sua organização Zulip, %(realm_name)s, foi desativada "
 "por%(deactivating_owner)s a %(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "Your Zulip organization, %(realm_name)s, was deactivated on "
@@ -3557,8 +3021,8 @@ msgid ""
 msgstr ""
 "A sua organização Zulip, %(realm_name)s, foi desativada a%(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
@@ -3566,8 +3030,8 @@ msgid ""
 msgstr ""
 "Desativou a sua organização Zulip, %(realm_name)s, a%(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
@@ -3576,8 +3040,8 @@ msgstr ""
 "A sua organização Zulip, %(realm_name)s, foi desativada "
 "por%(deactivating_owner)s a %(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
@@ -3585,22 +3049,22 @@ msgid ""
 msgstr ""
 "A sua organização Zulip, %(realm_name)s, foi desativada a%(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
@@ -3608,19 +3072,19 @@ msgstr ""
 "Quaisquer dúvidas ou questões, por favor responda a esta mensagem assim que "
 "possível."
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr "A sua organização Zulip%(realm_name)s foi desativada"
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr "Caros ex-administradores de%(realm_name)s,"
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "One of your administrators requested reactivation of the previously "
@@ -3632,8 +3096,8 @@ msgstr ""
 "Um dos administradores pediu a reativação de uma organização Zulip "
 "anteriormente alojada em%(realm_url)s."
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
@@ -3642,16 +3106,16 @@ msgstr ""
 "Um dos administradores pediu a reativação de uma organização Zulip "
 "anteriormente alojada em%(realm_url)s."
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr "Clique no botão abaixo para reativar a sua organização."
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr "Reativar organização"
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
@@ -3659,21 +3123,21 @@ msgstr ""
 "Se foi efetuado um pedido por engano, basta não tomar qualquer ação e esta "
 "ligação irá expirar dentro de 24 horas."
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Reactivate your Zulip organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "Reativar a sua organização Zulip"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr "Reativar a sua organização Zulip"
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr "Clique na ligação abaixo para reativar a sua organização."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3682,20 +3146,20 @@ msgstr ""
 "Você, ou alguém em seu nome, pediu uma ligação de início de sessão para "
 "gerir o plano Zulip para <b>%(remote_server_hostname)s</b>."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, fuzzy
 #| msgid "Click the link below to log in."
 msgid "Click the button below to log in."
 msgstr "Clique na ligação abaixo para iniciar sessão."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr "Esta ligação irá expirar dentro de %(validity_in_hours)s horas."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
@@ -3704,11 +3168,11 @@ msgstr ""
 "Questões? <a href=\"%(billing_help_link)s\">Saiba mais</a> ou "
 "contacte%(billing_contact_email)s."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr "Iniciar sessão na gestão de planos Zulip"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3717,12 +3181,12 @@ msgstr ""
 "Você, ou alguém em seu nome, pediu uma ligação de início de sessão para "
 "gerir o plano Zulip para %(remote_server_hostname)s."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr "Clique na ligação abaixo para iniciar sessão."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
@@ -3731,7 +3195,7 @@ msgstr ""
 "Questões? Saiba mais em%(billing_help_link)s ou "
 "contacte%(billing_contact_email)s."
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
@@ -3740,16 +3204,16 @@ msgstr ""
 "Clique no botão abaixo para confirmar o seu email e iniciar sessão na gestão "
 "de planos Zulip para <b>%(remote_realm_host)s</b>."
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr "Confirmar e iniciar sessão"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr "Confirmar email para gestão de plano Zulip"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
@@ -3758,7 +3222,7 @@ msgstr ""
 "Clique na ligação abaixo para confirmar o seu email e iniciar sessão na "
 "gestão de plano Zulip para %(remote_realm_host)s."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
@@ -3767,7 +3231,7 @@ msgstr ""
 "O seu pedido de patrocínio Zulip foi aprovado! A sua organização recebeu um "
 "upgrade para o <a href=\"%(plans_link)s\">plano comunitário Zulip</a>."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
@@ -3776,12 +3240,12 @@ msgstr ""
 "Se puder <a href=\"%(link_to_zulip)s\">listar o Zulip como patrocinador no "
 "seu site</a>, seria imensamente apreciado!"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr "Patrocínio de plano comunitário aprovado para %(billing_entity)s!"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
@@ -3789,7 +3253,7 @@ msgstr ""
 "O seu pedido para patrocínio Zulip foi aprovado! A sua organização recebeu "
 "um upgrade para o plano comunitário."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
@@ -3797,22 +3261,22 @@ msgstr ""
 "Se puder listar o Zulip como patrocinador no seu site, seria imensamente "
 "apreciado!"
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr "Encontrar contas"
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr "Encontrar as suas contas Zulip"
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 "Mensagens enviadas! Os endereços introduzidos na página anterior estão "
 "listados abaixo:"
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
@@ -3821,234 +3285,234 @@ msgstr ""
 "Se não receber um email, poderá <a href=\"%(current_url)s\">encontrar contas "
 "para outro endereço de email</a>."
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr "Endereço de email"
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "Encontrar contas"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr "Produto"
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr "Porquê o Zulip"
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr "Funcionalidades"
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr "Planos e preços"
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Zulip Cloud status"
 msgid "Zulip Cloud"
 msgstr "Estado da Cloud Zulip"
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr "Alojamento próprio"
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr "Segurança"
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "Integrações"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr "Aplicações de PC e móvel"
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr "Nova organização"
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr "Soluções"
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr "Empresa"
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr "Educação"
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr "Investigação"
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr "Eventos e conferências"
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr "Projetos open-source"
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr "Comunidades"
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr "Relatos de clientes"
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr "Comunidades abertas"
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr "Recursos"
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr "Primeiros passos"
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr "Centro de ajuda"
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr "Chat da comunidade"
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr "Estado da Cloud Zulip"
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr "Instalar um servidor Zulip"
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr "Atualizar um servidor Zulip"
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr "Contribuir"
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr "Guia de contribuição"
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr "Comunidade de Desenvolvimento"
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr "Tradução"
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr "GitHub"
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr "Sobre nós"
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr "Equipa"
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "Histórico"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr "Valores"
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr "Carreiras"
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr "Blog"
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr "Apoiar o Zulip"
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr "Mastodon"
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Values"
 msgid "Bluesky"
 msgstr "Valores"
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr "Termos de Serviço"
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr "Política de privacidade"
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr "Atribuições de site"
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr "Mais de %(integrations_count_display)s integrações nativas."
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 #, fuzzy
 #| msgid ""
 #| "And hundreds more through <a href=\"/integrations/doc/zapier\">Zapier</a> "
@@ -4060,51 +3524,47 @@ msgstr ""
 "E centenas mais através do <a href=\"/integrations/doc/zapier\">Zapier</a> e "
 "<a href=\"/integrations/doc/ifttt\">IFTTT</a>."
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr "Pesquisar integrações"
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr "Integrações personalizadas"
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr "Webhooks de entrada"
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr "Bots interativos"
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr "REST API"
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr "E-mail inválido"
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr "Email não permitido"
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr "O email que está a tentar utilizar para inscrever-se não é válido."
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4115,7 +3575,7 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>, não permite inscrições com "
 "endereços de email do seu domínio."
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4126,7 +3586,7 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>, não permite inscrições com "
 "endereços de email temporários."
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4137,24 +3597,24 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>, não permite inscrições com emails "
 "que contenham o símbolo \"+\"."
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr "Por favor utilize um endereço de email válido."
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr "Por favor utilize um endereço de email autorizado."
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr "Nenhuma organização encontrada"
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr "Não existe nenhuma organização Zulip em<b>%(current_url)s</b>."
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -4162,7 +3622,7 @@ msgid ""
 "%(support_email)s\">contact Zulip support</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -4170,67 +3630,67 @@ msgid ""
 "%(support_email)s\">contact this Zulip server's administrators</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
 "management for your Zulip server."
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr "Sessão inválida ou expirada"
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr "Sessão inválida ou expirada."
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr "Iniciar sessão no Zulip"
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 "Já está registado com este endereço de email. Por favor, inicie sessão "
 "abaixo."
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr "Email ou nome de utilizador"
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "Nome de utilizador"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr "Esqueceu-se da palavra-passe?"
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr "Iniciar sessão com %(identity_provider)s"
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr "Visualizar sem conta"
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 "Ainda não tem conta? Precisa de ser convidado para aderir a esta organização."
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr "Nenhuma licença disponível"
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr "A organização não pode aceitar novos membros neste momento"
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
@@ -4239,7 +3699,7 @@ msgstr ""
 "Novos membros não podem aderir a<a href=\"%(realm_url)s\">%(realm_name)s</a> "
 "pois todas as licenças Zulip Cloud estão em uso."
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
@@ -4247,19 +3707,19 @@ msgstr ""
 "Por favor contacte a pessoa que o/a convidou e peça que aumente o número de "
 "licenças, depois tente novamente."
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr "Saltar para o conteúdo principal"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr "Erro de autenticação de subdomínio"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr "Autenticação de subdomínio"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -4273,18 +3733,17 @@ msgstr ""
 "durante uma tentativa de início de sessão, será provavelmente um erro de "
 "servidor ou configuração."
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 #, fuzzy
 #| msgid "No organization found"
 msgid "Demo organizations disabled"
 msgstr "Nenhuma organização encontrada"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr "Atualização necessária"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
@@ -4292,7 +3751,7 @@ msgstr ""
 "Está utilizar uma versão desatualizada da aplicação Zulip de ambiente de "
 "trabalho que já não é suportada."
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
@@ -4300,22 +3759,21 @@ msgstr ""
 "A funcionalidade de atualização automática nesta aplicação de ambiente de "
 "trabalho já não funciona."
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr "Transferir última versão."
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 "Excedeu o limite da frequência com que um utilizador pode executar esta ação."
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr "Ligação de criação da organização obrigatória"
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -4327,12 +3785,11 @@ msgstr ""
 "en/stable/production/multiple-organizations.html\">documentação</a> sobre "
 "como criar uma nova organização para mais informações."
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr "Ligação de criação de organização expirado ou inválido"
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
@@ -4341,11 +3798,11 @@ msgstr ""
 "organização. Por favor <a href=\"/new/\">obtenha uma nova ligação</a> e "
 "tente novamente."
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr "Registo inesperado de servidor Zulip"
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -4357,17 +3814,16 @@ msgstr ""
 "%(support_email)s\">contacte o suporte Zulip </a> para assistência na "
 "resolução deste problema."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr "Navegador não suportado"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr "%(browser_name)s não é suportado pelo Zulip."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
@@ -4376,7 +3832,7 @@ msgstr ""
 "O Zulip suporta<a href=\"%(supported_browsers_page_link)s\">navegadores "
 "modernos</a> tais como o Firefox, Chrome, ou Edge."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
@@ -4384,25 +3840,24 @@ msgstr ""
 "Também pode utilizar a <a href=\"%(apps_page_link)s\">aplicação Zulip para "
 "PC</a>."
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr "Conta desativada"
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Invalid organization"
 msgid "Finalize organization import"
 msgstr "Organização inválida"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Organization moved"
 msgid "Organization import completed!"
 msgstr "Organização movida"
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -4410,56 +3865,55 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Select your account"
 msgstr "Crie a sua conta"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Create new account"
 msgstr "Crie a sua conta"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr "Organização reativada com sucesso"
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr "A sua organização foi reativada com sucesso."
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr "Ligação de reativação da organização expirado ou inválido"
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr "A ligação de reativação da organização expirou ou não é válida."
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr "Iniciar sessão na sua organização"
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr "Não sabe qual o URL da sua organização?"
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr "Encontre a sua organização."
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr "Próximo"
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4467,24 +3921,24 @@ msgid ""
 "have one yet."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 #, fuzzy
 #| msgid "Self-host Zulip"
 msgid "Self-hosting Zulip?"
 msgstr "Alojar o Zulip"
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">log in to manage plans and billing.</a>"
 msgstr ""
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr "Repor a sua palavra-passe"
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
@@ -4492,67 +3946,67 @@ msgstr ""
 "Esqueceu-se da palavra-passe? Sem problema, enviaremos uma ligação para "
 "reposição da sua palavra-passe para o email com o qual efetuou o registo."
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr "Enviar ligação de reposição"
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr "Definir nova palavra-passe"
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "Confirme a palavra-passe"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr ""
 "Pedimos desculpa, a ligação que forneceu não é válida ou já foi utilizada."
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr "Nova palavra-passe definida com sucesso"
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr "Definiu uma nova palavra-passe!"
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr ""
 "Por favor<a href=\"%(login_url)s\">inicie a sessão</a> com a sua nova "
 "palavra-passe."
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr "Mensagem de reposição de palavra-passe enviada com sucesso"
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr "Reposição de palavra-passe enviada!"
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr ""
 "Por favor verifique o seu email dentro de poucos minutos para finalizar o "
 "processo."
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 #, fuzzy
 #| msgid "Export still in progress"
 msgid "Import progress"
 msgstr "Exportação ainda em processamento"
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4560,7 +4014,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4569,60 +4023,60 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 #, fuzzy
 #| msgid ""
 #| "Nobody in this Zulip organization will be able to see this email address."
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr "Ninguém nesta organização Zulip poderá ver este endereço de email."
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4630,7 +4084,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4638,21 +4092,21 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr "Selecione uma conta para autenticação"
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr "<h1 class=\"get-started\">Selecione uma conta</h1>"
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 "A sua conta GitHub também tem endereços de email não verificados associados."
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
@@ -4661,15 +4115,15 @@ msgstr ""
 "href=\"https://github.com/settings/emails\">verificá-los no GitHub</a> "
 "primeiro."
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr "Erro ao cancelar subscrição"
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr "Pedido de cancelamento de subscrição desconhecido"
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
@@ -4677,7 +4131,7 @@ msgstr ""
 "Viva! Parece que tentou cancelar a subscrição a algo, mas não foi possível "
 "reconhecer o URL."
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4687,12 +4141,11 @@ msgstr ""
 "Por favor verifique o URL e tente novamente, ou<a href=\"mailto:"
 "%(support_email)s\">contacte-nos</a> e iremos resolver o seu problema!"
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr "Definições de e-mail atualizadas"
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
@@ -4701,7 +4154,7 @@ msgstr ""
 "Cancelou a subscrição de emails do Zulip  %(subscription_type)s para <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
@@ -4711,76 +4164,74 @@ msgstr ""
 "href=\"%(realm_url)s/#settings/notifications\">preferências de notificação</"
 "a>."
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr "Mapeamento de pedido inválido."
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr "Questões ou discussão acerca da utilização do Zulip."
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr "Experimente o Zulip aqui. :test_tube:"
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr "Para conversações em equipa"
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr "inscrições"
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr "{user} aderiu a esta organização."
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr "{user} aceitou o seu convite para se juntar ao Zulip!"
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 "Não é possível ativar conta de demonstração; por favor peça ao utilizador "
 "para se inscrever."
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 #, fuzzy
 #| msgid "Cannot deactivate the only {entity}."
 msgid "Cannot reactivate a deleted user"
 msgstr "Não pode desativar a única {entity}."
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr "Campo id {id} não encontrado."
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr "Nome pré-definido de grupo de canais inválido '{group_name}'"
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 "Nome pré-definido de grupo de canais demasiado longo (limite: {max_length} "
 "caracteres)"
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
@@ -4788,12 +4239,12 @@ msgstr ""
 "Nome pré-definido de grupo de canais '{group_name}' contém caracteres nulos "
 "NULL (0x00)."
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr "Nome pré-definido de grupo de canais inválido {group_name}"
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
@@ -4801,12 +4252,12 @@ msgstr ""
 "'{channel_name}' é o canal pré-definido e não pode ser adicionado a "
 "'{group_name}'"
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr "Grupo de canais pré-definido '{group_name}' já existe"
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
@@ -4815,7 +4266,7 @@ msgstr ""
 "O canal '{channel_name}' já está presente no grupo de canais pré-definido "
 "'{group_name}'"
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
@@ -4824,12 +4275,12 @@ msgstr ""
 "O canal '{channel_name}' não está presente no grupo de canais pré-definido "
 "'{group_name}'"
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr "Este grupo de canais pré-definido já é chamado'{group_name}'"
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
@@ -4837,7 +4288,7 @@ msgstr ""
 "Para proteger os utilizadores, o Zulip limita o número de convites que pode "
 "enviar num único dia. Por ter atingido o limite, nenhum convite foi enviado."
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
@@ -4846,79 +4297,79 @@ msgstr ""
 "organização. Peça a um administrador da organização, ou a um utilizador mais "
 "antigo."
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 "Não foi possível validar alguns endereços de email, por essa razão não foram "
 "enviados quaisquer convites."
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr "Não foi possível convidar ninguém."
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr "Nada a alterar"
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr "Mensagens privadas não podem ser movidas para canais."
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr "Mensagens privadas não podem ter tópicos."
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr "propagate_mode inválido sem edição de tópico"
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr ""
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 "Não é possível alterar o conteúdo da mensagem durante o processo de mudança "
 "de canal"
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr "Os widgets não podem ser editados."
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr "A sua organização desativou a edição de mensagens"
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr "Não tem permissão para editar esta mensagem"
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr "O tempo para edição desta mensagem foi ultrapassado"
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr "{user} marcou este tópico como resolvido."
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr "{user} marcou este tópico como não resolvido."
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr "Este tópico foi movido para {new_location} por {user}."
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr "A mensagem foi movida deste tópico para {new_location} por {user}."
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
@@ -4927,12 +4378,12 @@ msgstr ""
 "{changed_messages_count} mensagens foram movidas deste tópico para "
 "{new_location} por {user}."
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr "Este tópico foi movido para aqui de {old_location} por {user}."
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
@@ -4940,7 +4391,7 @@ msgstr ""
 "[A mensagem]({message_link}) foi movida para aqui de {old_location} por "
 "{user}."
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
@@ -4949,69 +4400,66 @@ msgstr ""
 "{changed_messages_count} mensagens foram movidas para aqui de {old_location} "
 "por {user}."
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 #, fuzzy
 #| msgid "You do not have permission to post in this channel."
 msgid "You don't have permission to resolve topics in this channel."
 msgstr "Não tem permissão para publicar neste canal."
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr "O tempo limite para edição do tópico desta mensagem foi ultrapassado."
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr "Não tem permissão para mover esta mensagem"
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr "O tempo limite para edição do canal desta mensagem foi ultrapassado"
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr "Sinalizador inválido: '{flag}'"
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr "Sinalizador não editável: '{flag}'"
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr "Operação de sinalização de mensagem inválida: '{operation}'"
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr "Mensagem(ns) inválida/s"
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr "Não foi possível visualizar a mensagem"
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr "Esperado apenas um canal"
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr "Tipo de dados para canal inválido"
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr "Tipo de dados para destinatários inválido"
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 "Lista de destinatários pode conter emails ou IDs de utilizador, mas nunca os "
 "dois."
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
@@ -5020,7 +4468,7 @@ msgstr ""
 "O seu bot {bot_identity} tentou enviar uma mensagem para o canal com ID "
 "{channel_id}, mas não foi encontrado nenhum canal com esse ID."
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -5031,7 +4479,7 @@ msgstr ""
 "{channel_name}, mas o canal não existe. Clique [aqui]({new_channel_link}) "
 "para o criar."
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
@@ -5040,30 +4488,30 @@ msgstr ""
 "O seu bot {bot_identity} tentou enviar uma mensagem para o canal "
 "{channel_name}. O canal existe mas não tem nenhum subscritor."
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr "Não tem permissão para aceder a alguns dos destinatários."
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr "Widgets: o programador API enviou conteúdo JSON inválido"
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr "Widgets: {error_msg}"
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, fuzzy, python-brace-format
 #| msgid "{user_name} created the following channels: {new_channels}."
 msgid "{user} has made the following changes to your account."
 msgstr "{user_name} criou os seguintes canais: {new_channels}."
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5071,27 +4519,25 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr "Um emoji personalizado com este nome já existe."
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr "Formato de imagem inválido"
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr "Uma lista ordenada não pode conter criadores de ligações em duplicado"
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 "Uma lista ordenada tem de enumerar todas os criadores de ligações exatamente "
 "uma vez"
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
@@ -5100,41 +4546,41 @@ msgstr ""
 "Necessita de efetuar um upgrade para o plano {required_upgrade_plan_name} "
 "para poder utilizar este método de autenticação."
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 "Método de autenticação inválido: {name}. O métodos válidos são: {methods}"
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 "O método de autenticação {name} não está disponível no seu plano atual."
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr ""
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr "Mensagem agendada já foi enviada"
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder could not be sent."
 msgstr "Código não existe"
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr "A mensagem não pôde ser enviada à hora agendada."
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
@@ -5143,40 +4589,40 @@ msgstr ""
 "A mensagem que agendou para entrega a {delivery_datetime} não foi enviada "
 "devido ao seguinte erro:"
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr "[Ver mensagens agendadas](#scheduled)"
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr "O canal já está desativado"
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, fuzzy, python-brace-format
 #| msgid "Channel {channel_name} un-archived."
 msgid "Channel #**{channel_name}** has been archived."
 msgstr "Canal {channel_name} retirado do arquivo."
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr "O canal não está desativado"
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr "Um canal chamado {channel_name} já existe"
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr ""
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, fuzzy, python-brace-format
 #| msgid "Channel {channel_name} un-archived."
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr "Canal {channel_name} retirado do arquivo."
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
@@ -5185,7 +4631,7 @@ msgstr ""
 "{user} alterou as [permissões de acesso]({help_link}) para este canal de "
 "**{old_policy}** de **{new_policy}**."
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -5194,42 +4640,40 @@ msgid ""
 "* **New**: {new_setting_description}\n"
 msgstr ""
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 "{user_name} alterou o nome do canal {old_channel_name} para "
 "{new_channel_name}."
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr "Sem descrição."
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr "{user} alterou a descrição deste canal."
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr "Descrição antiga"
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr "Nova descrição"
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr "Para sempre"
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr "{number_of_days} dias"
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
@@ -5238,11 +4682,11 @@ msgstr ""
 "A mensagens neste canal serão automaticamente apagadas {number_of_days} dias "
 "após o envio."
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr "As mensagens neste canal serão mantidas para sempre."
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -5259,99 +4703,89 @@ msgstr ""
 "\n"
 "{summary_line}"
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr "Não é possível anexar uma submensagem a esta mensagem."
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr "ID de utilizador inválido {user_id}"
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr "O grupo de utilizadores '{group_name}' já existe."
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr "Permissão insuficiente"
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr "Esta API não está disponível para webhook bots de entrada."
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr "A conta não está associada a este subdomínio"
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr "Este endpoint não aceita pedidos de bots."
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr "Tem de ser administrador do servidor"
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr "Este endpoint requer autenticação básica HTTP."
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr "Cabeçalho de autorização para autenticação básica inválido"
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr "Cabeçalho de autorização para autenticação básica em falta"
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr "Os webhook bots só podem aceder a webhooks"
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr ""
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
@@ -5360,53 +4794,52 @@ msgstr ""
 "A sua conta {username} foi desativada. Por favor contacte o administrador da "
 "sua organização para a reativar."
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr "A palavra-passe é demasiado fraca."
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr "O subdomínio necessita de ter 3 ou mais caracteres."
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr "O subdomínio não pode começar nem terminar com '-' traço."
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr "O subdomínio só pode conter letras minúsculas, números, e '-' traços."
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr "Subdomínio reservado. Por favor escolha outro."
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr "Por favor, utilize o seu endereço de e-mail real."
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr ""
 "A organização à qual está a tentar aderir com o email {email} não existe."
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr ""
 "Por favor peça um convite para {email} ao administrador da organização."
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
@@ -5415,12 +4848,12 @@ msgstr ""
 "O seu domínio de email, {email}, não se encontra autorizado nem faz parte "
 "dos domínios autorizados a registar contas nesta organização."
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr ""
 "Os endereços de email que contenham + não são permitidos nesta organização."
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
@@ -5430,34 +4863,33 @@ msgstr ""
 "Zulip estão em utilização. Por favor contacte o emissor do convite e peça "
 "para aumentar o número de licenças, depois tente novamente."
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 #, fuzzy
 #| msgid "Embedded bots are not enabled."
 msgid "Challenges are not enabled."
 msgstr "Os bots embebidos não estão ativos."
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "Nova palavra-passe"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr "Confirmação da nova palavra-passe"
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "You're making too many attempts to sign in. Try again in {seconds} "
@@ -5470,7 +4902,7 @@ msgstr ""
 "dentro de {seconds} segundos ou contacte o administrador da sua organização "
 "para obter ajuda."
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
@@ -5478,96 +4910,94 @@ msgstr ""
 "A sua palavra-passe foi desativada pois é demasiado fraca. Reponha a sua "
 "palavra.passe para criar uma nova."
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr "Código"
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 "Dica: Pode introduzir múltiplos endereços de email separados por vírgula "
 "entre cada um."
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr "Por favor introduza até uma máximo de 10 endereços de email."
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr "Não foi possível encontrar essa organização Zulip."
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr "Endereço de email inválido '{email}'"
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr "Tópico em falta"
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr "Não é possível enviar para múltiplos canais"
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr "Canal em falta"
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr "A mensagem tem de ter destinatários"
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr "Tipo de mensagem inválido"
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr "Anexo inválido"
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr ""
 "Ocorreu um erro ao eliminar o anexo. Por favor tente novamente mais tarde."
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr "A mensagem tem de ter destinatários!"
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Channel name can't be empty."
 msgid "Channel folder name can't be empty."
 msgstr "O nome do canal não pode estar em branco"
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid character in channel name, at position {position}."
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr "Caracter inválido no nome do canal, na posição {position}."
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Channel named {channel_name} already exists"
 msgid "Channel folder name already in use"
 msgstr "Um canal chamado {channel_name} já existe"
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Invalid channel ID"
 msgid "Invalid channel folder ID"
 msgstr "ID de canal inválido"
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 #, fuzzy
 #| msgid "Confirm your email address"
 msgid "Configure owner account email address."
 msgstr "Confirme o seu endereço de email"
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "\n"
@@ -5585,72 +5015,72 @@ msgstr ""
 "({demo_organization_help_url}) e\n"
 "será **eliminada automaticamente** ao fim de 30 dias.\n"
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a date"
 msgid "{var_name} is not Base64 encoded"
 msgstr "{var_name} não é uma data"
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 #, fuzzy
 #| msgid "Invalid emoji code."
 msgid "Invalid `device_id`"
 msgstr "Código de emoji inválido."
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr "Resumo de {service_name}"
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr "O domínio não pode estar em branco."
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr "O domínio tem de conter pelo menos um ponto (.)"
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr "O domínio é demasiado longo"
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr "O domínio não pode começar nem terminar com um ponto (.)"
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr "Não são permitidos pontos '.' consecutivos."
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr "Os subdomínios não podem começar nem terminar com '-' traço."
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr "O domínio só pode conter letras, números, '.' pontos e '-' traços."
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr "O carimbo temporal não pode ser negativo."
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr "O tópico não pode conter bytes nulos"
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr "Deve especificar exatamente 1 ID de canal para mensagens de canal"
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr "O utilizador desativou a sincronização de rascunhos."
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr "O rascunho não existe"
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5661,86 +5091,86 @@ msgstr ""
 "notificação de mensagem por email:\n"
 "{error_message}"
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr "Email sem assunto"
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr "Abrir o Zulip para ver o conteúdo escondido"
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr "Notificações de {service_name}"
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr "Endereço inválido."
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr "Fora do seu domínio."
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr "Endereços de email contendo + não são permitidos."
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr "Reservado para bots de sistema."
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr "O {email} já tem uma conta"
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr "Já tem uma conta."
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr "A conta foi desativada."
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr "O emoji '{emoji_name}' não existe"
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr "Emoji personalizado inválido."
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr "Nome de emoji personalizado inválido."
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr "Este emoji personalizado foi desativado."
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr "Código de emoji inválido."
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr "Nome de emoji inválido."
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr "Tipo emoji inválido."
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr "Tem de ser administrador da organização ou autor do emoji"
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr "Nomes dos emojis têm de terminar com uma letra ou dígito."
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
@@ -5748,121 +5178,120 @@ msgstr ""
 "Nomes de emoji só podem conter caracteres minúsculos ingleses, dígitos, "
 "espaços, traços, ou traços baixos."
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr "Nome de emoji em falta"
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr "Não é possível alocar à fila de evento"
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr ""
 "Não está autenticado: Autenticação na API ou sessão de utilizador obrigatória"
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, fuzzy, python-brace-format
 #| msgid "Channel named {channel_name} already exists"
 msgid "Channel '{channel_name}' already exists"
 msgstr "Um canal chamado {channel_name} já existe"
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr "O canal '{stream}' não existe"
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr "Canal com o ID '{stream_id}' não existe"
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr "Combinação de paramêtro não suportado: {parameters}"
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr "proprietário da organização"
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr "utilizador"
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr "Não pode desativar a única {entity}."
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr "Declaração de inclusão de Markdown inválida: {include_statement}"
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr "JSON incorreto"
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr "Tem de ser administrador da organização"
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr "Tem de ser proprietário da organização"
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Must be an organization owner"
 msgid "Must be a bot user"
 msgstr "Tem de ser proprietário da organização"
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr "O seu nome de utilizador ou palavra-passe está incorreto"
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr "Esta organização foi desativada"
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr ""
 "O registo do serviço de notificações push para o seu servidor foi desativado"
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr "Autenticação utilizando palavra-passe foi desativada nesta organização"
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr "A sua palavra-passe foi desativada e precisa de ser reposta"
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr "Chave API inválida"
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr "Chave API incorreta"
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
@@ -5871,57 +5300,56 @@ msgstr ""
 "O evento '{event_type}' não é suportado atualmente pelo {webhook_name} "
 "webhook; a ignorar"
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr "Não é possível processar o pedido:  {webhook_name} gerou este evento?"
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr "Utilizador não autenticado"
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr "Subdomínio inválido"
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 "Não tem permissão para iniciar conversas através de mensagens privadas."
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr "As mensagens privadas estão desativadas nesta organização."
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr "Esta conversa não inclui quaisquer utilizadores que a possa autorizar."
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr "Acesso negado"
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
@@ -5930,15 +5358,15 @@ msgstr ""
 "Só tem permissão para mover as  {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} mensagens mais recentes neste tópico."
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr "Reação já existe."
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr "Reação não existe."
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
@@ -5946,368 +5374,368 @@ msgstr ""
 "A sua organização está registada noutro servidor Zulip. Por favor contacte o "
 "suporte Zulip para assistência na resolução deste problema."
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr "Organização não registada"
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr "Não tem permissão para utilizar menções genéricas neste canal."
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 "Não tem permissão para utilizar menções genéricas de tópico neste tópico."
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, fuzzy, python-brace-format
 #| msgid "'old' value does not match the expected value."
 msgid "'{field_name}' value does not match the expected value."
 msgstr "valor anterior não corresponde ao valor esperado."
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr "'{setting_name}' deverá ser um grupo de utilizador de sistema."
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr ""
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr "O agendamento do envio deve ser no futuro."
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Server doesn't use the push notification service"
 msgid "Server is not configured to use push notification service."
 msgstr "O servidor não utiliza serviço de notificação push"
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Already has an account."
 msgid "Atlassian account ID"
 msgstr "Já tem uma conta."
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Behance username"
 msgstr "Nome ou nome de utilizador inválido"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Bitbucket username"
 msgstr "Nome de utilizador GitHub"
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Codeberg username"
 msgstr "Nome de utilizador X ou Twitter"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Dribbble username"
 msgstr "Nome de utilizador GitHub"
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Facebook username"
 msgstr "Nome ou nome de utilizador inválido"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr "Nome de utilizador GitHub"
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "GitLab username"
 msgstr "Nome de utilizador GitHub"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Instagram username"
 msgstr "Nome de utilizador X ou Twitter"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Mastodon"
 msgid "Mastodon profile"
 msgstr "Mastodon"
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Medium username"
 msgstr "Nome de utilizador GitHub"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Pinterest username"
 msgstr "Nome de utilizador X ou Twitter"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Reddit username"
 msgstr "Nome de utilizador GitHub"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Snapchat username"
 msgstr "Nome de utilizador GitHub"
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Threads username"
 msgstr "Nome de utilizador X ou Twitter"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "TikTok username"
 msgstr "Nome de utilizador X ou Twitter"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Twitch username"
 msgstr "Nome de utilizador X ou Twitter"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "Nome de utilizador"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr "Tipo de conta externa inválido"
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr "Frameworks de integração"
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 #, fuzzy
 #| msgid "Video call ended"
 msgid "Video calling"
 msgstr "A videochamada terminou"
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr "Integração contínua"
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr "Apoio ao cliente"
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr "Implementação"
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr "Entretenimento"
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr "Comunicação"
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr "Financeiro"
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr "Recursos humanos"
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr "Marketing"
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr "Diversos"
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr "Monitorização"
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr "Gestão de projeto"
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr "Produtividade"
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr "Controlo de versões"
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr "A mensagem não pode estar em branco"
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr "A mensagem não pode conter bytes nulos"
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 "Não tem autorização para mencionar grupo de utilizadores '{user_group_name}'."
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{fullname} moderation"
 msgstr "{full_name} mencionou-o/a:"
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr "Operador curto inválido: {desc}"
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr "Combinação de operadores curtos inválida: {desc}"
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr "Operadores 'com' duplicados."
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr "Operador 'com' inválido"
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr "Argumento 'ancora' em falta."
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 #, fuzzy
 #| msgid "Missing 'anchor' argument."
 msgid "Missing 'anchor_date' argument."
 msgstr "Argumento 'ancora' em falta."
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr "Âncora inválida"
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr "Operador {operator} não suportado."
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr "Operando {operand} não suportado."
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 #, fuzzy
 #| msgid "Confirmation link does not exist"
 msgid "Navigation view does not exist."
 msgstr "A ligação de confirmação não existe"
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6315,7 +5743,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6323,7 +5751,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6331,7 +5759,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6339,7 +5767,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "\n"
@@ -6358,7 +5786,7 @@ msgstr ""
 "({demo_organization_help_url}) e\n"
 "será **eliminada automaticamente** ao fim de 30 dias.\n"
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
@@ -6369,7 +5797,7 @@ msgstr ""
 "Poderá\n"
 "encontrá-las na sua [Caixa de entrada](/#inbox).\n"
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6377,7 +5805,7 @@ msgid ""
 "({navigation_tour_video_url}) for a quick app overview.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6392,7 +5820,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
@@ -6402,7 +5830,7 @@ msgstr ""
 "Pode [transferir](/apps/) as [aplicações de PC e móvel](/apps/).\n"
 "O Zulip também funciona bem no navegador.\n"
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -6414,7 +5842,7 @@ msgstr ""
 "perfil](/help/change-your-profile-picture)\n"
 "e atualize as suas [informações](/help/edit-your-profile).\n"
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -6432,7 +5860,7 @@ msgstr ""
 "o seu idioma](/help/change-your-language), ou personalizar a\n"
 "sua experiência Zulip nas suas [Preferências](#settings/preferences).\n"
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6449,7 +5877,7 @@ msgstr ""
 "\n"
 "[Explore e subscreva canais]({settings_link}).\n"
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -6477,7 +5905,7 @@ msgstr ""
 "Veja as [Conversas recentes](#recent) para obter uma lista de tópicos\n"
 "em discussão.\n"
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -6491,7 +5919,7 @@ msgstr ""
 "\n"
 "Pressione `?` a qualquer momento para obter [dicas](#keyboard-shortcuts).\n"
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -6511,7 +5939,7 @@ msgstr ""
 "escondidos, \n"
 "fusos horários, entre outros.\n"
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "\n"
@@ -6532,7 +5960,7 @@ msgstr ""
 "Veja o nosso [Guia de primeiros passos](/help/getting-started-with-zulip),\n"
 "ou navegue até ao [Centro de ajuda](/help/) para saber mais!\n"
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6543,7 +5971,7 @@ msgstr ""
 "Pode conversar comigo o quanto quiser! Para obter ajuda,\n"
 "tente uma das seguintes mensagens: {bot_commands}\n"
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6562,7 +5990,7 @@ msgstr ""
 "ou até mover o tópico [para outro canal]"
 "({move_content_another_channel_help_url}).\n"
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
@@ -6571,7 +5999,7 @@ msgstr ""
 ":point_right: Tente mover esta mensagem para outro tópico e de volta "
 "novamente.\n"
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6593,12 +6021,11 @@ msgstr ""
 "#**{zulip_discussion_channel_name}**, como pode verificar através da\n"
 "barra lateral esquerda e em cima.\n"
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr "bem-vindo/a ao Zulip!"
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -6610,7 +6037,7 @@ msgstr ""
 "contexto,\n"
 "independentemente de quantas conversas estejam em curso.\n"
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
@@ -6621,7 +6048,7 @@ msgstr ""
 "(/#inbox) para outras\n"
 "conversas com mensagens por ler.\n"
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -6629,7 +6056,7 @@ msgid ""
 "the `+` button next to its name.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -6637,7 +6064,7 @@ msgid ""
 "can we chat about…?”\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
@@ -6645,7 +6072,7 @@ msgstr ""
 "\n"
 ":point_right: Experimente começar uma nova conversa neste canal.\n"
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6656,7 +6083,7 @@ msgstr ""
 ":point_right:  Utilize este tópico para experimentar as [funcionalidades de "
 "conversação Zulip]({format_message_help_url}).\n"
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6691,7 +6118,7 @@ msgstr ""
 "\n"
 "```\n"
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
@@ -6701,7 +6128,7 @@ msgstr ""
 "Este tópico de **boas-vindas** é o sítio perfeito para dizer “olá” :wave: "
 "aos seus colegas.\n"
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
@@ -6711,117 +6138,117 @@ msgstr ""
 ":point_right: Clique nesta mensagem para começar uma nova mensagem nesta "
 "conversa.\n"
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr "a mover mensagens"
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr "experiências"
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr "iniciar uma conversa"
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr "saudações"
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr "JSON inválido na resposta"
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr "Formato de resposta inválido"
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr "Em branco ou código de comprimento inválido"
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr "Código APNS inválido"
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr "Opção GCM inválida para bouncer: prioridade {priority!r}"
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr "Opções GCM inválidas para bouncer: {options}"
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr "Código não existe"
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr "{full_name} mencionado/a @{user_group_name}:"
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr "{full_name} mencionou-o/a:"
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr "{full_name} mencionou todos:"
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "Nova mensagem"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr "Notificação de teste"
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr "Esta é uma notficação de teste de {realm_name} ({realm_url})."
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr "Dispositivo não reconhecido"
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr "Dispositivo não reconhecido pelo serviço de notificações"
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 #, fuzzy
 #| msgid "Server doesn't use the push notification service"
 msgid "Network error while connecting to Zulip push notification service."
 msgstr "O servidor não utiliza serviço de notificação push"
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 #, fuzzy
 #| msgid "Server doesn't use the push notification service"
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr "O servidor não utiliza serviço de notificação push"
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 #, fuzzy
 #| msgid "Invalid API key"
 msgid "Invalid `push_key`"
 msgstr "Chave API inválida"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
@@ -6829,743 +6256,725 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr "Tipo de dados para ID de canal inválido"
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr "O utilizador não tem autorização para esta consulta"
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr "'{email}' já não está a utilizar o Zulip."
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr "Não pode enviar mensagens privadas para fora da sua organização."
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "Channel name too long (limit: {max_length} characters)."
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr "O nome do canal é demasiado longo (limite: {max_length} caracteres)."
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder does not exist"
 msgstr "Código não existe"
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr "Erro de retorno de notificações push: {error}"
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr ""
 "Não é possível decidir entre o argumentos '{var_name1}' e '{var_name2}'"
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr "Argumento '{var_name}' em falta"
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr "Valor incorreto para '{var_name}': {bad_value}"
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr "A mensagem agendada não existe"
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr "Segurança de conta {service_name}"
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr "O canal pré-definido não pode ser privado."
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr "Os canais públicos web não estão ativados."
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr "Não tem permissão para publicar neste canal."
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr "Não autorizado para enviar para o canal '{channel_name}'"
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 #, fuzzy
 #| msgid "You do not have permission to post in this channel."
 msgid "You do not have permission to create new topics in this channel."
 msgstr "Não tem permissão para publicar neste canal."
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr "ID de canal inválido"
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr "Nome de canal inválido '{channel_name}'"
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr "O/os canal(ais) ({channel_names}) não existe/em"
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr "O canal de grupo pré-definido com o id '{group_id}' não existe."
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr "O nome do canal não pode estar em branco."
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr "O nome do canal é demasiado longo (limite: {max_length} caracteres)."
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr "Caracter inválido no nome do canal, na posição {position}."
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr "Caracter inválido no tópico, na posição {position}!"
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr "Dados de subscrição não estão disponíveis neste canal"
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr "Não foi possível obter os subscritores para o canal privado"
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr "Não foi possível descodificar a imagem; enviou um ficheiro de imagem?"
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr "O tamanho da imagem excede o limite."
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr "Imagem corrompida ou cortada"
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr "{var_name} não é booleano"
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} does not have a length"
 msgid "{var_name} does not have the expected format"
 msgstr "{var_name} não tem um comprimento"
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr "{var_name} não é uma data"
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr "{var_name} não é dicionário"
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr "{var_name} inválido"
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr "O argumento \"{argument}\" em {var_name} é inesperado"
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr "{var_name} não é ponto flutuante"
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr "{var_name} é demasiado pequeno"
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr "{var_name} não é um número inteiro"
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr "{var_name} não é JSON válido"
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr "{var_name} é demasiado grande"
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr "{var_name} não é uma lista"
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr "{var_name} é demasiado longo (limite: {max_length} caracteres)"
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr "{var_name} é demasiado curto."
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr "{var_name} não é texto"
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr "{var_name} tem formato inválido"
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr "{var_name} não tem o comprimento {length}"
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr "{var_name} é demasiado longo (limite: {max_length} caracteres)"
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr "{var_name} é demasiado longo (limite: {max_length} caracteres)"
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr "{var_name} não pode estar em branco"
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr "{var_name} inválido: {msg}"
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr "Campo {var_name} em falta: {msg}"
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr "Payload incorreto"
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr "Não está na lista de valores permitidos"
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr "Não é URL"
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr "{var_name} não é um código hex de cor válido"
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr "{setting_name} inválido"
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr "Carregamento iria exceder a quota de carregamentos da sua organização."
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr "Tamanho de imagem excede o limite"
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr ""
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr "Grupo de utilizadores inválido"
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid user group ID: {group_id}"
 msgid "Invalid user group ID: {user_group_id}"
 msgstr "ID de grupo de utilizadores inválido: {group_id}"
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr ""
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr "ID de grupo de utilizadores inválido: {group_id}"
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 "Definição '{setting_name}' não pode ser definida para grupo 'role:internet'."
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 "Definição '{setting_name}' não pode ser definida para o grupo 'role:nobody'."
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 "Definição '{setting_name}' não pode ser definida para o grupo 'role:"
 "everyone'."
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 "Definição '{setting_name}' não pode ser definida para o grupo '{group_name}'."
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr "O nome do grupo de utilizadores não estar em branco!"
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr ""
 "O nome do grupo de utilizadores não pode exceder os {max_length} caracteres."
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr "O nome do grupo de utilizadores não pode começar por '{prefix}'."
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr "Cliente não passou nenhum valor novo."
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 "Cliente tem de passar emoji_name se quiser passar emoji_code ou "
 "reaction_type."
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr "Nome demasiado longo!"
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 #, fuzzy
 #| msgid "Message must not be empty"
 msgid "Name must not be empty!"
 msgstr "A mensagem não pode estar em branco"
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr "Caracteres inválidos no nome!"
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr "Formato inválido!"
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr "São obrigatórios nomes únicos nesta organização."
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr ""
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr "Nome ou nome de utilizador inválido"
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr "Integração inválida '{integration_name}'."
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr "Parâmetros de configuração em falta: {keys}"
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr "Valor {value} chave {key} inválido ({error})"
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr "Dados de configuração inválidos!"
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr "Tipo de bot inválido"
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr "Tipo de interface inválido"
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr "ID de utilizador inválido: {user_id}"
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr "Nenhum bot"
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr "Nenhum utilizador"
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr "O utilizador está desativado"
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr "{item} não pode ser branco."
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr "{var_name} tem tamanho incorreto {length}; tem de ser {target_length}"
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a string"
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr "{var_name} não é texto"
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr "{container} deve ter exactamente {length} itens"
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr "Chave {key_name} está em falta em {var_name}"
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr "Argumentos inesperados: {keys}"
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr "{var_name} não é allowed_type"
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr "{variable} != {expected_value} ({value} está errado)"
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr "{var_name} não é um URL"
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr "Padrão de URL deve conter '%(username)s'."
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr "'{item}' não pode ser branco."
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr "Campo não deve ter escolhas duplicadas."
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr "'{value}' não é uma opção válida para '{field_name}'."
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr "{var_name} não é texto ou uma lista de números inteiros"
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr "{var_name} não é texto ou número"
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr "{var_name} não tem um comprimento"
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr "{var_name} em falta"
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr "Cabeçalho de evento HTTP em falta '{header}'"
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, fuzzy, python-brace-format
 #| msgid "Operator {operator} not supported."
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr "Operador {operator} não suportado."
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr "Deve haver uma barra no início do comando zcommand."
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr "Comando inexistente: {command}"
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr "Erro CSRF: {reason}"
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr "Configuração incorreta do proxy reverso: {proxy_reason}"
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr "IDs de utilizador inválido: {invalid_ids}"
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr "O utilizador com o ID {user_id} está desativado"
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr "O utilizador com o ID {user_id} é um bot"
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr "Data"
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr "Conta externa"
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr "Pronomes"
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr "Ninguém"
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr ""
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "Membros"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr "Qualquer pessoa na Internet"
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Invalid characters in emoji name"
 msgid "Invalid auto-conversion field: empty field name."
 msgstr "Caracteres inválidos no nome do emoji"
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid ""
@@ -7574,20 +6983,20 @@ msgstr ""
 "Grupo %(name)r no modelo de URL não está presente no padrão de criador de "
 "ligações."
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr "Expressão regular inválida: {regex}"
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr "Erro de expressão regular desconhecido"
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr "Modelo de URL inválido."
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid "Example input does not match the linkifier pattern."
@@ -7595,33 +7004,33 @@ msgstr ""
 "Grupo %(name)r no modelo de URL não está presente no padrão de criador de "
 "ligações."
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 "Grupo %(name)r no modelo de URL não está presente no padrão de criador de "
 "ligações."
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 "Grupo %(name)r no padrão de criador de ligações não está presente no modelo "
 "de URL."
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid ""
@@ -7631,7 +7040,7 @@ msgstr ""
 "Grupo %(name)r no modelo de URL não está presente no padrão de criador de "
 "ligações."
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgid ""
@@ -7641,334 +7050,331 @@ msgstr ""
 "Grupo %(name)r no padrão de criador de ligações não está presente no modelo "
 "de URL."
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr "Emoji unicode"
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "Emoji personalizado"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr "Emoji extra do Zulip"
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr "Caracteres inválidos no nome do emoji"
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr "Caracteres inválidos na linguagem pygments"
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr "Variável \"code\"  obrigatória no modelo de URL encontra-se em falta"
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr "\"code\"  deve ser a única variável no modelo de URL"
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr "sandbox"
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr "geral"
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr "eventos do canal"
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr "Atualizações do Zulip"
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr "Disponível na Cloud Zulip Standard. Faça upgrade para aceder."
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr "Disponível na Cloud Zulip Plus. Faça upgrade para aceder."
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr "Permitir GIFs classificados para audiências gerais (G)"
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr "Permitir GIFs classificados para guias parentais (PG)"
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 "Permitir GIFs classificados para guias parentais - abaixo dos 13 anos (PG-13)"
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr "Permitir GIFs classificados como restritos (R)"
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr "Web-pública"
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "Público"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr "Privado, histórico partilhado"
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr "Privado, histórico protegido"
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr "Administradores, moderadores, membros e visitantes"
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr "Administradores, moderadores e membros"
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr "Administradores e moderadores"
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr "Apenas administradores"
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr "Utilizador desconhecido"
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr "Proprietário da organização"
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr "Administrador da organização"
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr "Moderador"
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "Membro"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "Visitante"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr "Endereço de IP desconhecido"
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr "um sistema operativo desconhecido"
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr "Um navegador desconhecido"
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr "Argumento 'queue_id' em falta"
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr "Argumento 'last_event_id' em falta"
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr "Um evento mais recente {event_id} já foi removido!"
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr "O evento {event_id} não estava nesta fila"
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr "ID evento de fila inválido: {queue_id}"
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 #, fuzzy
 #| msgid "Failed to create Zoom call"
 msgid "Failed to generate challenge"
 msgstr "A criação de chamada Zoom falhou"
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr "A autenticação JWT não está ativada para esta organização"
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr "Não foi passado um token web JSON no pedido"
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr "Token web JSON inválido"
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr "Não foi especificado nenhum email na reivindicação de token web JSON"
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr "Subdomínio obrigatório"
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr "Palavra-passe incorreta."
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr "Cabeçalho User-Agent em falta no pedido"
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr "Etiqueta não pode estar em branco."
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr "O campo tem de ter pelo menos uma opção."
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr "Tipo de campo não suportado no resumo de perfil."
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 #, fuzzy
 #| msgid "Field type not supported for display in profile summary."
 msgid "Field type not supported for use for user matching."
 msgstr "Tipo de campo não suportado no resumo de perfil."
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr "Tipo de campo inválido."
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr "Só podem ser mostrados 2 campos personalizados no resumo do perfil."
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr "Já existe um campo com essa etiqueta."
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr "O campo pré-definido não pode ser atualizado."
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr "O endpoint não está disponível em produção."
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr "DevAuthBackend não está ativado."
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr "Parâmetro '{key}' inválido para pedido anónimo"
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr "Base de dados vazia"
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr "Não é possível consultar PostgreSQL"
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr "Não é possível conectar ao RabbitMQ"
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr "Não é possível consultar o RabbitMQ"
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr "Não é possível consultar o Redis"
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr "Não é possível escrever no MemCached"
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr "Não é possível consultar o MemCached"
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr "Nenhum convite"
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 #, fuzzy
 #| msgid "Invitation has already been revoked"
 msgid "Invitation already used or deactivated."
 msgstr "O convite já foi revogado"
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr "O convite já foi revogado"
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr "ID de canal inválido {channel_id}. Não foi enviado nenhum convite."
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr "Não tem permissão para subscrever outros utilizadores aos canais."
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr "Tem de especificar pelo menos um endereço de email."
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
@@ -7976,108 +7382,106 @@ msgstr ""
 "Alguns desses endereços já estão a usar o Zulip, por isso não lhes enviamos "
 "convite. Enviámos convites para os restantes!"
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr "Histórico da edição de mensagens foi desativado nesta organização"
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr "Não tem permissão para apagar esta mensagem"
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr "O tempo limite para eliminar esta mensagem já foi ultrapassado"
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr "Mensagem já foi apagada"
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr "Foram pedidas demasiadas mensagens (máximo {max_messages})."
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr "A âncora só pode ser excluída no fim da faixa"
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr "Nenhum tópico '{topic}'"
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Organization creation link required"
 msgid "An explanation is required."
 msgstr "Ligação de criação da organização obrigatória"
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Zephyr mirroring is not allowed in this organization"
 msgid "Message reporting is not enabled in this organization."
 msgstr "Espelhamento Zephyr não é permitido nesta organização"
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr "Destinatário em falta"
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr "Espelhamento não é permitido com IDs de utilizador dos destinatários"
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr "Mensagem espelhada inválida"
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr ""
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr ""
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr ""
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr "Não é possível silenciar o próprio"
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr "Utilizador já foi silenciado"
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr "Utilizador não está silenciado"
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 #, fuzzy
 #| msgid "{hostname} is not a valid hostname"
 msgid "Custom views must have a valid name."
 msgstr "{hostname} não é um hostname válido"
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 #, fuzzy
 #| msgid "Reaction already exists."
 msgid "Navigation view already exists."
 msgstr "Reação já existe."
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr "Passo de entrada desconhecido: {onboarding_step}"
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -8085,58 +7489,58 @@ msgid ""
 "later. Is this a good time?\n"
 msgstr ""
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr "Presença não é suportada por utilizadores bot."
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr "Sem dados de presença para {user_id_or_email}"
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr "Estado inválido: {status}"
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 #, fuzzy
 #| msgid "You do not have permission to post in this channel."
 msgid "You do not have permission to manage plans and billing."
 msgstr "Não tem permissão para publicar neste canal."
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr "O servidor não utiliza serviço de notificação push"
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr "Devolvido erro de retorno: {result}"
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr ""
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
@@ -8144,298 +7548,297 @@ msgstr ""
 "Pelo menos um dos seguintes argumentos tem de estar presente: emoji_name, "
 "emoji_code"
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr "Os recibos de leitura estão desativados nesta organização."
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr "Idioma inválido '{language}'"
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr "Tem de ter pelo menos um método de autenticação ativo."
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr "video_chat_provider inválido {video_chat_provider}"
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid giphy_rating {giphy_rating}"
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr "giphy_rating inválido {giphy_rating}"
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr "Deve ser uma organização de demonstração."
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr "Domínio inválido: {error}"
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr "O domínio {domain} já faz parte da sua organização."
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr "Não foi encontrado nenhum registo para o domínio {domain}."
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr "Tem de carregar exatamente um ficheiro."
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr "Só administradores podem substituir o emoji pré-definido."
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr "O ficheiro carregado é maior que o limite {max_size} de MiB"
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 #, fuzzy
 #| msgid "JWT authentication is not enabled for this organization"
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr "A autenticação JWT não está ativada para esta organização"
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr "Excedeu a frequência limite de pedidos."
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr "ID de exportação de dados inválido"
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr "Exportação já foi eliminada"
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr "A exportação falhou, não existe nada a apagar"
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr "Exportação ainda em processamento"
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr "Tem de carregar exatamente um ícone."
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr "Criador de ligações não foi encontrado."
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr "Tem de carregar exatamente um logótipo."
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid characters in pygments language"
 msgid "Invalid character in language: {character}"
 msgstr "Caracteres inválidos na linguagem pygments"
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid language '{language}'"
 msgid "Language '{language}' is not allowed."
 msgstr "Idioma inválido '{language}'"
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr "Playground inválido"
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "User not authenticated"
 msgid "Unauthenticated"
 msgstr "Utilizador não autenticado"
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "moving messages"
 msgid "Importing messages…"
 msgstr "a mover mensagens"
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "Your full name"
 msgid "Your name"
 msgstr "O seu nome completo"
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr "É obrigatório o destinatário ao atualizar o tipo de mensagem agendada."
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 "Tópico obrigatório ao atualizar o tipo de mensagem agendada para o canal."
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr "Formato de pedido inválido"
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr "DSN inválido"
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr "Canais privados não podem ser tornados pré-definidos."
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr "Tem de passar \"new_description\" ou \"new_group_name\"."
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr ""
 "Valor inválido para \"op\". Especificar um de \"adicionar\" ou \"remover\"."
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr "Parâmetros inválidos"
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr ""
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr "Já existe um canal com esse nome."
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr ""
 "Nada para fazer. Especifique pelo menos um entre \"adicionar\" ou \"apagar\"."
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, fuzzy, python-brace-format
 #| msgid "{user_full_name} subscribed you to the channel {channel_name}."
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr "{user_full_name} subscreveu em seu nome ao canal {channel_name}."
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr "{user_full_name} subscreveu em seu nome aos seguintes canais:"
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr "Não é possível aceder ao canal ({channel_name})."
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr "{user_name} criou os seguintes canais: {new_channels}."
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr "{user_name} criou um novo canal {new_channels}."
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr "novos canais"
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, fuzzy, python-brace-format
 #| msgid "**{policy}** channel created by {user_name}. **Description:**"
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr "**{policy}** canal criado por {user_name}. **Descrição:**"
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, fuzzy, python-brace-format
 #| msgid "**{policy}** channel created by {user_name}. **Description:**"
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr "**{policy}** canal criado por {user_name}. **Descrição:**"
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, fuzzy, python-brace-format
 #| msgid "**{policy}** channel created by {user_name}. **Description:**"
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr "**{policy}** canal criado por {user_name}. **Descrição:**"
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, fuzzy, python-brace-format
 #| msgid "**{policy}** channel created by {user_name}. **Description:**"
 msgid ""
@@ -8443,124 +7846,123 @@ msgid ""
 "**"
 msgstr "**{policy}** canal criado por {user_name}. **Descrição:**"
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr "{property} não é boleano"
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr "Propriedade de subscrição desconhecida: {property}"
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr "Não está subscrito/a ao canal ID {channel_id}"
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr "JSON inválido para submensagem"
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr ""
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 "O utilizador desativou as notificações de escrita para mensagens do canal"
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr "Argumento 'para' em falta"
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr "Lista 'para' em branco"
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr "Utilizador desativou notificações de escrita para mensagens privadas"
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr "<p>Este ficheiro não existe ou foi apagado.</p>"
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr "<p>Não está autorizado a ver este ficheiro.</p>"
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr "Código inválido"
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr "Nome de ficheiro inválido"
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr "Tem de especificar um ficheiro para carregar"
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr "Só pode carregar um ficheiro simultaneamente"
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr "Não foram fornecidas novas informações"
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 msgstr ""
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr "{user_full_name} adicionou-o/a ao grupo {group_name}."
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr "{user_full_name} removeu-o/a do grupo {group_name}."
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr "O utilizador {user_id} já é um membro deste grupo"
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr "Não existe nenhum membro '{user_id}' neste grupo de utilizadores"
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr "O grupo de utilizadores {group_id} já é um um subgrupo deste grupo."
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
@@ -8569,57 +7971,57 @@ msgstr ""
 "O grupo de utilizadores {user_group_id} já é um subgrupo de um dos subgrupos "
 "fornecidos."
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr "O grupo de utilizadores {group_id} não é um subgrupo deste grupo."
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr "A alteração de avatar está desativada nesta organização."
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr "A alteração do endereço de email está desativada nesta organização."
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr "default_language inválida"
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr "Som de notificação inválido '{notification_sound}'"
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr ""
 "Período de envio de mensagens de email em massa inválido: {seconds} segundos"
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr "A sua palavra-passe Zulip é gerida no LDAP"
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr "Palavra-passe incorreta!"
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, fuzzy, python-brace-format
 #| msgid "You're making too many attempts! Try again in {seconds} seconds."
 msgid "You're making too many attempts! Try again in {retry_after_string}."
@@ -8627,50 +8029,50 @@ msgstr ""
 "Está a efetuar demasiadas tentativas! Tente novamente dentro de {seconds} "
 "segundos."
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr "Nova palavra-passe demasiado fraca!"
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr "Tem de carregar exatamente um avatar."
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr "Tópico não está silenciado"
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr "Não pode desativar o único proprietário da organização"
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Nobody in this Zulip organization will be able to see this email address."
 msgid "User is not allowed to delete other user's messages."
 msgstr "Ninguém nesta organização Zulip poderá ver este endereço de email."
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 "A permissão de proprietário não pode ser removida do único proprietário da "
 "organização."
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr ""
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr ""
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
@@ -8682,27 +8084,27 @@ msgstr ""
 "Não poderá criar bots até FAKE_EMAIL_DOMAIN estar corretamente configurado.\n"
 "Por favor contacte o administrador do servidor."
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 #, fuzzy
 #| msgid "Channel named {channel_name} already exists"
 msgid "Email address already in use"
 msgstr "Um canal chamado {channel_name} já existe"
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr "A alteração de proprietário falhou, utilizador inexistente"
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr "A alteração de proprietário falhou, o utilizador está desativado"
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr ""
 "A alteração de proprietário falhou, os bots não podem ser proprietários de "
 "outros bots"
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
@@ -8710,140 +8112,140 @@ msgstr ""
 "Não poderá criar bots até FAKE_EMAIL_DOMAIN estar corretamente configurado.\n"
 "Por favor contacte o administrador do servidor."
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr "Os bots embebidos não estão ativos."
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr "Nome de bot embebido inválido."
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr "Utilizador não autorizado a criar utilizadores"
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr "Email '{email}' não é permitido nesta organização"
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr "Endereços de email descartáveis não são permitidos nesta organização"
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom access token"
 msgid "Invalid {provider_name} access token"
 msgstr "Código de acesso Zoom inválido"
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} call"
 msgstr "A criação de chamada Zoom falhou"
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Zoom credentials have not been configured"
 msgid "{provider_name} credentials have not been configured"
 msgstr "As credenciais do Zoom não foram configuradas"
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom credentials"
 msgid "Invalid {provider_name} credentials"
 msgstr "Credenciais Zoom inválidas"
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error connecting to the BigBlueButton server."
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr "Erro ao conectar ao servidor BigBlueButton."
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error authenticating to the BigBlueButton server."
 msgid "Error authenticating to the {provider_name} server"
 msgstr "Erro ao autenticar no servidor BigBlueButton."
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "BigBlueButton server returned an unexpected error."
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr "O servidor BigBlueButton devolveu um erro inesperado."
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom session identifier"
 msgid "Invalid {provider_name} session identifier"
 msgstr "Identificador de sessão Zoom inválido"
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr ""
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} public room."
 msgstr "A criação de chamada Zoom falhou"
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr "Assinatura inválida."
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{full_name}'s Zulip room"
 msgstr "{full_name} mencionou-o/a:"
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 "Projetos que utilizem este fornecedor de sistema de controlo de versões não "
 "são suportados"
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr "Payload inválido"
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr "Pedido webhook desconhecido"
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr "O tópico não pode ficar em branco"
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr "O conteúdo não pode estar em branco"
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr ""
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr "Introdução JSON mal formatada"
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr "Eventos chave encontram-se em falta no payload"
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr "Erro: Parâmetro channels_map_to_topics diferente de 0 ou 1"
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr "Ação webhook Wordpress desconhecida: {hook}"
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
@@ -8852,103 +8254,103 @@ msgstr ""
 "A sua exportação de dados foi concluída. [Ver e transferir exportação]"
 "({export_settings_link})."
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr ""
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr ""
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr ""
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr ""
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr "Subdomínio inválido para bouncer de notificações push"
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr "Tem de validar com uma chave API de servidor Zulip válida"
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr "UUID inválido"
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr "Tipo de código inválido"
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr "{hostname} não é um hostname válido"
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr ""
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr "{domain} é inválido por não contém nenhum registo dns tipo MX"
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr "{domain} não existe"
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
 "try again later or reach out to {support_email} for assistance."
 msgstr ""
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr ""
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr ""
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr "ios_app_id em falta"
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr "user_id ou user_uuid em falta"
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
@@ -8957,50 +8359,50 @@ msgstr ""
 "O seu plano não permite o envio de notificações push. A razão dada pelo "
 "servidor:  {reason}"
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr "O seu plano não permite o envio de notificações push."
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr "Propriedade inválida {property}"
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr "Tipo de evento inválido."
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr "Dados estão desordenados."
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr "Detetado registo duplicado."
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr "Dados de registo de auditoria mal formatados"
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr "É necessário repor a palavra-passe."
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr "Parâmetro id_token em falta"
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 #, fuzzy
 #| msgid "Missing id_token parameter"
 msgid "Missing idp param"
 msgstr "Parâmetro id_token em falta"
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr "OTP inválido"
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr "Não pode usar mobile_flow_otp e desktop_flow_otp em simultâneo."
 

--- a/locale/ro/LC_MESSAGES/django.po
+++ b/locale/ro/LC_MESSAGES/django.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 19:25+0000\n"
 "Last-Translator: Alex Vandiver <alexmv@zulip.com>\n"
 "Language-Team: Romanian <https://hosted.weblate.org/projects/zulip/django/ro/"
@@ -28,52 +28,52 @@ msgstr ""
 "20)) ? 1 : 2;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "Nu este permis pentru utilizatorii în vizită"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "Organizație nevalidă"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr ""
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr ""
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr "Mesaje directe"
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr "Mesaje directe de grup"
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr "Numele necunoscut al hărții: {chart_name}"
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr ""
 "Începutul este mai târziu decât sfârșitul. Început: {start}, Sfârșit: {end}"
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr ""
 "Nu există date analitice. Vă rugăm contactați administratorul serverului."
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -87,7 +87,7 @@ msgstr ""
 "({deactivate_user_help_page_link}) pentru a permite noilor utilizatori să se "
 "alăture."
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -99,7 +99,7 @@ msgstr ""
 "inactivi]({deactivate_user_help_page_link}) pentru a permite mai multor "
 "utilizatori să se alăture."
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -111,7 +111,7 @@ msgstr ""
 "inactivi]({deactivate_user_help_page_link}) pentru a permite mai mult de doi "
 "utilizatori să se alăture."
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -123,7 +123,7 @@ msgstr ""
 "inactivi]({deactivate_user_help_page_link}) pentru a permite mai mult de "
 "trei utilizatori să se alăture."
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -132,28 +132,27 @@ msgid ""
 "({billing_page_link}) is greater than the current number of users."
 msgstr ""
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr ""
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr "Înregistrarea este dezactivată"
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr "Server la distanță invalid."
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
@@ -162,7 +161,7 @@ msgstr ""
 "Trebuie să achiziționați licențe pentru toți utilizatorii activi din "
 "organizația dvs. (minim {min_licenses})."
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
@@ -172,44 +171,44 @@ msgstr ""
 "această pagină. Pentru a finaliza actualizarea, vă rugăm să contactați "
 "{email}."
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr "Nu există nicio metodă de plată în dosar."
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr "{brand} se termină în {last4}"
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr "Metodă de plată necunoscută. Vă rugam contactați-ne aici {email}."
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr "Ceva nu a mers bine. Vă rugam contactați {email}."
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "Ceva a funcționat greșit. Te rugam reîncărcă pagina."
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr ""
 "Ceva a funcționat greșit. Te rugam să aștepți câteva secunde apoi reîncearcă."
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 "Vă rugăm să adăugați un card de credit înainte de a începe testarea gratuită."
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr "Vă rugăm să adăugați un card de credit pentru a programa upgrade-ul."
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
@@ -217,18 +216,18 @@ msgstr ""
 "Nu se poate actualiza planul. Planul a fost expirat și înlocuit cu un nou "
 "plan."
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr "Nu se poate actualiza planul. Planul s-a încheiat."
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 "Nu se pot actualiza licențele în perioada de facturare curentă pentru planul "
 "de testare gratuită."
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
@@ -236,18 +235,18 @@ msgstr ""
 "Nu se pot actualiza manual licențele. Planul dvs. este de gestionare "
 "automată a licențelor."
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr ""
 "Planul dvs. este deja pe licențe {licenses} în perioada de facturare curentă."
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr "Nu puteți reduce licențele în perioada curentă de facturare."
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
@@ -255,7 +254,7 @@ msgstr ""
 "Nu se pot modifica licențele pentru următorul ciclu de facturare pentru un "
 "plan care este retrogradat."
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
@@ -264,34 +263,34 @@ msgstr ""
 "Planul dvs. este deja programat să fie reînnoit cu licențe "
 "{licenses_at_next_renewal}."
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
 "billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr "Nimic de schimbat."
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr "Niciun client pentru această organizație!"
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr "Sesiune nu a fost găsită"
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr "Intenția de plată nu a fost găsită"
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr ""
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -306,58 +305,56 @@ msgstr ""
 "Dacă ați putea {begin_link}să menționați Zulip ca sponsor pe site-ul dvs."
 "{end_link}, am aprecia foarte mult!"
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr "Tokenul de acces la facturare a expirat."
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr "Token de acces la facturare nevalabil."
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
 "{support_email}"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr "Trebuie să acceptați Termenii de utilizare pentru a continua."
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr "Înregistrarea serverului dvs. a fost dezactivată."
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "Eroare"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr "Pagina nu a fost găsită (404)"
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, fuzzy, python-format
 #| msgid ""
 #| "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd "
@@ -369,42 +366,41 @@ msgstr ""
 "Întrebări? <a href=\"mailto:%(support_email)s\">Contactați-ne</a> - ne-ar "
 "face plăcere să vă ajutăm!"
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr ""
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
 msgstr ""
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr ""
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
 msgstr ""
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr "Metoda nu este permisă (405)"
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr "Eroare internă a serverului"
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
 msgstr ""
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -412,13 +408,13 @@ msgid ""
 "a> with any questions."
 msgstr ""
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, fuzzy, python-format
 #| msgid ""
 #| "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd "
@@ -430,145 +426,143 @@ msgstr ""
 "Întrebări? <a href=\"mailto:%(support_email)s\">Contactați-ne</a> - ne-ar "
 "face plăcere să vă ajutăm!"
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
 "href=\"%(troubleshooting_url)s\">Zulip server troubleshooting guide</a>."
 msgstr ""
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr "Analize pentru %(target_name)s | Zulip"
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 "Analizele sunt disponibile în totalitate la 24 de ore de la crearea "
 "organizației."
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr "Analitice Zulip pentru %(target_name)s"
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr "Rezumatul organizației"
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr "Număr utilizatori"
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr "Utilizatori activi în ultimele 15 zile"
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr "Numărul de oaspeți"
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr "Numărul total de mesaje"
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr "Numărul de mesaje din ultimele 30 de zile"
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr "Stocarea fișierelor în uz"
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "Utilizatorii activi"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr "Active zilnice"
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr "Active în 15 zile"
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr "Toți utilizatorii"
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "Utilizatorii"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr "Mesaje trimise după tipul destinatarului"
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "Eu"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "Toți"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "Săptămâna trecută"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "Ultima lună"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "Ultimul an"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "Tot timpul"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr "Mesaje trimise în timp"
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "Zilnic"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "Săptămânal"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr "Cumulativ"
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "Oameni"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "Boți"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr "Mesaje citite de-a lungul timpului"
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr "Mesaje trimise de client"
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr "Ultima actualizare"
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
@@ -576,15 +570,15 @@ msgstr ""
 "O actualizare completă a tuturor graficelor are loc o dată pe zi. Graficul "
 "\"mesaje trimise în timp\" este actualizat o dată pe oră."
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr "Email schimbat"
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr "Email schimbat!"
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
@@ -593,49 +587,49 @@ msgstr ""
 "Acest lucru confirmă că adresa de e-mail pentru contul tău Zulip s-a "
 "schimbat de la %(old_email_html_tag)s la %(new_email_html_tag)s"
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr "Confirmarea adresei de e-mail"
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr "Link-ul de confirmare nu există"
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr "Ups. Nu am găsit în sistem link-ul de confirmare."
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr "Linkul de confirmare a expirat sau dezactivat"
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr "Ups. Linkul de confirmare a expirat sau a fost dezactivat."
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr ""
 "Vă rugăm să contactați administratorul organizației dvs. pentru un nou link."
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr "Link de confirmare malformat"
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr "Ups. Linkul de confirmare este deformat."
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
@@ -644,72 +638,55 @@ msgstr ""
 "încă mai întâmpinați această pagină, probabil că este vina noastră. Ne cerem "
 "scuze."
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr "Facturare"
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr "Închidere modal"
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr "Nu contează"
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr "Retrogradare"
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "Renunță"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr "Confirmă"
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr ""
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr "Starea facturării"
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -720,19 +697,19 @@ msgid ""
 "server."
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -740,736 +717,246 @@ msgid ""
 "%(support_email)s'>contact support</a> with any questions."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr "Limita ratei a fost depășită"
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr "Limita ratei a fost depășită."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, fuzzy, python-format
 #| msgid "You can try again in %(retry_after)s seconds."
 msgid "You can try again in %(retry_after_string)s."
 msgstr "Puteți încerca din nou în %(retry_after)s secunde."
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr "Actualizați"
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr ""
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr "Deschideți directorul comunităților"
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr "Filtrează pe categorie"
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "Toate"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr "Categorii"
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr ""
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr "Comunitatea de dezvoltare Zulip"
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr "Alăturați-vă ca utilizator"
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr "Alăturați-vă ca auto-găzduitor"
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr "Alăturați-vă ca colaborator"
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "Creează organizația"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr ""
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr "Auto-gazdă Zulip"
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr "Solicitați sponsorizare"
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr "Prețuri pentru educație"
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr "Vedeți prețurile"
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr "Zulip pentru afaceri"
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Zulip guide for open-source projects"
 msgid "Zulip for open source"
 msgstr "Ghidul Zulip pentru proiecte open-source"
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Create your Zulip organization"
 msgid "Screenshot of Zulip conversation"
 msgstr "Creați-vă organizația Zulip"
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Messages sent over time"
 msgid "Message with code"
 msgstr "Mesaje trimise în timp"
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr "Link"
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr "Contactează echipa de suport"
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr "Din"
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr "Organizație"
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr "Subiect"
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr "Mesaj"
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr "Trimite"
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr "Multumim pentru mesaj"
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr "Multumim pentru mesaj!"
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr "Vom fi în contact cu tine în curând."
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
@@ -1477,13 +964,13 @@ msgstr ""
 "Puteți găsi răspunsuri la întrebări frecvente în <a href=\"/help/\">Centrul "
 "de ajutor Zulip</a>."
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 #, fuzzy
 #| msgid "Getting started"
 msgid "Get started"
 msgstr "Noțiuni de bază"
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
@@ -1493,51 +980,50 @@ msgstr ""
 "<a href=\"https://zulip.com/policies/terms\">Termenii și condițiile Zulip</"
 "a>  pentru a continua."
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr "Sau, alternativ, foloseste unul din telefoanele tale de backup:"
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr "Ca ultimă soluție, puteți utiliza un token de backup:"
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr "Folosește token pentru backup"
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr "Acceptați Termenii și condițiile"
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr "Bine ați venit la Zulip"
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "E-mail"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr ""
 "Abonați-mă la buletinul informativ Zulip cu trafic redus (câteva e-mailuri "
 "pe an)."
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr "Continuă"
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr "Confirmați-vă adresa de e-mail"
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1548,7 +1034,7 @@ msgstr ""
 "class=\"user_email semi-bold\">%(email)s</span>) pentru un e-mail de "
 "confirmare din partea Zulip."
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
@@ -1556,30 +1042,30 @@ msgstr ""
 "Dacă nu vedeți un e-mail de confirmare în căsuța de primire sau în dosarul "
 "Spam, îl putem <a href=\"#\" id=\"resend_email_link\">retrimite</a>."
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr ""
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
@@ -1587,39 +1073,38 @@ msgstr ""
 "Dacă acest mesaj nu dispare, încercați să <a class=\"reload-"
 "lnk\">reîncărcați</a> pagina."
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 "Eroare la încărcarea Zulip. Încercați să <a class=\"reload-"
 "lnk\">reîncărcați</a> pagina."
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr ""
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr ""
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr ""
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr "Apelul video s-a încheiat"
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr "Acum puteți închide această fereastră."
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr "Eroare de configurare"
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
@@ -1628,7 +1113,7 @@ msgstr ""
 "utilizator organizație mai întâi. Vă rugăm să utilizați EmailAuthBackend "
 "pentru a crea organizația dvs. și apoi încercați din nou."
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1636,199 +1121,192 @@ msgid ""
 "href=\"%(doc_url)s\">documentation</a>."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr "Cont nu a fost găsit"
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr "Contul Zulip nu a fost găsit."
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, fuzzy, python-format
 #| msgid "Your account email: %(email)s"
 msgid "No account found for %(email)s."
 msgstr "Adresa de e-mail a contului dumneavoastră: %(email)s"
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr "Autentificare cu un alt cont"
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr "Continua la înregistrare"
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Must be a demo organization."
 msgid "Try Zulip in a demo organization"
 msgstr "Trebuie să fie o organizație demonstrativă."
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Try Zulip now"
 msgid "Try Zulip"
 msgstr "Încercați Zulip acum"
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "Creează o organizație nouă"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr "Creează o nouă organizație Zulip"
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr "Introdu adresa ta de e-mail"
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr "Adresa ta de email"
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr "Tipul organizației"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr "Limba de organizare"
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 #, fuzzy
 #| msgid "Private, shared history"
 msgid "Import chat history?"
 msgstr "Istorie privată, comună"
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr "Numele organizației"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "URL-ul organizatiei"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr "Folosește %(external_host)s"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "SAU"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "Înscriere"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "Inscrie-te pentru Zulip"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr "Ai nevoie de o invitație pentru a te alătura acestei organizații."
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr "Înregistrează-te cu %(identity_provider)s"
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr "Ai deja un cont?"
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "Autentificare"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr "Configurați confidențialitatea adresei de e-mail"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
@@ -1836,7 +1314,7 @@ msgstr ""
 "Zulip vă permite să controlați ce roluri din organizație vă pot vedea adresa "
 "de e-mail."
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
@@ -1844,11 +1322,11 @@ msgstr ""
 "Doriți să modificați setarea de confidențialitate pentru e-mailul dvs. de la "
 "configurația implicită pentru această organizație?"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr "Cine poate avea acces la adresa dvs. de e-mail"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1859,7 +1337,7 @@ msgstr ""
 "help/configure-email-visibility\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">după ce vă înscrieți</a>."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
@@ -1867,7 +1345,7 @@ msgstr ""
 "Administratorii acestei organizații Zulip vor putea vedea această adresă de "
 "e-mail."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
@@ -1875,14 +1353,14 @@ msgstr ""
 "Administratorii și moderatorii acestei organizații Zulip vor putea vedea "
 "această adresă de e-mail."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 "Nimeni din această organizație Zulip nu va putea vedea această adresă de e-"
 "mail."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
@@ -1890,81 +1368,80 @@ msgstr ""
 "Alți utilizatori din această organizație Zulip vor putea vedea această "
 "adresă de e-mail."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "Schimbă"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr "Înregistrare"
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr "Creați organizația dvs"
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr "Creeaza-ți contul"
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr ""
 "<p>Introduceți detaliile contului dvs. pentru a finaliza înregistrarea.</p>"
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr "Organizația ta"
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr "Contul tău"
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr "Nu importa setările"
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr "Importați setările din contul Zulip existent"
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "Nume"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "Parolă"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr "Introdu parola ta LDAP/Active Directory ."
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 "Acesta este folosit pentru aplicații de mobil sau alte unelte care necesită "
 "parola."
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr "Siguranța parolei"
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr "Ce te interesează?"
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
@@ -1973,22 +1450,22 @@ msgstr ""
 "Sunt de acord cu <a href=\"%(root_domain_url)s/policies/terms\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">Termenii de utilizare</a>."
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr "Organizație dezactivată"
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr ""
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -1996,7 +1473,7 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid ""
@@ -2004,41 +1481,41 @@ msgid ""
 "deleted."
 msgstr "Această organizație a fost dezactivată"
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
 "inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
 "administrators</a> to inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid "This organization has been deactivated."
 msgstr "Această organizație a fost dezactivată"
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
 "%(support_email)s\">contact Zulip support</a> to reactivate it."
 msgstr ""
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, fuzzy, python-format
 #| msgid ""
 #| "If you have any questions, please contact this Zulip server's "
@@ -2051,15 +1528,15 @@ msgstr ""
 "Dacă aveți întrebări, vă rugăm să contactați administratorii acestui server "
 "Zulip la %(support_email)s."
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr "Terminați conectarea la aplicația desktop"
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr "Finalizez autentificarea pe desktop"
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
@@ -2067,110 +1544,109 @@ msgstr ""
 "Folosiți browserul web pentru a vă autentifica, apoi reveniți aici pentru a "
 "introduce simbolul de autentificare."
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr "Lipește tokenul aici"
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr "Finalizează"
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr "Token incorect."
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr "Token acceptat.  Te loghez…"
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr "Conectați-vă la aplicația desktop"
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 "Copiază tokenul de autentificare și întoarce-te în aplicația Zulip să "
 "finalizezi autentificarea:"
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "Copiază"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr "Apoi poți închide această fereastră."
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr "Sau continuă în browserul tău."
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr "Utilizator anonim"
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr "Proprietari"
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "Administratori"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr "Moderatori"
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr "Utilizatorii vizitatori"
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "Utilizatori obișnuiți"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr "Redirecționarea e-mailurilor către un cont de e-mail"
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "Închide"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "Actualizează"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr "Zulip"
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr "Digera"
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
 "<b>%(realm_name)s</b>."
 msgstr "Felicitări, ați creat un nou Zulip organizație: <b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr "Bine ai venit pe Zulip!"
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr "Te-ai alăturat organizației Zulip <b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
@@ -2179,43 +1655,43 @@ msgstr ""
 "Veți utiliza următoarele informații pentru a vă conecta la aplicațiile web, "
 "<a href=\"%(apps_page_link)s\">mobilă și desktop</a> Zulip:"
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr "URL-ul organizației: %(organization_url)s"
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr "Numele tău de utilizator: %(ldap_username)s"
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr "Utilizați contul LDAP pentru a vă conecta"
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr "Adresa de e-mail a contului dumneavoastră: %(email)s"
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr "Mergeți la organizație"
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
 "href=\"%(getting_user_started_link)s\">getting started guide</a>!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2223,7 +1699,7 @@ msgid ""
 "Zulip</a>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
@@ -2232,28 +1708,28 @@ msgstr ""
 "Întrebări? <a href=\"mailto:%(support_email)s\">Contactați-ne</a> - ne-ar "
 "face plăcere să vă ajutăm!"
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr "%(realm_name)s pe Zulip: Noile detalii ale organizației tale"
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr "%(realm_name)s pe Zulip: Detaliile noului tău cont"
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr "Felicitări, ați creat o nouă organizație Zulip: %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr "Te-ai înscris în organizația Zulip %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
@@ -2262,33 +1738,33 @@ msgstr ""
 "Veți utiliza următoarele informații pentru a vă conecta la aplicațiile web, "
 "mobilă și desktop ale Zulip (%(apps_page_link)s):"
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
 "(%(getting_user_started_link)s)!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
 "(%(getting_organization_started_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 "Întrebări? Contactați-ne la %(support_email)s - ne-ar face plăcere să vă "
 "ajutăm!"
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2297,17 +1773,17 @@ msgstr ""
 "Dacă aveți întrebări, vă rugăm să contactați administratorii acestui server "
 "Zulip la %(support_email)s."
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr "Bună,"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2315,12 +1791,12 @@ msgid ""
 "password for this account, please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr "Confirmați și setați parola"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2329,14 +1805,14 @@ msgstr ""
 "Dacă nu ați solicitat această modificare, vă rugăm să ne contactați imediat "
 "la %(support_email)s."
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 #, fuzzy
 #| msgid "Verify your new email address for your demo Zulip organization"
 msgid "Verify your email address for your Zulip demo organization"
 msgstr "Verifică noua ta adresă de e-mail pentru organizația Zulip demo"
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2345,8 +1821,8 @@ msgstr ""
 "Dacă nu ai solicitat tu această modificare, te rog contactează-ne imediat la "
 "<%(support_email)s>."
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2354,33 +1830,33 @@ msgid ""
 "please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr "Confirmă schimbarea de email"
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr "Verifică noua ta adresă de e-mail pentru %(organization_host)s"
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr "Ați solicitat o nouă organizație Zulip:"
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr "Tipul de organizație: %(organization_type)s"
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr "Recent te-ai înscris pe Zulip. Fantastic!"
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
@@ -2388,33 +1864,33 @@ msgstr ""
 "Faceți clic pe butonul de mai jos pentru a crea organizația și a vă "
 "înregistra contul. Veți putea actualiza informațiile de mai sus, dacă doriți."
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr "Apasă butonul de mai jos pentru a termina înregistrarea."
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr "Finalizează înregistrarea"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr "Creați-vă organizația Zulip"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr "Activează-ți contul Zulip"
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr "Apasă pe linkul de mai jos pentru a finaliza înregistrarea."
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
@@ -2423,48 +1899,48 @@ msgstr ""
 "Aveți întrebări sau feedback de împărtășit? Contactați-ne la "
 "%(support_email)s - ne-ar face plăcere să vă ajutăm!"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr "Administrează preferințe emailurilor"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr "Dezabonarea de la e-mailurile de marketing"
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
 "deactivated, and you will no longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr "Administratorii au oferit următorul comentariu:"
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr "Notificarea dezactivării contului pe %(realm_name)s"
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr ""
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2472,22 +1948,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because your organization has "
@@ -2504,8 +1980,8 @@ msgstr ""
 "href=\"%(help_url)s\">afișarea conținutului mesajelor în notificările prin "
 "email</a>."
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because you have disabled <a "
@@ -2520,40 +1996,40 @@ msgstr ""
 "class=\"content_disabled_help_link\" href=\"%(alert_notif_url)s\">afișarea "
 "conținutului mesajelor în notificările prin email</a>."
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, fuzzy, python-format
 #| msgid "Click here to log in to Zulip and catch up."
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr "Apasă aici pentru autentificare în Zulip și vezi ultimele discuții."
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr "Dezabonarea de la e-mailurile de sinteză"
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr "Rezumat Zulip pentru %(realm_name)s"
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2570,8 +2046,8 @@ msgstr ""
 "dezactivat  afișarea conținutului mesajelor în notificările prin email.\n"
 "Vezi %(hide_content_url)s pentru mai multe detalii.\n"
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2587,7 +2063,7 @@ msgstr ""
 "conținutului mesajelor în notificările prin email.\n"
 "Vezi %(alert_notif_url)s pentru mai multe detalii.\n"
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, fuzzy, python-format
 #| msgid "Click here to log in to Zulip and catch up: %(organization_url)s."
 msgid "Log in to Zulip to catch up: %(organization_url)s."
@@ -2595,35 +2071,32 @@ msgstr ""
 "Faceți clic aici pentru a vă conecta la Zulip și a vă pune la curent: "
 "%(organization_url)s."
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr "Administrează preferințele emailului:"
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr "Dezabonează de la emailurile cu rezumate:"
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr "Pește care înoată"
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr "Vă mulțumim pentru cererea dumneavoastră!"
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
 "organizations:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
@@ -2632,33 +2105,29 @@ msgstr ""
 "Adresa dvs. de e-mail %(email)s are conturi la următoarele organizații Zulip "
 "găzduite de %(external_host)s:"
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
 "href=\"%(help_reset_password_link)s\">reset your password</a>."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
 "%(external_host)s."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2666,38 +2135,35 @@ msgid ""
 "to find your account."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr "Conturile tale Zulip"
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
 "try another way to find your account (%(help_logging_in_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr "Salut,"
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
@@ -2706,18 +2172,18 @@ msgstr ""
 "%(referrer_name)s dorește să li te alături pe Zulip - instrumentul de "
 "comunicare în echipă conceput pentru productivitate."
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr "Pentru a începe, apasă butonul de mai jos."
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 "%(referrer_full_name)s v-a invitat să vă alăturați %(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
@@ -2727,17 +2193,17 @@ msgstr ""
 "Zulip -- platforma de comunicare între echipe concepută pentru "
 "productivitate."
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr "Pentru a începe, apasă pe link-ul de mai jos."
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr "Salut,"
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
@@ -2747,13 +2213,13 @@ msgstr ""
 "dorește să vă alăturați lor pe Zulip - instrumentul de comunicare în echipă "
 "conceput pentru productivitate."
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr "Acesta este ultimul reminder pentru această invitație."
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
@@ -2762,12 +2228,12 @@ msgstr ""
 "Această invitație expira în doua zile. Dacă va expira, vei fi nevoit să mai "
 "ceri încă una lui  %(referrer_name)s."
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr "Reamintesc: Alătură-te %(referrer_name)s la %(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2778,7 +2244,7 @@ msgstr ""
 "dorește să vă alăturați lor pe Zulip -- platforma de comunicare între echipe "
 "concepută pentru productivitate."
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2787,7 +2253,7 @@ msgstr ""
 "Dacă aveți întrebări, vă rugăm să contactați administratorii acestui server "
 "Zulip la adresa <a href=\"mailto:%(email)s\">%(email)s</a>."
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
@@ -2796,31 +2262,29 @@ msgstr ""
 "Aveți întrebări sau feedback de împărtășit? <a href=\"mailto:"
 "%(email)s\">Contactați-ne</a> - ne-ar face plăcere să vă ajutăm!"
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr "Primiți acest lucru pentru că ați fost menționat personal."
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr ""
 "Primiți acest lucru deoarece @%(mentioned_user_group_name)s a fost menționat."
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
 "#%(channel_name)s > %(topic_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
@@ -2828,15 +2292,15 @@ msgstr ""
 "Primiți acest mesaj pentru că aveți activate notificările de mențiuni "
 "wildcard pentru subiectele pe care le urmăriți."
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
@@ -2844,15 +2308,15 @@ msgstr ""
 "Primiți acest mesaj pentru că aveți activate notificările prin e-mail pentru "
 "subiectele pe care le urmăriți."
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2863,7 +2327,7 @@ msgstr ""
 "în %(realm_name)s Zulip</a> sau <a href=\"%(notif_url)s\">gestionați "
 "preferințele de e-mail</a>."
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
@@ -2873,7 +2337,7 @@ msgstr ""
 "Zulip</a>, sau <a href=\"%(notif_url)s\">de a gestiona preferințele de e-"
 "mail</a>."
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
@@ -2882,7 +2346,7 @@ msgstr ""
 "<a href=\"%(narrow_url)s\">Răspuns în %(realm_name)s Zulip</a>, sau <a "
 "href=\"%(notif_url)s\">de a gestiona preferințele de e-mail</a>."
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
@@ -2891,42 +2355,42 @@ msgstr ""
 "Nu răspunde acestui email. Acest server Zulip nu este configurat să "
 "primească emailuri  (<a href=\"%(url)s\">ajutor</a>)."
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr "Grupați DM cu %(direct_message_group_display_name)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr "DM-uri cu %(sender_str)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr "Mesaje noi"
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 "Răspundeți direct la acest e-mail sau vizualizați-l în %(realm_name)s Zulip:"
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr "Vizualizați sau răspundeți în %(realm_name)s Zulip:"
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr "Răspundeți în %(realm_name)s Zulip:"
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
@@ -2934,7 +2398,7 @@ msgstr ""
 "Nu răspunde acestui email. Acest server Zulip nu este configurat să "
 "primeasca emailuri. Ajutor:"
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2945,22 +2409,22 @@ msgstr ""
 "%(new_email)s. Dacă nu ați solicitat această modificare, vă rugăm să ne "
 "contactați imediat la %(support_email)s."
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr "Cel mai bun,"
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr "Echipa Zulip"
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr "Emailul Zulip schimbat pentru %(realm_name)s"
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2971,53 +2435,53 @@ msgstr ""
 "Daca nu ai făcut tu modificarea, te rog să ne contactezi imediat la "
 "<%(support_email)s>."
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 msgstr ""
 "Organizația: %(organization_url)s Ora: %(login_time)s Email: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr "Am observat o autentificare recentă pentru următorul cont Zulip."
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr "Organizație: %(organization_link)s"
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr "Email: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr "Ora: %(login_time)s"
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr "Dispozitiv: %(device_browser)s pe %(device_os)s."
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr "Adresa IP: %(device_ip)s"
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr "Dacă ai fost tu, grozav! Nu mai trebuie să faceți nimic altceva."
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3028,31 +2492,31 @@ msgstr ""
 "fost compromis, vă rugăm să <a href=\"%(reset_link)s\">vă resetați parola</"
 "a> sau să ne contactați imediat la %(support_email)s."
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr "Multumim,"
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr "Securitate Zulip"
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr "Dezactivează notifcările la autentificare"
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr "Autentificare nouă din %(device_browser)s pe %(device_os)s"
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr "Organizația: %(organization_url)s"
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3063,7 +2527,7 @@ msgstr ""
 "fost compromis, vă rugăm să vă resetați parola la %(reset_link)s sau să ne "
 "contactați imediat la %(support_email)s."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -3071,7 +2535,7 @@ msgid ""
 "Zulip</a> to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
@@ -3079,7 +2543,7 @@ msgstr ""
 "Altfel, iată câteva sfaturi pe care le auzim adesea de la clienți pentru "
 "evaluarea <i>oricărui</i> produs de chat în echipă:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
@@ -3089,13 +2553,13 @@ msgstr ""
 "exploreze împreună cu dumneavoastră și să vă împărtășească perspectivele lor "
 "unice."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr ""
 "Folosiți aplicația în sine pentru a discuta despre impresiile dumneavoastră."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -3107,7 +2571,7 @@ msgstr ""
 "singurul mod de a experimenta cu adevărat modul în care o nouă aplicație de "
 "chat va ajuta echipa dumneavoastră să comunice."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -3118,27 +2582,27 @@ msgstr ""
 "href=\"%(why_zulip)s\">comunicare eficientă</a> și sperăm că aceste sfaturi "
 "vor ajuta echipa dumneavoastră să îl experimenteze în acțiune."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr "Dezabonați-vă de la e-mailurile de bun venit pentru %(realm_name)s"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr "Alegerea aplicației de chat pentru echipa ta"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
@@ -3146,7 +2610,7 @@ msgstr ""
 "Altfel, iată câteva sfaturi pe care le auzim adesea de la clienți pentru "
 "evaluarea oricărui produs de chat în echipă:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
@@ -3154,7 +2618,7 @@ msgstr ""
 "Invitați-vă colegii de echipă să exploreze împreună cu dumneavoastră și să "
 "vă împărtășească perspectivele lor unice."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
@@ -3165,7 +2629,7 @@ msgstr ""
 "modul în care o nouă aplicație de chat va ajuta echipa dumneavoastră să "
 "comunice."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
@@ -3173,8 +2637,8 @@ msgstr ""
 "Zulip a fost conceput pentru a permite o comunicare eficientă și sperăm că "
 "aceste sfaturi vor ajuta echipa dumneavoastră să îl experimenteze în acțiune."
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
@@ -3185,71 +2649,71 @@ msgstr ""
 "Consultați acest ghid al caracteristicilor cheie ale Zulip pentru "
 "organizații ca a dumneavoastră!"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr "Vezi ghidul Zulip pentru întreprinderi"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr "Vezi ghidul Zulip pentru proiecte open-source"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr "Vezi ghidul Zulip pentru educație"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr "Vezi ghidul Zulip pentru cercetare"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr "Vezi ghidul Zulip pentru evenimente și conferințe"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr "Vezi ghidul Zulip pentru organizațiile non-profit"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr "Vezi ghidul Zulip pentru comunități"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr "Ghidul Zulip pentru întreprinderi"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr "Ghidul Zulip pentru proiecte open-source"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr "Ghidul Zulip pentru educație"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr "Ghidul Zulip pentru cercetare"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr "Ghidul Zulip pentru evenimente și conferințe"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr "Ghidul Zulip pentru organizațiile non-profit"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr "Ghidul Zulip pentru comunități"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
@@ -3257,14 +2721,14 @@ msgstr ""
 "Iată câteva sfaturi pentru a vă păstra conversațiile Zulip organizate pe "
 "subiecte."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
@@ -3273,12 +2737,12 @@ msgstr ""
 "vedea fiecare mesaj în context, indiferent de câte discuții diferite sunt în "
 "desfășurare."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3286,11 +2750,11 @@ msgid ""
 "about…?”"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr "Exemple de subiecte scurte"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3299,23 +2763,23 @@ msgid ""
 "href=\"%(move_channels_link)s\">move a topic to a different channel</a>."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr "Mergi la Zulip"
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr "Păstrați-vă conversațiile organizate cu subiecte"
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3324,23 +2788,23 @@ msgid ""
 "(%(move_channels_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
 "%(email)s on %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr "Apasă butonul de mai jos pentru a reseta parola ta."
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr "Resetează parola"
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3351,18 +2815,18 @@ msgstr ""
 "dezactivat. Puteți contacta un administrator al organizației pentru a <a "
 "href=\"%(help_link)s\">vă reactiva contul</a>."
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr "Nu ai un cont în acea organizație Zulip."
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr "Ai conturi active în următoarea organizație(i)."
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
@@ -3370,30 +2834,30 @@ msgstr ""
 "Puteți încerca să vă autentificați sau să vă resetați parola în organizația "
 "(organizațiile) de mai sus."
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 "Dacă nu recunoști această activitate, poți ignora liniștit acest email."
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr "Solicitare de resetare a parolei pentru %(realm_name)s"
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr "Apasă pe linkul de mai jos pentru a reseta parola."
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
 "You can contact an organization administrator to reactivate your account."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3404,7 +2868,7 @@ msgstr ""
 "Zulip Cloud Plan gratuit din cauza facturilor neplătite. Facturile "
 "neachitate au fost anulate."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
@@ -3413,7 +2877,7 @@ msgstr ""
 "Pentru a continua cu planul Zulip Cloud Standard, faceți upgrade din nou "
 "accesând %(upgrade_url)s."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
@@ -3422,8 +2886,8 @@ msgstr ""
 "Dacă credeți că aceasta a fost o greșeală sau aveți nevoie de mai multe "
 "detalii, vă rugăm să ne contactați la %(support_email)s."
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid "You've joined the Zulip organization %(realm_name)s."
 msgid ""
@@ -3431,104 +2895,104 @@ msgid ""
 "%(localized_date)s."
 msgstr "Te-ai înscris în organizația Zulip %(realm_name)s."
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr "Dragă fost administrator al%(realm_name)s,"
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip demo organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr "Apasă pe butonul de mai jos să reactivezi organizația ta."
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr "Reactivează organizația"
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
@@ -3536,94 +3000,94 @@ msgstr ""
 "Dacă solicitarea a fost eronat făcută, poți să nu faci nimic și acest link "
 "va expira in 24 de ore."
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Reactivate your Zulip organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "Reactivează-ți organizația ta Zulip"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr "Reactivează-ți organizația ta Zulip"
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr "Apasă linkul de mai jos pentru a reactiva organizația ta."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for <b>%(remote_server_hostname)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, fuzzy
 #| msgid "Click the button below to complete registration."
 msgid "Click the button below to log in."
 msgstr "Apasă butonul de mai jos pentru a termina înregistrarea."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for %(remote_server_hostname)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
 "management for <b>%(remote_realm_host)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
 "management for %(remote_realm_host)s."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
@@ -3632,7 +3096,7 @@ msgstr ""
 "Cererea dumneavoastră de sponsorizare Zulip a fost aprobată! Organizația "
 "dvs. a fost trecută la <a href=\"%(plans_link)s\">planul Zulip Community</a>."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
@@ -3641,13 +3105,13 @@ msgstr ""
 "Dacă ați putea <a href=\"%(link_to_zulip)s\">lista Zulip ca sponsor pe site-"
 "ul dvs.</a>, am aprecia foarte mult!"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr ""
 "Sponsorizarea planului comunitar a fost aprobată pentru %(billing_entity)s!"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
@@ -3655,260 +3119,260 @@ msgstr ""
 "Cererea dumneavoastră de sponsorizare Zulip a fost aprobată! Organizația "
 "dvs. a fost trecută la planul Zulip Community."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
 msgstr ""
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr "Găsește-ți conturile"
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr "Gasește-ți conturile Zulip"
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
 "accounts for another email address</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr "Adresa de email"
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "Găsește conturi"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr "Produs"
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr "De ce Zulip"
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr "Caracteristici"
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr "Planuri și prețuri"
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Zulip Cloud status"
 msgid "Zulip Cloud"
 msgstr "Starea Zulip Cloud"
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr "Găzduire-personală"
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr "Securitate"
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "Integrări"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr "Aplicații desktop și mobile"
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr "Organizație nouă"
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr "Soluții"
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr "Afacere"
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr "Educație"
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr "Cercetare"
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr "Evenimente și conferințe"
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr "Proiecte open source"
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr "Comunitățile"
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr "Poveștile clienților"
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr "Deschideți directorul comunităților"
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr "Resurse"
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr "Noțiuni de bază"
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr "Centru de ajutor"
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr "Chat comunitate"
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr "Starea Zulip Cloud"
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr "Instalarea unui server Zulip"
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr "Actualizarea unui server Zulip"
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr "Contribuții"
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr "Ghid de contribuție"
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr "Comunitatea de dezvoltare"
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr "Traducere"
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr "GitHub"
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr "Despre noi"
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr "Echipa"
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "Istorie"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr "Valori"
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr "Locuri de munca"
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr "Blog"
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr "Sprijină Zulip"
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr "Mastodont"
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Values"
 msgid "Bluesky"
 msgstr "Valori"
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr "Termenii serviciului"
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr "Politică de confidențialitate"
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr "Website atribuiri"
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr "Peste %(integrations_count_display)s integrări native."
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 #, fuzzy
 #| msgid ""
 #| "And hundreds more through <a href=\"/integrations/doc/zapier\">Zapier</a> "
@@ -3920,51 +3384,47 @@ msgstr ""
 "Și alte sute prin <a href=\"/integrations/doc/zapier\">Zapier</a> și <a "
 "href=\"/integrations/doc/ifttt\">IFTTT</a>."
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr "Integrări de căutare"
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr "Integrări personaliate"
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr "Webhooks de intrare"
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr "Boți interactivi"
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr "REST API"
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr "Email nevalid"
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr "Email interzis"
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr "Adresa de e-mail cu care încercați să vă înscrieți nu este validă."
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3972,7 +3432,7 @@ msgid ""
 "emails with your email domain."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3980,7 +3440,7 @@ msgid ""
 "disposable email addresses."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3988,24 +3448,24 @@ msgid ""
 "emails that contain \"+\"."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr "Vă rugăm să vă înscrieți folosind o adresă de e-mail validă."
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr "Vă rugăm să vă înscrieți folosind o adresă de e-mail permisă."
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -4013,7 +3473,7 @@ msgid ""
 "%(support_email)s\">contact Zulip support</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -4021,75 +3481,75 @@ msgid ""
 "%(support_email)s\">contact this Zulip server's administrators</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
 "management for your Zulip server."
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr "Sesiune de autentificare nevalidă sau expirată"
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr "Sesiune de autentificare nevalidă sau expirată."
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr "Autentifică-te pe Zulip"
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 "V-ați înregistrat deja cu această adresă de e-mail. Vă rugăm să vă conectați "
 "mai jos."
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr "Email sau nume de utilizator"
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "Nume de utilizator"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr "Ai uitat parola?"
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr "Autentificare cu %(identity_provider)s"
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr "Vizualizare fără cont"
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 "Nu ai un cont încă? Ai nevoie de invitație pentru a intra in această "
 "organizație."
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr "Nu există licențe disponibile"
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr "Organizația nu poate accepta noi membri în acest moment"
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> because all Zulip Cloud licenses are in use."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
@@ -4098,19 +3558,19 @@ msgstr ""
 "Zulip sunt în uz. Contactați persoana care v-a invitat și cereți-i să "
 "mărească numărul de licențe, apoi încercați din nou."
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr "Eroare de subdomeniu de autentificare"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr "Subdomeniu de autentificare"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -4119,44 +3579,42 @@ msgid ""
 "or misconfiguration."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 #, fuzzy
 #| msgid "New organization"
 msgid "Demo organizations disabled"
 msgstr "Organizație nouă"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr "Actualizare necesară"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr "Descărcați cea mai recentă versiune."
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr "Este necesar un link de creare a organizației"
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -4164,22 +3622,21 @@ msgid ""
 "organization for more information."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr "Linkul de creare a organizației a expirat sau a fost nevalid"
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -4187,49 +3644,47 @@ msgid ""
 "Zulip support</a> for assistance in resolving this issue."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr "Browser neacceptat"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, fuzzy, python-format
 #| msgid "Presence is not supported for bot users."
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr "Presence nu este suportat pentru utilizatorii boți."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
 "a> like Firefox, Chrome, and Edge."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr "Contul este dezactivat"
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Invalid organization"
 msgid "Finalize organization import"
 msgstr "Organizație nevalidă"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Organization not registered"
 msgid "Organization import completed!"
 msgstr "Organizație neînregistrată"
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -4237,56 +3692,55 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Select your account"
 msgstr "Creeaza-ți contul"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Create new account"
 msgstr "Creeaza-ți contul"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr "Organizație reactivată cu succes"
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr "Organizația ta a fost reactivată cu succes."
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr "Link-ul de reactivare a organizației a expirat sau nevalid"
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr "Linkul de reactivare a organizației a expirat sau nu este valabil."
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr "Autentifica-te în organizația ta"
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr "Nu știi URL-ul organizației tale?"
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr "Găsește-ți organizația."
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr "Urmatorul"
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4294,24 +3748,24 @@ msgid ""
 "have one yet."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 #, fuzzy
 #| msgid "Self-host Zulip"
 msgid "Self-hosting Zulip?"
 msgstr "Auto-gazdă Zulip"
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">log in to manage plans and billing.</a>"
 msgstr ""
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr "Resetează-ți parola"
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
@@ -4319,62 +3773,62 @@ msgstr ""
 "Ați uitat parola? Nici o problemă, vă vom trimite un link pentru a vă reseta "
 "parola la adresa de e-mail cu care v-ați înregistrat."
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr "Trimite linkul de resetare"
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr "Setați o nouă parolă"
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "Confirmă parola"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr "Ups, link-ul furnizat este nevalid sau a fost deja utilizat."
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr "Parola nouă setată cu succes"
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr "Ați setat o nouă parolă!"
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr "Te rog <a href=\"%(login_url)s\">autentifică-te</a> cu parola noua."
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr "E-mail de resetare a parolei trimis"
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr "Parola resetată a fost trimisă!"
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr "Verifică emailul în câteva minute pentru a finaliza procesul."
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 #, fuzzy
 #| msgid "Export still in progress"
 msgid "Import progress"
 msgstr "Exportul este încă în desfășurare"
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4382,7 +3836,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4391,30 +3845,30 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 #, fuzzy
 #| msgid ""
 #| "Nobody in this Zulip organization will be able to see this email address."
@@ -4423,30 +3877,30 @@ msgstr ""
 "Nimeni din această organizație Zulip nu va putea vedea această adresă de e-"
 "mail."
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4454,7 +3908,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4462,20 +3916,20 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr "Selectați contul pentru autentificare"
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr "<h1 class=\"get-started\">Selectează contul</h1>"
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr "Și contul tău GitHub are adrese neverificate de email asociate cu el."
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
@@ -4484,15 +3938,15 @@ msgstr ""
 "mai întâi să <a href=\"https://github.com/settings/emails\">să îl verificați "
 "cu GitHub.</a>"
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr "Eroare la dezabonarea e-mailului"
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr "Solicitare de dezabonare la email necunoscută"
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
@@ -4500,7 +3954,7 @@ msgstr ""
 "Bună ziua! Se pare că ai încercat să te dezabonezi de la ceva, dar nu "
 "recunoaștem URL-ul."
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4511,134 +3965,131 @@ msgstr ""
 "încercați din nou sau să <a href=\"mailto:%(support_email)s\">ne trimiteți "
 "un e-mail</a> și vom obține acest pătrat departe!"
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr "Setarea emailului actualizată"
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
 "href=\"%(realm_url)s/#settings/notifications\">notification settings</a>."
 msgstr ""
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr "Cartografiere invalidă a comenzilor."
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr ""
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr ""
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr ""
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr "abonări"
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr ""
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr "{user} a acceptat invitația ta pe Zulip!"
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 "Nu se poate activa un cont de tip \"placeholder\"; cereți utilizatorului să "
 "se înregistreze."
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 #, fuzzy
 #| msgid "Cannot deactivate the only {entity}."
 msgid "Cannot reactivate a deleted user"
 msgstr "Nu pot dezactiva singura {entity}."
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr "Id-ul câmpului {id} nu a fost găsit."
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr ""
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr ""
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr ""
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
@@ -4647,7 +4098,7 @@ msgstr ""
 "le puteți trimite într-o zi. Pentru că ați atins limita, nu au fost trimise "
 "invitații."
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
@@ -4656,76 +4107,76 @@ msgstr ""
 "organizație. Întrebați un administrator al organizației sau un utilizator "
 "mai experimentat."
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr "Câteva emailuri nu au fost validate așa că nu am trimis invitațile."
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr "Nu am putut să invităm nici o persoană."
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr "Nimic de schimbat"
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr ""
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr "Mesajele directe nu pot avea subiecte."
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr "propagate_mode invalid fără editare a subiectului"
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr ""
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr "Widgeturile nu pot fi editate."
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr "Modificarea mesajelor este oprită în această organizație"
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr "Nu aveți permisiunea de a edita acest mesaj"
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr "Timpul limită pentru editarea acestui mesaj a expirat"
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr "{user} a marcat acest subiect ca rezolvat."
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr "{user} a marcat acest subiect ca nerezolvat."
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr "Acest subiect a fost mutat în {new_location} de către {user}."
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr ""
 "Un mesaj a fost mutat din acest subiect în {new_location} de către {user}."
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
@@ -4734,12 +4185,12 @@ msgstr ""
 "{changed_messages_count} mesaje au fost mutate din acest subiect în "
 "{new_location} de către {user}."
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr "Acest subiect a fost mutat aici de la {old_location} de către {user}."
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
@@ -4747,7 +4198,7 @@ msgstr ""
 "[Un mesaj]({message_link}) a fost mutat aici din {old_location} de către "
 "{user}."
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
@@ -4756,74 +4207,71 @@ msgstr ""
 "{changed_messages_count} mesaje au fost mutate aici din {old_location} de "
 "către {user}."
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 #, fuzzy
 #| msgid "You don't have permission to delete this message"
 msgid "You don't have permission to resolve topics in this channel."
 msgstr "Nu ai permisiuni să ștegi acest mesaj"
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr "Termenul limită pentru editarea subiectului acestui mesaj a expirat."
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr "Nu aveți permisiunea de a muta acest mesaj"
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr ""
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr "Indicator invalid: \"{flag}"
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr "Steguleț care nu poate fi editat: \"{flag}"
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr "Operațiune de marcare a mesajului invalidă: \"{operation}"
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr "Mesaj nevalid(e)"
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr "Imposibil de redat mesajul"
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr "Tip de date nevalid pentru destinatari"
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr "Lista destinatarilor poate conține emailuri sau ID, dar nu ambele."
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
 "but there is no channel with that ID."
 msgstr ""
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4831,36 +4279,36 @@ msgid ""
 "it."
 msgstr ""
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
 "The channel exists but does not have any subscribers."
 msgstr ""
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr "Nu aveți permisiunea de a accesa unii dintre destinatari."
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr "Widgets: Programatorul API a trimis JSON conținut nevalid"
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr "Widgets: {error_msg}"
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4868,65 +4316,63 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr "Un emoji personalizat cu acest nume deja există."
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr "Lista ordonată nu trebuie să conțină linkificatori duplicați"
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 "Lista ordonată trebuie să enumere toți linkificatorii existenți exact o dată"
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
 "authentication method."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr ""
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr "Mesajul programat a fost deja trimis"
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder could not be sent."
 msgstr "Tokenul nu există"
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr "Mesajul nu a putut fi trimis la ora programată."
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
@@ -4935,45 +4381,45 @@ msgstr ""
 "Mesajul pe care l-ați programat pentru {delivery_datetime} nu a fost trimis "
 "din cauza următoarei erori:"
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr "[Vezi mesajele programate](#scheduled)"
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr ""
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr ""
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr ""
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr ""
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
 "**{old_policy}** to **{new_policy}**."
 msgstr ""
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -4982,51 +4428,49 @@ msgid ""
 "* **New**: {new_setting_description}\n"
 msgstr ""
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr "Fără descriere."
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr ""
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr "Descriere veche"
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr "Descriere nouă"
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr "Pentru totdeauna"
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr ""
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 msgstr ""
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr ""
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -5037,99 +4481,89 @@ msgid ""
 "{summary_line}"
 msgstr ""
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr "Nu puteți atașa un submesaj la acest mesaj."
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr "ID-ul de utilizator invalid {user_id}"
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr "Grupul de utilizatori \"{group_name}\" există deja."
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr "Permisiune insuficientă"
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr "Acest APInu este disponibil pentru incoming webhook bots."
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr "Contul nu este asociat cu acest subdomeniu"
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr "Acest endpoint nu acceptă solicitări de la boți."
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr "Trebuie să fii un administrator de server"
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr "Acest endpoint necesită autorizare HTTP de bază."
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr "Antet de autorizare nevalid pentru auth basic"
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr "Lipsește antetul autorizației pentru autentificarea de bază"
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr "Boții webhook pot accesa doar webhooks"
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr ""
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
@@ -5138,41 +4572,40 @@ msgstr ""
 "{username} contului a fost dezactivat. Vă rugăm să contactați "
 "administratorul organizației pentru a-l reactiva."
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr "Parola este prea slabă."
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr "Subdomeniul trebuie să aibă lungimea 3 sau mai mare."
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr "Subdomeniul nu poate începe sau termina cu '-'."
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr "Subdomeniul poate avea litere mici, numere și  '-'s."
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr "Subdomeniu rezervat. Vă rugăm să alegeți un alt domeniu."
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr "Te rog folosește-ți adresa ta reală de email."
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr "Organizația în care vrei să intri cu {email} nu există."
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
@@ -5180,11 +4613,11 @@ msgstr ""
 "Vă rugăm să solicitați o invitație pentru {email} de la administratorul "
 "organizației."
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
@@ -5193,11 +4626,11 @@ msgstr ""
 "Adresa de email, {email}, nu este între domeniile care sunt permise pentru a "
 "crea un cont în această organizație."
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr "Adresele de e-mail conținând + nu sunt permise în această organizație."
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
@@ -5207,34 +4640,33 @@ msgstr ""
 "Zulip sunt în uz. Contactați persoana care v-a invitat și cereți-i să "
 "mărească numărul de licențe, apoi încercați din nou."
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 #, fuzzy
 #| msgid "Embedded bots are not enabled."
 msgid "Challenges are not enabled."
 msgstr "Boții incorporați nu sunt activi."
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "Parola nouă"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr "Confirmare parolă nouă"
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "You're making too many attempts to sign in. Try again in {seconds} "
@@ -5247,7 +4679,7 @@ msgstr ""
 "{seconds} secunde sau contactați administratorul organizației dumneavoastră "
 "pentru ajutor."
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
@@ -5255,93 +4687,91 @@ msgstr ""
 "Parola a fost dezactivată deoarece este prea slabă. Resetați parola pentru a "
 "crea una nouă."
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr "Token"
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 "Sfat: Puteți introduce mai multe adrese de e-mail cu virgule între ele."
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr "Te rog introdu cel puțin 10 emailuri."
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr "Nu am găsit acea organizație Zulip."
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr "E-mail invalid '{email}'"
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr "Lipsește subiectul"
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr ""
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr ""
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr "Mesajul trebuie să aibă destinatari"
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr "Tip de mesaj nevalid"
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr "Atașament nevalid"
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr ""
 "A apărut o eroare la ștergerea atașamentului. Te rog încearcă mai târziu."
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr "Mesajul trebuie să aibă destinatari!"
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "User group name can't be empty!"
 msgid "Channel folder name can't be empty."
 msgstr "Numele grupului de utilizatori nu poate fi gol!"
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid character in topic, at position {position}!"
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr "Caracter nevalabil în subiect, la poziția {position}!"
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Invalid data export ID"
 msgid "Invalid channel folder ID"
 msgstr "ID exportului de date nevalid"
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 #, fuzzy
 #| msgid "Confirm your email address"
 msgid "Configure owner account email address."
 msgstr "Confirmați-vă adresa de e-mail"
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| " Congratulations, you have created a new demo Zulip organization. Note "
@@ -5357,72 +4787,72 @@ msgstr ""
 "organizație va fi ștearsă automat în 30 de zile. Aflați mai multe despre "
 "organizațiile demo aici: %(demo_organizations_help_link)s!"
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a date"
 msgid "{var_name} is not Base64 encoded"
 msgstr "{var_name} nu este o dată"
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 #, fuzzy
 #| msgid "Invalid emoji code."
 msgid "Invalid `device_id`"
 msgstr "Cod emoji invalid."
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr "{service_name} digest"
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr "Domeniul nu poate fi gol."
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr "Domeniul trebuie să aibă cel puțin un (.)"
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr "Domeniul este prea lung"
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr "Domeniul nu poate începe sau termina cu (.)"
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr "'.' consecutive nu sunt permise."
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr "Subdomeniile nu pot începe sau termina cu '-'."
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr "Domeniul poate avea doar litere, numere, '.' și '-'s."
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr "Timestamp nu trebuie să fie negativ."
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr "Subiectul nu trebuie să conțină octeți nule"
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr "Utilizatorul a dezactivat sincronizarea schițelor."
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr "Proiectul nu există"
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5430,86 +4860,86 @@ msgid ""
 "{error_message}"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr "Deschide Zulip pentru a vedea conținutul spoiler"
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr "{service_name} notificări"
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr "Adresă nevalidă."
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr "În afara domeniului tău."
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr "Adrese de email care conțin + nu sunt permise."
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr "Rezervat pentru boții de sistem."
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr "{email} are deja un cont"
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr "Are deja un cont."
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr "Contul a fost dezactivat."
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr "Emoji \"{emoji_name}\" nu există"
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr "Emoji personalizat nevalid."
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr "Nume emoji nevalid."
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr "Acest emoji personalizat a fost dezactivat."
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr "Cod emoji invalid."
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr "Nume emoji nevalid."
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr "Tip emoji nevalid."
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr "Trebuie să fii un administrator al organizației sau autorul emoji-ului"
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr "Numele emoji trebuie să se termine fie cu o literă, fie cu o cifră."
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
@@ -5517,98 +4947,97 @@ msgstr ""
 "Numele emoji trebuie să conțină numai litere englezești minuscule, cifre, "
 "spații, liniuțe și caractere de subliniere."
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr "Numele emoji-ului lipsește"
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr "Nu pot aloca lista de evenimente"
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr ""
 "Deconectat: este necesară autentificarea API sau sesiunea de utilizator"
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, fuzzy, python-brace-format
 #| msgid "User group '{group_name}' already exists."
 msgid "Channel '{channel_name}' already exists"
 msgstr "Grupul de utilizatori \"{group_name}\" există deja."
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr "proprietarul organizației"
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr "utilizator"
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr "Nu pot dezactiva singura {entity}."
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr "Instrucțiune de includere Markdown nevalidă: {include_statement}"
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr "JSON malformat"
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr "Trebuie să fie un administrator de organizație"
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr "Trebuie să fie un proprietar al organizației"
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Must be an organization owner"
 msgid "Must be a bot user"
 msgstr "Trebuie să fie un proprietar al organizației"
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr "Numele dvs. de utilizator sau parola sunt incorecte"
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr "Această organizație a fost dezactivată"
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
@@ -5616,23 +5045,23 @@ msgstr ""
 "Înregistrarea serviciului de notificare push mobil pentru serverul dvs. a "
 "fost dezactivată"
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr "Autentificarea prin parolă este dezactivată în această organizație"
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr "Parola dvs. a fost dezactivată și trebuie resetată"
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr "Cheie API nevalidă"
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr "Cheie API malformată"
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
@@ -5641,57 +5070,56 @@ msgstr ""
 "Evenimentul '{event_type}' nu este în prezent acceptat de către webhook-ul "
 "{webhook_name}; ignorarea"
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 "Nu se poate analiza solicitarea: {webhook_name} a generat acest eveniment?"
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr "Utilizatorul nu este autentificat"
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr "Domeniu nevalid"
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr "Mesajele directe sunt dezactivate în această organizație."
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr ""
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr "Acces interzis"
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
@@ -5700,379 +5128,379 @@ msgstr ""
 "Aveți permisiunea de a muta doar {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} cele mai recente mesaje din acest subiect."
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr "Reacția deja există."
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr "Reacția nu există."
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
 msgstr ""
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr "Organizație neînregistrată"
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 "Nu aveți permisiunea de a utiliza mențiunile wildcard ale subiectului în "
 "acest subiect."
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr ""
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr "'{setting_name}' trebuie să fie un grup de utilizatori de sistem."
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr ""
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr "Termenul de livrare programat trebuie să fie în viitor."
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Already has an account."
 msgid "Atlassian account ID"
 msgstr "Are deja un cont."
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Behance username"
 msgstr "Nume sau nume de utilizator incorect"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Bitbucket username"
 msgstr "Numele de utilizator GitHub"
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Codeberg username"
 msgstr "Nume utilizator Twitter"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Dribbble username"
 msgstr "Numele de utilizator GitHub"
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Facebook username"
 msgstr "Nume sau nume de utilizator incorect"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr "Numele de utilizator GitHub"
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "GitLab username"
 msgstr "Numele de utilizator GitHub"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Instagram username"
 msgstr "Nume utilizator Twitter"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Mastodon"
 msgid "Mastodon profile"
 msgstr "Mastodont"
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Medium username"
 msgstr "Numele de utilizator GitHub"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Pinterest username"
 msgstr "Nume utilizator Twitter"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Reddit username"
 msgstr "Numele de utilizator GitHub"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Snapchat username"
 msgstr "Numele de utilizator GitHub"
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Threads username"
 msgstr "Nume utilizator Twitter"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "TikTok username"
 msgstr "Nume utilizator Twitter"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Twitch username"
 msgstr "Nume utilizator Twitter"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "Nume de utilizator"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr "Tip de cont extern nevalid"
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr "Integration frameworks"
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 #, fuzzy
 #| msgid "Video call ended"
 msgid "Video calling"
 msgstr "Apelul video s-a încheiat"
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr "Integrare continua"
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr "Relații clienți"
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr "Implementare"
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr "Divertisment"
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr "Comunicare"
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr "Financiar"
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr "Resurse umane"
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr "CAD-CAM"
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr "Diverse"
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr "Monitorizare"
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr "Managementul proiectului"
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr "Productivitate"
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr "Controlul versiunii"
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr "Mesajul nu trebuie să fie gol"
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr "Mesajul nu poate conține biți null"
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{fullname} moderation"
 msgstr "{full_name} te-a menționat:"
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr "Operator de limitare nevalid: {desc}"
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr ""
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr ""
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr "Lipsește argumentul 'anchor' ."
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 #, fuzzy
 #| msgid "Missing 'anchor' argument."
 msgid "Missing 'anchor_date' argument."
 msgstr "Lipsește argumentul 'anchor' ."
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr "Ancora nevalidă"
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr "Operatorul {operator} nu este acceptat."
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr ""
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 #, fuzzy
 #| msgid "Confirmation link does not exist"
 msgid "Navigation view does not exist."
 msgstr "Link-ul de confirmare nu există"
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6080,7 +5508,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6088,7 +5516,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6096,7 +5524,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6104,7 +5532,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| " Congratulations, you have created a new demo Zulip organization. Note "
@@ -6121,14 +5549,14 @@ msgstr ""
 "organizație va fi ștearsă automat în 30 de zile. Aflați mai multe despre "
 "organizațiile demo aici: %(demo_organizations_help_link)s!"
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
 "them in your [Inbox](/#inbox).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6136,7 +5564,7 @@ msgid ""
 "({navigation_tour_video_url}) for a quick app overview.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6151,14 +5579,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -6166,7 +5594,7 @@ msgid ""
 "and edit your [profile information](/help/edit-your-profile).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -6177,7 +5605,7 @@ msgid ""
 "experience in your [Preferences](#settings/preferences).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6188,7 +5616,7 @@ msgid ""
 "[Browse and subscribe to channels]({settings_link}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -6205,7 +5633,7 @@ msgid ""
 "discussed.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -6214,7 +5642,7 @@ msgid ""
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -6226,7 +5654,7 @@ msgid ""
 "times, and more.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6236,7 +5664,7 @@ msgid ""
 "or browse the [help center](/help/) to learn more!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6244,7 +5672,7 @@ msgid ""
 "get help, try one of the following messages: {bot_commands}\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6256,13 +5684,13 @@ msgid ""
 "({move_content_another_channel_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6276,12 +5704,11 @@ msgid ""
 "and above.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr ""
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -6289,14 +5716,14 @@ msgid ""
 "no matter how many other conversations are going on.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
 "conversations with unread messages.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -6304,7 +5731,7 @@ msgid ""
 "the `+` button next to its name.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -6312,13 +5739,13 @@ msgid ""
 "can we chat about…?”\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6326,7 +5753,7 @@ msgid ""
 "({format_message_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6346,127 +5773,127 @@ msgid ""
 "```\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
 "teammates.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
 "conversation.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr ""
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr ""
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr ""
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr "JSON nevalid în răspuns"
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr "Format de răspuns nevalid"
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr "Token gol sau de lungime nevalidă"
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr "Token APNS nevalid"
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr "Opțiune GCM invalidă pentru bouncer: prioritate {priority!r}"
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr "Opțiuni MCG nevalabile pentru bouncer: {options}"
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr "Tokenul nu există"
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr "{full_name} a menționat @{user_group_name}:"
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr "{full_name} te-a menționat:"
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr "{full_name} a menționat pe toți:"
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "Mesaj nou"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr "Notificare de testare"
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr "Dispozitivul nu este recunoscut"
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr "Dispozitiv nerecunoscut de către push bouncer"
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 #, fuzzy
 #| msgid "Invalid API key"
 msgid "Invalid `push_key`"
 msgstr "Cheie API nevalidă"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
@@ -6474,740 +5901,722 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr "Utilizator neautorizat pentru această interogare"
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr "'{email}' nu mai folosește Zulip."
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr "Nu puteți trimite mesaje directe în afara organizației dumneavoastră."
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr "{var_name} este prea lung (limit: {max_length} caractere)"
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder does not exist"
 msgstr "Tokenul nu există"
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr "Eroare de respingere a notificărilor push: {error}"
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr "Nu se poate decide între argumentele '{var_name1}' și '{var_name2}'"
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr "Argument '{var_name}' lipsă"
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr "Valoare greșită pentru  '{var_name}': {bad_value}"
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr "Mesajul programat nu există"
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr "{service_name} securitatea contului"
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr ""
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr ""
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 #, fuzzy
 #| msgid "You don't have permission to delete this message"
 msgid "You do not have permission to create new topics in this channel."
 msgstr "Nu ai permisiuni să ștegi acest mesaj"
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr ""
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr ""
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr ""
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr ""
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr ""
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr "Caracter nevalabil în subiect, la poziția {position}!"
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr "Nu am reușit să decodăm imaginea; sigur ai urcat o imagine?"
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr "Mărimea imaginii depășește limitele permise."
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr "{var_name} nu este boolean"
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} does not have a length"
 msgid "{var_name} does not have the expected format"
 msgstr "{var_name} nu are o lungime"
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr "{var_name} nu este o dată"
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr "{var_name} nu este dict"
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr "{var_name} nevalid"
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr "Argumentul \"{argument}\" la {var_name} este neașteptat"
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr "{var_name} nu este float"
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr "{var_name} este prea mic"
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr "{var_name} nu este integer"
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr "{var_name} nu este JSON valid"
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr "{var_name} este prea mare"
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr "{var_name} nu este o listă"
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr "{var_name} este prea lung (limit: {max_length} caractere)"
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr "{var_name} este prea scurt."
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr "{var_name} nu este un șir"
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr "{var_name} este prea lung (limit: {max_length} caractere)"
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr "{var_name} este prea lung (limit: {max_length} caractere)"
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr "{var_name} nu poate fi gol"
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr "Invalid {var_name}: {msg}"
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr "Sarcină utilă malformată"
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr "{var_name} nu este un cod hex valid"
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr "{setting_name} nevalid"
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr "Numărul de cuvinte urcate depașesc limita impusă de organizația ta."
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr ""
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr ""
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr "Grup nevalid"
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid user group ID: {group_id}"
 msgid "Invalid user group ID: {user_group_id}"
 msgstr "ID-ul grupului de utilizatori invalid: {group_id}"
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr ""
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr "ID-ul grupului de utilizatori invalid: {group_id}"
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 "setarea '{setting_name}' nu poate fi setată pentru grupul 'role:internet'."
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 "setarea '{setting_name}' nu poate fi setată pentru grupul 'role:nobody'."
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 "setarea '{setting_name}' nu poate fi setată pentru grupul 'role:everyone'."
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr "setarea '{setting_name}' nu poate fi setată la grupul '{group_name}'."
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr "Numele grupului de utilizatori nu poate fi gol!"
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr "Numele grupului de utilizatori nu poate depăși {max_length} caractere."
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr "Numele grupului de utilizatori nu poate începe cu \"{prefix}\"."
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr "Clientul nu a trecut nici o valoare nouă."
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 "Clientul trebuie să transmită emoji_name dacă transmite fie emoji_code, fie "
 "reaction_type."
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr "Nume prea lung!"
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 #, fuzzy
 #| msgid "Message must not be empty"
 msgid "Name must not be empty!"
 msgstr "Mesajul nu trebuie să fie gol"
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr "Caractere nevalide în nume!"
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr "Format nevalid!"
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr ""
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr ""
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr "Nume sau nume de utilizator incorect"
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr "Integrare invalidă '{integration_name}'."
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr "Lipsesc parametrii de configurare: {keys}"
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr "Valoare {key} invalidă {value} ({error})"
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr "Date de configurare nevalide!"
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr "Tip de bot nevalid"
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr "Tip de interfață nevalidă"
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr "ID-ul de utilizator invalid: {user_id}"
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr "Nu există un astfel de bot"
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr "Nu există un astfel de utilizator"
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr "Utilizator dezactivat"
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr "{item} nu poate fi gol."
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr ""
 "{var_name} are lungime incorectă {length}; ar trebui să fie {target_length}"
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a string"
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr "{var_name} nu este un șir"
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr "{container} trebuie să aibă exact {length} elemente"
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr "Cheia {key_name} lipsește din {var_name}"
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr "Argumente neașteptate: {keys}"
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr "{var_name} nu este allowed_type"
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr "{variable} != {expected_value} ({value} este greșit/ă)"
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr "{var_name} nu este un URL"
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr "Modelul adresei URL trebuie să conțină \"%(username)s\"."
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr "'{item}' nu poate fi gol."
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr "Câmpul nu trebuie să aibă opțiuni dublate."
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr "'{value}' nu este o opțiune validă pentru '{field_name}'."
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr "{var_name} nu este un șir sau o listă integer"
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr "{var_name} nu este un string sau integer"
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr "{var_name} nu are o lungime"
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr "{var_name} lipsește"
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr "Lipsește antetul evenimentului HTTP '{header}'"
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, fuzzy, python-brace-format
 #| msgid "Operator {operator} not supported."
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr "Operatorul {operator} nu este acceptat."
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr "În zcommand ar trebui să existe un slash la început."
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr "Nu există o astfel de comandă: {command}"
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr "Eroare CSRF: {reason}"
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr "Configurarea greșită a proxy-ului invers: {proxy_reason}"
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr "Utilizatorul cu ID {user_id} este dezactivat"
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr "Utilizatorul cu ID-ul {user_id} este un bot"
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr "Cont extern"
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr "Pronume"
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr "Nimeni"
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr ""
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "Membru"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr ""
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Invalid characters in emoji name"
 msgid "Invalid auto-conversion field: empty field name."
 msgstr "Caractere nevalide în numele emoji"
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid ""
@@ -7215,51 +6624,51 @@ msgid ""
 msgstr ""
 "Grupul %(name)r din șablonul URL nu este prezent în modelul de linkifier."
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr "Expresie regulată greșită: {regex}"
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr "Eroare de expresie regulată necunoscută"
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr "Șablon URL invalid."
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid "Example input does not match the linkifier pattern."
 msgstr ""
 "Grupul %(name)r din șablonul URL nu este prezent în modelul de linkifier."
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 "Grupul %(name)r din șablonul URL nu este prezent în modelul de linkifier."
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 "Grupul %(name)r din modelul de linkifier nu este prezent în șablonul URL."
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid ""
@@ -7268,7 +6677,7 @@ msgid ""
 msgstr ""
 "Grupul %(name)r din șablonul URL nu este prezent în modelul de linkifier."
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgid ""
@@ -7277,336 +6686,333 @@ msgid ""
 msgstr ""
 "Grupul %(name)r din modelul de linkifier nu este prezent în șablonul URL."
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr "Emoji unicode"
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "Emoji personalizat"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr "Emoji extra Zulip"
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr "Caractere nevalide în numele emoji"
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr "Caractere nevalabile în limbajul pygments"
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr "Lipsește variabila necesară \"code\" în șablonul URL"
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr "\"code\" ar trebui să fie singura variabilă prezentă în șablonul URL"
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr ""
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr ""
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr ""
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr ""
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr "Disponibil pe Zulip Cloud Standard. Faceți upgrade pentru acces."
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr "Disponibil pe Zulip Cloud Plus. Faceți upgrade pentru a avea acces."
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr "Permiteți GIF-uri clasificate G (Public general)"
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr "Permiteți GIF-uri clasificate PG (Indicații pentru părinți)"
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 "Permiteți GIF-uri clasificate PG-13 (Indicații pentru părinți - sub 13 ani)"
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr "Permiteți GIF-uri clasificate R (Restricționat)"
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr "Web-public"
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "Public"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr "Istorie privată, comună"
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr "Istorie privată, protejată"
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr "Administratori, moderatori, membri și invitați"
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr "Administratori, moderatori și membri"
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr "Administratori și moderatori"
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr "Administratori doar"
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr "Utilizator necunoscut"
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr "Proprietarul organizaţiei"
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr "Administratorul organizației"
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr "Moderator"
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "Membru"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "Vizitator"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr "Adresă IP necunoscută"
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr "un sistem de operare necunoscut"
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr "Un browser necunoscut"
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr "Lipsește argumentul 'queue_id'"
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr "Lipsește argumentul 'last_event_id'"
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr "Un eveniment mai nou decât  {event_id} a fost șters!"
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr "Evenimentul {event_id} nu a fost în această listă"
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr "ID greșit listă evenimente: {queue_id}"
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 #, fuzzy
 #| msgid "Failed to create Zoom call"
 msgid "Failed to generate challenge"
 msgstr "Am eșuat apelul Zoom"
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr "Autentificarea JWT nu este activată pentru această organizație"
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr "Nici un token web JSON nu a trecut în cerere"
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr "JSON web token greșit"
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr "Nu este specificat niciun e-mail în cererile de token web JSON"
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr "Subdomeniul este necesar"
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr "Parola este incorectă."
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr "Lipsește antetul User-Agent din cerere"
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr "Eticheta nu poate fi goală."
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr "Câmpul trebuie să aibă măcar o opțiune."
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr "Tipul de câmp nu este acceptat pentru afișare în rezumatul profilului."
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 #, fuzzy
 #| msgid "Field type not supported for display in profile summary."
 msgid "Field type not supported for use for user matching."
 msgstr "Tipul de câmp nu este acceptat pentru afișare în rezumatul profilului."
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr "Tip de câmp nevalid."
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 "Doar 2 câmpuri de profil particularizate pot fi afișate în rezumatul "
 "profilului."
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr "Un câmp cu această etichetă deja există."
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr "Câmplul implicit personalizat nu poate fi actualizat."
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr "Endpointul nu este disponibil în producţie."
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr "DevAuthBackend nu este activat."
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr "Parametru \"{key}\" nevalabil pentru o cerere anonimă"
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr "Baza de date este goală"
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr "Nu se poate interoga postgresql"
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr "Nu se poate conecta la rabbitmq"
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr "Nu se poate interoga rabbitmq"
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr "Nu se poate interoga redis"
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr "Nu se poate scrie în memcached"
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr "Nu se poate interoga memcached"
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr "Nu există această invitație"
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 #, fuzzy
 #| msgid "Invitation has already been revoked"
 msgid "Invitation already used or deactivated."
 msgstr "Invitația a fost deja revocată"
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr "Invitația a fost deja revocată"
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr ""
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr "Specifică macar o adresă de email."
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
@@ -7614,109 +7020,107 @@ msgstr ""
 "Unele dintre aceste adrese folosesc deja Zulip, așa că nu le-am trimis o "
 "invitație. Le-am trimis invitații tuturor celorlalți!"
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr ""
 "Istoria modificărilor unui mesaj este dezactivată în această organizație"
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr "Nu ai permisiuni să ștegi acest mesaj"
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr "A trecut perioada de timp în care poți modifica acest mesaj"
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr "Mesaj deja șters"
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr "Prea multe mesaje solicitate (maxim {max_messages})."
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr "Ancora poate fi exclusă numai la un capăt al intervalului"
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr "Nu există un astfel de subiect '{topic}'"
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Organization creation link required"
 msgid "An explanation is required."
 msgstr "Este necesar un link de creare a organizației"
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Zephyr mirroring is not allowed in this organization"
 msgid "Message reporting is not enabled in this organization."
 msgstr "Mirroring Zephyr nu este permis în această organizație"
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr "Lipseste expeditorul"
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr "Mirroring nu este permis cu ID-urile de utilizator destinatar"
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr "Mesaj mirrored nevalid"
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr ""
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr ""
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr ""
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr "Nu se poate amuți pe sine"
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr "Utilizator deja dezactivat"
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr "Utilizatorul nu este dezactivat"
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 #, fuzzy
 #| msgid "{hostname} is not a valid hostname"
 msgid "Custom views must have a valid name."
 msgstr "{hostname} nu este un nume de gazdă valid"
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 #, fuzzy
 #| msgid "Reaction already exists."
 msgid "Navigation view already exists."
 msgstr "Reacția deja există."
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr "Necunoscut onboarding_step: {onboarding_step}"
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7724,58 +7128,58 @@ msgid ""
 "later. Is this a good time?\n"
 msgstr ""
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr "Presence nu este suportat pentru utilizatorii boți."
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr "Nu există date de prezență pentru {user_id_or_email}"
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr "Stare invalidă: {status}"
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 #, fuzzy
 #| msgid "You don't have permission to delete this message"
 msgid "You do not have permission to manage plans and billing."
 msgstr "Nu ai permisiuni să ștegi acest mesaj"
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr ""
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr "Eroare returnată de către bouncer: {result}"
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr ""
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
@@ -7783,417 +7187,415 @@ msgstr ""
 "Cel puțin unul din următoarele argumente trebuie să fie prezente: "
 "emoji_name, emoji_code"
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr "Confirmările de citire sunt dezactivate în această organizație."
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr "Limba invalidă '{language}'"
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr "Cel puțin o metodă de autentificare trebuie activată."
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr "Video_chat_provider invalid {video_chat_provider}"
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid giphy_rating {giphy_rating}"
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr "Giphy_rating nevalabil {giphy_rating}"
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr "Trebuie să fie o organizație demonstrativă."
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr "Domeniu invalid: {error}"
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr "Domeniul {domain} este deja parte din organizația ta."
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr "Nu am găsit date despre domeniul {domain}."
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr "Urca doar un fișier."
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr "Numai administratorii pot modifica emoji implicite."
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr "Fișierul încărcat este mai mare decât limita permisă de {max_size} MiB"
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 #, fuzzy
 #| msgid "JWT authentication is not enabled for this organization"
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr "Autentificarea JWT nu este activată pentru această organizație"
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr "A depășit limita ratei."
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr "ID exportului de date nevalid"
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr "Export deja șters"
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr "Exportul a eșuat, nimic de șters"
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr "Exportul este încă în desfășurare"
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr "Urcă doar un icon."
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr "Linkifier not found."
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr "Trebuie să încărcați exact un singur logo."
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid characters in pygments language"
 msgid "Invalid character in language: {character}"
 msgstr "Caractere nevalabile în limbajul pygments"
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid language '{language}'"
 msgid "Language '{language}' is not allowed."
 msgstr "Limba invalidă '{language}'"
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr "Loc de joacă nevalid"
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "User not authenticated"
 msgid "Unauthenticated"
 msgstr "Utilizatorul nu este autentificat"
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "Direct messages"
 msgid "Importing messages…"
 msgstr "Mesaje directe"
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "Your email"
 msgid "Your name"
 msgstr "Adresa ta de email"
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr "Destinatarul este necesar la actualizarea tipului de mesaj programat."
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr "Format de cerere nevalabil"
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr "DSN invalid"
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr ""
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr "Trebuie să treci \"new_description\" sau \"new_group_name\"."
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr ""
 "Valoare nevalidă pentru \"op\". Specifică unul din \"add\" sau \"remove\"."
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr "Parametri Incorecţi"
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr ""
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr ""
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr "Nimic de făcut. Specifică cel puțin un \"adaugă\" sau \"șterge\"."
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, fuzzy, python-brace-format
 #| msgid "{user_full_name} added you to the group {group_name}."
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr "{user_full_name} te-a adăugat la grupul {group_name}."
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr ""
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr ""
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr ""
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
 "**"
 msgstr ""
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr ""
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr "Proprietate de abonament necunoscută: {property}"
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr ""
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr "Json nevalid pentru submesaj"
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr ""
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr "Lipsește argumentul \"to"
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr "Listă goală \"către"
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr ""
 "Utilizatorul a dezactivat notificările de tastare pentru mesajele directe"
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr "<p>Acest fișier nu există sau a fost șters.</p>"
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr "<p>Nu eești autorizat să vezi acest fișier.</p>"
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr "Token nevalid"
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr "Nume de fișier nevalid"
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr "Specifică un fișier să îl urcăm"
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr "Poți urca un fișier odată"
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr "Nu sunt date noi"
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 msgstr ""
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr "{user_full_name} te-a adăugat la grupul {group_name}."
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr "{user_full_name} te-a eliminat din grup {group_name}."
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr "Utilizatorul {user_id} este deja membru în acest grup"
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr "Nu există niciun membru \"{user_id}\" în acest grup de utilizatori"
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr "Grupul de utilizatori {group_id} este deja un subgrup al acestui grup."
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
@@ -8202,80 +7604,80 @@ msgstr ""
 "Grupul de utilizatori {user_group_id} este deja un subgrup al unuia dintre "
 "subgrupurile transmise."
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr "Grupul de utilizatori {group_id} nu este un subgrup al acestui grup."
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr "Schimbările de avataruri sunt dezactivate în această organizație."
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr "Modificarea adresei de email este interzisă de această organizație."
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr "default_language invalidă"
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr "Sunet de notificare invalid '{notification_sound}'"
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr ""
 "Perioadă nevalabilă de distribuire pe loturi a e-mailurilor: {seconds} "
 "secunde"
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr "Parola ta Zulip este administrata în LDAP"
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr "Parolă greșită!"
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, fuzzy, python-brace-format
 #| msgid "You're making too many attempts! Try again in {seconds} seconds."
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr "Faci prea multe încercări! Încearcă din nou în {seconds} secunde."
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr "Noua parolă e prea nesigură!"
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr "Urcă doar un avatar."
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr "Subiectul nu este marcat - fără alertă sonoră"
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr "Nu pot dezactiva singurul proprietar al organizației"
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Nobody in this Zulip organization will be able to see this email address."
@@ -8284,25 +7686,25 @@ msgstr ""
 "Nimeni din această organizație Zulip nu va putea vedea această adresă de e-"
 "mail."
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr "Nu pot fi revocate permisiunile singurului proprietar."
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr ""
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr ""
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
@@ -8314,25 +7716,25 @@ msgstr ""
 "Nu pot crea roboți până când FAKE_EMAIL_DOMAIN este configurat corect.\n"
 "Vă rugăm să contactați administratorul serverului."
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 #, fuzzy
 #| msgid "Email address"
 msgid "Email address already in use"
 msgstr "Adresa de email"
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr "Schimbare de utilizator eșuată, utilizator inexistent"
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr "Schimbare de utilizator eșuată, utilizator deactivat"
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr "Nu a reușit să schimbe proprietarul, roboții nu pot deține alți roboți"
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
@@ -8340,140 +7742,140 @@ msgstr ""
 "Nu pot crea roboți până când FAKE_EMAIL_DOMAIN este configurat corect.\n"
 "Vă rugăm să contactați administratorul serverului."
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr "Boții incorporați nu sunt activi."
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr "Nume nevalid de bot încorporat."
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr "Utilizatorul nu este autorizat să creeze utilizatori"
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr "Emailul '{email}' nu este permis în această organizație"
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr "Adrese de email dispozabile nu sunt permise în aceasta organizație"
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom access token"
 msgid "Invalid {provider_name} access token"
 msgstr "Token de acces Zoom nevalid"
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} call"
 msgstr "Am eșuat apelul Zoom"
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Zoom credentials have not been configured"
 msgid "{provider_name} credentials have not been configured"
 msgstr "Nu s-au configurat datele de acreditare pentru Zoom"
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom credentials"
 msgid "Invalid {provider_name} credentials"
 msgstr "Credențiale Zoom nevalide"
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error connecting to the BigBlueButton server."
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr "Eroare la conectarea la serverul BigBlueButton."
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error authenticating to the BigBlueButton server."
 msgid "Error authenticating to the {provider_name} server"
 msgstr "Eroare la autentificare pe serverul BigBlueButton."
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "BigBlueButton server returned an unexpected error."
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr "Serverul BigBlueButton a returnat o eroare neașteptată."
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom session identifier"
 msgid "Invalid {provider_name} session identifier"
 msgstr "Identificator de sesiune Zoom nevalid"
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr ""
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} public room."
 msgstr "Am eșuat apelul Zoom"
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr "Semnătură invalidă."
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{full_name}'s Zulip room"
 msgstr "{full_name} te-a menționat:"
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 "Proiectele care utilizează acest furnizor de sistem de control al versiunii "
 "nu sunt acceptate"
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr "Încărcare nevalidă"
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr "Solicitare webhook necunoscută"
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr "Subiectul nu poate fi gol"
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr "Conținutul nu poate fi gol"
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr ""
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr "Input JSON malformat"
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr "Cheia evenimentelor lipsește din sarcina utilă"
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr "Eroare: parametrul channels_map_to_topics altul decât 0 sau 1"
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr "Acțiune webhook necunoscută pentru WordPress: {hook}"
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
@@ -8482,153 +7884,153 @@ msgstr ""
 "Exportul de date este finalizat. [Vizualizați și descărcați exporturile]"
 "({export_settings_link})."
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr ""
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr ""
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr ""
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr ""
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr "Subdomeniu nevalid pentru bouncerul cu notificări push"
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr "Trebuie validat cu o cheie API validă Zulip"
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr "UUID nevalid"
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr "Tip de token nevalid"
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr "{hostname} nu este un nume de gazdă valid"
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr ""
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr ""
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr ""
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
 "try again later or reach out to {support_email} for assistance."
 msgstr ""
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr ""
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr ""
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr "Lipsește ios_app_id"
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr "Lipsă user_id sau user_uuid"
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
 "server: {reason}"
 msgstr ""
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr ""
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr "Proprietate invalidă {property}"
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr ""
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr "Datele sunt în dezordine."
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr "Înregistrare duplicată detectată."
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr "Date de jurnal de audit malformate"
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr "Trebuie să vă resetați parola."
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr "Lipsește parametrul id_token"
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 #, fuzzy
 #| msgid "Missing id_token parameter"
 msgid "Missing idp param"
 msgstr "Lipsește parametrul id_token"
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr "OTP nevalid"
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr "Nu pot folosi mobile_flow_otp și desktop_flow_otp împreună."
 

--- a/locale/ru/LC_MESSAGES/django.po
+++ b/locale/ru/LC_MESSAGES/django.po
@@ -26,7 +26,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-04-27 01:48+0000\n"
 "Last-Translator: Lev Shereshevsky <Lev.Shereshevsky@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/zulip/django/ru/"
@@ -40,50 +40,50 @@ msgstr ""
 "(n%100>=11 && n%100<=14)? 2 : 3);\n"
 "X-Generator: Weblate 5.17.1-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "Не разрешено для гостевых пользователей"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "Недопустимая организация"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr "Открытые каналы"
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr "Закрытые каналы"
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr "Личные сообщения"
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr "Групповые личные сообщения"
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr "Отсутствует канал для графика: {chart_name}"
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr "Неизвестное название графика: {chart_name}"
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr "Начальное время больше конечного. Начало: {start}, конец: {end}"
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr "Данные аналитики недоступны. Обратитесь к администратору сервера."
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -97,7 +97,7 @@ msgstr ""
 "({deactivate_user_help_page_link}), чтобы дать новым пользователям "
 "возможность присоединиться."
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -109,7 +109,7 @@ msgstr ""
 "неактивных пользователей]({deactivate_user_help_page_link}), чтобы дать "
 "возможность присоединиться более чем одному пользователю."
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -121,7 +121,7 @@ msgstr ""
 "пользователей]({deactivate_user_help_page_link}), чтобы дать возможность "
 "присоединиться более чем двум пользователям."
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -133,7 +133,7 @@ msgstr ""
 "пользователей]({deactivate_user_help_page_link}), чтобы дать возможность "
 "присоединиться более чем трем пользователям."
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -147,7 +147,7 @@ msgstr ""
 "следующий расчетный период]({billing_page_link}) больше, чем текущее "
 "количество пользователей."
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
@@ -155,7 +155,7 @@ msgstr ""
 "У вашей организации недостаточно лицензий Zulip. Приглашения не были "
 "отправлены."
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
@@ -163,16 +163,15 @@ msgstr ""
 "У вашей организации недостаточно лицензий Zulip для смены роли гостевого "
 "пользователя."
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr "Регистрация отключена"
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr "Неверный удаленный сервер."
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
@@ -181,7 +180,7 @@ msgstr ""
 "Вам необходимо приобрести лицензии для всех активных пользователей вашей "
 "организации (минимум {min_licenses})."
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
@@ -190,64 +189,64 @@ msgstr ""
 "Счета на более чем {max_licenses} лицензий не могут быть обработаны на этой "
 "странице. Для завершения апгрейда, пожалуйста, свяжитесь с {email}."
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr "Не указан способ оплаты."
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr "{brand} заканчивается через {last4}"
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr "Неизвестный способ оплаты. Пожалуйста, свяжитесь с {email}."
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr "Что-то пошло не так. Пожалуйста, свяжитесь с {email}."
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "Что-то пошло не так. Пожалуйста, перезагрузите страницу."
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr ""
 "Что-то пошло не так. Пожалуйста, подождите несколько секунд и попробуйте еще "
 "раз."
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 "Пожалуйста, укажите данные платежной карты перед началом бесплатного "
 "пробного использования."
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr ""
 "Пожалуйста, укажите данные платежной карты для планирования обновления."
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
 msgstr "Нет возможности обновить тариф. Тарифный план истёк и заменён новым."
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr "Невозможно обновить тариф. Тарифный план закончился."
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 "Не удается обновить лицензии в текущем расчетном периоде для бесплатного "
 "пробного тарифа."
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
@@ -255,19 +254,19 @@ msgstr ""
 "Невозможно обновить лицензии вручную. На вашем тарифе лицензия управляется "
 "автоматически."
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr ""
 "Ваш тариф уже включает {licenses} лицензий в текущем расчётном периоде."
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr ""
 "Вы не можете уменьшить количество лицензий в текущем расчётном периоде."
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
@@ -275,7 +274,7 @@ msgstr ""
 "Не удается изменить лицензии для следующего платежного периода для тарифа, "
 "уровень которого будет понижен."
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
@@ -284,7 +283,7 @@ msgstr ""
 "Ваш тариф уже запланирован к продлению на {licenses_at_next_renewal} "
 "лицензий."
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
@@ -293,27 +292,27 @@ msgstr ""
 "Вы уже приобрели {licenses_at_next_renewal} лицензий на очередной расчетный "
 "период."
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr "Нечего менять."
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr "У этой организации нет клиентов!"
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr "Сеанс не найден"
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr "Назначение платежа не найдено"
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr "Передайте stripe_session_id или stripe_invoice_id"
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -328,20 +327,19 @@ msgstr ""
 "Если вы сможете {begin_link}указать Zulip в качестве спонсора на своем веб-"
 "сайте{end_link}, мы будем вам очень признательны!"
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr "Параметр 'подтверждено' обязателен"
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr "Срок действия токена платежного доступа истек."
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr "Недействительный токен платежного доступа."
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
@@ -350,39 +348,38 @@ msgstr ""
 "Не удалось согласовать данные тарификации между сервером и организацией. "
 "Пожалуйста, свяжитесь с {support_email}"
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr "Учетная запись пользователя еще не создана."
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr "Чтобы продолжить, вы должны принять Условия использования."
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 "Этот zulip_org_id не зарегистрирован в системе управления платежами Zulip."
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr "Неверный zulip_org_key для данного zulip_org_id."
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr "Регистрация вашего сервера отозвана."
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "Ошибка"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr "Страница не найдена (404)"
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
@@ -391,11 +388,11 @@ msgstr ""
 "Если эта ошибка непредвиденная, вы можете <a href=\"mailto:"
 "%(support_email)s\">связаться со службой поддержки</a>."
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr "Доступ запрещен (403)"
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
@@ -403,11 +400,11 @@ msgstr ""
 "Ваш запрос не выполнен, потому что ваш браузер не отправил учетные данные "
 "для проверки прав доступа. Чтобы устранить проблему:"
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr "Убедитесь, что ваш браузер разрешает cookie для этого сайта."
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
@@ -415,16 +412,15 @@ msgstr ""
 "Проверьте настройки конфиденциальности браузера и расширения, которые "
 "блокируют заголовки Referer, и отключите их для этого сайта."
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr "Метод не разрешен (405)"
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr "Внутренняя ошибка сервера"
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
@@ -432,7 +428,7 @@ msgstr ""
 "Что-то пошло не так. Приносим извинения! Мы знаем о проблеме и работаем над "
 "ее устранением. Zulip загрузится автоматически, как только снова заработает."
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -443,7 +439,7 @@ msgstr ""
 "для получения дополнительной информации или направьте запрос в <a "
 "href=\"mailto:%(support_email)s\">техническую поддержку Zulip</a>."
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
@@ -451,7 +447,7 @@ msgstr ""
 "Что-то пошло не так. Приносим извинения! Zulip загрузится автоматически, как "
 "только снова заработает."
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
@@ -460,7 +456,7 @@ msgstr ""
 "<a href=\"mailto:%(support_email)s\">Свяжитесь с администраторами сервера</"
 "a> для получения технической поддержки."
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
@@ -470,138 +466,136 @@ msgstr ""
 "href=\"%(troubleshooting_url)s\">руководству по устранению неполадок сервера "
 "Zulip</a>."
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr "Аналитика для %(target_name)s | Zulip"
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 "Данные по аналитике будут полностью доступны через 24 часа после создания "
 "организации."
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr "Аналитика Zulip для %(target_name)s"
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr "Сводка организации"
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr "Количество пользователей"
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr "Активных пользователей за последние 15 дней"
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr "Количество гостей"
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr "Общее количество сообщений"
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr "Количество сообщений за последние 30 дней"
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr "Использование файлового хранилища"
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "Активные пользователи"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr "Активность по дням"
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr "15-дневная активность"
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr "Всего пользователей"
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "Пользователи"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr "Отправленные сообщения по типу получателей"
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "Я"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "Все"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "За прошедшую неделю"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "За прошедший месяц"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "За прошедший год"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "За все время"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr "Отправленные сообщения за период"
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "По дням"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "По неделям"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr "Совокупно"
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "Люди"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "Боты"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr "Прочитанные сообщения за период"
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr "Отправленные сообщения по приложениям"
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr "Последнее обновление"
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
@@ -609,15 +603,15 @@ msgstr ""
 "Полное обновление всех графиков происходит один раз в день. График "
 "“отправленные сообщения за период” обновляется каждый час."
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr "Адрес электронной почты изменен"
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr "Адрес электронной почты изменен!"
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
@@ -626,21 +620,21 @@ msgstr ""
 "Выполнена смена адреса электронной почты вашей учетной записи Zulip с "
 "%(old_email_html_tag)s на %(new_email_html_tag)s"
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr "Подтверждение вашего адреса электронной почты"
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr "Ссылка для подтверждения отсутствует"
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr "Ой. Мы не смогли найти вашу ссылку подтверждения в системе."
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
@@ -649,29 +643,29 @@ msgstr ""
 "В любом случае, напишите нам по адресу %(support_email_html_tag)s, и мы "
 "быстро решим проблему."
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr "Срок действия ссылки истек или она отозвана"
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr "Ой. Срок действия ссылки подтверждения истек или она была отозвана."
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr ""
 "Пожалуйста, свяжитесь с администратором вашей организации, чтобы получить "
 "новую ссылку."
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr "Неверный формат ссылки для подтверждения"
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr "Ой. Ссылка подтверждения неверна."
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
@@ -679,72 +673,55 @@ msgstr ""
 "Убедитесь, что вы правильно скопировали ссылку в браузер. Если вы и далее "
 "будете попадать на эту страницу, то, скорее всего, это наша ошибка. Извините."
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr "Платежи"
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr "Закрыть модальное окно"
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr "Не имеет значения"
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr "Даунгрейд"
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "Отмена"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr "Подтвердить"
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr "Отменить апгрейд"
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr "Состояние оплаты"
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr "Отключить регистрацию сервера?"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr "Управление тарифом недоступно"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -760,7 +737,7 @@ msgstr ""
 "com/help/self-hosted-billing#log-in-to-billing-management\">протоколе "
 "рекомендаций</a> для управления тарифом вашего сервера Zulip."
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
@@ -768,7 +745,7 @@ msgstr ""
 "Для переноса тарифа с сервера в эту организацию и по другим вопросам <a "
 "href=\"mailto:{{ support_email }}\">обратитесь в службу поддержки</a>."
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
@@ -776,7 +753,7 @@ msgstr ""
 "Управление тарифом для этого сервера недоступно, т.к. как минимум у одной "
 "организации на этом сервере уже есть активный тариф."
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -787,730 +764,240 @@ msgstr ""
 "billing\">войти</a> в систему управления тарифом организации или <a "
 "href='mailto:%(support_email)s'>обратиться в службу поддержки</a>."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr "Превышено ограничение частоты"
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr "Превышено ограничение частоты."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 "Ваш сервер превысил разрешенный предел частоты выполнения этого действия."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, python-format
 msgid "You can try again in %(retry_after_string)s."
 msgstr "Вы можете попробовать снова через %(retry_after_string)s."
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr "Апгрейд"
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr "Отправить счет и начать бесплатный пробный период"
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr "Отправить счет"
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr "Каталог открытых сообществ"
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr "Фильтр по категориям"
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "Все"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr "Категории"
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr "10 000 сообщений"
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr "Без ограничений"
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr "Файлы до 10 Mб"
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr "Файлы до 1 Гб"
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr "С поддержкой"
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr "Управляется самостоятельно"
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr "Для организаций до 10 пользователей"
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr "25 пользователей минимум"
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr "Недоступно"
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr "Сообщество разработки Zulip"
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr "Присоединиться как пользователь"
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr "Присоединиться как самостоятельный хостер"
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr "Присоединиться как участник"
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "Создать организацию"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr "Получить демо-версию"
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr "Самостоятельный хостинг Zulip"
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr "Запросить спонсорство"
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr "Цены на образование"
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr "Показать цены"
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr "Zulip для бизнеса"
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 msgid "Zulip for open source"
 msgstr "Zulip для открытого исходного кода"
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr "Собака в очках с ноутбуком"
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation"
 msgstr "Скриншот беседы в Zulip"
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr "Скриншот беседы в Zulip со сторожевым ботом"
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr "Скриншот входящих сообщений в Zulip"
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr "Открытый ноутбук с книгой внутри"
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr "Две руки, собирающие пазл"
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 msgid "Message with code"
 msgstr "Сообщение с кодом"
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr "Молния"
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr "Ссылка"
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr "Штурвал"
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr "Обратиться в службу поддержки"
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr "От"
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr "Организация"
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr "Тема"
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr "Сообщение"
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr "Отправить"
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr "Спасибо, что связались с нами"
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr "Спасибо, что связались с нами!"
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr "Мы скоро свяжемся с вами."
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
@@ -1518,11 +1005,11 @@ msgstr ""
 "Вы можете найти отчеты на частые вопросы в <a href=\"/help/\">центре помощи "
 "Zulip</a>."
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 msgid "Get started"
 msgstr "Начать"
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
@@ -1532,49 +1019,48 @@ msgstr ""
 "Пожалуйста, подтвердите <a href=\"https://zulip.com/policies/terms\">Условия "
 "использования Zulip</a>, чтобы продолжить."
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr "Как вариант, использовать в качестве резерва один из ваших телефонов:"
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr "В крайнем случае вы можете использовать резервный токен:"
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr "Использовать резервный токен"
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr "Принять условия использования"
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr "Добро пожаловать в Zulip"
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "Почта"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr "Подписаться на ненавязчивые новости Zulip (несколько писем в год)."
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr "Продолжить"
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr "Подтвердите ваш адрес электронной почты"
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1584,7 +1070,7 @@ msgstr ""
 "Для завершения регистрации проверьте почтовый ящик (<span class=\"user_email "
 "semi-bold\">%(email)s</span>) на наличие проверочного письма от Zulip."
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
@@ -1592,25 +1078,25 @@ msgstr ""
 "Если вы не нашли проверочное письмо ни во входящих сообщениях, ни в спаме, "
 "мы можем его <a href=\"#\" id=\"resend_email_link\">отправить повторно</a>."
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr "Публичное представление {org_name} | Чат команды в Zulip"
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr "Просматривайте общедоступные каналы в {org_name}, не входя в систему."
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 "Поскольку вы используете неподдерживаемый или очень старый браузер, Zulip "
 "может не загрузиться."
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
@@ -1620,7 +1106,7 @@ msgstr ""
 "загрузиться. <a href=\"https://zulip.com/apps/\" target=\"_blank\" "
 "rel=\"noopener noreferrer\">Загрузите актуальную версию.</a>"
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
@@ -1628,39 +1114,38 @@ msgstr ""
 "Если это сообщение не пропадает, попробуйте <a class=\"reload-"
 "lnk\">перезагрузить</a> страницу."
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 "Сбой загрузки Zulip. Попробуйте <a class=\"reload-lnk\">перезагрузить</a> "
 "страницу."
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr "Нет бесед, соответствующих вашим фильтрам."
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr "Этот вид все еще загружает сообщения."
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr "Загрузить еще"
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr "Видеозвонок завершен"
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr "Теперь вы можете закрыть это окно."
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr "Ошибка настройки"
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
@@ -1668,7 +1153,7 @@ msgstr ""
 "Вы пытаетесь войти с помощью LDAP, еще не создав организацию. Используйте "
 "EmailAuthBackend для создания организации и повторите попытку."
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1678,33 +1163,32 @@ msgstr ""
 "Этот сервер не настроен для отправки push-уведомлений. Информацию по "
 "настройке push-уведомлений см. в <a href=\"%(doc_url)s\">документации</a>."
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr "Учетная запись не найдена"
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr "Учетная запись Zulip не найдена."
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, python-format
 msgid "No account found for %(email)s."
 msgstr "Нет учетных записей для %(email)s."
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr "Войдите с другой учетной записью"
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr "Продолжить регистрацию"
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 msgid "Try Zulip in a demo organization"
 msgstr "Попробуйте Zulip в демонстрационной организации"
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
@@ -1713,19 +1197,19 @@ msgstr ""
 "Адрес почты не нужен. Или <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">создайте постоянную организацию</a>."
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 msgid "Try Zulip"
 msgstr "Попробуйте Zulip"
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "Создать новую организацию"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr "Создать новую организацию Zulip"
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
@@ -1734,16 +1218,15 @@ msgstr ""
 "Или <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">создайте демо-организацию</a> — адрес почты не нужен!"
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr "Введите ваш адрес электронной почты"
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr "Ваш адрес электронной почты"
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
@@ -1753,11 +1236,11 @@ msgstr ""
 "href=\"/help/import-from-mattermost\">Mattermost</a>, или <a href=\"/help/"
 "import-from-rocketchat\">Rocket.Chat</a>."
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr "Как вы узнали о Zulip?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
@@ -1765,42 +1248,41 @@ msgstr ""
 "Это значение используется только при оформлении платного тарифа, тогда оно "
 "будет отправлено команде Zulip."
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr "Выберите вариант"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr "Пожалуйста, опишите"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr "Где вы увидели рекламу?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr "Какая организация?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr "Который?"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr "Выберите"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr "Тип организации"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr "Язык организации"
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
@@ -1810,73 +1292,69 @@ msgstr ""
 "mattermost\">Mattermost</a> или <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid "Import chat history?"
 msgstr "Импортировать историю переписки?"
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr "Название организации"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "URL организации"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr "Используйте %(external_host)s"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "ИЛИ"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "Зарегистрироваться"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "Регистрация в Zulip"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr ""
 "У вас должно быть приглашение, чтобы присоединиться к этой организации."
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr "Зарегистрируйтесь с помощью %(identity_provider)s"
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr "Уже есть учетная запись?"
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "Войти"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr "Настроить конфиденциальность адреса электронной почты"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
@@ -1884,7 +1362,7 @@ msgstr ""
 "Zulip позволяет вам контролировать, какие роли в организации могут "
 "просматривать ваш адрес электронной почты."
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
@@ -1892,11 +1370,11 @@ msgstr ""
 "Вы хотите изменить настройки конфиденциальности для своей электронной почты "
 "со значения по умолчанию для этой организации?"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr "Кто имеет доступ к моему адресу электронной почты"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1907,7 +1385,7 @@ msgstr ""
 "configure-email-visibility\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">после присоединения</a>."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
@@ -1915,7 +1393,7 @@ msgstr ""
 "Администраторы этой организации Zulip смогут видеть данный адрес электронной "
 "почты."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
@@ -1923,14 +1401,14 @@ msgstr ""
 "Администраторы и модераторы этой организации Zulip смогут видеть данный "
 "адрес электронной почты."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 "Никто в этой организации Zulip не сможет видеть данный адрес электронной "
 "почты."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
@@ -1938,81 +1416,80 @@ msgstr ""
 "Другие пользователи в этой организации Zulip смогут видеть данный адрес "
 "электронной почты."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "Изменить"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr "Регистрация"
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr "Создать свою организацию"
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr "Создать свою учетную запись"
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr ""
 "<p>Введите данные своей учетной записи, чтобы завершить регистрацию.</p>"
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr "Ваша организация"
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr "Ваша учетная запись"
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr "Не импортировать настройки"
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr "Импорт настроек из существующей учетной записи Zulip"
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr "Ваше полное имя"
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "Имя"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr "Так ваша учетная запись отображается в Zulip."
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "Пароль"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr "Введите ваш пароль LDAP/Active Directory."
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 "Используется приложениями для смартфонов и другими инструментами, которые "
 "требуют пароль."
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr "Надежность пароля"
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr "В чем вы заинтересованы?"
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
@@ -2021,15 +1498,15 @@ msgstr ""
 "Я соглашаюсь с <a href=\"%(root_domain_url)s/policies/terms\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">условиями использования</a>."
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr "Отключенная организация"
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr "Организация перемещена"
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
@@ -2038,7 +1515,7 @@ msgstr ""
 "Эта организация была перемещена в <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -2049,13 +1526,13 @@ msgstr ""
 "id=\"deactivated-org-auto-redirect\">новый URL</a> через <span "
 "id=\"deactivated-org-auto-redirect-countdown\">5</span> секунд."
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 msgid ""
 "This organization has been deactivated, and all organization data has been "
 "deleted."
 msgstr "Эта организация была отключена, и все ее данные удалены."
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
@@ -2065,7 +1542,7 @@ msgstr ""
 "поддержки Zulip</a> возможность повторного использования этого URL для новой "
 "организации."
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
@@ -2075,11 +1552,11 @@ msgstr ""
 "этого сервера Zulip</a> возможность повторного использования этого URL для "
 "новой организации."
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 msgid "This organization has been deactivated."
 msgstr "Эта организация была отключена."
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -2089,7 +1566,7 @@ msgstr ""
 "%(support_email)s\">связаться со службой поддержки Zulip</a> для ее "
 "восстановления."
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
@@ -2098,7 +1575,7 @@ msgstr ""
 "Если вы являетесь членом организации и хотите выяснить причину ее "
 "отключения, обратитесь непосредственно к администраторам организации."
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -2109,15 +1586,15 @@ msgstr ""
 "%(support_email)s\">связаться с администраторами этого сервера Zulip</a> для "
 "ее восстановления."
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr "Завершить вход в приложение для компьютера"
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr "Завершить вход на компьютере"
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
@@ -2125,110 +1602,109 @@ msgstr ""
 "Используйте ваш браузер, чтобы завершить авторизацию, затем возвращайтесь "
 "сюда и вставьте ваш токен для логина."
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr "Вставьте токен тут"
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr "Завершить"
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr "Неверный токен."
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr "Токен принят. Производится авторизация…"
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr "Войти в приложение для компьютера"
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 "Скопируйте этот токен для логина и вернитесь в ваше приложение Zulip для "
 "завершения авторизации:"
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "Копировать"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr "Затем вы можете закрыть это окно."
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr "Либо продолжайте в вашем браузере."
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr "Анонимный пользователь"
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr "Владельцы"
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "Администраторы"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr "Модераторы"
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr "Гостевые пользователи"
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "Обычные пользователи"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr "Пересылать сообщения на адрес электронной почты"
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "Закрыть"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "Обновить"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr "Zulip"
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr "Дайджест"
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
 "<b>%(realm_name)s</b>."
 msgstr "Вы создали новую организацию Zulip: <b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr "Добро пожаловать в Zulip!"
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr "Вы присоединились к организации Zulip <b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
@@ -2238,36 +1714,36 @@ msgstr ""
 "браузер, <a href=\"%(apps_page_link)s\">мобильные и компьютерные</a> "
 "приложения:"
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr "URL организации: %(organization_url)s"
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr "Ваше имя пользователя: %(ldap_username)s"
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr "Для входа в систему используйте вашу учетную запись LDAP"
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr "Адрес электронной почты вашей учетной записи: %(email)s"
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr "К организации"
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
@@ -2276,7 +1752,7 @@ msgstr ""
 "Если вы не знакомы с Zulip, посмотрите наше <a "
 "href=\"%(getting_user_started_link)s\">руководство по началу работы</a>!"
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2287,7 +1763,7 @@ msgstr ""
 "href=\"%(getting_organization_started_link)s\">переводу организации в Zulip</"
 "a>."
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
@@ -2296,28 +1772,28 @@ msgstr ""
 "Вопросы? <a href=\"mailto:%(support_email)s\">Свяжитесь с нами</a> — будем "
 "рады помочь!"
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr "%(realm_name)s в Zulip: подробности вашей новой организации"
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr "%(realm_name)s в Zulip: подробности вашей новой учетной записи"
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr "Вы создали новую организацию Zulip: %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr "Вы присоединились к организации Zulip %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
@@ -2326,7 +1802,7 @@ msgstr ""
 "Вам будет необходима следующая информация, когда будете подключаться через "
 "браузер, мобильные и компьютерные приложения (%(apps_page_link)s):"
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
@@ -2335,7 +1811,7 @@ msgstr ""
 "Если вы не знакомы с Zulip, посмотрите наше руководство по началу работы "
 "(%(getting_user_started_link)s)!"
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
@@ -2344,18 +1820,18 @@ msgstr ""
 "У нас также есть руководство по переводу организации в Zulip "
 "(%(getting_organization_started_link)s)."
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 "Есть вопросы? Свяжитесь с нами по %(support_email)s — мы с радостью поможем!"
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2364,17 +1840,17 @@ msgstr ""
 "Если у вас есть вопросы, пожалуйста, свяжитесь с администраторами этого "
 "сервера Zulip по %(support_email)s."
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr "Привет,"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2385,12 +1861,12 @@ msgstr ""
 "вашей демо-организации Zulip на %(realm_url)s. Для подтверждения и установки "
 "пароля учетной записи, пожалуйста, нажмите ниже:"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr "Подтвердить и задать пароль"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2399,12 +1875,12 @@ msgstr ""
 "Если вы не запрашивали этого изменения, пожалуйста, немедленно свяжитесь с "
 "нами через %(support_email)s."
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 msgid "Verify your email address for your Zulip demo organization"
 msgstr "Подтвердите свой адрес почты для демонстрационной организации Zulip"
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2413,8 +1889,8 @@ msgstr ""
 "Если вы не запрашивали данного изменения, пожалуйста, немедленно свяжитесь с "
 "нами по <%(support_email)s>."
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2425,34 +1901,34 @@ msgstr ""
 "Zulip на %(realm_url)s с %(old_email)s на %(new_email)s. Для подтверждения "
 "изменения нажмите ниже:"
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr "Подтвердить изменение адреса электронной почты"
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr ""
 "Подтвердите ваш новый адрес электронной почты для %(organization_host)s"
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr "Вы запросили новую организацию Zulip:"
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr "Тип организации: %(organization_type)s"
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr "Недавно вы зарегистрировались в Zulip. Отлично!"
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
@@ -2460,33 +1936,33 @@ msgstr ""
 "Нажмите на кнопку ниже, чтобы создать организацию и зарегистрировать свою "
 "учетную запись. Вы сможете обновить указанную выше информацию, если захотите."
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr "Нажмите кнопку ниже, чтобы завершить регистрацию."
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr "Завершить регистрацию"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr "Создайте свою организацию Zulip"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr "Активируйте вашу учетную запись Zulip"
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr "Нажмите на ссылку ниже, чтобы завершить регистрацию."
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
@@ -2495,20 +1971,20 @@ msgstr ""
 "Есть вопросы или хотите поделиться отзывом? Свяжитесь с нами по "
 "%(support_email)s — мы с радостью поможем!"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr "Управление настройками электронной почты"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr "Отписаться от рекламных писем"
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
@@ -2517,17 +1993,17 @@ msgstr ""
 "Ваша учетная запись Zulip в <a href=\"%(realm_url)s\">%(realm_url)s</a> была "
 "отключена, теперь вы не cможете авторизоваться.."
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr "Администраторы предоставили следующий комментарий:"
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr "Оповещение об отключении учетной записи в %(realm_name)s"
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
@@ -2536,11 +2012,11 @@ msgstr ""
 "Ваша учетная запись Zulip в %(realm_url)s была отключена, теперь вы не "
 "cможете авторизоваться."
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr "Новые каналы"
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2550,7 +2026,7 @@ msgstr ""
 "У вас %(new_messages_count)s новых сообщений и %(new_streams_count)s новых "
 "каналов в <a href=\"%(realm_url)s\">%(realm_name)s</a>."
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
@@ -2559,7 +2035,7 @@ msgstr ""
 "У вас %(new_messages_count)s новых сообщений в <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
@@ -2568,8 +2044,8 @@ msgstr ""
 "В <a href=\"%(realm_url)s\">%(realm_name)s</a> есть %(new_streams_count)s "
 "новых каналов."
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because your organization <a "
@@ -2580,8 +2056,8 @@ msgstr ""
 "class=\"content_disabled_help_link\" href=\"%(help_url)s\">сообщения в "
 "почтовые оповещения не включаются</a>."
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to <a "
@@ -2592,23 +2068,23 @@ msgstr ""
 "class=\"content_disabled_help_link\" href=\"%(help_url)s\">не включать "
 "сообщения</a> в почтовые оповещения."
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr ""
 "<a href=\"%(realm_url)s\">Войдите</a> в Zulip, чтобы посмотреть новые "
 "сообщения."
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr "Отписаться от дайджест-писем"
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr "Дайджест Zulip для %(realm_name)s"
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2617,18 +2093,18 @@ msgstr ""
 "У вас %(new_messages_count)s новых сообщений и %(new_streams_count)s новых "
 "каналов в %(realm_name)s."
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr "У вас %(new_messages_count)s новых сообщений в %(realm_name)s."
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr "В %(realm_name)s есть %(new_streams_count)s новых каналов."
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because your organization hides "
@@ -2639,8 +2115,8 @@ msgstr ""
 "сообщения в почтовые оповещения не включаются. Смотрите подробности в "
 "%(hide_content_url)s."
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to hide "
@@ -2649,33 +2125,31 @@ msgstr ""
 "В этом письме нет содержания сообщений, потому что вы предпочли не включать "
 "сообщения в почтовые оповещения. Смотрите подробности в %(help_url)s."
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr ""
 "Войдите в Zulip, чтобы посмотреть новые сообщения: %(organization_url)s."
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr "Управление настройками электронной почты:"
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr "Отписаться от дайджест-писем:"
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr "Робот Zulip"
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr "Спасибо за ваше обращение!"
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
@@ -2684,8 +2158,7 @@ msgstr ""
 "Ваш адрес электронной почты %(email)s связан с учетными записями в облаке "
 "Zulip для следующих организаций:"
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
@@ -2694,7 +2167,7 @@ msgstr ""
 "Ваш адрес электронной почты %(email)s связан с учетными записи в следующих "
 "организациях Zulip, размещенных на %(external_host)s:"
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
@@ -2703,20 +2176,16 @@ msgstr ""
 "Если у вас проблемы со входом, вы можете <a "
 "href=\"%(help_reset_password_link)s\">сбросить пароль</a>."
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 "Вы запросили список учетных записей Zulip для этого адреса электронной почты."
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr "К сожалению, облачные учетные записи Zulip не найдены."
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
@@ -2725,7 +2194,7 @@ msgstr ""
 "К сожалению, учетные записи организаций Zulip, размещенных на "
 "%(external_host)s, не найдены."
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2737,27 +2206,24 @@ msgstr ""
 "=\"%(help_logging_in_link)s\">попробовать иной способ</a> поиска вашей "
 "учетной записи."
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 "Если вы не в курсе этого запроса, не обращайте внимание на данное письмо."
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr "Ваши учетные записи Zulip"
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr "Учетные записи Zulip не найдены"
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr "Если у вас проблемы со входом, вы можете сбросить пароль."
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
@@ -2767,12 +2233,12 @@ msgstr ""
 "(%(find_accounts_link)s) или попробовать иной способ поиска вашей учетной "
 "записи (%(help_logging_in_link)s)."
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr "Здравствуйте,"
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
@@ -2781,19 +2247,19 @@ msgstr ""
 "%(referrer_name)s приглашает вас присоединиться к Zulip &mdash; системе "
 "командного общения, ориентированной на эффективность."
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr "Чтобы начать, нажмите кнопку ниже."
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 "%(referrer_full_name)s приглашает вас присоединиться к "
 "%(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
@@ -2802,17 +2268,17 @@ msgstr ""
 "%(referrer_full_name)s (%(referrer_email)s) приглашает вас присоединиться к "
 "Zulip -- системе командного общения, ориентированной на эффективность."
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr "Чтобы начать, пожалуйста, нажмите ссылку ниже."
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr "Снова здравствуйте,"
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
@@ -2821,13 +2287,13 @@ msgstr ""
 "Это напоминание о том, что %(referrer_name)s приглашает вас присоединиться к "
 "Zulip &mdash; системе командного общения, ориентированной на эффективность."
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr "Это последнее напоминание, которое вы получите о данном приглашении."
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
@@ -2837,13 +2303,13 @@ msgstr ""
 "приглашения истечет, вам необходимо будет попросить %(referrer_name)s "
 "выслать еще одно."
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr ""
 "Напоминание: присоединяйтесь к %(referrer_name)s на %(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2854,7 +2320,7 @@ msgstr ""
 "вас присоединиться к Zulip -- системе командного общения, ориентированной на "
 "эффективность."
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2863,7 +2329,7 @@ msgstr ""
 "Если у вас есть вопросы, пожалуйста, свяжитесь с администраторами этого "
 "сервера Zulip по <a href=\"mailto:%(email)s\">%(email)s</a>."
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
@@ -2872,13 +2338,13 @@ msgstr ""
 "Есть вопросы или хотите поделиться отзывом? <a href=\"mailto:"
 "%(email)s\">Свяжитесь с нами</a> — будем рады помочь!"
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr "Вы получили это оповещение, потому что вас лично упомянули."
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
@@ -2886,10 +2352,8 @@ msgstr ""
 "Вы получили это оповещение, потому что была упомянута группа "
 "@%(mentioned_user_group_name)s."
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
@@ -2898,8 +2362,8 @@ msgstr ""
 "Вы получили это оповещение, потому что все участники темы были упомянуты в "
 "#%(channel_name)s > %(topic_name)s."
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
@@ -2907,8 +2371,8 @@ msgstr ""
 "Вы получили это оповещение, потому что у вас включены оповещения о "
 "подстановочных упоминаниях в отслеживаемых темах."
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
@@ -2916,8 +2380,8 @@ msgstr ""
 "Вы получили это оповещение, потому что все были упомянуты в "
 "#%(channel_name)s."
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
@@ -2925,8 +2389,8 @@ msgstr ""
 "Вы получили это оповещение, потому что у вас включены оповещения об "
 "отслеживаемых темах."
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
@@ -2935,7 +2399,7 @@ msgstr ""
 "Вы получили это оповещение, потому что у вас включены оповещения по "
 "электронной почте для #%(channel_name)s."
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2946,7 +2410,7 @@ msgstr ""
 "%(realm_name)s Zulip</a>, или <a href=\"%(notif_url)s\">настройте оповещения "
 "по электронной почте</a>."
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
@@ -2955,7 +2419,7 @@ msgstr ""
 "<a href=\"%(narrow_url)s\">Посмотрите или ответьте в %(realm_name)s Zulip</"
 "a> или <a href=\"%(notif_url)s\">проверьте настройки электронной почты</a>."
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
@@ -2964,7 +2428,7 @@ msgstr ""
 "<a href=\"%(narrow_url)s\">Ответьте в %(realm_name)s Zulip</a> или <a "
 "href=\"%(notif_url)s\">проверьте настройки электронной почты</a>."
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
@@ -2973,42 +2437,42 @@ msgstr ""
 "Не отвечайте на это письмо. Этот сервер Zulip не настроен так, чтобы "
 "принимать входящие письма (<a href=\"%(url)s\">помощь</a>)."
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr "Групповые личные сообщения c %(direct_message_group_display_name)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr "Личные сообщения с %(sender_str)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr "[решено] #%(channel_name)s > %(topic_name)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr "Новые сообщения"
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 "Ответьте прямо на это письмо, или посмотрите его в %(realm_name)s Zulip:"
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr "Посмотрите или ответьте в %(realm_name)s Zulip:"
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr "Ответьте в %(realm_name)s Zulip:"
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
@@ -3016,7 +2480,7 @@ msgstr ""
 "Не отвечайте на это письмо. Этот сервер Zulip не настроен так, чтобы "
 "принимать входящие письма. Помощь:"
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -3027,22 +2491,22 @@ msgstr ""
 "%(new_email)s. Если вы не запрашивали этого изменения, пожалуйста, "
 "немедленно свяжитесь с нами по %(support_email)s."
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr "Всех благ,"
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr "команда Zulip"
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr "Адрес электронной почты Zulip изменен для %(realm_name)s"
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -3053,7 +2517,7 @@ msgstr ""
 "%(new_email)s. Если вы не запрашивали этого изменения, пожалуйста, "
 "немедленно свяжитесь с нами по <%(support_email)s>."
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
@@ -3061,46 +2525,46 @@ msgstr ""
 "Организация: %(organization_url)s Время: %(login_time)s Электронная почта: "
 "%(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr "Мы заметили недавно выполненный вход с учётной записью Zulip."
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr "Организация: %(organization_link)s"
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr "Адрес электронной почты: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr "Время: %(login_time)s"
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr "Устройство: %(device_browser)s под %(device_os)s."
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr "IP-адрес: %(device_ip)s"
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr "Если это были вы, то все в порядке! Вам ничего не нужно предпринимать."
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3111,31 +2575,31 @@ msgstr ""
 "стать доступна посторонним, пожалуйста, <a href=\"%(reset_link)s\">сбросьте "
 "ваш пароль</a> или немедленно свяжитесь с нами по %(support_email)s."
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr "Спасибо,"
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr "Служба безопасности Zulip"
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr "Отписаться от уведомлений авторизации"
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr "Новый логин с %(device_browser)s под %(device_os)s"
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr "Организация: %(organization_url)s"
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3146,7 +2610,7 @@ msgstr ""
 "стать доступна посторонним, пожалуйста, сбросьте ваш пароль по ссылке "
 "%(reset_link)s или немедленно свяжитесь с нами через %(support_email)s."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -3157,7 +2621,7 @@ msgstr ""
 "пожаловать! Для начала можете воспользоваться нашим <a "
 "href=\"%(get_organization_started)s\">руководством переходу в Zulip</a>."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
@@ -3166,7 +2630,7 @@ msgstr ""
 "программного обеспечения для группового общения, которые мы часто слышим от "
 "заказчиков:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
@@ -3176,13 +2640,13 @@ msgstr ""
 "участвовать вместе с вами в тестировании и поделиться своими личными "
 "результатами."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr ""
 "Используйте тестируемое приложение для обсуждения своих впечатлений от него."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -3194,7 +2658,7 @@ msgstr ""
 "можно по-настоящему проверить, как новое чат-приложение позволяет вашей "
 "команде общаться."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -3205,21 +2669,21 @@ msgstr ""
 "взаимодействия</a>, и мы надеемся, что эти советы помогут вашей команде "
 "испытать его на практике."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr "Отписаться от приветственных писем %(realm_name)s"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr "Выбор приложения для общения вашей команды"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
@@ -3228,7 +2692,7 @@ msgstr ""
 "пожаловать! Для начала можете воспользоваться нашим руководством по переходу "
 "в Zulip."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
@@ -3237,7 +2701,7 @@ msgstr ""
 "программного обеспечения для группового общения, которые мы часто слышим от "
 "заказчиков:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
@@ -3245,7 +2709,7 @@ msgstr ""
 "Предложите членам вашей команды участвовать вместе с вами в тестировании и "
 "поделиться своими личными результатами."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
@@ -3255,7 +2719,7 @@ msgstr ""
 "других средств общения. Только так можно по-настоящему проверить, как новое "
 "чат-приложение позволяет вашей команде общаться."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
@@ -3263,8 +2727,8 @@ msgstr ""
 "Zulip нацелен на организацию эффективного взаимодействия, и мы надеемся, что "
 "эти советы помогут вашей команде испытать его на практике."
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
@@ -3274,78 +2738,78 @@ msgstr ""
 "как он может наилучшим образом подойти для ваших нужд. Ознакомьтесь с этим "
 "руководством по ключевым функциям Zulip для организаций, подобных вашей!"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr "Посмотреть руководство Zulip для бизнеса"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr "Посмотреть руководство Zulip для проектов с открытым исходным кодом"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr "Посмотреть руководство Zulip для образования"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr "Посмотреть руководство Zulip для исследований"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr "Посмотреть руководство Zulip для событий и конференций"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr "Посмотреть руководство Zulip для некоммерческих организаций"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr "Посмотреть руководство Zulip для сообществ"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr "Руководство Zulip для бизнеса"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr "Руководство Zulip для проектов с открытым исходным кодом"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr "Руководство Zulip для образования"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr "Руководство Zulip для исследований"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr "Руководство Zulip для событий и конференций"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr "Руководство Zulip для некоммерческих организаций"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr "Руководство Zulip для сообществ"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
 msgstr ""
 "Вот несколько рекомендаций о том, как упорядочить переписку в Zulip по темам."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
@@ -3353,8 +2817,8 @@ msgstr ""
 "В Zulip <b>каналы</b> определяют, кто получает сообщения. <b>Темы</b> дают "
 "понять, о чем переписка."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
@@ -3363,12 +2827,12 @@ msgstr ""
 "бесед. Вы увидите каждое сообщение в контексте, независимо от того, сколько "
 "различных обсуждений ведется."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr "Каналы и темы в приложении Zulip"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3380,11 +2844,11 @@ msgstr ""
 "хорошего названия темы подумайте о том, как закончить предложение: «Привет, "
 "мы можем обсудить…?»"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr "Примеры коротких тем"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3398,17 +2862,17 @@ msgstr ""
 "href=\"%(rename_topics_link)s\">переименовать тему</a>, или даже <a "
 "href=\"%(move_channels_link)s\">переместить тему в другой канал</a>."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr "Перейти к Zulip"
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr "Держите переписку упорядоченной по темам"
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
@@ -3416,7 +2880,7 @@ msgstr ""
 "В Zulip каналы определяют, кто получает сообщения. Темы дают понять, о чем "
 "переписка."
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3429,8 +2893,8 @@ msgstr ""
 "(%(move_messages_link)s), переименовать тему (%(rename_topics_link)s), или "
 "даже переместить тему в другой канал (%(move_channels_link)s)."
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
@@ -3439,15 +2903,15 @@ msgstr ""
 "Кто-то (возможно, вы) запросил новый пароль для учетной записи Zulip "
 "%(email)s на %(realm_url)s."
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr "Нажмите на кнопку ниже, чтобы сбросить ваш пароль."
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr "Сбросить пароль"
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3458,19 +2922,19 @@ msgstr ""
 "отключена. Вы можете связаться с администратором организации с тем, чтобы <a "
 "href=\"%(help_link)s\">включить вашу учетную запись</a>."
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr "У вас нет учетной записи в этой организации Zulip."
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr ""
 "У вас нет активных учетных записей в следующей / -их организации / -ях Zulip."
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
@@ -3478,24 +2942,24 @@ msgstr ""
 "Вы можете попытаться авторизации или сбросить пароль в орагнизации (-ях), "
 "приведенных выше."
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 "Если вы не в курсе о данной активности, вы можете спокойно игнорировать это "
 "сообщение."
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr "Запрос сброса пароля для %(realm_name)s"
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr "Нажмите на ссылку ниже, чтобы сбросить пароль."
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
@@ -3505,7 +2969,7 @@ msgstr ""
 "можете связаться с администратором организации, чтобы включить вашу учетную "
 "запись."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3516,7 +2980,7 @@ msgstr ""
 "до Zulip Cloud Free из-за неоплаченных счетов. Неоплаченные счета "
 "аннулированы."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
@@ -3525,7 +2989,7 @@ msgstr ""
 "Чтобы продолжить использовать тарифный план Zulip Cloud Standard, обновитесь "
 "еще раз пройдя по %(upgrade_url)s."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
@@ -3534,8 +2998,8 @@ msgstr ""
 "Если вы считаете, что это была ошибка, или вам нужна дополнительная "
 "информация, свяжитесь с нами по адресу %(support_email)s."
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip demo organization, %(realm_name)s, on "
@@ -3543,8 +3007,8 @@ msgid ""
 msgstr ""
 "Вы отключили свою демо-организацию Zulip %(realm_name)s %(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
@@ -3553,8 +3017,8 @@ msgstr ""
 "Ваша демо-организация Zulip %(realm_name)s была отключена "
 "%(deactivating_owner)s %(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
@@ -3562,16 +3026,16 @@ msgid ""
 msgstr ""
 "Ваша демо-организация Zulip %(realm_name)s была отключена %(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr "Вы отключили свою организацию Zulip %(realm_name)s %(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
@@ -3580,8 +3044,8 @@ msgstr ""
 "Ваша организация Zulip %(realm_name)s была отключена %(deactivating_owner)s "
 "%(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
@@ -3589,14 +3053,14 @@ msgid ""
 msgstr ""
 "Ваша организация Zulip %(realm_name)s была отключена %(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr "Все данные, связанные с этой организацией, были безвозвратно удалены."
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
@@ -3605,8 +3069,8 @@ msgstr ""
 "Все данные, связанные с этой организацией, будут безвозвратно удалены "
 "%(deletion_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
@@ -3614,19 +3078,19 @@ msgstr ""
 "Если у вас есть вопросы или опасения, пожалуйста, ответьте на это письмо как "
 "можно скорее."
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr "Ваша организация Zulip %(realm_name)s была отключена"
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr "Уважаемые бывшие администраторы %(realm_name)s,"
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
@@ -3635,8 +3099,8 @@ msgstr ""
 "Один из ваших администраторов запросил включение ранее отключенной демо-"
 "организации Zulip, размещенной на %(realm_url)s."
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
@@ -3645,16 +3109,16 @@ msgstr ""
 "Один из ваших администраторов запросил включение ранее отключенной "
 "организации Zulip, которая располагалась на %(realm_url)s."
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr "Нажмите кнопку ниже, чтобы восстановить вашу организацию."
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr "Реактивировать организацию"
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
@@ -3662,19 +3126,19 @@ msgstr ""
 "Если запрос произошел по ошибке, вы можете ничего не предпринимать, и данная "
 "ссылка устареет через 24 часа."
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip demo organization"
 msgstr "Восстановите свою демо-организацию Zulip"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr "Восстановить свою организацию Zulip"
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr "Нажмите ссылку ниже, чтобы восстановить вашу организацию."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3683,18 +3147,18 @@ msgstr ""
 "Вы или кто-то от вашего имени запросил ссылку для входа в систему управления "
 "тарифом Zulip для <b>%(remote_server_hostname)s</b>."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 msgid "Click the button below to log in."
 msgstr "Для входа нажмите на кнопку ниже."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr "Срок действия этой ссылки истечет через %(validity_in_hours)s ч."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
@@ -3703,11 +3167,11 @@ msgstr ""
 "Есть вопросы? <a href=\"%(billing_help_link)s\">Узнайте больше</a> или "
 "свяжитесь с %(billing_contact_email)s."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr "Вход в систему управления тарифом Zulip"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3716,12 +3180,12 @@ msgstr ""
 "Вы или кто-то от вашего имени запросил ссылку для входа в систему управления "
 "тарифом Zulip для %(remote_server_hostname)s."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr "Для входа нажмите ссылку ниже."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
@@ -3730,7 +3194,7 @@ msgstr ""
 "Есть вопросы? Узнайте больше на %(billing_help_link)s или свяжитесь с "
 "%(billing_contact_email)s."
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
@@ -3739,16 +3203,16 @@ msgstr ""
 "Нажмите кнопку ниже для подтверждения адреса почты и входа в систему "
 "управления тарифом Zulip для <b>%(remote_realm_host)s</b>."
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr "Подтвердить и войти"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr "Подтвердите адрес почты для управления тарифом Zulip"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
@@ -3757,7 +3221,7 @@ msgstr ""
 "Нажмите на ссылку ниже для подтверждения адреса почты и входа в систему "
 "управления тарифом Zulip для %(remote_realm_host)s."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
@@ -3766,7 +3230,7 @@ msgstr ""
 "Ваш запрос на спонсорство Zulip одобрен! Ваша организация переведена в "
 "статус <a href=\"%(plans_link)s\">Zulip Community</a>."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
@@ -3775,12 +3239,12 @@ msgstr ""
 "Если вы сможете <a href=\"%(link_to_zulip)s\">упомянуть спонсорство Zulip на "
 "вашем веб-сайте</a>, мы будем очень признательны!"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr "Спонсорская программа одобрена для %(billing_entity)s!"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
@@ -3788,7 +3252,7 @@ msgstr ""
 "Ваш запрос на спонсорство Zulip одобрен! Ваша организация переведена в "
 "статус Zulip Community."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
@@ -3796,22 +3260,22 @@ msgstr ""
 "Если вы сможете упомянуть спонсорство Zulip на вашем веб-сайте, мы будем "
 "очень признательны!"
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr "Найти свои учетные записи"
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr "Найти свою учетную запись Zulip"
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 "Письма отправлены! Адреса, введенные на предыдущей странице, перечислены "
 "ниже:"
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
@@ -3820,7 +3284,7 @@ msgstr ""
 "Если вы не получили письмо, вы можете <a href=\"%(current_url)s\">найти "
 "учетные записи для другого адреса</a>."
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
@@ -3828,7 +3292,7 @@ msgstr ""
 "Введите свой адрес электронной почты, чтобы получить письмо с URL-адресами "
 "всех организаций Zulip Cloud, в которых у вас есть активные учетные записи."
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
@@ -3837,7 +3301,7 @@ msgstr ""
 "всех организаций Zulip этого сервера, в которых у вас есть активные учетные "
 "записи."
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
@@ -3845,214 +3309,214 @@ msgstr ""
 "Если вы также забыли пароль, можете <a href=\"/help/change-your-"
 "password\">сбросить его</a>."
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr "Адрес электронной почты"
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "Найти учетные записи"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr "Продукт"
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr "Почему Zulip"
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr "Возможности"
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr "Тарифы и цены"
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 msgid "Zulip Cloud"
 msgstr "Облако Zulip"
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr "Самостоятельный хостинг"
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr "Безопасность"
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "Интеграции"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr "Приложения для установки"
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr "Новая организация"
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr "Решения"
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr "Бизнес"
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr "Образование"
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr "Исследование"
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr "События и конференции"
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr "Проекты с открытым кодом"
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr "Сообщества"
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr "Инженеры"
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr "Истории пользователей"
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr "Открытые сообщества"
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr "Русурсы"
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr "Приступаем"
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr "Центр помощи"
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr "Чат сообщества"
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr "Партнёры"
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr "Состояние облачного Zulip"
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr "Переход в Zulip"
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr "Установка сервера Zulip"
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr "Обновление сервера Zulip"
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr "Сотрудничество"
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr "Руководство по сотрудничеству"
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr "Сообщество разработчиков"
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr "Перевод"
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr "GitHub"
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr "О нас"
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr "Команда"
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "История"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr "Значения"
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr "Работа"
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr "Блог"
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr "Поддержать Zulip"
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr "Mastodon"
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Bluesky handle"
 msgid "Bluesky"
 msgstr "Идентификатор Bluesky"
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr "Работает на <a href=\"https://zulip.com\">Zulip</a>"
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr "Условия использования"
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr "Политика конфиденциальности"
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr "Атрибуция веб-сайта"
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr "Более %(integrations_count_display)s собственных интеграций."
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 msgid ""
 "And hundreds more through <a href=\"/integrations/zapier\">Zapier</a> and <a "
 "href=\"/integrations/ifttt\">IFTTT</a>."
@@ -4060,53 +3524,49 @@ msgstr ""
 "И еще сотни с использованием <a href=\"/integrations/zapier\">Zapier</a> и "
 "<a href=\"/integrations/ifttt\">IFTTT</a>."
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr "Поиск интергаций"
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr "Дополнительная интеграция"
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr "Входящие вебхуки"
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr "Интерактивные боты"
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr "REST API"
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr "Неверный адрес электронной почты"
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr "Электронный адрес не разрешен"
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr ""
 "Адрес электронной почты, с которым вы пытаетесь зарегистрироваться, "
 "недействителен."
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4117,7 +3577,7 @@ msgstr ""
 "пытаетесь присоединиться, не разрешает регистрацию с адресами в вашем "
 "почтовом домене."
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4128,7 +3588,7 @@ msgstr ""
 "пытаетесь присоединиться, не разрешает регистрацию с использованием "
 "одноразовых адресов электронной почты."
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4139,26 +3599,26 @@ msgstr ""
 "пытаетесь присоединиться, не разрешает регистрацию с почтовыми адресами, "
 "содержащими \"+\"."
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr ""
 "Пожалуйста, зарегистрируйтесь, используя действующий адрес электронной почты."
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr ""
 "Пожалуйста, зарегистрируйтесь, используя разрешенный адрес электронной почты."
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr "Организация не найдена"
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr "По адресу <b>%(current_url)s</b> нет организации Zulip."
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -4169,7 +3629,7 @@ msgstr ""
 "accounts/find/\">получить список ваших учетных записей Zulip Cloud</a>, или "
 "<a href=\"mailto:%(support_email)s\">обратиться в службу поддержки Zulip</a>."
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -4181,7 +3641,7 @@ msgstr ""
 "или <a href=\"mailto:%(support_email)s\">обратиться к администраторам "
 "сервера Zulip</a>."
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
@@ -4190,61 +3650,61 @@ msgstr ""
 "<a href=\"%(current_url)s/serverlogin/\">Нажмите здесь</a> для перехода к "
 "управлению тарификацией вашего сервера Zulip."
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr "Недействительный или просроченный сеанс входа в систему"
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr "Неверный или истекший сеанс."
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr "Войти в Zulip"
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 "Вы уже зарегистрированы под этим адресом электронной почты. Пожалуйста, "
 "войдите ниже."
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr "Адрес почты или имя пользователя"
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "Имя пользователя"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr "Забыли свой пароль?"
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr "Войти с помощью %(identity_provider)s"
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr "Просмотр без учетной записи"
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 "Нет учетной записи? У вас должно быть приглашение, чтобы присоединиться к "
 "этой организации."
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr "Нет доступных лицензий"
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr "В данный момент организация не может принять новых членов"
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
@@ -4254,7 +3714,7 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>, поскольку все лицензии Zulip "
 "Cloud используются."
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
@@ -4262,19 +3722,19 @@ msgstr ""
 "Пожалуйста, свяжитесь с тем, кто вас пригласил, и попросите его/ее увеличить "
 "количество лицензий, а затем повторите попытку."
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr "Перейти к основному содержанию"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr "Ошибка аутентификации поддомена"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr "Аутентификация поддомена"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -4287,16 +3747,15 @@ msgstr ""
 "пришли сюда напрямую, вы, наверное, ошиблись адресом. Если вы застряли тут, "
 "пытаясь войти, это, скорее всего, ошибка сервера или неправильная настройка."
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 msgid "Demo organizations disabled"
 msgstr "Демо-организации отключены"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr "Необходимо обновление"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
@@ -4304,7 +3763,7 @@ msgstr ""
 "Вы используете устаревшую версию приложения Zulip для компьютера, которая "
 "больше не поддерживается."
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
@@ -4312,21 +3771,20 @@ msgstr ""
 "Функция автообновления в этой устаревшей версии приложения Zulip для "
 "компьютера уже не работает."
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr "Скачайте последнюю версию."
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr "Вы превысили предел частоты выполнения этого действия."
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr "Необходима ссылка создания организации"
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -4338,12 +3796,11 @@ msgstr ""
 "production/multiple-organizations.html\">документации</a> по созданию новой "
 "организации."
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr "Ссылка создания организации истекла или недействительна"
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
@@ -4351,11 +3808,11 @@ msgstr ""
 "К сожалению, это не действующая ссылка для создания организации. Пожалуйста, "
 "<a href=\"/new/\">получите новую ссылку</a> и попробуйте снова."
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr "Неожиданная регистрация сервера Zulip"
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -4366,17 +3823,16 @@ msgstr ""
 "%(support_email)s\">Свяжитесь с поддержкой Zulip</a> для помощи в решении "
 "этой проблемы."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr "Браузер не поддерживается"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr "%(browser_name)s не поддерживается Zulip."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
@@ -4385,7 +3841,7 @@ msgstr ""
 "Zulip поддерживает <a href=\"%(supported_browsers_page_link)s\">современные "
 "браузеры</a>, такие как Firefox, Chrome и Edge."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
@@ -4393,21 +3849,20 @@ msgstr ""
 "Вы также можете использовать <a href=\"%(apps_page_link)s\">приложение Zulip "
 "для компьютера</a>."
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr "Учётная запись отключена"
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 msgid "Finalize organization import"
 msgstr "Завершить импорт организации"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 msgid "Organization import completed!"
 msgstr "Импорт организации завершен!"
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -4419,55 +3874,54 @@ msgstr ""
 "(<strong>%(verified_email)s</strong>). Выберите учётную запись, с которой "
 "нужно связать свой адрес электронной почты."
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 msgid "Select your account"
 msgstr "Выберите учетную запись"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 msgid "Create new account"
 msgstr "Создать новую учетную запись"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr "Организация успешно восстановлена"
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr "Ваша организация успешно восстановлена."
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr ""
 "Время действия ссылки реактивации организации истекло или она недействительна"
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr ""
 "Время действия ссылки для реактивации организации истекло или она "
 "недействительна."
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr "Зайти в вашу организацию"
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr "ваша-организация"
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr "Вам не известна URL вашей организации?"
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr "Найдите свою организацию."
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr "Далее"
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4478,11 +3932,11 @@ msgstr ""
 "href=\"%(org_creation_link)s\">Создайте новую организацию</a>, если у вас ее "
 "еще нет."
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 msgid "Self-hosting Zulip?"
 msgstr "Собственный хостинг Zulip?"
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4492,11 +3946,11 @@ msgstr ""
 "href=\"%(self_hosted_login_help)s\">войти для управления тарифом и оплатой.</"
 "a>"
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr "Сбросить пароль"
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
@@ -4504,61 +3958,61 @@ msgstr ""
 "Забыли пароль? Ничего страшного, мы вышлем вам ссылку для сброса пароля на "
 "адрес электронной почты, который вы указали при регистрации."
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr "Выслать ссылку для сброса"
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr "Установить новый пароль"
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "Подтвердите пароль"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr "К сожалению, эта ссылка неверна или уже использовалась."
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr "Новый пароль успешно установлен"
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr "Вы установили новый пароль!"
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr "<a href=\"%(login_url)s\">Войдите</a> с помощью вашего нового пароля."
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr "Отправлено электронное письмо для сброса пароля"
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr "Сброс пароля отправлен!"
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr ""
 "Проверьте вашу электронную почту через пару минут, чтобы завершить процесс."
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr "Импорт из Slack"
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr "Ход импорта"
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr "Проверка статуса импорта…"
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4570,7 +4024,7 @@ msgstr ""
 "zulip\"> импорту в Zulip Cloud (через службу поддержки) </a>, для завершения "
 "процедуры."
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4583,15 +4037,15 @@ msgstr ""
 "rel=\"noopener noreferrer\" target=\"_blank\">этим инструкциям</a>, чтобы "
 "получить <strong>токен OAuth пользователя-бота</strong>."
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr "OAuth токен пользователя бота Slack"
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr "Закачайте файл экспорта Slack"
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
@@ -4601,19 +4055,19 @@ msgstr ""
 "slack-data\" target=\"_blank\" rel=\"noopener noreferrer\">этим инструкциям</"
 "a>, чтобы получить экспорт истории сообщений Slack."
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr "Начать загрузку"
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr "Закачанный файл экспорта"
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr "Кто сможет видеть адреса почты других пользователей?"
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
@@ -4623,11 +4077,11 @@ msgstr ""
 "visibility\" target=\"_blank\">изменить</a> настройки видимости адреса почты "
 "после входа в систему."
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr "Начать импорт"
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
@@ -4635,7 +4089,7 @@ msgstr ""
 "Не бойтесь покинуть страницу. Вы всегда можете вернуться сюда,<br /> нажав "
 "кнопку <b>Завершить регистрацию</b> в электронном письме."
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
@@ -4643,7 +4097,7 @@ msgstr ""
 "Или <span id=\"cancel-slack-import\" tabindex=\"0\">создайте организацию</"
 "span> без импорта данных."
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4655,7 +4109,7 @@ msgstr ""
 "rel=\"noopener noreferrer\" target=\"_blank\">процедуру</a> через службу "
 "поддержки."
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4667,22 +4121,22 @@ msgstr ""
 "rel=\"noopener noreferrer\" target=\"_blank\">процедуре</a> импорта для "
 "собственного хостинга."
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr "Выберите учетную запись для аутентификации"
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr "<h1 class=\"get-started\">Выбрать учетную запись</h1>"
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 "У вашей учетной записи на GitHub также имеются ассоциированные с ней "
 "непроверенные адреса электронной почты."
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
@@ -4691,15 +4145,15 @@ msgstr ""
 "<a href=\"https://github.com/settings/emails\">пройти подтверждение на "
 "GitHub.</a>"
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr "Ошибка отписки от электронной почты"
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr "Неизвестный почтовый адрес в запросе для отписки"
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
@@ -4707,7 +4161,7 @@ msgstr ""
 "Привет! Похоже, вы пытались отписаться от чего-то, но мы не распознали URL-"
 "адрес."
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4717,12 +4171,11 @@ msgstr ""
 "Убедитесь, что у вас есть полный URL-адрес, и повторите попытку, или <a "
 "href=\"mailto:%(support_email)s\">напишите нам</a> , и мы решим эту проблему!"
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr "Настройки электронной почты обновлены"
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
@@ -4731,7 +4184,7 @@ msgstr ""
 "Вы успешно отписались от рассылок Zulip %(subscription_type)s для <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
@@ -4740,49 +4193,48 @@ msgstr ""
 "Вы можете отменить изменения или пересмотреть ваши <a href=\"%(realm_url)s/"
 "#settings/notifications\">настройки оповещений</a>."
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr "Неверное размещение заказа."
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr "Вопросы и обсуждения, касающиеся использования Zulip."
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr "Экспериментируйте с Zulip здесь. :test_tube:"
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr "Для общения всей команды"
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr "регистрации"
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr "{user} присоединился/лась к этой организации."
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr "{user} принял/а ваше приглашение присоединиться к Zulip!"
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 "Нельзя активировать демонстрационную учетную запись, предложите пользователю "
 "зарегистрироваться."
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 msgid "Cannot reactivate a deleted user"
 msgstr "Нельзя включить удаленного пользователя"
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
@@ -4790,26 +4242,25 @@ msgstr ""
 "Вам не разрешено изменять это поле. Обратитесь к администратору, чтобы "
 "обновить его."
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr "Поле с ID {id} не найдено."
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr "Неверное название группы каналов по умолчанию '{group_name}'"
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 "Слишком длинное название группы каналов по умолчанию (предел: {max_length} "
 "символов)"
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
@@ -4817,12 +4268,12 @@ msgstr ""
 "Название группы каналов по умолчанию '{group_name}' содержит символы NULL "
 "(0x00)."
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr "Неверная группа каналов по умолчанию {group_name}"
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
@@ -4830,12 +4281,12 @@ msgstr ""
 "'{channel_name}' - это канал по умолчанию, он не может быть добавлен к "
 "'{group_name}'"
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr "Группа каналов по умолчанию '{group_name}' уже есть"
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
@@ -4844,7 +4295,7 @@ msgstr ""
 "Канал '{channel_name}' уже включен в группу каналов по умолчанию "
 "'{group_name}'"
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
@@ -4853,12 +4304,12 @@ msgstr ""
 "Канал '{channel_name}' не включен в группу каналов по умолчанию "
 "'{group_name}'"
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr "Эта группа каналов по умолчанию уже названа '{group_name}'"
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
@@ -4867,7 +4318,7 @@ msgstr ""
 "вы можете отправить в день. Вы исчерпали ваш лимит, поэтому приглашения не "
 "были отправлены."
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
@@ -4876,78 +4327,78 @@ msgstr ""
 "организации. Попросите администратора организации или более опытного "
 "пользователя."
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 "Некоторые адреса электронной почты не прошли проверку, поэтому мы не выслали "
 "ни одного приглашения."
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr "Мы не смогли никого пригласить."
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr "Ничего не изменилось"
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr "Личные сообщения не могут быть перенесены в канал."
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr "Личные сообщения не могут иметь тему."
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr "Неверный propagate_mode без редактирования темы"
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr "Общий чат нельзя отметить как решённый"
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr "Нельзя менять содержание сообщения при изменении канала"
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr "Виджеты нельзя редактировать."
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr "В вашей организации выключено редактирование сообщений"
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr "У вас нет прав для редактирования этого сообщения"
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr "Разрешенное время редактирования сообщения истекло"
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr "{user} пометил эту тему как решенную."
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr "{user} пометил/а эту тему как нерешенную."
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr "Эта тема была перенесена в {new_location} пользователем {user}."
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr ""
 "Сообщение было перенесено из этой темы в {new_location} пользователем {user}."
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
@@ -4956,12 +4407,12 @@ msgstr ""
 "{changed_messages_count} сообщений было перенесено из этой темы в "
 "{new_location} пользователем {user}."
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr "Эта тема была перенесена сюда из {old_location} пользователем {user}."
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
@@ -4969,7 +4420,7 @@ msgstr ""
 "[Сообщение]({message_link}) было перенесено сюда из {old_location} "
 "пользователем {user}."
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
@@ -4978,67 +4429,64 @@ msgstr ""
 "{changed_messages_count} сообщений было перенесено сюда из {old_location} "
 "пользователем {user}."
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to resolve topics in this channel."
 msgstr "У вас нет права отмечать темы в этом канале как решенные."
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr "Разрешенное время редактирования темы сообщения истекло."
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr "У вас нет прав для переноса этого сообщения"
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr "Разрешенное время для редактирования канала этого сообщения истекло"
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr "Неверный флаг: '{flag}'"
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr "Флаг нередактируемый: '{flag}'"
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr "Неверное действие над флагом сообщения: '{operation}'"
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr "Неверное сообщение(я)"
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr "Невозможно отобразить сообщение"
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr "Ожидался ровно один канал"
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr "Неверный тип данных для канала"
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr "Неверный тип данных для получателей"
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 "В списках получателей могут быть адреса электронной почты или ID "
 "пользователей, но не то и другое."
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
@@ -5047,7 +4495,7 @@ msgstr ""
 "Ваш бот {bot_identity} попытался послать сообщение в канал с ID "
 "{channel_id}, но канал с таким ID отсутствует."
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -5058,7 +4506,7 @@ msgstr ""
 "но такой канал отсутствует. Нажмите [тут]({new_channel_link}), чтобы его "
 "создать."
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
@@ -5067,29 +4515,29 @@ msgstr ""
 "Ваш бот {bot_identity} попытался послать сообщение в канал {channel_name}. "
 "Этот канал присутствует, но на него никто не подписан."
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr "У вас нет права доступа к некоторым получателям."
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr "Виджеты: программист API послал неверное JSON-содержание"
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr "Виджеты: {error_msg}"
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr "В вашу учетную запись внесены следующие изменения."
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr "{user} внес/ла следующие изменения в вашу учетную запись."
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5100,27 +4548,25 @@ msgstr ""
 "- **Прежнее значение {field_name}:** {old_value}\n"
 "- **Новое значение {field_name}:** {new_value}\n"
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr "Пользовательский эмодзи с таким именем уже есть."
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr "Неверный формат изображения"
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr "В упорядоченном списке не должно быть повторяющихся шаблонов ссылок"
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 "Упорядоченный список должен включать все имеющиеся шаблоны ссылок ровно по "
 "одному разу"
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
@@ -5129,40 +4575,40 @@ msgstr ""
 "Вам необходимо перейти на тариф {required_upgrade_plan_name} для "
 "использования данного способа аутентификации."
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 "Недопустимый способ аутентификации: {name}. Допустимые способы: {methods}"
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr "Способ аутентификации {name} недоступен в вашем текущем тарифе."
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr "Модерируемый канал должен быть закрытым."
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr "Сохраненный сниппет отсутствует."
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr "Отложенное сообщение уже отправлено"
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 #, fuzzy
 #| msgid "Reminder does not exist"
 msgid "Reminder could not be sent."
 msgstr "Напоминание отсутствует"
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr "Сообщение не удалось отправить в запланированное время."
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
@@ -5171,38 +4617,38 @@ msgstr ""
 "Сообщение, которое вы запланировали на {delivery_datetime}, не было "
 "отправлено из-за следующей ошибки:"
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr "[Показать отложенные сообщения](#scheduled)"
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr "Канал уже отключен"
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr "Канал #**{channel_name}** перенесен в архив."
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr "Сейчас канал не отключен"
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr "Канал с названием {channel_name} уже есть"
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr "Канал закрытый и без подписчиков"
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr "Канал #**{channel_name}** возвращен из архива."
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
@@ -5211,7 +4657,7 @@ msgstr ""
 "{user} изменил/а [права доступа]({help_link}) для этого канала с "
 "**{old_policy}** на **{new_policy}**."
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -5225,42 +4671,40 @@ msgstr ""
 "* **Было**: {old_setting_description}\n"
 "* **Стало**: {new_setting_description}\n"
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 "{user_name} изменил/а название канала с {old_channel_name} на "
 "{new_channel_name}."
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr "Нет описания."
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr "{user} изменил/а описание этого канала."
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr "Старое описание"
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr "Новое описание"
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr "Навсегда"
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr "{number_of_days} дней"
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
@@ -5269,11 +4713,11 @@ msgstr ""
 "Сообщения в этом канале теперь будут автоматически удаляться через "
 "{number_of_days} д. после отправки."
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr "Теперь сообщения в этом канале будут храниться постоянно."
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -5289,26 +4733,26 @@ msgstr ""
 "\n"
 "{summary_line}"
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr "Автоматически"
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr "Тема *{empty_topic_display_name}* разрешена"
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr "Без темы *{empty_topic_display_name}*"
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr "Разрешена только тема *{empty_topic_display_name}*"
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
@@ -5317,73 +4761,63 @@ msgstr ""
 "{user_name} изменил/а настройку «Разрешить публикацию в теме *общий чат*?» с "
 "{old_topics_policy} на {new_topics_policy}."
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr "Вы не можете прикрепить вложенное сообщение к этому сообщению."
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr "Неверный ID пользователя {user_id}"
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr "Группа пользователей '{group_name}' уже есть."
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr "Недостаточно прав"
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr "Этот API не доступен для входящих вебхук ботов."
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr "Учетная запись не связана с этим поддоменом"
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr "Конечная точка не принимает запросы бота."
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr "Нужно быть администратором сервера"
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr "Конечная точка требует базовую HTTP аутентификацию."
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr "Неверный заголовок для Basic-авторизации"
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr "Отсутствует заголовок авторизации для Basic-авторизации"
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr "Вебхук-ботам доступны только вебхуки"
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr "Неверный адрес почты или пароль."
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
@@ -5392,57 +4826,56 @@ msgstr ""
 "Ваша учетная запись {username} была отключена. Пожалуйста, свяжитесь с "
 "администратором вашей организации чтобы восстановить ее."
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr "Пароль слишком простой."
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr "Длина поддомена должна быть 3 символа или больше."
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr "Поддомен не должен начинаться с или заканчиваться на '-'."
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr ""
 "Название поддомена должно содержать только латинские строчные буквы, цифры и "
 "знаки '-'."
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr "Поддомен уже используется. Пожалуйста, выберите другой."
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr "Поддомен зарезервирован. Пожалуйста, выберите другой."
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr "Пожалуйста, используйте реальный адрес электронной почты."
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr ""
 "Организация, к которой вы пытаетесь подключиться с использованием {email}, "
 "отсутствует."
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr "Запросите приглашение для {email} у администратора организации."
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 "Не удается присоединиться к организации: аутентификация по паролю не "
 "включена."
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
@@ -5451,13 +4884,13 @@ msgstr ""
 "Ваш адрес электронной почты {email} не находится в одном из доменов, которым "
 "разрешено регистрироваться в этой организации."
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr ""
 "Адреса электронной почты, содержащие, знак '+', не разрешены в этой "
 "организации."
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
@@ -5467,32 +4900,31 @@ msgstr ""
 "лицензии Zulip используются. Свяжитесь с тем, который вас пригласил, и "
 "попросите его/ее увеличить количество лицензий, а затем повторите попытку."
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr "Подтверждено, что вы человек!"
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr "Проверка, что вы не бот…"
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 msgid "Challenges are not enabled."
 msgstr "Антибот-проверки не включены."
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr "Проверка не пройдена, повторите попытку."
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "Новый пароль"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr "Подтвердить новый пароль"
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "You're making too many attempts to sign in. Try again in "
@@ -5502,7 +4934,7 @@ msgstr ""
 "{retry_after_string} или обратитесь за помощью к администратору вашей "
 "организации."
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
@@ -5510,87 +4942,85 @@ msgstr ""
 "Ваш пароль был отключен, т.к. он слишком слабый. Сбросьте пароль, чтобы "
 "создать новый."
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr "Токен"
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 "Совет: Вы можете ввести несколько адресов электронной почты, разделяя их "
 "запятыми."
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr "Введите не более 10 адресов электронной почты."
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr "Мы не можем найти такую организацию Zulip."
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr "Неверный адрес электронной почты '{email}'"
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr "Не заполнена тема"
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr "Нельзя отправить в несколько каналов"
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr "Отсутствует канал"
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr "У сообщения должны быть получатели"
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr "Неверный тип сообщения"
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr "Недопустимое вложение"
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr ""
 "При удалении вложения произошла ошибка. Пожалуйста, повторите попытку позже."
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr "У сообщения должен быть получатель!"
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name can't be empty."
 msgstr "Название папки каналов не может быть пустым."
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr "Недопустимый символ в названии папки каналов на месте {position}."
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr "Название папки каналов уже используется"
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 msgid "Invalid channel folder ID"
 msgstr "Неверный ID папки каналов"
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 msgid "Configure owner account email address."
 msgstr "Задайте адрес электронной почты учетной записи владельца."
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5603,69 +5033,69 @@ msgstr ""
 "удалена {deletion_time}, если она не будет [преобразована в постоянную "
 "организацию]({convert_demo}).\n"
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, python-brace-format
 msgid "{var_name} is not Base64 encoded"
 msgstr "{var_name} не в кодировке Base64"
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 msgid "Invalid `device_id`"
 msgstr "Недопустимый `device_id`"
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr "дайджест {service_name}"
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr "Домен не может быть пустым."
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr "Домен должен содержать хотя бы одну точку (.)"
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr "Слишком длинный домен"
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr "Домен не может начинаться или заканчиваться точкой (.)"
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr "Последовательные '.' не допускаются."
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr "Поддомен не может начинаться или заканчиваться '-'."
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr "Домен может содержать только буквы, цифры, '.' и '-'."
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr "Метка времени не должна быть отрицательной."
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr "Тема на должна содержать нулевых байтов"
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr "Должен быть указан ровно один ID канала для сообщений"
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr "Пользователь отключил синхронизацию черновиков."
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr "Черновик отсутствует"
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5676,86 +5106,86 @@ msgstr ""
 "электронного письма:\n"
 "{error_message}"
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr "Письмо без темы"
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr "Открыть Zulip, чтобы посмотреть содержание спойлера"
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr "Оповещения {service_name}"
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr "Неверный адрес."
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr "Не принадлежит вашему домену."
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr "Адреса электронной почты, содержащие знак '+', не разрешены."
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr "Зарезервировано для системных ботов."
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr "У {email} уже есть учетная запись"
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr "Уже имеет учетную запись."
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr "Учетная запись отключена."
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr "Эмодзи '{emoji_name}' отсутствует"
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr "Неверный пользовательский эмодзи."
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr "Неверное имя пользовательского эмодзи."
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr "Этот пользовательский эмодзи отключен."
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr "Неверный код эмодзи."
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr "Неверное имя эмодзи."
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr "Неверный тип эмодзи."
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr "Нужно быть администратором организации или автором эмодзи"
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr "Название эмодзи должно заканчиваться на букву или цифру."
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
@@ -5763,64 +5193,64 @@ msgstr ""
 "Название эмодзи должно содержать только строчные латинские буквы, цифры, "
 "пробелы, тире или подчерки."
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr "Отсутствует название эмодзи"
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr "Не удается выделить очередь событий"
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr ""
 "Не авторизован: требуется аутентификация через API или пользовательский сеанс"
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr "Канал '{channel_name}' уже есть"
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr "Канал '{stream}' отсутствует"
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr "Канал с ID '{stream_id}' отсутствует"
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr "Неподдерживаемое сочетание параметров: {parameters}"
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 "Требуется {required_parameter}, если установлено значение {set_parameter}."
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr "владелец организации"
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr "пользователь"
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr "Нельзя отключить {entity}, т.к. других нет."
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr "Неверный оператор включения разметки Markdown: {include_statement}"
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
@@ -5828,58 +5258,57 @@ msgstr ""
 "Использование API превысило лимит частоты запросов; см. https://zulip.com/"
 "api/http-headers#rate-limiting-response-headers"
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr "Неверный JSON"
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr "Нужно быть администратором организации"
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr "Нужно быть владельцем организации"
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Must be an organization owner"
 msgid "Must be a bot user"
 msgstr "Нужно быть владельцем организации"
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr "Неправильное имя пользователя или пароль"
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr "Эта организация отключена"
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr ""
 "Регистрация сервиса мобильных push-уведомлений вашего сервера была отключена"
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr "Парольная аутентификация отключена в этой организации"
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr "Ваш пароль отключён, его необходимо сбросить"
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr "Неверный API-ключ"
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr "неверно оформленный API-ключ"
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
@@ -5888,27 +5317,26 @@ msgstr ""
 "Событие '{event_type}' в настоящее время не поддерживается вебхуком "
 "{webhook_name}; игнорируем"
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 "Не удалось выделить данные из запроса: данное событие сгенерировано "
 "{webhook_name}?"
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr "Пользователь не аутентифицирован"
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr "Неверный поддомен"
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr "У вас нет права начинать беседу личным сообщением."
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
@@ -5916,13 +5344,13 @@ msgid ""
 msgstr ""
 "Отправка сообщений в {empty_topic_display_name} не разрешена в этом канале."
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 "В этом канале разрешено использовать только тему {empty_topic_display_name}."
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
@@ -5932,19 +5360,19 @@ msgstr ""
 "{empty_topic_display_name}. Рассмотрите возможность переименования или "
 "удаления других тем."
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr "Личные сообщения в этой организации отключены."
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr "Эта беседа не включает никого, кто может ее согласовать."
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr "Доступ запрещен"
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
@@ -5953,15 +5381,15 @@ msgstr ""
 "У вас есть право переместить только {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} самых последних сообщений в этой теме."
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr "Реакция уже есть."
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr "Реакция отсутствует."
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
@@ -5969,241 +5397,241 @@ msgstr ""
 "Ваша организация привязана к другому серверу Zulip. Пожалуйста, свяжитесь с "
 "поддержкой Zulip для помощи в решении этой проблемы."
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr "Организация не зарегистрирована"
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 "У вас нет права использовать подстановочные упоминания канала в этом канале."
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 "У вас нет права использовать подстановочные упоминания темы в этой теме."
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr "'{field_name}' значение не соответствует ожидаемому."
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr "'{setting_name}' должно быть системной группой пользователей."
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr "Нельзя отключить используемую группу пользователей."
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr "У вас нет права управлять этим каналом."
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr "У вас нет права изменять каналы по умолчанию."
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr "Адрес электронной почты уже используется."
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr "Запланированное время доставки должно быть в будущем."
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr "Неверный bouncer_public_key"
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr "Запрос истёк"
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr "Неверный encrypted_push_registration"
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr "Сервер не настроен на использование службы push-уведомлений."
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Already has an account."
 msgid "Atlassian account ID"
 msgstr "Уже имеет учетную запись."
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 msgid "Behance username"
 msgstr "Имя пользователя Behance"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 msgid "Bitbucket username"
 msgstr "Имя пользователя Bitbucket"
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr "Идентификатор Bluesky"
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 msgid "Codeberg username"
 msgstr "Имя пользователя Codeberg"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr "Тег Discord"
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 msgid "Dribbble username"
 msgstr "Имя пользователя Dribbble"
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 msgid "Facebook username"
 msgstr "Имя пользователя Facebook"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr "Имя пользователя GitHub"
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 msgid "GitLab username"
 msgstr "Имя пользователя GitLab"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 msgid "Instagram username"
 msgstr "Имя пользователя Instagram"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr "Имя профиля LinkedIn"
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 msgid "Mastodon profile"
 msgstr "Профиль Mastodon"
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 msgid "Medium username"
 msgstr "Имя пользователя Medium"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 msgid "Pinterest username"
 msgstr "Имя пользователя Pinterest"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 msgid "Reddit username"
 msgstr "Имя пользователя Reddit"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 msgid "Snapchat username"
 msgstr "Имя пользователя Snapchat"
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 msgid "Threads username"
 msgstr "Имя пользователя Threads"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 msgid "TikTok username"
 msgstr "Имя пользователя TikTok"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 msgid "Twitch username"
 msgstr "Имя пользователя Twitch"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 msgid "X username"
 msgstr "Имя пользователя X"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr "Идентификатор YouTube"
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr "Неверный тип внешней учетной записи"
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr "Фреймворки интерации"
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 msgid "Video calling"
 msgstr "Видеозвонки"
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr "Непрерывная интеграция"
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr "Поддержка пользователей"
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr "Установка"
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr "Развлечения"
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr "Общение"
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr "Финансы"
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr "Человеческие ресурсы"
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr "Маркетинг"
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr "Разное"
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr "Мониторинг"
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr "Управление проектами"
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr "Продуктивность"
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr "Контроль версий"
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr "Сообщение не должно быть пустым"
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr "Сообщение не должно содержать нулевые байты"
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr "Вам не разрешено упоминать группу пользователей '{user_group_name}'."
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr "{other_users} и {last_user}"
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
@@ -6212,7 +5640,7 @@ msgstr ""
 "{reporting_user_mention} направил/а жалобу на сообщение от "
 "{reported_user_mention}, отправленное {reported_message_date_sent}."
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
@@ -6222,7 +5650,7 @@ msgstr ""
 "{reported_user_mention} в адрес {recipient_user}, отправленное "
 "{reported_message_date_sent}."
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
@@ -6232,71 +5660,71 @@ msgstr ""
 "{reported_user_mention} в адрес {list_of_direct_message_recipients}, "
 "отправленное {reported_message_date_sent}."
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr "Исходное сообщение в {channel_message_link}"
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr "[Исходное сообщение]({direct_message_link})"
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "{fullname} moderation"
 msgstr "Модерация {fullname}"
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr "Неверные уточняющий оператор: {desc}"
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr "Неверное сочетание операторов уточнения: {desc}"
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr "Повтор оператора 'with'."
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr "Неверный оператор 'with'"
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr "Отсутствует аргумент 'anchor'."
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor_date' argument."
 msgstr "Отсутствует аргумент 'anchor_date'."
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr "Неверный якорь"
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr "Оператор {operator} не поддерживается."
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr "Операнд {operand} не поддерживается."
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 msgid "Navigation view does not exist."
 msgstr "Навигационный вид отсутствует."
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr "Заметка от {admin_group_syntax}:"
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6307,7 +5735,7 @@ msgstr ""
 "Чтобы узнать больше, посмотрите наше [руководство по использованию Zulip для "
 "занятий]({getting_started_url})!\n"
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6318,7 +5746,7 @@ msgstr ""
 "Чтобы узнать больше, посмотрите наше [руководство по использованию Zulip]"
 "({getting_started_url})!\n"
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6329,7 +5757,7 @@ msgstr ""
 "У нас также есть руководство по [настройке Zulip для занятий]"
 "({organization_setup_url}).\n"
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6340,7 +5768,7 @@ msgstr ""
 "У нас также есть руководство по [переводу организации в Zulip]"
 "({organization_setup_url}).\n"
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6354,7 +5782,7 @@ msgstr ""
 "удалена** {deletion_global_time}, если не будет [преобразована в\n"
 "постоянную организацию]({convert_demo_organization_help_url}).\n"
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
@@ -6364,7 +5792,7 @@ msgstr ""
 "Я начал несколько бесед, чтобы помочь вам освоиться. \n"
 "Вы найдете их в папке [Входящие](/#inbox).\n"
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6376,7 +5804,7 @@ msgstr ""
 "({navigation_tour_video_url}) для быстрого ознакомления с приложением на "
 "английском языке.\n"
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6401,7 +5829,7 @@ msgstr ""
 "{demo_organization_text}\n"
 "\n"
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
@@ -6411,7 +5839,7 @@ msgstr ""
 "Вы можете [скачать](/apps/) [мобильные и настольные приложения](/apps/).\n"
 "Zulip также отлично работает в браузере.\n"
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -6423,7 +5851,7 @@ msgstr ""
 "[изображение профиля](/help/change-your-profile-picture)\n"
 "и отредактировать вашу [информацию профиля](/help/edit-your-profile).\n"
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -6441,7 +5869,7 @@ msgstr ""
 "пользовательские\n"
 "настройки Zulip в разделе [Предпочтения](#settings/preferences).\n"
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6457,7 +5885,7 @@ msgstr ""
 "\n"
 "[Просмотр каналов и подписка]({settings_link}).\n"
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -6484,7 +5912,7 @@ msgstr ""
 "Посмотрите [Последние беседы](#recent), чтобы увидеть перечень\n"
 "обсуждаемых тем.\n"
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -6498,7 +5926,7 @@ msgstr ""
 "\n"
 "Нажмите `?`, чтобы посмотреть [шпаргалку](#keyboard-shortcuts).\n"
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -6516,7 +5944,7 @@ msgstr ""
 "Посмотрите [шпаргалку](#message-formatting), чтобы узнать о спойлерах,\n"
 "глобальном времени и других возможностях.\n"
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6532,7 +5960,7 @@ msgstr ""
 "zulip),\n"
 "или перейдите в [центр помощи](/help/), чтобы узнать больше!\n"
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6543,7 +5971,7 @@ msgstr ""
 "Вы можете общаться со мной сколько угодно! Для получения\n"
 "помощи, попробуйте одно из следующих сообщений: {bot_commands}\n"
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6562,7 +5990,7 @@ msgstr ""
 "или даже переместить тему [в другой канал]"
 "({move_content_another_channel_help_url}).\n"
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
@@ -6571,7 +5999,7 @@ msgstr ""
 ":point_right: Попробуйте переместить это сообщение в другую тему, а потом "
 "обратно.\n"
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6592,12 +6020,11 @@ msgstr ""
 "канала #**{zulip_discussion_channel_name}**, это видно\n"
 "в левой панели и в заголовке.\n"
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr "добро пожаловать в Zulip!"
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -6609,7 +6036,7 @@ msgstr ""
 "контексте,\n"
 "независимо от того, сколько ведется других обсуждений.\n"
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
@@ -6619,7 +6046,7 @@ msgstr ""
 ":point_right: Когда будете готовы, проверьте [Входящие](/#inbox) на наличие\n"
 "бесед с непрочитанными сообщениями.\n"
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -6630,7 +6057,7 @@ msgstr ""
 "Чтобы начать новую беседу, выберите канал в левой панели и \n"
 "нажмите кнопку `+` рядом с его названием.\n"
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -6641,7 +6068,7 @@ msgstr ""
 "Обозначьте тему беседы. Подумайте о том, как закончить предложение: \n"
 "«Привет, мы можем обсудить…?»\n"
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
@@ -6649,7 +6076,7 @@ msgstr ""
 "\n"
 ":point_right: Попробуйте начать новую беседу в этом канале.\n"
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6660,7 +6087,7 @@ msgstr ""
 ":point_right: Используйте эту тему, чтобы попробовать возможности "
 "[оформления сообщений Zulip]({format_message_help_url}).\n"
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6695,7 +6122,7 @@ msgstr ""
 "\n"
 "```\n"
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
@@ -6705,7 +6132,7 @@ msgstr ""
 "Эта **приветственная** тема — подходящее место, чтобы сказать “привет!” :"
 "wave: членам команды.\n"
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
@@ -6714,103 +6141,103 @@ msgstr ""
 "\n"
 ":point_right: Нажмите на это сообщение, чтобы написать в ту же беседу.\n"
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr "перенос сообщений"
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr "эксперименты"
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr "начать беседу"
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr "приветствие"
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr "Неверный JSON в ответе"
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr "Неверный формат ответа"
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr "Пустой или неверной длины токен"
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr "Неверный токен APNS"
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr "Неверный параметр GCM для отражателя: приоритет {priority!r}"
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr "Неверные параметры GCM для отражателя: {options}"
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr "Токен отсутствует"
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr "{full_name} упомянул/а @{user_group_name}:"
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr "{full_name} упомянул/а вас:"
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr "{full_name} упомянул/а всех:"
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "Новое сообщение"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr "Проверить оповещение"
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr "Это пробное оповещение от {realm_name} ({realm_url})."
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr "Устройство не опознано"
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr "Устройство не опознано отражателем push-уведомлений"
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr "Нет активного зарегистрированного push-устройства"
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr "Ошибка сети при подключении к службе push-уведомлений Zulip."
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 "Внутренняя ошибка сервера службы push-уведомлений Zulip, повторите попытку "
 "позже."
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
@@ -6818,11 +6245,11 @@ msgstr ""
 "Проблема настройки push-уведомлений на сервере, обратитесь к администратору "
 "сервера или повторите попытку позже."
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 msgid "Invalid `push_key`"
 msgstr "Неверный `push_key`"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
@@ -6831,32 +6258,30 @@ msgstr[1] "{secs}{nbsp}секунды"
 msgstr[2] "{secs}{nbsp}секунд"
 msgstr[3] "{secs}{nbsp}секунд"
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr "Неверный тип данных для идентификатора канала"
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr "У пользователя нет полномочий для такого запроса"
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr "'{email}' больше не использует Zulip."
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr "Вы не можете отправлять личные сообщения за пределы своей организации."
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr "Максимальная длина заметки к напоминанию: {max_length} символов"
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
@@ -6865,11 +6290,11 @@ msgstr ""
 "Вы запросили напоминание о следующем сообщении. Заметка:\n"
 " > {note}"
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr "Вы запросили напоминание о следующем сообщении."
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
@@ -6878,11 +6303,11 @@ msgstr ""
 "Вы запросили напоминание о следующем личном сообщении. Заметка:\n"
 " > {note}"
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr "Вы запросили напоминание о следующем личном сообщении."
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
@@ -6891,14 +6316,14 @@ msgstr ""
 "{user_silent_mention} [отправил/а]({conversation_url}) {widget} в "
 "{topic_pretty_link}."
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 "{user_silent_mention} [сказал/а]({conversation_url}) в {topic_pretty_link}:"
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
@@ -6907,7 +6332,7 @@ msgstr ""
 "{user_silent_mention} [отправил/а]({conversation_url}) {widget} в адрес "
 "{list_of_recipient_mentions}."
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
@@ -6916,351 +6341,338 @@ msgstr ""
 "{user_silent_mention} [сказал/а]({conversation_url}) в адрес "
 "{list_of_recipient_mentions}:"
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr "Вы [отправили]({conversation_url}) себе {widget}."
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr "Вы [отправили]({conversation_url}) себе заметку:"
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 msgid "Reminder does not exist"
 msgstr "Напоминание отсутствует"
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr "Ошибка отражателя push-уведомлений: {error}"
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr ""
 "Невозможно сделать выбор между аргументами '{var_name1}' и '{var_name2}'"
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr "Отсутствует аргумент '{var_name}'"
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr "Неверное значение для '{var_name}': {bad_value}"
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr "Отложенное сообщение отсутствует"
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr "Безопасность учётной записи {service_name}"
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr "Канал по умолчанию не может быть закрытым."
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr "Веб-открытые каналы не активированы."
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr "У вас нет права писать в этом канале."
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr "Нет полномочий для отправки в канал '{channel_name}'"
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 msgid "You do not have permission to create new topics in this channel."
 msgstr "У вас нет права создавать новые темы в этом канале."
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr "Неверный ID канала"
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr "Неверное название канала '{channel_name}'"
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr "Канала(ов) ({channel_names}) нет"
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr "Группа каналов по умолчанию с ID '{group_id}' отсутствует."
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr "Название канала не может быть пустым."
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr "Слишком длинное название канала (предел: {max_length} символов)."
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr "Недопустимый символ в названии канала на месте {position}."
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr "Недопустимый символ в теме на месте {position}!"
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr "Данные о подписке недоступны для этого канала"
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr "Невозможно получить подписчиков закрытого канала"
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr ""
 "Невозможно декодировать изображение; вы на самом деле загрузили файл "
 "изображения?"
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr "Размер изображения превышает ограничения."
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr "Изображение повреждено или усечено"
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr "{var_name} не является булевым типом"
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} does not have the expected format"
 msgstr "{var_name} не имеет ожидаемого формата"
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr "{var_name} не является датой"
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr "{var_name} не является словарем"
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr "Недопустимая {var_name}"
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr "Непредвиденный аргумент \"{argument}\" в {var_name}"
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr "{var_name} не является числом с плавающей запятой"
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr "{var_name} слишком маленькая"
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr "{var_name} не является целочисленной"
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr "{var_name} не является корректным JSON"
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr "{var_name} слишком большая"
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr "{var_name} не является списком"
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr "{var_name} слишком длинная (предел: {max_length} символов)"
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr "{var_name} слишком короткая."
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr "{var_name} не является строкой"
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr "у {var_name} неверный формат"
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr "длина {var_name} не равна {length}"
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr "{var_name} слишком длинный (предел: {max_length} элементов)"
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr "{var_name} слишком короткий (минимум {min_length} элементов)"
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr "{var_name} не может быть пустой"
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr "Неверное {var_name}: {msg}"
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr "поле {var_name} отсутствует: {msg}"
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr "Неверные данные"
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr "Не в списке возможных значений"
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr "Не URL"
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr "Часовой пояс не распознан"
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr "{var_name} не является корректным шестнадцатеричным кодом цвета"
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr "Недопустимая {setting_name}"
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr "Не 32-битное целое число без знака"
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr "Загрузка превысит квоту вашей организации."
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr "Размер изображения превышает ограничения"
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr "Группа пользователей отключена."
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr "Неверная группа пользователей"
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {user_group_id}"
 msgstr "Неверный ID группы пользователей: {user_group_id}"
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr "Неверное название системной группы."
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr "Неверный ID группы пользователей: {group_id}"
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr "Настройку '{setting_name}' нельзя применить к группе 'role:internet'."
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr "Настройку '{setting_name}' нельзя применить к группе 'role:nobody'."
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr "Настройку '{setting_name}' нельзя применить к группе 'role:everyone'."
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr "Настройку '{setting_name}' нельзя применить к группе '{group_name}'."
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr "Название группы пользователей не может быть пустым!"
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr ""
 "Название группы пользователей не может быть длинее {max_length} символов."
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr "Название группы пользователей не может начинаться с '{prefix}'."
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
@@ -7269,7 +6681,7 @@ msgstr ""
 "Доступ к '{setting_name}' для групп, используемых в 'workplace_users_group', "
 "должен предоставляться только администраторам организации."
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
@@ -7278,192 +6690,189 @@ msgstr ""
 "администраторам организации, если 'workplace_users_group' включает "
 "пользовательские группы."
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr "Клиент не послал никаких новых значений."
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 "Клиент должен передать emoji_name, если он передает emoji_code или "
 "reaction_type."
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr "Слишком длинное имя!"
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 msgid "Name must not be empty!"
 msgstr "Имя не должно быть пустым!"
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr "Неверные символы в имени!"
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr "Неверный формат!"
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr "В данной организации требуются неповторяющиеся имена."
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr "Название уже используется."
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr "Неверное имя или имя пользователя"
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr "Неверная интеграция '{integration_name}'."
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr "Отсутствуют параметры настройки: {keys}"
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr "Для {key} неверное значение {value} ({error})"
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr "Неверные данные конфигурации!"
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr "Неверный тип бота"
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr "Неверный тип интерфейса"
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr "Неверный ID пользователя: {user_id}"
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr "Нет такого бота"
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr "Нет такого пользователя"
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr "Пользователь отключен"
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr "{item} не может быть пустым."
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr "У {var_name} неверная длина {length}; должна быть {target_length}"
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr "{var_name} не является строкой datetime ISO 8601"
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr "{container} должен содержать ровно {length} элементов"
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr "ключ {key_name} отсутствует в {var_name}"
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr "Непредвиденные аргументы: {keys}"
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr "{var_name} не является allowed_type"
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr "{variable} != {expected_value} ({value} неверно)"
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr "{var_name} не является URL"
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr "Шаблон URL должен содержать '%(username)s'."
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr "'{item}' не может быть пустым."
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr "Поле не должно содержать одинаковые варианты."
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr "'{value}' не является допустимым выбором для '{field_name}'."
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr "{var_name} не является списком строк или целых чисел"
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr "{var_name} не является строкой или цельным числом"
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr "{var_name} не имеет длины"
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr "{var_name} отсутствует"
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr "Неизвестный 'PresetUrlOption': {config}"
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr "Отсутствует заголовок события HTTP '{header}'"
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr "Алгоритм «{algorithm}» не поддерживается."
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
@@ -7471,11 +6880,11 @@ msgstr ""
 "Отсутствует секретный код вебхука. Задайте webhook_secret при формировании "
 "URL."
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr "Проверка подписи вебхука не пройдена."
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
@@ -7483,93 +6892,93 @@ msgstr ""
 "Членством в группе 'workplace_users_group' должны управлять только "
 "администраторы организации."
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr "Должен присутствовать ведущий слэш в zcommand."
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr "Нет такой команды: {command}"
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr "`zulip_update_announcements_stream` неожиданно отключен."
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr "Ошибка CSRF: {reason}"
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr "Неправильная настройка обратного прокси-сервера: {proxy_reason}"
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr "Неверные ID пользователей: {invalid_ids}"
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr "Пользователь с ID {user_id} отключен"
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr "Пользователь с ID {user_id} является ботом"
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr "Выбор из списка"
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr "Короткий текст"
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr "Абзац"
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr "Дата"
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr "Внешняя учетная запись"
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr "Местоимения"
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr "Никто"
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr "Полноправные участники"
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "Участники"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr "Все в интернете"
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr "Неверное поле автоконвертации: отсутствует символ '}'."
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: empty field name."
 msgstr "Недопустимое поле автоконвертации: пустое имя поля."
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
@@ -7577,49 +6986,49 @@ msgstr ""
 "Группа %(name)r в поле автоматического преобразования отсутствует в шаблоне "
 "преобразования ссылок."
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr "Неверное регулярное выражение: {regex}"
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr "Неизвестная ошибка регулярного выражения"
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr "Неверный шаблон URL-адреса."
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 msgid "Example input does not match the linkifier pattern."
 msgstr "Пример входных данных не соответствует шаблону преобразования ссылок."
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr "Текст примера не соответствует полю автоконвертации."
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 "Группа %(name)r в шаблоне URL отсутствует в шаблоне преобразования ссылок."
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 "Группа %(name)r в шаблоне преобразования ссылок отсутствует в шаблоне URL."
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 "Альтернативный шаблон URL-адреса не может совпадать с шаблоном URL-адреса."
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr "Альтернативные шаблоны URL-адресов должны быть уникальными."
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in alternative URL template is not present in linkifier "
@@ -7628,7 +7037,7 @@ msgstr ""
 "Группа %(name)r в альтернативном URL отсутствует в шаблоне преобразования "
 "ссылок."
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in linkifier pattern is not present in alternative URL "
@@ -7637,332 +7046,329 @@ msgstr ""
 "Группа %(name)r в шаблоне преобразования ссылок отсутствует в шаблоне "
 "альтернативных URL."
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr "Юникод эмодзи"
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "Дополнительные эмодзи"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr "Дополнительные эмодзи Zulip"
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr "Неверные символы в имени эмодзи"
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr "Неверные символы в языке pygments"
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr "Отсутствует обязательная переменная \"code\" в шаблоне URL"
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr "Переменная \"code\" должна быть единственной в шаблоне URL"
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr "песочница"
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr "общее"
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr "события канала"
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr "Спам"
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr "Оскорбления"
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr "Неприемлемое содержание"
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr "Нарушение норм сообщества"
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr "Другая причина"
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr "Обновления Zulip"
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr ""
 "Доступно в тарифе Zulip Cloud Standard. Выполните апгрейд, чтобы получить "
 "доступ."
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr "Доступно в тарифе Zulip Cloud Plus. Повысьте тариф для доступа."
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr "Отключено"
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr "Разрешить GIF-файлы с рейтингом G (широкая аудитория)"
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr "Разрешить GIF-файлы с рейтингом PG (родительский контроль)"
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 "Разрешить GIF-файлы с рейтингом PG-13 (родительский контроль — до 13 лет)"
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr "Разрешить GIF-файлы с рейтингом R (ограниченное)"
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr "Веб-открытый"
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "Открытый"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr "Закрытый, открытая история переписки"
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr "Закрытый, защищенная история переписки"
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr "Администраторы, модераторы, участники и гости"
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr "Администраторы, модераторы и участники"
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr "Администраторы и модераторы"
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr "Только администраторы"
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr "Неизвестный пользователь"
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr "Владелец организации"
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr "Администратор организации"
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr "Модератор"
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "Участник"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "Гость"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr "Неизвестный IP адрес"
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr "неизвестная операционная система"
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr "Неизвестный браузер"
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr "Отсутствует аргумент 'queue_id'"
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr "Отсутствует аргумент 'last_event_id'"
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr "Более новое событие чем {event_id} уже было удалено!"
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr "События {event_id} не было в этой очереди"
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr "Недопустимый идентификатор очереди событий: {queue_id}"
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 msgid "Failed to generate challenge"
 msgstr "Не удалось создать антибот-проверку"
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr "Парольная аутентификация отключена в этой организации"
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr "В запросе отсутствует JSON web token"
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr "Неверный JSON web token"
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr "В параметрах JSON не указан адрес электронной почты"
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr "Необходим поддомен"
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr "Неверный пароль."
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 "Вам необходимо удалить все каналы из этой папки, чтобы архивировать её."
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr "В запросе отсутствует параметр User-Agent"
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr "Метка не может быть пустой."
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr "Поле должно содержать хотя бы один пункт."
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr "Тип поля не поддерживается для отображения в сводке профиля."
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for use for user matching."
 msgstr "Тип поля не поддерживается для сопоставления пользователей."
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr "Неверный тип поля."
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 "В сводке профиля могут отображаться только 2 дополнительных поля профиля."
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr "Поле с такой меткой уже есть."
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr "Дополнительное поле по умолчанию не может быть обновлено."
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr "Эта конечная точка недоступна в производственном режиме."
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr "DevAuthBackend не включен."
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr "Неверный параметр '{key}' для анонимного запроса"
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr "База данных пуста"
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr "Не удается сделать запрос к postgresql"
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr "Не удается подключиться к rabbitmq"
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr "Не удается сделать запрос к rabbitmq"
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr "Не удается сделать запрос к redis"
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr "Не удается выполнить запись в memcached"
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr "Не удается сделать запрос к memcached"
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr "Такого приглашения нет"
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 msgid "Invitation already used or deactivated."
 msgstr "Приглашение уже использовано или отозвано."
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr "Приглашение уже отозвано"
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr "Неверный ID канала {channel_id}. Приглашения не были отправлены."
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr "У вас нет права подписывать других пользователей на каналы."
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr "Укажите хотя бы один адрес электронной почты."
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
@@ -7970,100 +7376,98 @@ msgstr ""
 "Некоторые из этих адресов электронной почты уже используют Zulip, поэтому мы "
 "не стали отправлять им приглашение. А всем остальным выслали!"
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr "История редактирования сообщений отключена в этой организации"
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr "У вас нет прав для удаления этого сообщения"
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr "Разрешенное время удаления сообщения истекло"
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr "Сообщение уже удалено"
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr "Затребовано слишком много сообщений (максимум {max_messages})."
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr "Якорь можно исключить только в конце диапазона"
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr "Нет такой темы '{topic}'"
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr "Требуется объяснение."
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 msgid "Message reporting is not enabled in this organization."
 msgstr "В этой организации не включена возможность жалоб на сообщения."
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr "Не указан отправитель"
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr "Зеркалирование не разрешено с ID пользователя получателей"
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr "Неверное зеркалированное сообщение"
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr "Возможности ИИ не включены на этом сервере."
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr "Исчерпан месячный кредит ИИ."
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr "В беседе нет сообщений для обобщения"
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr "Нельзя заглушить себя"
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr "Пользователь уже заглушен"
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr "Пользователь не заглушен"
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr "Для встроенных видов нельзя задать пользовательское название."
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr "У пользовательских видов должно быть правильное название."
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 msgid "Navigation view already exists."
 msgstr "Навигационный вид уже существует."
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr "Неизвестный onboarding_step: {onboarding_step}"
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -8074,38 +7478,38 @@ msgstr ""
 "Вы предпочли отложить посмотр ознакомительного видео [Welcome to Zulip]"
 "({navigation_tour_video_url}). Сейчас подходящее время?\n"
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr "Присутствие не поддерживается для пользователей-ботов."
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr "Нет данных о присутствии {user_id_or_email}"
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr "Неверный статус: {status}"
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 msgid "You do not have permission to manage plans and billing."
 msgstr "У вас нет права управления тарифными планами и оплатой."
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr "Сервер не использует службу push-уведомлений"
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr "Отражатель вернул ошибку: {result}"
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr "Секретный код проверки не подготовлен"
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
@@ -8113,19 +7517,19 @@ msgstr ""
 "Недостающие параметры: должны быть указаны все поля ключей push, все поля "
 "токенов или и то, и другое."
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr "Нет push-регистрации для обновления ключа."
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr "Регистрация устройства уже началась."
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr "Нет push-регистрации для обновления токена."
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
@@ -8133,35 +7537,35 @@ msgstr ""
 "Как минимум один из следующих аргументов должен присутствовать: emoji_name, "
 "emoji_code"
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr "Уведомления о прочтении отключены в этой организации."
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr "Неверный язык '{language}'"
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr "Включите хотя бы один способ аутентификации."
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr "Неверный провайдер видеочатов {video_chat_provider}"
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr "Неверная gif_rating_policy {gif_rating_policy}"
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr "Организация не имеет права на льготные цены для внешних пользователей."
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
@@ -8169,69 +7573,69 @@ msgstr ""
 "Действующий тарифный план со скидкой не позволяет использовать скидки для "
 "внутренних пользователей."
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr "Должна быть демонстрационная организация."
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr "Неверное время удаления данных для демонстрационной организации."
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 "Удаление данных должно быть не позднее, чем через {max_allowed_days} дней."
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 "Удаление данных должно быть не ранее, чем через {min_allowed_days} дней."
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr "Неверный домен: {error}"
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr "Домен {domain} уже является частью вашей организации."
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr "Не найдена запись для домена {domain}."
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr "Вы должны загрузить только один файл."
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr "Только администраторы могут переопределять встроенные эмодзи."
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr ""
 "Размер загруженного файла больше установленного ограничения {max_size} MiB"
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr ""
 "Экспорт всех общедоступных и личных данных недоступен в этой организации."
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr "Превышена частота использования."
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
@@ -8240,57 +7644,57 @@ msgstr ""
 "Запрошенный вами экспорт слишком велик для автоматической обработки. "
 "Пожалуйста, запросите ручной экспорт письмом в адрес {email}."
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr "Неверный ID выгрузки данных"
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr "Выгрузка данных уже удалена"
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr "Выгрузка данных не удалась, удалять нечего"
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr "Выгрузка данных еще продолжается"
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr "Вы должны загрузить только одну иконку."
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr "Фильтр URL не найден."
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr "Вы должны загрузить только один логотоп."
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Invalid character in language: {character}"
 msgstr "Недопустимый символ в языке: {character}"
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Language '{language}' is not allowed."
 msgstr "Недопустимый язык '{language}'."
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr "Неверная интерактивная среда"
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr "Невозможно отменить импорт после начала."
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr "Не аутентифицирован"
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
@@ -8299,120 +7703,119 @@ msgstr ""
 "закроете эту вкладку, вы сможете вернуться сюда по ссылке «Завершить "
 "регистрацию» в письме."
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 msgid "Importing messages…"
 msgstr "Импорт сообщений…"
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr "Импорт данных вложений…"
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr "Импорт преобразованных данных Slack…"
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr "Завершение импорта…"
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr "Готово!"
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 "Нет пользователей, соответствующих указанному адресу электронной почты."
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 msgid "Your name"
 msgstr "Ваше имя"
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr "При обновлении типа отложенного сообщения требуется получатель."
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr "При обновлении типа отложенного сообщения для канала требуется тема."
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr "Неверный формат запроса"
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr "Неверный DSN"
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr "Закрытый канал нельзя сделать каналом по умолчанию."
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr "Вы должны передать \"new_description\" или \"new_group_name\"."
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr "Неверное значение для \"op\". Укажите \"add\" или \"remove\"."
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr "Неверные параметры"
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr "Требуется доступ к содержимому канала."
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr "У канала уже есть такое название."
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr "Не указано действие. Укажите хотя бы один 'add' или 'delete'."
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr "{user_full_name} подписал/а вас на {channel_name}."
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr "{user_full_name} подписал/а вас на следующие каналы:"
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr "Не удалось получить доступ к каналу ({channel_name})."
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr "{user_name} создал/а следующие каналы: {new_channels}."
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr "{user_name} создал/а новый канал {new_channels}."
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr "новые каналы"
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr "**Веб-открытый** канал создан пользователем {user_name}. **Описание:**"
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr "**Открытый** канал создан пользователем {user_name}. **Описание:**"
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
@@ -8420,7 +7823,7 @@ msgstr ""
 "**Закрытый, с открытой историей** канал создан пользователем {user_name}. "
 "**Описание:**"
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
@@ -8429,26 +7832,26 @@ msgstr ""
 "**Закрытый, с защищённой историей** канал создан пользователем {user_name}. "
 "**Описание:**"
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr "{property} не является булевым значением"
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr "Неизвестное свойство подписки: {property}"
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr "Нет подписки на канал с ID {channel_id}"
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr "Неверный json для субсообщения"
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
@@ -8457,7 +7860,7 @@ msgstr ""
 "Размер файла превышает предел ({max_size} МиБ), предусмотренный тарифом "
 "вашей организации."
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
@@ -8466,7 +7869,7 @@ msgstr ""
 "Размер файла превышает предел, установленный для закачек этого сервера "
 "({max_size} МиБ)."
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
@@ -8475,52 +7878,51 @@ msgstr ""
 "Размер закачанного файла превышает допустимый предел для импортов "
 "({max_file_size} МиБ)."
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr "Пользователь отключил оповещения о наборе текста для сообщений канала"
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr "Отсутствует аргумент 'to'"
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr "Пустой список 'to'"
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr "Пользователь отключил оповещения о наборе текста для личных сообщений"
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr "<p>Этот файл отсутствует или был удален.</p>"
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr "<p>Вы не уполномочены просматривать этот файл.</p>"
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr "Неверный токен"
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr "Неверное имя файла"
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr "Выберите файл для загрузки"
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr "За раз можно загрузить только один файл"
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr "Не указаны новые данные"
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
@@ -8528,33 +7930,33 @@ msgstr ""
 "Нечего исполнять. Укажите хотя бы одно из значений: \"add\", \"delete\", "
 "\"add_subgroups\" или \"delete_subgroups\"."
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr "{user_full_name} добавил/а вас в группу {group_name}."
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr "{user_full_name} удалил/а вас из группы {group_name}."
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr "Пользователь {user_id} уже является участником этой группы"
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr "В этой группе пользоваталей нет участника '{user_id}'"
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr ""
 "Группа пользователей {group_id} уже является подгруппой настоящей группы."
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
@@ -8563,7 +7965,7 @@ msgstr ""
 "Группа пользователей {user_group_id} уже является подгруппой одной из "
 "переданных подгрупп."
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
@@ -8571,97 +7973,97 @@ msgstr ""
 "Членство в подгруппах группы, используемой для 'workplace_users_group', "
 "должно управляться только администраторами организации."
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr ""
 "Группа пользователей {group_id} не является подгруппой настоящей группы."
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr "Изменение аватаров отключено в данной организации."
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr "Изменение адреса электронной почты отключено в этой организации."
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr "Неверный язык по умолчанию default_language"
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr "Неверный звук оповещения '{notification_sound}'"
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr "Неверный период пакетной рассылки: {seconds} с"
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr "Необходимо указать user_ids или group_ids."
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr "Нельзя изменить эту настройку для других пользователей."
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr "Ваш пароль Zulip задается в LDAP"
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr "Неверный пароль!"
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr ""
 "Вы сделали слишком много попыток! Попробуйте еще раз через "
 "{retry_after_string}."
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr "Новый пароль слишком слабый!"
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr "Вы должны загрузить ровно один аватар."
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr "Тема не заглушена"
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr "Нельзя отключить единственного владельца организации"
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 msgid "User is not allowed to delete other user's messages."
 msgstr "Пользователю не разрешается удалять сообщения другого пользователя."
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr "У пользователя нет полномочий для изменения адресов почты"
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 "Полномочия владельца нельзя снять с единственного владельца организации."
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr "Неверный новый адрес электронной почты."
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr "Ошибка в новом адресе почты: {message}"
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 msgid ""
 "Can't change bot email until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
@@ -8670,24 +8072,24 @@ msgstr ""
 "FAKE_EMAIL_DOMAIN.\n"
 "Обратитесь к администратору сервера."
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 msgid "Email address already in use"
 msgstr "Адрес электронной почты уже используется"
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr "Не удалось изменить владельца, нет такого пользователя"
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr "Не удалось изменить владельца, пользователь отключен"
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr ""
 "Не удалось изменить владельца, бот не может быть владельцем другого бота"
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
@@ -8696,130 +8098,130 @@ msgstr ""
 "правильно настроено.\n"
 "Пожалуйста, свяжитесь с администратором вашего сервера."
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr "Встроенные боты не включены."
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr "Недопустимое имя встроенного бота."
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr "У пользователя нет полномочий для создания пользователей"
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr "Адрес электронной почты '{email}' не допускается в этой организации"
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr "Одноразовые адреса электронной почты не допускаются в этой организации"
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} access token"
 msgstr "Неверный токен доступа {provider_name}"
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} call"
 msgstr "Не удалось создать вызов в {provider_name}"
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} credentials have not been configured"
 msgstr "Учетные данные {provider_name} не настроены"
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} credentials"
 msgstr "Неверные учетные данные {provider_name}"
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr "Ошибка подключения к серверу {provider_name}: {reason}"
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error authenticating to the {provider_name} server"
 msgstr "Ошибка аутентификации на сервере {provider_name}"
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr "{provider_name} сервер вернул непредвиденную ошибку: {status}"
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} session identifier"
 msgstr "Неверный идентификатор сеанса {provider_name}"
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr "Неизвестная электронная почта пользователя Zoom"
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} public room."
 msgstr "Не удалось создать публичную комнату {provider_name}."
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr "Неверная подпись."
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{full_name}'s Zulip room"
 msgstr "Комната Zulip: {full_name}"
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 "Проекты, использующие этого поставщика системы контроля версий, не "
 "поддерживаются"
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr "Недействительные данные"
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr "Неизвестный вебхук-запрос"
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr "Тема не может быть пустой"
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr "Содержимое не может быть пустым"
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr "Не удалось обработать полезную нагрузку Jotform"
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr "Неверные данные JSON"
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr "Ключ Events отсутствует в данных"
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr "Ошибка: параметр channels_map_to_topics, не является 0 или 1"
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr "Неизвестное действие вебхука WordPress: {hook}"
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
@@ -8828,77 +8230,77 @@ msgstr ""
 "Выгрузка ваших данных завершена. [Просмотрите и скачайте их]"
 "({export_settings_link})."
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr "Срок действия секретного кода проверки истек"
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr "Неверный секретный код проверки"
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr "Секретный код проверки сформирован неверно"
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr "Этот секретный код проверки для другого имени хоста"
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr "Неверный поддомен для отражателя push-уведомлений"
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr "Необходимо проверить с помощью действительного API-ключа сервера Zulip"
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr "Неверный UUID"
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr "Неверный тип токена"
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 "{hostname} содержит неверные составляющие (например, путь, запрос, фрагмент)."
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr "{hostname} не является корректным именем хоста"
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr "{hostname} еще не зарегистрирован"
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 "Неверный адрес электронной почты администратора сервера: {email_reason}"
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr "example.com не является допустимым доменом электронной почты."
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr "{domain} недопустим, потому что не имеет MX-записей"
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr "{domain} отсутствует"
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
@@ -8908,28 +8310,28 @@ msgstr ""
 "Пожалуйста, повторите попытку позже или обратитесь за помощью по адресу "
 "{support_email}."
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr "Регистрация для этого имени хоста не найдена"
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr "Хост сообщил об отсутствии секретного кода проверки."
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr "От хоста получен неожиданный код состояния: {status_code}"
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr "Отсутствует ios_app_id"
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr "Отсутствует user_id или user_uuid"
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
@@ -8938,48 +8340,48 @@ msgstr ""
 "Ваш тариф не позволяет отправлять push-уведомления. Причина, указанная "
 "сервером: {reason}"
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr "Ваш тариф не позволяет отправлять push-уведомления."
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr "Неверное свойство {property}"
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr "Неверный тип события."
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr "Данные не в порядке."
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr "Обнаружена повторная регистрация."
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr "Искаженные данные журнала аудита"
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr "Вам необходимо сбросить пароль."
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr "Отсутствует параметр id_token"
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 msgid "Missing idp param"
 msgstr "Отсутствует параметр idp"
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr "Неверный OTP"
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr "Нельзя одновременно использовать mobile_flow_otp и desktop_flow_otp."
 

--- a/locale/si/LC_MESSAGES/django.po
+++ b/locale/si/LC_MESSAGES/django.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 19:03+0000\n"
 "Last-Translator: Alex Vandiver <alexmv@zulip.com>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/zulip/django/si/"
@@ -22,50 +22,50 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "අමුත්තන්ට ඉඩ නැත"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "සංවිධානය වලංගු නොවේ"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr ""
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr ""
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr ""
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr "විශ්ලේෂණ දත්ත නැත. ඔබගේ සේවාදායක පරිපාලක අමතන්න."
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -74,7 +74,7 @@ msgid ""
 "users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -82,7 +82,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than one user to join."
 msgstr ""
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -90,7 +90,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than two users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -98,7 +98,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than three users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -107,150 +107,149 @@ msgid ""
 "({billing_page_link}) is greater than the current number of users."
 msgstr ""
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr ""
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr ""
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
 "(minimum {min_licenses})."
 msgstr ""
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
 "page. To complete the upgrade, please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr ""
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr "{brand} {last4} න් අවසන් වේ"
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "යම් වැරැද්දක් සිදුවී ඇත. පිටුව නැවත පූරණය කරන්න."
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr "යම් වැරැද්දක් සිදු වී ඇත. තත්පර කිහිපයක් රැඳී සිට යළි උත්සාහ කරන්න."
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr ""
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
 msgstr ""
 "සැලසුම යාවත්කාල කිරීමට නොහැකිය. සැලසුම කල් ඉකුත් වී නව සැලසුමක් සමඟ ප්‍රතිස්ථාපනය කර ඇත."
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr "සැලසුම යාවත්කාල කිරීමට නොහැකිය. සැලසුම අවසන් වී ඇත."
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
 msgstr ""
 "බලපත්‍ර අතින් යාවත්කාල කිරීමට නොහැකිය. ඔබගේ සැලසුම ස්වයංක්‍රීය බලපත්‍ර කළමනාකරණය යටතේ ය."
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr "වත්මන් ලදුපත් කාල සීමාව තුළ ඔබගේ සැලසුම දැනටමත් බලපත්‍ර {licenses} යටතේ ඇත."
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr "වත්මන් ලදුපත් කාල සීමාව තුළ ඔබට බලපත්‍ර අඩු කළ නොහැකිය."
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
 msgstr ""
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
 "licenses."
 msgstr "ඔබගේ සැලසුම දැනටමත් {licenses_at_next_renewal} බලපත්‍ර සමඟ අලුත් කිරීමට නියමිතය."
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
 "billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr "සංශෝධනයට කිසිත් නැත."
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr "මෙම සංවිධානයට පාරිභෝගිකයින් නැත!"
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr ""
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -260,100 +259,97 @@ msgid ""
 "we would really appreciate it!"
 msgstr ""
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
 "{support_email}"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr ""
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "දෝෂයකි"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr ""
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
 "%(support_email)s\">contact support</a>."
 msgstr ""
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr ""
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
 msgstr ""
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr ""
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
 msgstr ""
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr ""
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr "අභ්යන්තර සේවාදායකයේ දෝෂයකි"
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
 msgstr ""
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -361,219 +357,217 @@ msgid ""
 "a> with any questions."
 msgstr ""
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
 "a> for support."
 msgstr ""
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
 "href=\"%(troubleshooting_url)s\">Zulip server troubleshooting guide</a>."
 msgstr ""
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, fuzzy, python-format
 #| msgid "Zulip analytics for %(target_name)s"
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr "%(target_name)s සඳහා සුලිප් විශ්ලේෂණ"
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr "සංවිධානය සෑදීමෙන් පැය 24 කට පසු විශ්ලේෂණ සම්පූර්ණයෙන්ම ලබා ගත හැකිය."
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr "%(target_name)s සඳහා සුලිප් විශ්ලේෂණ"
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr ""
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr ""
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr ""
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr ""
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr ""
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr ""
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr ""
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "සක්‍රිය පරිශීලකයින්"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr "දෛනික ක්‍රියාකාරී"
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr ""
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr "මුළු පරිශීලකයින්"
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "පරිශීලකයින්"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr "ලබන්නාගේ වර්ගය අනුව යැවූ පණිවිඩ"
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "මා"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "සෑම දෙනාම"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "පසුගිය සතිය"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "පසුගිය මාසය"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "පසුගිය අවුරුද්ද"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "සෑම වෙලාවෙම"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr ""
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "දිනපතා"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "සතිපතා"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr ""
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "මනුෂ්‍යයින්"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "ස්වයංක්‍රමලේඛ"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr ""
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr "අනුග්‍රාහකයා යැවූ පණිවිඩ"
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr "අන්තිම යාවත්කාලය"
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr "වි-තැපෑල වෙනස් කෙරිණි!"
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
 "%(old_email_html_tag)s to %(new_email_html_tag)s"
 msgstr ""
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr ""
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
@@ -581,72 +575,55 @@ msgstr ""
 "සබැඳිය ඔබගේ අතිරික්සුවට නිවැරදිව පිටපත් කර තිබේ දැයි බලන්න. ඔබට තවමත් මෙම පිටුව මුණ ගැසෙනවා "
 "නම් එය බොහෝ විට අපගේ වරදක් විය හැකිය. සමාවන්න."
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr "ලදුපත්"
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "අවලංගු"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr ""
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr ""
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -657,19 +634,19 @@ msgid ""
 "server."
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -677,795 +654,304 @@ msgid ""
 "%(support_email)s'>contact support</a> with any questions."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr "අනුපාත සීමාව ඉක්මවිණි."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, fuzzy, python-format
 #| msgid "You can try again in %(retry_after)s seconds."
 msgid "You can try again in %(retry_after_string)s."
 msgstr "ඔබට තත්. %(retry_after)s කින් නැවත උත්සාහ කළ හැකිය."
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr ""
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr ""
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr "ප්‍රවර්ගය අනුව පෙරන්න"
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "සියළුම"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr "ප්‍රවර්ග"
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr ""
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr "සුලිප් සංවර්ධන ප්‍රජාව"
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr "පරිශීලකයෙකු ලෙස එක්වන්න"
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr ""
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr "දායකයෙකු ලෙස එකතු වන්න"
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "සංවිධානය සාදන්න"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr ""
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr ""
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr ""
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr "අධ්යාපනික මිලකරණය"
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr "මිලකරණය දකින්න"
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 msgid "Zulip for open source"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Create your Zulip organization"
 msgid "Screenshot of Zulip conversation"
 msgstr "ඔබගේ සුලිප් සංවිධානය සාදන්න"
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Messages sent by client"
 msgid "Message with code"
 msgstr "අනුග්‍රාහකයා යැවූ පණිවිඩ"
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr "සබැඳිය"
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr "සහාය අමතන්න"
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr "වෙත"
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr "සංවිධානය"
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr "මාතෘකාව"
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr "පණිවිඩය"
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr "යොමුකරන්න"
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
 msgstr ""
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 #, fuzzy
 #| msgid "Getting started"
 msgid "Get started"
 msgstr "ආරම්භය ගන්න"
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
 "continue."
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr "හෝ, ඔබගේ උපස්ථ දුරකථන වලින් එකක් භාවිතා කරන්න:"
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "වි-තැපෑල"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1473,78 +959,77 @@ msgid ""
 "from Zulip."
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
 msgstr ""
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr ""
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr ""
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr ""
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr ""
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr ""
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr ""
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr ""
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
 msgstr ""
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1552,214 +1037,207 @@ msgid ""
 "href=\"%(doc_url)s\">documentation</a>."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr "සුලිප් ගිණුම හමු නොවිණි."
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, python-format
 msgid "No account found for %(email)s."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr "වෙනත් ගිණුමක් සමඟ ඇතුල් වන්න"
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr "ලියාපදිංචිය සඳහා ඉදිරියට යන්න"
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Create your Zulip organization"
 msgid "Try Zulip in a demo organization"
 msgstr "ඔබගේ සුලිප් සංවිධානය සාදන්න"
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Why Zulip"
 msgid "Try Zulip"
 msgstr "ඇයි සුලිප්"
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "නව සංවිධානයක් සාදන්න"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr "නව සුලිප් සංවිධානයක් සාදන්න"
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr "ඔබගේ වි-තැපැල් ලිපිනය ඇතුල් කරන්න"
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr "සංවිධානයේ වර්ගය"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 #, fuzzy
 #| msgid "Private, shared history"
 msgid "Import chat history?"
 msgstr "පෞද්ගලික, හවුල් ඉතිහාසය"
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr "සංවිධානයේ නම"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "සංවිධානයේ ඒ.ස.නි."
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr "%(external_host)s භාවිතා කරන්න"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "හෝ"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "ලියාපදිංචිය"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "සුලිප් සඳහා ලියාපදිංචි වන්න"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr "මෙම සංවිධානයට එක්වීමට ඔබට ඇරයුමක් අවශ්‍යයි."
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr "%(identity_provider)s සමඟ ලියාපදිංචි වන්න"
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "ඇතුල් වන්න"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1767,125 +1245,124 @@ msgid ""
 "noreferrer\">after you join</a>."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "වෙනස් කරන්න"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr "ඔබගේ සංවිධානය සාදන්න"
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr "ඔබගේ ගිණුම සාදන්න"
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 #, fuzzy
 #| msgid "Click the button below to complete registration."
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr "ලියාපදිංචිය සම්පූර්ණ කිරීම සඳහා පහත බොත්තම ඔබන්න."
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr "ඔබගේ ගිණුම"
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr "සැකසුම් ආයාත නොකරන්න"
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr "පවතින සුලිප් ගිණුමෙන් සැකසුම් ආයාත කරන්න"
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "නම"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "මුරපදය"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr "මුරපදයක් අවශ්‍ය ජංගම යෙදුම් සහ වෙනත් මෙවලම් සඳහා මෙය භාවිතා කෙරේ."
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr "මුරපදයේ ශක්තිය"
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr "ඔබ උනන්දු වන්නේ කුමක් ගැනද?"
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">Terms of Service</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr ""
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr ""
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -1893,45 +1370,45 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 msgid ""
 "This organization has been deactivated, and all organization data has been "
 "deleted."
 msgstr ""
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
 "inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
 "administrators</a> to inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 msgid "This organization has been deactivated."
 msgstr ""
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
 "%(support_email)s\">contact Zulip support</a> to reactivate it."
 msgstr ""
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -1939,105 +1416,104 @@ msgid ""
 "reactivate it."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr "අහවරයි"
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "පිටපතක්"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr "ඉන්පසු ඔබට මෙම කවුළුව වසා දැමිය හැකිය."
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr "හෝ, ඔබගේ අතිරික්සුව තුළ ඉදිරියට යන්න."
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr "නිර්නාමික පරිශීලක"
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr "හිමිකරුවන්"
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "පරිපාලකයින්"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr "මැදිහත්කරුවන්"
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr "පරිශීලක අමුත්තන්"
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "සාමාන්‍ය පුද්ගලයින්"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "වසන්න"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "යාවත්කාල"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr "සුලිප්"
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, fuzzy, python-format
 #| msgid "You've joined the Zulip organization %(realm_name)s."
 msgid ""
@@ -2045,61 +1521,61 @@ msgid ""
 "<b>%(realm_name)s</b>."
 msgstr "ඔබ %(realm_name)s සුලිප් සංවිධානයට එක් වී ඇත."
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr "සුලිප් වෙත සාදරයෙන් පිළිගනිමු!"
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, fuzzy, python-format
 #| msgid "You've joined the Zulip organization %(realm_name)s."
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr "ඔබ %(realm_name)s සුලිප් සංවිධානයට එක් වී ඇත."
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
 "href=\"%(apps_page_link)s\">mobile and desktop</a> apps:"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr "සංවිධානයේ ඒ.ස.නි.: %(organization_url)s"
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
 "href=\"%(getting_user_started_link)s\">getting started guide</a>!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2107,83 +1583,83 @@ msgid ""
 "Zulip</a>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
 "to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr "සුලිප් හි %(realm_name)s: ඔබගේ නව සංවිධානයේ විස්තර"
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr "සුලිප් හි %(realm_name)s: ඔබගේ නව ගිණුමේ විස්තර"
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr "ඔබ %(realm_name)s සුලිප් සංවිධානයට එක් වී ඇත."
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
 "desktop apps (%(apps_page_link)s):"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
 "(%(getting_user_started_link)s)!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
 "(%(getting_organization_started_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr "ආයුබෝ,"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2191,34 +1667,34 @@ msgid ""
 "password for this account, please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "%(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 #, fuzzy
 #| msgid "Create your Zulip organization"
 msgid "Verify your email address for your Zulip demo organization"
 msgstr "ඔබගේ සුලිප් සංවිධානය සාදන්න"
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "<%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2226,113 +1702,113 @@ msgid ""
 "please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr "ඔබ මෑතකදී සුලිප් සඳහා ලියාපදිංචි වී ඇත. නියමයි!"
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr "ලියාපදිංචිය සම්පූර්ණ කිරීම සඳහා පහත බොත්තම ඔබන්න."
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr "ලියාපදිංචිය සම්පූර්ණ කරන්න"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr "ඔබගේ සුලිප් සංවිධානය සාදන්න"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr "ඔබගේ සුලිප් ගිණුම ක්‍රියාත්මක කරන්න"
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
 "— we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
 "deactivated, and you will no longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr ""
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2340,22 +1816,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because your organization has "
@@ -2371,8 +1847,8 @@ msgstr ""
 "තැපැල් දැනුම්දීම් හි පණිවිඩයේ අන්තර්ගතය දිස්වීම</a> අබල කර ඇති හෙයින් මෙම වි-තැපෑලෙහි පණිවිඩයේ "
 "අන්තර්ගතය ඇතුළත් නොවේ."
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because you have disabled <a "
@@ -2387,40 +1863,40 @@ msgstr ""
 "තැපැල් දැනුම්දීම් හි පණිවිඩයේ අන්තර්ගතය දිස්වීම</a> අබල කර ඇති හෙයින් මෙම වි-තැපෑලෙහි පණිවිඩයේ "
 "අන්තර්ගතය ඇතුළත් නොවේ."
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, fuzzy, python-format
 #| msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr "ඔබගේ නව මුරපදය සමඟ <a href=\"%(login_url)s\">ඇතුල් වන්න</a>"
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr ""
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because your organization has "
@@ -2436,8 +1912,8 @@ msgstr ""
 "තැපැල් දැනුම්දීම් හි පණිවිඩයේ අන්තර්ගතය දිස්වීම</a> අබල කර ඇති හෙයින් මෙම වි-තැපෑලෙහි පණිවිඩයේ "
 "අන්තර්ගතය ඇතුළත් නොවේ."
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because you have disabled <a "
@@ -2451,41 +1927,38 @@ msgstr ""
 "තැපැල් දැනුම්දීම් හි පණිවිඩයේ අන්තර්ගතය දිස්වීම</a> අබල කර ඇති හෙයින් මෙම වි-තැපෑලෙහි පණිවිඩයේ "
 "අන්තර්ගතය ඇතුළත් නොවේ."
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, fuzzy, python-format
 #| msgid "Log in to your organization"
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr "ඔබගේ සංවිධානයට ඇතුල් වන්න"
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr ""
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr "පිහිනුම් මාළු"
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr "ඔබගේ ඉල්ලීමට ස්තූතියි!"
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
 "organizations:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
@@ -2494,33 +1967,29 @@ msgstr ""
 "ඔබගේ වි-තැපැල් ලිපිනය %(email)s ට %(external_host)s මගින් සත්කාරකත්වය දරනු ලබන පහත "
 "දැක්වෙන සුලිප් සංවිධානයන් හි ගිණුම් ඇත:"
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
 "href=\"%(help_reset_password_link)s\">reset your password</a>."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
 "%(external_host)s."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2528,86 +1997,83 @@ msgid ""
 "to find your account."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr "ඔබගේ සුලිප් ගිණුම්"
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
 "try another way to find your account (%(help_logging_in_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr "ආයුබෝවන්,"
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
 "communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr "ආරම්භයට පහත බොත්තම ඔබන්න."
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 "%(referrer_full_name)s ඔබට %(referrer_realm_name)s හා එක් වීමට ආරාධනා කර ඇත"
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
 "-- the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr "ආරම්භයට පහත සබැඳිය ඔබන්න."
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr "ආයුබෝ,"
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
 "Zulip &mdash; the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr "මෙම ආරාධනය සඳහා ඔබට ලැබෙන අවසාන සිහිකැඳවීම මෙයයි."
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
@@ -2616,12 +2082,12 @@ msgstr ""
 "මෙම ඇරයුම දවස් දෙකකින් කල් ඉකුත් වේ. කල් ඉකුත් වුවහොත් ඔබට වෙනත් එකක් සඳහා "
 "%(referrer_name)s න් විමසිය යුතුය."
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr "සිහිකැඳවීම: %(referrer_realm_name)s හි %(referrer_name)s හා එක් වන්න"
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2629,72 +2095,70 @@ msgid ""
 "productivity."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at <a href=\"mailto:%(email)s\">%(email)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
 "%(email)s\">Contact us</a> — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
 "#%(channel_name)s > %(topic_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2702,21 +2166,21 @@ msgid ""
 "preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2731,41 +2195,41 @@ msgstr ""
 "වි-තැපෑලට පිළිතුරු නොදෙන්න. සුලිප් සේවාදායකය ලැබෙන වි-තැපැල් පිළිගැනීමට\n"
 "වින්‍යාසගත කර නැත. උදව්:\n"
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr "නව පණිවිඩ"
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
@@ -2773,7 +2237,7 @@ msgstr ""
 "වි-තැපෑලට පිළිතුරු නොදෙන්න. සුලිප් සේවාදායකය ලැබෙන වි-තැපැල් පිළිගැනීමට වින්‍යාසගත කර නැත. "
 "උදව්:"
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2781,22 +2245,22 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr "හොඳම,"
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr "සුලිප් කණ්ඩායම"
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr "%(realm_name)s සඳහා සුලිප් වි-තැපෑල වෙනස් කෙරිණි"
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2804,53 +2268,53 @@ msgid ""
 "immediately at <%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 msgstr ""
 "සංවිධානය: %(organization_url)s වේලාව: %(login_time)s වි-තැපෑල: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr "පහත දැක්වෙන සුලිප් ගිණුම සඳහා මෑතකදී ඇතුල් වීමක් අපි දුටුවෙමු."
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr "සංවිධානය: %(organization_link)s"
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr "වි-තැපෑල: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr "වේලාව: %(login_time)s"
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr "උපාංගය: %(device_browser)s %(device_os)s හි."
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr "අ.ජා.කෙ. ලිපිනය: %(device_ip)s"
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr "මේ ඔබ නම්, හොඳයි! ඔබට කළ යුතු වෙනත් කිසිවක් නැත."
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2858,31 +2322,31 @@ msgid ""
 "contact us immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr "ස්තුතියි,"
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr "සුලිප් ආරක්‍ෂාව"
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr "%(device_os)s හි %(device_browser)s මඟින් නව ඇතුල් වීමක්"
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr "සංවිධානය: %(organization_url)s"
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2890,7 +2354,7 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -2898,25 +2362,25 @@ msgid ""
 "Zulip</a> to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
 "with you and share their unique perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -2924,7 +2388,7 @@ msgid ""
 "experience how a new chat app will help your team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -2932,148 +2396,148 @@ msgid ""
 "action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
 "team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
 "organizations like yours!"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3081,11 +2545,11 @@ msgid ""
 "about…?”"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr "කෙටි මාතෘකා සඳහා උදාහරණ"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3094,23 +2558,23 @@ msgid ""
 "href=\"%(move_channels_link)s\">move a topic to a different channel</a>."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr "සුලිප් වෙත යන්න"
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3119,23 +2583,23 @@ msgid ""
 "(%(move_channels_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
 "%(email)s on %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr "ඔබගේ මුරපදය නැවත සැකසීමට පහත බොත්තම ඔබන්න."
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr "මුරපදය නැවත සකසන්න"
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3143,47 +2607,47 @@ msgid ""
 "href=\"%(help_link)s\">reactivate your account</a>."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr "එම සුලිප් සංවිධානයෙහි ඔබට ගිණුමක් නැත."
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr "පහත දැක්වෙන සංවිධාන(ය) තුළ ඔබගේ ක්‍රියාත්මක ගිණුම් තිබේ."
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
 msgstr "ඉහත සංවිධාන(ය) ට ඇතුල් වීමට හෝ ඔබගේ මුරපදය නැවත සැකසීමට උත්සාහ කළ හැකිය."
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 "ඔබට මෙම ක්‍රියාකාරකම හඳුනාගත නොහැකි නම්, මෙම වි-තැපෑල ආරක්ෂිතව නොසලකා හැරීමට හැකිය."
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr "%(realm_name)s සඳහා මුරපදය යළි සැකසීමේ ඉල්ලීම"
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr "ඔබගේ මුරපදය නැවත සැකසීමට පහත සබැඳිය ඔබන්න."
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
 "You can contact an organization administrator to reactivate your account."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3191,22 +2655,22 @@ msgid ""
 "have been voided."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
 "to %(upgrade_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid "You've joined the Zulip organization %(realm_name)s."
 msgid ""
@@ -3214,104 +2678,104 @@ msgid ""
 "%(localized_date)s."
 msgstr "ඔබ %(realm_name)s සුලිප් සංවිධානයට එක් වී ඇත."
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr "හිතවත් %(realm_name)s හි හිටපු පරිපාලකයින් වෙත,"
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip demo organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
@@ -3319,420 +2783,416 @@ msgstr ""
 "ඉල්ලීම වැරදීමක් නම්, ඔබට කිසිදු ක්‍රියාමාර්ගයක් ගත නොහැකි අතර මෙම සබැඳිය පැය 24 කින් කල් ඉකුත් "
 "වේ."
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Create your Zulip organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "ඔබගේ සුලිප් සංවිධානය සාදන්න"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for <b>%(remote_server_hostname)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, fuzzy
 #| msgid "Click the button below to complete registration."
 msgid "Click the button below to log in."
 msgstr "ලියාපදිංචිය සම්පූර්ණ කිරීම සඳහා පහත බොත්තම ඔබන්න."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for %(remote_server_hostname)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
 "management for <b>%(remote_realm_host)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
 "management for %(remote_realm_host)s."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the <a href=\"%(plans_link)s\">Zulip Community plan</a>."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
 "website</a>, we would really appreciate it!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
 msgstr ""
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
 "accounts for another email address</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr "වි-තැපැල් ලිපිනය"
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "ගිණුම් සොයාගන්න"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr "නිෂ්පාදනය"
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr "ඇයි සුලිප්"
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr "විශේෂාංග"
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr ""
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Zulip"
 msgid "Zulip Cloud"
 msgstr "සුලිප්"
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr ""
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr "ආරක්ෂාව"
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "අනුකලන"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr ""
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr "නව සංවිධානය"
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr "විසඳුම්"
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr ""
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr "අධ්යාපනය"
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr "පර්යේෂණ"
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr ""
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr "විවෘත මූලාශ්‍ර ව්‍යාපෘති"
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr "ප්‍රජාවන්"
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr "පාරිභෝගික කථා"
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr ""
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr ""
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr "ආරම්භය ගන්න"
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr "උපකාරක මධ්‍යස්ථානය"
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr "ප්‍රජා සංවාදය"
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr ""
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr "සුලිප් සේවාදායකයක් ස්ථාපනය කිරීම"
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr "සුලිප් සේවාදායකයක් ශ්‍රේණිකරනය"
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr ""
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr ""
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr "සංවර්ධන ප්‍රජාව"
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr "පරිවර්තනය"
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr "ගිට්හබ්"
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr "අපි ගැන"
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr "කණ්ඩායම"
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "ඉතිහාසය"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr ""
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr "රැකියා"
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr ""
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr "සුලිප් ට සහයවන්න"
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr ""
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr ""
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 msgid "Bluesky"
 msgstr ""
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr ""
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr "සේවාවේ නියම"
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr "රහස්‍යතා ප්‍රතිපත්තිය"
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 msgid ""
 "And hundreds more through <a href=\"/integrations/zapier\">Zapier</a> and <a "
 "href=\"/integrations/ifttt\">IFTTT</a>."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr "අනුකලන සොයන්න"
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr "අභිරුචි අනුකලන"
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr "වි-තැපෑල වලංගු නොවේ"
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3740,7 +3200,7 @@ msgid ""
 "emails with your email domain."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3748,7 +3208,7 @@ msgid ""
 "disposable email addresses."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3756,24 +3216,24 @@ msgid ""
 "emails that contain \"+\"."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3781,7 +3241,7 @@ msgid ""
 "%(support_email)s\">contact Zulip support</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3789,89 +3249,89 @@ msgid ""
 "%(support_email)s\">contact this Zulip server's administrators</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
 "management for your Zulip server."
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr ""
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr "සුලිප් වෙත ඇතුල් වන්න"
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr "ඔබ දැනටමත් මෙම වි-තැපැල් ලිපිනය සමඟ ලියාපදිංචි වී ඇත. පහතින් ඇතුල් වන්න."
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr "වි-තැපෑල හෝ පරිශීලක නාමය"
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "පරිශීලක නාමය"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr "මුරපදය අමතක වුනාද?"
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr "%(identity_provider)s සමඟ ඇතුල් වන්න"
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr ""
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr "තවම ගිණුමක් නැද්ද? මෙම සංවිධානයට එක්වීමට ඔබට ආරාධනා කර තිබිය යුතුය."
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> because all Zulip Cloud licenses are in use."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -3880,44 +3340,42 @@ msgid ""
 "or misconfiguration."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 #, fuzzy
 #| msgid "New organization"
 msgid "Demo organizations disabled"
 msgstr "නව සංවිධානය"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr "යාවත්කාල කිරීම අවශ්‍යයි"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr "නවතම නිකුතුව බාගන්න."
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -3925,22 +3383,21 @@ msgid ""
 "organization for more information."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -3948,48 +3405,46 @@ msgid ""
 "Zulip support</a> for assistance in resolving this issue."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr "සහාය නොදක්වන අතිරික්සුවකි"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
 "a> like Firefox, Chrome, and Edge."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Invalid organization"
 msgid "Finalize organization import"
 msgstr "සංවිධානය වලංගු නොවේ"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Organization type"
 msgid "Organization import completed!"
 msgstr "සංවිධානයේ වර්ගය"
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -3997,56 +3452,55 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Select your account"
 msgstr "ඔබගේ ගිණුම සාදන්න"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Create new account"
 msgstr "ඔබගේ ගිණුම සාදන්න"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr ""
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr "ඔබගේ සංවිධානයට ඇතුල් වන්න"
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr "ඔබගේ සංවිධානයේ ඒ.ස.නි. නොදන්නේද?"
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr "ඊළඟ"
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4054,81 +3508,81 @@ msgid ""
 "have one yet."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 msgid "Self-hosting Zulip?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">log in to manage plans and billing.</a>"
 msgstr ""
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr "ඔබගේ මුරපදය නැවත සකසන්න"
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
 msgstr ""
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr "යළි පිහිටුවීමේ සබැඳිය යවන්න"
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr "කණගාටුයි, ඔබ ලබා දුන් සබැඳිය වලංගු නැත හෝ දැනටමත් භාවිතා කර ඇත."
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr ""
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr ""
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr "ඔබගේ නව මුරපදය සමඟ <a href=\"%(login_url)s\">ඇතුල් වන්න</a>."
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr "මුරපදය යළි සැකසීම යවන ලදි!"
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr "ක්‍රියාවලිය අවසන් කිරීම සඳහා විනාඩි කිහිපයකින් ඔබගේ වි-තැපෑල පරීක්‍ෂා කරන්න."
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr ""
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4136,7 +3590,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4145,57 +3599,57 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr ""
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4203,7 +3657,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4211,40 +3665,40 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4252,136 +3706,133 @@ msgid ""
 "away!"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr "වි-තැපැල් සැකසුම් යාවත්කාල කෙරිණි"
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
 "href=\"%(realm_url)s/#settings/notifications\">notification settings</a>."
 msgstr ""
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr ""
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr ""
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr ""
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr ""
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr "ලියාපදිංචි කිරීම්"
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr ""
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr "සුලිප් හා එක් වීමට ඔබගේ ඇරයුම {user} පිළිගෙන ඇත!"
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 msgid "Cannot reactivate a deleted user"
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr ""
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr ""
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr ""
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr ""
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
 msgstr ""
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
@@ -4389,167 +3840,164 @@ msgstr ""
 "මෙම සංවිධානය සඳහා ආරාධනා යැවීමට ඔබගේ ගිණුම ඉතා අළුත් ය. සංවිධාන පරිපාලකයෙකුගෙන් හෝ "
 "වඩාත් පළපුරුදු පරිශීලකයෙකුගෙන් අසන්න."
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr "අපට කිසිවෙකුට ආරාධනා කිරීමට නොහැකි විය."
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr "වෙනස් කිරීමට කිසිවක් නැත"
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr ""
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr ""
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr ""
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr ""
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr ""
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr "ඔබගේ සංවිධානය පණිවිඩ සංස්කරණය අක්‍රිය කර ඇත"
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr "මෙම පණිවිඩය සංස්කරණය කිරීමට ඔබට අවසර නැත"
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr "මෙම පණිවිඩය සංස්කරණ කාල සීමාව පසු වී ඇත"
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr "{user} මෙම මාතෘකාව විසඳා ඇති ලෙස සලකුණු කර ඇත."
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr "{user} මෙම මාතෘකාව නොවිසඳුනු ලෙස සලකුණු කර ඇත."
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
 "{new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
 "{user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 #, fuzzy
 #| msgid "You don't have permission to move this message"
 msgid "You don't have permission to resolve topics in this channel."
 msgstr "මෙම පණිවිඩය ගෙන යාමට ඔබට අවසර නැත"
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr "මෙම පණිවිඩය ගෙන යාමට ඔබට අවසර නැත"
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr ""
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr "පණිවිඩ(ය) වලංගු නොවේ"
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr "පණිවිඩය ගෙනහැර දැක්වීමට නොහැකිය"
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr "ලබන්නන් සඳහා වලංගු නොවන දත්ත වර්ගයකි"
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr "ලබන්නන්ගේ ලැයිස්තු වල වි-තැපැල් හෝ පරිශීලක හැඳු. අඩංගු විය හැකිය නමුත් දෙකම නොවේ."
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
 "but there is no channel with that ID."
 msgstr ""
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4557,36 +4005,36 @@ msgid ""
 "it."
 msgstr ""
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
 "The channel exists but does not have any subscribers."
 msgstr ""
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr ""
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr ""
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr ""
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4594,107 +4042,105 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr "මෙම නම සහිත අභිරුචි ඉමොජියක් දැනටමත් පවතී."
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
 "authentication method."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr ""
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 msgid "Reminder could not be sent."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
 "the following error:"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr ""
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr ""
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr ""
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr ""
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr ""
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
 "**{old_policy}** to **{new_policy}**."
 msgstr ""
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -4703,51 +4149,49 @@ msgid ""
 "* **New**: {new_setting_description}\n"
 msgstr ""
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr "සවිස්තරයක් නැත."
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr ""
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr ""
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr ""
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr ""
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr ""
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 msgstr ""
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr ""
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -4758,150 +4202,139 @@ msgid ""
 "{summary_line}"
 msgstr ""
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr "ඔබට මෙම පණිවිඩයට උප පණිවිඩයක් ඇමුණිය නොහැකිය."
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr ""
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr ""
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr "ප්‍රමාණවත් අවසරයක් නැත"
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr ""
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr "මෙම උප වසම සමඟ ගිණුමෙහි සම්බන්ධතාවයක් නැත"
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr ""
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr "සේවාදායක පරිපාලකයෙකු විය යුතුය"
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr ""
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr ""
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr ""
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
 "organization administrator to reactivate it."
 msgstr ""
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr ""
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr ""
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr "උපවසම '-' සමඟ ආරම්භ හෝ අවසන් විය නොහැකිය."
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr "උපවසම් වල තිබිය හැකි වන්නේ කුඩා අකුරු, අංක සහ '-' පමණි."
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr "ඔබගේ නියම වි-තැපැල් ලිපිනය භාවිතා කරන්න."
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr "ඔබ {email} භාවිතයෙන් එක් වීමට උත්සාහ කරන සංවිධානය නොපවතී."
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr "කරුණාකර සංවිධානයේ පරිපාලකගෙන් {email} සඳහා ඇරයුමක් ඉල්ලන්න."
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
@@ -4910,11 +4343,11 @@ msgstr ""
 "ඔබගේ වි-තැපැල් ලිපිනය, {email}, මෙම සංවිධානයේ ගිණුම් සඳහා ලියාපදිංචි වීමට ඉඩ දී ඇති  වසම් "
 "තුළ නැත."
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr "මෙම සංවිධානය තුළ + අඩංගු වි-තැපැල් ලිපින වලට ඉඩ නැත."
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
@@ -4923,130 +4356,127 @@ msgstr ""
 "සියළුම සුලිප් බලපත්‍ර භාවිතා වන බැවින් නව සාමාජිකයින්ට මෙම සංවිධානයට එක් විය නොහැකිය. කරුණාකර "
 "ඔබට ආරාධනා කළ පුද්ගලයාට බලපත්‍ර ගණන වැඩි කරන ලෙස පවසා නැවත උත්සාහ කරන්න."
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 #, fuzzy
 #| msgid "Embedded bots are not enabled."
 msgid "Challenges are not enabled."
 msgstr "එබ්බවූ ස්වයංක්‍රමලේඛ සබල කර නැත."
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "නව මුරපදය"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr ""
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "You're making too many attempts to sign in. Try again in "
 "{retry_after_string} or contact your organization administrator for help."
 msgstr ""
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
 msgstr ""
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr ""
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr "උපරිම වශයෙන් වි-තැපැල් 10 ක් ඇතුල් කරන්න."
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr ""
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr ""
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr ""
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr ""
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr ""
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr "පණිවිඩයට ලබන්නන් සිටිය යුතුය"
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr "පණිවිඩ වර්ගය වලංගු නොවේ"
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr "ඇමුණුම වලංගු නොවේ"
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr ""
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr "පණිවිඩයට ලබන්නන් සිටිය යුතුය!"
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Content can't be empty"
 msgid "Channel folder name can't be empty."
 msgstr "අන්තර්ගතය හිස් විය නොහැකිය"
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Invalid data export ID"
 msgid "Invalid channel folder ID"
 msgstr "වලංගු නොවන දත්ත නිර්යාත හැඳු."
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 #, fuzzy
 #| msgid "Enter your email address"
 msgid "Configure owner account email address."
 msgstr "ඔබගේ වි-තැපැල් ලිපිනය ඇතුල් කරන්න"
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5055,72 +4485,72 @@ msgid ""
 "organization]({convert_demo}).\n"
 msgstr ""
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a date"
 msgid "{var_name} is not Base64 encoded"
 msgstr "{var_name} දිනයක් නොවේ"
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 #, fuzzy
 #| msgid "Invalid emoji code."
 msgid "Invalid `device_id`"
 msgstr "වලංගු නොවන ඉමොජි කේතය."
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr ""
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr "වසම හිස් විය නොහැකිය."
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr "වසමෙහි අවම වශයෙන් එක් තිතක් (.) තිබිය යුතුය"
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr "වසම ඉතා දිගු ය"
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr "වසම තිතකින් (.) ආරම්භ හෝ අවසන් විය නොහැකිය"
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr ""
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr "උපවසම් '-' සමඟ ආරම්භ හෝ අවසන් විය නොහැකිය."
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr "වසමක තිබිය හැකි වන්නේ අකුරු, අංක සහ '-' පමණි."
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr ""
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr ""
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5128,626 +4558,624 @@ msgid ""
 "{error_message}"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr ""
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr "ලිපිනය වලංගු නොවේ."
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr "ඔබගේ වසමෙන් පිටත."
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr "+ අඩංගු වි-තැපැල් ලිපින වලට ඉඩ නැත."
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr "පද්ධතියේ ස්වයංක්‍රමලේඛ සඳහා වෙන් කර ඇත."
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr "{email} ට දැනටමත් ගිණුමක් ඇත"
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr "දැනටමත් ගිණුමක් තිබේ."
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr ""
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr "වලංගු නොවන අභිරුචි ඉමොජි කි."
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr "වලංගු නොවන අභිරුචි ඉමොජි නම."
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr "වලංගු නොවන ඉමොජි කේතය."
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr "වලංගු නොවන ඉමොජි නම."
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr "වලංගු නොවන ඉමොජි වර්ගය."
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr "සංවිධාන පරිපාලකයෙකු හෝ ඉමොජි කතුවරයෙකු විය යුතුය"
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr ""
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
 msgstr ""
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr "ඉමොජි නම අස්ථානගත වී ඇත"
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr ""
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr ""
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr ""
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr "සංවිධානයේ හිමිකරු"
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr "පරිශීලක"
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr ""
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr ""
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr "සංවිධානයේ පරිපාලකයෙකු විය යුතුය"
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr "සංවිධානයේ හිමිකරුවෙකු විය යුතුය"
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Must be an organization owner"
 msgid "Must be a bot user"
 msgstr "සංවිධානයේ හිමිකරුවෙකු විය යුතුය"
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr "ඔබගේ පරිශීලක නාමය හෝ මුරපදය වැරදි ය"
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr ""
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr "ඔබගේ මුරපදය අබල කර ඇති අතර එය නැවත සැකසිය යුතුය"
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr "යෙ.ක්‍ර.මු. යතුර වලංගු නොවේ"
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
 "webhook; ignoring"
 msgstr ""
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr "වලංගු නොවන උපවසමකි"
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr ""
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr ""
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr ""
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} most recent messages in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr ""
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr ""
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
 msgstr ""
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr ""
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr ""
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr ""
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr ""
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr ""
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Already has an account."
 msgid "Atlassian account ID"
 msgstr "දැනටමත් ගිණුමක් තිබේ."
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Behance username"
 msgstr "වි-තැපෑල හෝ පරිශීලක නාමය"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 msgid "Bitbucket username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Codeberg username"
 msgstr "වි-තැපෑල හෝ පරිශීලක නාමය"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Dribbble username"
 msgstr "වි-තැපෑල හෝ පරිශීලක නාමය"
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Facebook username"
 msgstr "වි-තැපෑල හෝ පරිශීලක නාමය"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "GitLab username"
 msgstr "වි-තැපෑල හෝ පරිශීලක නාමය"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Instagram username"
 msgstr "වි-තැපෑල හෝ පරිශීලක නාමය"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 msgid "Mastodon profile"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Medium username"
 msgstr "වි-තැපෑල හෝ පරිශීලක නාමය"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Pinterest username"
 msgstr "වි-තැපෑල හෝ පරිශීලක නාමය"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Reddit username"
 msgstr "වි-තැපෑල හෝ පරිශීලක නාමය"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 msgid "Snapchat username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Threads username"
 msgstr "වි-තැපෑල හෝ පරිශීලක නාමය"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "TikTok username"
 msgstr "වි-තැපෑල හෝ පරිශීලක නාමය"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Twitch username"
 msgstr "වි-තැපෑල හෝ පරිශීලක නාමය"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "පරිශීලක නාමය"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr "වලංගු නොවන බාහිර ගිණුම් වර්ගයකි"
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr ""
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 #, fuzzy
 #| msgid "Billing"
 msgid "Video calling"
 msgstr "ලදුපත්"
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr ""
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr "පාරිභෝගික සහාය"
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr ""
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr ""
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr "සන්නිවේදන"
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr ""
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr ""
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr "අලෙවිකරණය"
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr ""
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr ""
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr "ව්යාපෘති කළමනාකරණය"
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr "ඵලදායිතාව"
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr "අනුවාද පාලනය"
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr "පණිවිඩය හිස් නොවිය යුතුය"
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{fullname} moderation"
 msgstr "{full_name} ඔබ ගැන සඳහන් කළා:"
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr ""
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr ""
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor_date' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr ""
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 msgid "Navigation view does not exist."
 msgstr ""
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5755,7 +5183,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5763,7 +5191,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5771,7 +5199,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5779,7 +5207,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5789,14 +5217,14 @@ msgid ""
 "a permanent organization]({convert_demo_organization_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
 "them in your [Inbox](/#inbox).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5804,7 +5232,7 @@ msgid ""
 "({navigation_tour_video_url}) for a quick app overview.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5819,14 +5247,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -5834,7 +5262,7 @@ msgid ""
 "and edit your [profile information](/help/edit-your-profile).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -5845,7 +5273,7 @@ msgid ""
 "experience in your [Preferences](#settings/preferences).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5856,7 +5284,7 @@ msgid ""
 "[Browse and subscribe to channels]({settings_link}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -5873,7 +5301,7 @@ msgid ""
 "discussed.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -5882,7 +5310,7 @@ msgid ""
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -5894,7 +5322,7 @@ msgid ""
 "times, and more.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5904,7 +5332,7 @@ msgid ""
 "or browse the [help center](/help/) to learn more!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5912,7 +5340,7 @@ msgid ""
 "get help, try one of the following messages: {bot_commands}\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5924,13 +5352,13 @@ msgid ""
 "({move_content_another_channel_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5944,12 +5372,11 @@ msgid ""
 "and above.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr ""
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -5957,14 +5384,14 @@ msgid ""
 "no matter how many other conversations are going on.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
 "conversations with unread messages.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -5972,7 +5399,7 @@ msgid ""
 "the `+` button next to its name.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -5980,13 +5407,13 @@ msgid ""
 "can we chat about…?”\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5994,7 +5421,7 @@ msgid ""
 "({format_message_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6014,1239 +5441,1218 @@ msgid ""
 "```\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
 "teammates.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
 "conversation.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr ""
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr ""
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr ""
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr "වලංගු නොවන JSON ප්‍රතිචාරයකි"
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr ""
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr "{full_name} ඔබ ගැන සඳහන් කළා:"
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr "{full_name} සෑම කෙනෙකුම සඳහන් කළා:"
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "නව පණිවිඩය"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 #, fuzzy
 #| msgid "Invalid API key"
 msgid "Invalid `push_key`"
 msgstr "යෙ.ක්‍ර.මු. යතුර වලංගු නොවේ"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr "'{email}' තවදුරටත් සුලිප් භාවිතා නොකරයි."
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr ""
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr "{var_name} ඉතා දිගයි (සීමාව: අකුරු {max_length})"
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 msgid "Reminder does not exist"
 msgstr ""
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr ""
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr ""
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr ""
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr ""
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr ""
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr ""
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr ""
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr ""
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 #, fuzzy
 #| msgid "You don't have permission to move this message"
 msgid "You do not have permission to create new topics in this channel."
 msgstr "මෙම පණිවිඩය ගෙන යාමට ඔබට අවසර නැත"
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr ""
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr ""
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr ""
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr ""
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr ""
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr "රූපයේ ප්‍රමාණය සීමාව ඉක්මවයි."
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr "{var_name} බූලියන් නොවේ"
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a date"
 msgid "{var_name} does not have the expected format"
 msgstr "{var_name} දිනයක් නොවේ"
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr "{var_name} දිනයක් නොවේ"
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr "{var_name} වලංගු නොවේ"
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr "{var_name} ඉතා කුඩා ය"
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr "{var_name} යනු නිඛිලයක් නොවේ"
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr "{var_name} ඉතා විශාලයි"
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr "{var_name} ලැයිස්තුවක් නොවේ"
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr "{var_name} ඉතා දිගයි (සීමාව: අකුරු {max_length})"
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr "{var_name} ඉතා දිගයි (සීමාව: අකුරු {max_length})"
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr "{var_name} ඉතා දිගයි (සීමාව: අකුරු {max_length})"
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr "{var_name} වලංගු හෙක්ස් වර්ණ කේතයක් නොවේ"
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr "{setting_name} වලංගු නොවේ"
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr ""
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr ""
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr "පරිශීලක සමූහය වලංගු නොවේ"
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid user group"
 msgid "Invalid user group ID: {user_group_id}"
 msgstr "පරිශීලක සමූහය වලංගු නොවේ"
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr ""
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr ""
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr ""
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr ""
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr "නම දිග වැඩියි!"
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 #, fuzzy
 #| msgid "Message must not be empty"
 msgid "Name must not be empty!"
 msgstr "පණිවිඩය හිස් නොවිය යුතුය"
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr "නමෙහි වලංගු නොවන අකුරු ඇත!"
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr ""
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr ""
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr ""
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr ""
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr ""
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr ""
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr ""
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr "වින්‍යාස දත්ත වලංගු නොවේ!"
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr "ස්වයංක්‍රමලේඛ වර්ගය වලංගු නොවේ"
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr "අතුරු මුහුණතෙහි වර්ගය වලංගු නොවේ"
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr ""
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr "එවැනි ස්වයංක්‍රමලේඛයක් නැත"
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr "එබඳු පරිශීලකයෙකු නැත"
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr ""
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr ""
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a date"
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr "{var_name} දිනයක් නොවේ"
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr ""
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr ""
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr ""
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr ""
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr "{variable}! = {expected_value} ({value} වැරදියි)"
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr "{var_name} යනු ඒ.ස.නි. නොවේ"
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr ""
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr "'{item}' හිස් විය නොහැකිය."
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr ""
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr ""
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr ""
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr ""
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr ""
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr ""
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr ""
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr "CSRF දෝෂයකි: {reason}"
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr "බාහිර ගිණුම"
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr ""
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr "කිසිවෙක් නැත"
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr ""
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "සාමාජිකයින්"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr ""
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Invalid characters in emoji name"
 msgid "Invalid auto-conversion field: empty field name."
 msgstr "ඉමොජි නමෙහි වලංගු නොවන අකුරු ඇත"
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr ""
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr ""
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 msgid "Example input does not match the linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in alternative URL template is not present in linkifier "
 "pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in linkifier pattern is not present in alternative URL "
 "template."
 msgstr ""
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr "යුනිකේත ඉමොජි"
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "අභිරුචි ඉමොජි"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr "සුලිප් අමතර ඉමොජි"
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr "ඉමොජි නමෙහි වලංගු නොවන අකුරු ඇත"
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr ""
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr ""
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr ""
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr ""
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr ""
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr ""
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr ""
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr ""
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr ""
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "ප්‍රසිද්ධ"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr "පෞද්ගලික, හවුල් ඉතිහාසය"
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr "පෞද්ගලික, ආරක්‍ෂිත ඉතිහාසය"
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr ""
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr ""
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr ""
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr "පරිපාලකයින් පමණි"
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr ""
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr "සංවිධානයේ හිමිකරු"
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr "සංවිධානයේ පරිපාලක"
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr ""
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "සාමාජිකයා"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "අමුත්තා"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr "නොදන්නා අ.ජා.කෙ. ලිපිනයකි"
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr "නොදන්නා මෙහෙයුම් පද්ධතියකි"
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr "නොදන්නා අතිරික්සුවකි"
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr ""
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr ""
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 #, fuzzy
 #| msgid "Failed to create Zoom call"
 msgid "Failed to generate challenge"
 msgstr "සූම් ඇමතුම සෑදීමට අසමත් විය"
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr ""
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr ""
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr ""
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr ""
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr "උපවසම අවශ්‍යයි"
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr ""
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for use for user matching."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr "ක්ෂේත්‍ර වර්ගය වලංගු නොවේ."
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr "පෙරනිමි අභිරුචි ක්ෂේත්‍රය යාවත්කාල කළ නොහැකිය."
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr ""
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr ""
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr ""
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr ""
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr ""
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr ""
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr ""
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr "එවැනි ආරාධනාවක් නැත"
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 msgid "Invitation already used or deactivated."
 msgstr ""
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr ""
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr ""
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr ""
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
@@ -7254,102 +6660,100 @@ msgstr ""
 "එම ලිපිනය වලින් සමහරක් දැනටමත් සුලිප් භාවිතා කරන බැවින් ඔවුන්ට ආරාධනා කළේ නැත. අපි අනෙක් සැම "
 "දෙනාටම ආරාධනා කළෙමු!"
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr "මෙම සංවිධානය තුළ පණිවිඩ සංස්කරණ ඉතිහාසය අබල කර ඇත"
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr ""
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr ""
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr ""
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr ""
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr ""
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr ""
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr ""
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Message edit history is disabled in this organization"
 msgid "Message reporting is not enabled in this organization."
 msgstr "මෙම සංවිධානය තුළ පණිවිඩ සංස්කරණ ඉතිහාසය අබල කර ඇත"
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr ""
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr ""
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr ""
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr ""
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr ""
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr ""
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr ""
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr "පරිශීලකයා දැනටමත් නිහඬ කර ඇත"
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr "පරිශීලකයා නිහඬ කර නැත"
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 msgid "Navigation view already exists."
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7357,563 +6761,561 @@ msgid ""
 "later. Is this a good time?\n"
 msgstr ""
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr ""
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr ""
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 #, fuzzy
 #| msgid "You don't have permission to move this message"
 msgid "You do not have permission to manage plans and billing."
 msgstr "මෙම පණිවිඩය ගෙන යාමට ඔබට අවසර නැත"
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr ""
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr ""
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr ""
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr ""
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr ""
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr ""
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr ""
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr ""
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr ""
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr "{domain} වසම දැනටමත් ඔබගේ සංවිධානයේ කොටසකි."
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr "ඔබ හරියටම එක් ගොනුවක් උඩුගත කළ යුතුය."
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr ""
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 #, fuzzy
 #| msgid "Email addresses containing + are not allowed in this organization."
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr "මෙම සංවිධානය තුළ + අඩංගු වි-තැපැල් ලිපින වලට ඉඩ නැත."
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr "අනුපාත සීමාව ඉක්මවිය."
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr "වලංගු නොවන දත්ත නිර්යාත හැඳු"
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr ""
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr ""
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr ""
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr "ඔබ හරියටම එක් නිරූපකයක් උඩුගත කළ යුතුය."
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr ""
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr "ඔබ හරියටම එක් ලාංඡනයක් උඩුගත කළ යුතුය."
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid characters in name!"
 msgid "Invalid character in language: {character}"
 msgstr "නමෙහි වලංගු නොවන අකුරු ඇත!"
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Language '{language}' is not allowed."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr "වලංගු නොවන ක්‍රීඩා පිටියකි"
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr ""
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 msgid "Importing messages…"
 msgstr ""
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 msgid "Your name"
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr ""
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr ""
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr ""
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr ""
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr ""
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr ""
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr ""
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr ""
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr ""
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr ""
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr ""
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr ""
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr ""
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
 "**"
 msgstr ""
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr ""
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr ""
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr ""
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr "උප පණිවිඩ සඳහා වලංගු නොවන json කි"
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr ""
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr ""
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr ""
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr ""
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr ""
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr "ගොනුවේ නම වලංගු නොවේ"
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr ""
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr "ඔබට වරකට එක් ගොනුවක් පමණක් උඩුගත කළ හැකිය"
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr "නව දත්ත සපයා නැත"
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 msgstr ""
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr "{user_id} පරිශීලක දැනටමත් මෙම සමූහයේ සාමාජිකයෙකි"
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr ""
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
 "subgroups."
 msgstr ""
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr "මෙම සංවිධානය තුළ වි-තැපැල් ලිපිනය වෙනස් කිරීම් අබල කර ඇත."
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr "වලංගු නොවන පෙරනිමි_භාෂා"
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr ""
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr ""
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr ""
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr "වැරදි මුරපදයකි!"
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, fuzzy, python-brace-format
 #| msgid "You can try again in %(retry_after)s seconds."
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr "ඔබට තත්. %(retry_after)s කින් නැවත උත්සාහ කළ හැකිය."
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr "නව මුරපදය ඉතා දුර්වලයි!"
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr ""
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr "මාතෘකාව නිහඬ කර නැත"
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr ""
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 msgid "User is not allowed to delete other user's messages."
 msgstr ""
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr "සංවිධානයේ හිමිකරුගෙන් පමණක් හිමිකාරීත්ව අවසරය ඉවත් කළ නොහැකිය."
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr ""
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr ""
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "No analytics data available. Please contact your server administrator."
@@ -7922,311 +7324,311 @@ msgid ""
 "Please contact your server administrator."
 msgstr "විශ්ලේෂණ දත්ත නැත. ඔබගේ සේවාදායක පරිපාලක අමතන්න."
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 #, fuzzy
 #| msgid "Email address"
 msgid "Email address already in use"
 msgstr "වි-තැපැල් ලිපිනය"
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr "හිමිකරු වෙනස් කිරීමට අසමත් විය, එවැනි පරිශීලකයෙක් නැත"
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr ""
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr ""
 "හිමිකරු වෙනස් කිරීමට අසමත් විය, ස්වයංක්‍රමලේඛ වලට වෙනත් ස්වයංක්‍රමලේඛ අයිති කර ගත නොහැකිය"
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 msgstr ""
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr "එබ්බවූ ස්වයංක්‍රමලේඛ සබල කර නැත."
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr "එබ්බවූ ස්වයංක්‍රමලේඛයේ නම වලංගු නොවේ."
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr ""
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr "මෙම සංවිධානය තුළ '{email}' වි-තැපෑලට ඉඩ නැත"
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr ""
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid {var_name}"
 msgid "Invalid {provider_name} access token"
 msgstr "{var_name} වලංගු නොවේ"
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} call"
 msgstr "සූම් ඇමතුම සෑදීමට අසමත් විය"
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} credentials have not been configured"
 msgstr ""
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid {var_name}"
 msgid "Invalid {provider_name} credentials"
 msgstr "{var_name} වලංගු නොවේ"
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error connecting to the BigBlueButton server."
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr "බිග්බ්ලූබටන් සේවාදායකයට සම්බන්ධ වීමේ දෝෂයකි."
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error connecting to the BigBlueButton server."
 msgid "Error authenticating to the {provider_name} server"
 msgstr "බිග්බ්ලූබටන් සේවාදායකයට සම්බන්ධ වීමේ දෝෂයකි."
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr ""
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} session identifier"
 msgstr ""
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr ""
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} public room."
 msgstr "සූම් ඇමතුම සෑදීමට අසමත් විය"
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr ""
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{full_name}'s Zulip room"
 msgstr "{full_name} ඔබ ගැන සඳහන් කළා:"
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr ""
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr ""
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr "මාතෘකාව හිස් නොවිය යුතුය"
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr "අන්තර්ගතය හිස් විය නොහැකිය"
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr ""
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr ""
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr ""
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr ""
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr ""
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
 "({export_settings_link})."
 msgstr ""
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr ""
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr ""
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr ""
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr ""
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr ""
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr ""
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr ""
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr ""
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr ""
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr ""
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr ""
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr ""
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
 "try again later or reach out to {support_email} for assistance."
 msgstr ""
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr ""
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr ""
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr ""
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr ""
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
 "server: {reason}"
 msgstr ""
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr ""
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr ""
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr ""
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr ""
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr ""
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr ""
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr "ඔබගේ මුරපදය නැවත සැකසිය යුතුය."
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr ""
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 msgid "Missing idp param"
 msgstr ""
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr ""
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr ""
 

--- a/locale/sl/LC_MESSAGES/django.po
+++ b/locale/sl/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 19:21+0000\n"
 "Last-Translator: BobTB <jf@kfm.si>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/zulip/django/"
@@ -21,50 +21,50 @@ msgstr ""
 "n%100==4 ? 2 : 3;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "Ni dovoljeno za gostujoče uporabnike"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "Neveljavna organizacija"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr "Javni kanali"
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr "Zasebni kanali"
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr "Neposredna sporočila"
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr "Skupinska neposredna sporočila"
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr "Manjkajoč kanal za graf: {chart_name}"
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr "Neznano ime grafa: {chart_name}"
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr "Čas začetka je po času konca. Začetek: {start}, Konec: {end}"
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr "Podatki analitike niso na voljo. Obrnite se na skrbnika strežnika."
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -77,7 +77,7 @@ msgstr ""
 "[deaktivirajte neaktivne uporabnike]({deactivate_user_help_page_link}), da "
 "omogočite pridružitev novim uporabnikom."
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -88,7 +88,7 @@ msgstr ""
 "licenc]({billing_page_link}) ali [deaktivirate neaktivne uporabnike]"
 "({deactivate_user_help_page_link}), da omogočite več uporabnikom pridružitev."
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -100,7 +100,7 @@ msgstr ""
 "({deactivate_user_help_page_link}), da omogočite več kot dvema uporabnikoma "
 "pridružitev."
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -112,7 +112,7 @@ msgstr ""
 "({deactivate_user_help_page_link}), da omogočite več kot trem uporabnikom "
 "pridružitev."
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -125,14 +125,14 @@ msgstr ""
 "da je [število licenc za trenutno in naslednje obračunsko obdobje]"
 "({billing_page_link}) večje od števila trenutnih uporabnikov."
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr ""
 "Vaša organizacija nima dovolj Zulip licenc. Povabila niso bila poslana."
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
@@ -140,16 +140,15 @@ msgstr ""
 "Vaša organizacija nima dovolj licenc Zulip za spremembo vloge gostujočega "
 "uporabnika."
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr "Registracija je deaktivirana"
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr "Neveljaven oddaljeni strežnik."
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
@@ -158,7 +157,7 @@ msgstr ""
 "Kupiti morate licence za vse aktivne uporabnike v vaši organizaciji (najmanj "
 "{min_licenses})."
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
@@ -167,62 +166,62 @@ msgstr ""
 "Računov z več kot {max_licenses} licencami ni mogoče obdelati s te strani. "
 "Za nadgradnjo se obrnite na {email}."
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr "Ni zabeleženega načina plačila."
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr "{brand}, ki se konča s {last4}"
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr "Neznan način plačila. Obrnite se na {email}."
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr "Nekaj je šlo narobe. Obrnite se na {email}."
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "Nekaj je šlo narobe. Prosimo, osvežite stran."
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr "Nekaj je šlo narobe. Počakajte nekaj sekund in poskusite znova."
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 "Prosimo, dodajte kreditno kartico, preden začnete brezplačno preskusno "
 "obdobje."
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr "Prosimo, dodajte kreditno kartico za načrtovanje nadgradnje."
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
 msgstr ""
 "Načrta ni bilo mogoče posodobiti. Načrt je potekel in bil zamenjan z novim."
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr "Načrta ni bilo mogoče posodobiti. Načrt se je zaključil."
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 "V trenutnem obračunskem obdobju ni mogoče posodobiti licenc za načrt "
 "brezplačnega preskusnega obdobja."
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
@@ -230,17 +229,17 @@ msgstr ""
 "Licenc ni mogoče ročno posodobiti. Vaš načrt uporablja samodejno upravljanje "
 "licenc."
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr "Vaš načrt že ima {licenses} licenc v trenutnem obračunskem obdobju."
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr "V trenutnem obračunskem obdobju ne morete zmanjšati števila licenc."
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
@@ -248,7 +247,7 @@ msgstr ""
 "Ni mogoče spremeniti licenc za naslednji obračunski cikel za načrt, ki se "
 "ponižuje."
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
@@ -257,7 +256,7 @@ msgstr ""
 "Vaš načrt je že načrtovan za podaljšanje z {licenses_at_next_renewal} "
 "licencami."
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
@@ -266,27 +265,27 @@ msgstr ""
 "Za naslednje obračunsko obdobje ste že kupili {licenses_at_next_renewal} "
 "licenc."
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr "Ničesar ni treba spremeniti."
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr "Ni stranke za to organizacijo!"
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr "Seja ni bila najdena"
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr "Namen plačila ni bil najden"
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr "Posredujte stripe_session_id ali stripe_invoice_id"
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -301,20 +300,19 @@ msgstr ""
 "Če bi lahko {begin_link}Zulip navedli kot sponzorja na svoji spletni "
 "strani{end_link}, bi bili zelo hvaležni!"
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr "Parameter 'potrjeno' je obvezen"
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr "Žeton za dostop do obračunavanja je potekel."
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr "Neveljaven žeton za dostop do obračunavanja."
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
@@ -323,39 +321,38 @@ msgstr ""
 "Podatkov o obračunu med strežnikom in območjem ni bilo mogoče uskladiti. "
 "Obrnite se na {support_email}"
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr "Uporabniški račun še ne obstaja."
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr "Za nadaljevanje morate sprejeti pogoje storitve."
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 "Ta zulip_org_id ni registriran v sistemu za upravljanje obračunavanja Zulip."
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr "Neveljaven zulip_org_key za ta zulip_org_id."
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr "Registracija vašega strežnika je bila deaktivirana."
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "Napaka"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr "Stran ni bila najdena (404)"
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
@@ -364,11 +361,11 @@ msgstr ""
 "Če je ta napaka nepričakovana, se lahko <a href=\"mailto:"
 "%(support_email)s\">obrnete na podporo</a>."
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr "Dostop prepovedan (403)"
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
@@ -376,12 +373,12 @@ msgstr ""
 "Vaše zahteve ni bilo mogoče dokončati, ker vaš brskalnik ni poslal "
 "poverilnic, potrebnih za overjanje vašega dostopa. Za rešitev težave:"
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr ""
 "Prepričajte se, da vaš brskalnik dovoljuje piškotke za to spletno mesto."
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
@@ -389,16 +386,15 @@ msgstr ""
 "Preverite nastavitve zasebnosti v brskalniku ali razširitve, ki blokirajo "
 "glave Referer, in jih onemogočite za to spletno mesto."
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr "Metoda ni dovoljena (405)"
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr "Notranja napaka strežnika"
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
@@ -406,7 +402,7 @@ msgstr ""
 "Nekaj je šlo narobe. Se opravičujemo! Zavedamo se težave in jo odpravljamo. "
 "Zulip se bo samodejno naložil, ko bo spet deloval."
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -417,7 +413,7 @@ msgstr ""
 "Cloud</a> in se z morebitnimi vprašanji <a href=\"mailto:"
 "%(support_email)s\">obrnite na podporo za Zulip</a>."
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
@@ -425,7 +421,7 @@ msgstr ""
 "Nekaj je šlo narobe. Se opravičujemo! Zulip se bo samodejno naložil, ko bo "
 "spet deloval."
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
@@ -434,7 +430,7 @@ msgstr ""
 "<a href=\"mailto:%(support_email)s\">Obrnite se na skrbnike tega strežnika</"
 "a> za pomoč."
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
@@ -444,136 +440,134 @@ msgstr ""
 "href=\"%(troubleshooting_url)s\">vodnik za odpravljanje težav strežnika "
 "Zulip</a>."
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr "Analitika za %(target_name)s | Zulip"
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr "Analitika je v celoti na voljo 24 ur po ustvarjanju organizacije."
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr "Analitika Zulip za %(target_name)s"
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr "Povzetek organizacije"
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr "Število uporabnikov"
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr "Uporabniki, aktivni v zadnjih 15 dneh"
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr "Število gostov"
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr "Skupno število sporočil"
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr "Število sporočil v zadnjih 30 dneh"
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr "Uporabljena shramba datotek"
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "Aktivni uporabniki"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr "Dnevno aktivni"
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr "15-dnevno aktivni"
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr "Vsi uporabniki"
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "Uporabniki"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr "Poslana sporočila po vrsti prejemnika"
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "Jaz"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "Vsi"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "Prejšnji teden"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "Prejšnji mesec"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "Prejšnje leto"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "Ves čas"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr "Poslana sporočila skozi čas"
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "Dnevno"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "Tedensko"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr "Skupno"
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "Uporabniki"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "Boti"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr "Prebrana sporočila skozi čas"
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr "Poslana sporočila po odjemalcu"
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr "Zadnja posodobitev"
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
@@ -581,15 +575,15 @@ msgstr ""
 "Popolna posodobitev vseh grafov se zgodi enkrat dnevno. Graf \"sporočila "
 "skozi čas\" se posodablja vsako uro."
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr "E-pošta spremenjena"
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr "E-pošta spremenjena!"
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
@@ -598,48 +592,48 @@ msgstr ""
 "To potrjuje, da se je e-poštni naslov za vaš račun Zulip spremenil iz "
 "%(old_email_html_tag)s v %(new_email_html_tag)s"
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr "Potrjevanje vašega e-poštnega naslova"
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr "Povezava za potrditev ne obstaja"
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr "Ups. Vaše potrditvene povezave ni bilo mogoče najti v sistemu."
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 msgstr "Pišite nam na %(support_email_html_tag)s in hitro vam bomo pomagali."
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr "Povezava za potrditev je potekla ali je deaktivirana"
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr "Ups. Potrditvena povezava je potekla ali je bila deaktivirana."
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr "Za novo povezavo se obrnite na skrbnika organizacije."
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr "Povezava za potrditev je napačno oblikovana"
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr "Ups. Potrditvena povezava je napačno oblikovana."
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
@@ -647,72 +641,55 @@ msgstr ""
 "Preverite, ali ste povezavo pravilno kopirali v brskalnik. Če se stran še "
 "vedno prikazuje, je verjetno napaka na naši strani. Opravičujemo se."
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr "Obračunavanje"
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr "Zapri modalno okno"
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr "Pozabi"
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr "Ponižaj"
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "Prekliči"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr "Potrdi"
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr "Prekliči nadgradnjo"
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr "Stanje obračunavanja"
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr "Deaktiviraj registracijo strežnika?"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr "Upravljanje načrta ni na voljo"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -729,7 +706,7 @@ msgstr ""
 "management\">navodilih za prijavo</a>, da boste lahko upravljali načrt za "
 "svoj strežnik Zulip."
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
@@ -737,7 +714,7 @@ msgstr ""
 "Za premik načrta s strežnika na to organizacijo ali za druga vprašanja <a "
 "href=\"mailto:{{ support_email }}\">stopite v stik s podporo</a>."
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
@@ -745,7 +722,7 @@ msgstr ""
 "Upravljanje načrta za ta strežnik ni na voljo, ker ima vsaj ena "
 "organizacija, gostovana na tem strežniku, že aktiven načrt."
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -757,737 +734,247 @@ msgstr ""
 "se za vsa vprašanja <a href='mailto:%(support_email)s'>obrnite na podporo</"
 "a>."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr "Omejitev hitrosti presežena"
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr "Omejitev hitrosti presežena."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 "Vaš strežnik je presegel omejitev, kako pogosto se lahko to dejanje izvede."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, fuzzy, python-format
 #| msgid "You can try again in %(retry_after)s seconds."
 msgid "You can try again in %(retry_after_string)s."
 msgstr "Ponovno lahko poskusite čez %(retry_after)s sekund."
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr "Nadgradi"
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr "Pošlji račun in začni brezplačno preskusno obdobje"
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr "Pošlji račun"
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr "Imenik odprtih skupnosti"
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr "Filtriraj po kategoriji"
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "Vse"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr "Kategorije"
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr "10.000 sporočil"
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr "Neomejeno"
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr "Datoteke do 10 MB"
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr "Datoteke do 1 GB"
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr "Podprto"
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr "Samoupravljano"
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr "Za organizacije z do 10 uporabniki"
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr "Najmanj 25 uporabnikov"
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr "Ni na voljo"
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr "Razvojna skupnost Zulip"
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr "Pridruži se kot uporabnik"
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr "Pridruži se kot samostojni gostitelj"
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr "Pridruži se kot sodelavec"
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "Ustvari organizacijo"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr "Pridobite predstavitev"
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr "Gostite Zulip sami"
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr "Zahtevaj sponzorstvo"
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr "Cene za izobraževanje"
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr "Ogled cen"
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr "Zulip za podjetja"
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Zulip guide for open-source projects"
 msgid "Zulip for open source"
 msgstr "Vodnik Zulip za odprtokodne projekte"
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "start a conversation"
 msgid "Screenshot of Zulip conversation"
 msgstr "začni pogovor"
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Messages sent over time"
 msgid "Message with code"
 msgstr "Poslana sporočila skozi čas"
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr "Povezava"
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr "Obrnite se na podporo"
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr "Od"
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr "Organizacija"
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr "Zadeva"
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr "Sporočilo"
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr "Pošlji"
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr "Hvala, ker ste nas kontaktirali"
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr "Hvala, ker ste nas kontaktirali!"
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr "Kmalu bomo stopili v stik z vami."
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
@@ -1495,13 +982,13 @@ msgstr ""
 "Odgovore na pogosto zastavljena vprašanja najdete v <a href=\"/help/"
 "\">centru za pomoč Zulip</a>."
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 #, fuzzy
 #| msgid "Getting started"
 msgid "Get started"
 msgstr "Uvod"
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
@@ -1511,49 +998,48 @@ msgstr ""
 "sprejmite <a href=\"https://zulip.com/policies/terms\">Pogoje uporabe Zulip</"
 "a>."
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr "Ali pa uporabite enega od svojih varnostnih telefonov:"
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr "Kot zadnjo možnost lahko uporabite varnostni žeton:"
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr "Uporabi varnostni žeton"
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr "Sprejmi pogoje storitve"
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr "Dobrodošli v Zulip"
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "E-pošta"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr "Naroči me na občasne novice Zulipa (nekaj e-poštnih sporočil na leto)."
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr "Nadaljuj"
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr "Potrdite svoj e-poštni naslov"
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1564,7 +1050,7 @@ msgstr ""
 "class=\"user_email semi-bold\">%(email)s</span>) za potrditveno e-poštno "
 "sporočilo od Zulipa."
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
@@ -1573,30 +1059,30 @@ msgstr ""
 "»Neželena pošta«, ga lahko <a href=\"#\" id=\"resend_email_link\">ponovno "
 "pošljemo</a>."
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr "Javni pogled {org_name} | Timski klepet Zulip"
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr "Brskajte po javno dostopnih kanalih v {org_name} brez prijave."
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
@@ -1604,39 +1090,38 @@ msgstr ""
 "Če to sporočilo ne izgine, poskusite <a class=\"reload-lnk\">ponovno "
 "naložiti</a> stran."
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 "Napaka pri nalaganju Zulipa. Poskusite <a class=\"reload-lnk\">ponovno "
 "naložiti</a> stran."
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr "Noben pogovor ne ustreza vašim filtrom."
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr "Ta pogled še vedno nalaga sporočila."
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr "Naloži več"
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr "Videoklic končan"
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr "Zdaj lahko zaprete to okno."
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr "Napaka pri konfiguraciji"
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
@@ -1644,7 +1129,7 @@ msgstr ""
 "Poskušate se prijaviti z LDAP, ne da bi najprej ustvarili organizacijo. Za "
 "ustvarjanje organizacije uporabite EmailAuthBackend in poskusite znova."
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1654,72 +1139,70 @@ msgstr ""
 "Ta strežnik ni konfiguriran za uporabo potisnih obvestil. Za navodila za "
 "konfiguracijo si oglejte <a href=\"%(doc_url)s\">dokumentacijo</a>."
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr "Račun ni bil najden"
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr "Račun Zulip ni bil najden."
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, python-format
 msgid "No account found for %(email)s."
 msgstr "Za %(email)s ni bilo mogoče najti računa."
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr "Prijavite se z drugim računom"
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr "Nadaljuj z registracijo"
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Must be a demo organization."
 msgid "Try Zulip in a demo organization"
 msgstr "Mora biti predstavitvena organizacija."
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Try Zulip now"
 msgid "Try Zulip"
 msgstr "Preizkusite Zulip zdaj"
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "Ustvari novo organizacijo"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr "Ustvari novo organizacijo Zulip"
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr "Vnesite svoj e-poštni naslov"
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr "Vaša e-pošta"
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
@@ -1729,11 +1212,11 @@ msgstr ""
 "import-from-mattermost\">Mattermosta</a>, ali <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chata</a>."
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr "Kako ste prvič slišali za Zulip?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
@@ -1741,42 +1224,41 @@ msgstr ""
 "Ta vrednost se uporablja le, če se prijavite za načrt, v tem primeru bo "
 "poslana ekipi Zulip."
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr "Izberite možnost"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr "Prosimo, opišite"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr "Kje ste videli oglas?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr "Katero organizacijo?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr "Katero?"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr "Izberite eno"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr "Vrsta organizacije"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr "Jezik organizacije"
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
@@ -1786,72 +1268,68 @@ msgstr ""
 "mattermost\">Mattermosta</a> ali <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid "Import chat history?"
 msgstr "Uvoziti zgodovino klepeta?"
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr "Ime organizacije"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "URL organizacije"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr "Uporabi %(external_host)s"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "ALI"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "Registrirajte se"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "Prijavite se za Zulip"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr "Za pridružitev tej organizaciji potrebujete povabilo."
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr "Prijavite se z %(identity_provider)s"
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr "Že imate račun?"
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "Prijavite se"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr "Konfiguriraj zasebnost e-poštnega naslova"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
@@ -1859,7 +1337,7 @@ msgstr ""
 "Zulip vam omogoča nadzor nad tem, katere vloge v organizaciji lahko vidijo "
 "vaš e-poštni naslov."
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
@@ -1867,11 +1345,11 @@ msgstr ""
 "Ali želite spremeniti nastavitev zasebnosti za svojo e-pošto iz privzete "
 "konfiguracije za to organizacijo?"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr "Kdo lahko dostopa do vašega e-poštnega naslova"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1882,13 +1360,13 @@ msgstr ""
 "configure-email-visibility\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">po pridružitvi</a>."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr "Skrbniki te organizacije Zulip bodo lahko videli ta e-poštni naslov."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
@@ -1896,13 +1374,13 @@ msgstr ""
 "Skrbniki in moderatorji te organizacije Zulip bodo lahko videli ta e-poštni "
 "naslov."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 "Nihče v tej organizaciji Zulip ne bo mogel videti tega e-poštnega naslova."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
@@ -1910,79 +1388,78 @@ msgstr ""
 "Drugi uporabniki v tej organizaciji Zulip bodo lahko videli ta e-poštni "
 "naslov."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "Spremeni"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr "Registracija"
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr "Ustvarite svojo organizacijo"
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr "Ustvarite svoj račun"
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr "<p>Vnesite podatke o svojem računu, da dokončate registracijo.</p>"
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr "Vaša organizacija"
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr "Vaš račun"
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr "Ne uvozi nastavitev"
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr "Uvozi nastavitve iz obstoječega računa Zulip"
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr "Vaše polno ime"
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "Ime"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr "Tako je vaš račun prikazan v Zulipu."
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "Geslo"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr "Vnesite svoje geslo za LDAP/Active Directory."
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 "To se uporablja za mobilne aplikacije in druga orodja, ki zahtevajo geslo."
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr "Moč gesla"
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr "Kaj vas zanima?"
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
@@ -1991,15 +1468,15 @@ msgstr ""
 "Strinjam se s <a href=\"%(root_domain_url)s/policies/terms\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">pogoji storitve</a>."
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr "Deaktivirana organizacija"
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr "Organizacija premaknjena"
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
@@ -2008,7 +1485,7 @@ msgstr ""
 "Ta organizacija se je preselila na <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -2019,13 +1496,13 @@ msgstr ""
 "id=\"deactivated-org-auto-redirect\">nov URL</a> v <span id=\"deactivated-"
 "org-auto-redirect-countdown\">5</span> sekundah."
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 msgid ""
 "This organization has been deactivated, and all organization data has been "
 "deleted."
 msgstr "Ta organizacija je bila deaktivirana, vsi njeni podatki pa izbrisani."
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
@@ -2034,7 +1511,7 @@ msgstr ""
 "Za ponovno uporabo tega URL-ja za novo organizacijo se lahko <a "
 "href=\"mailto:%(support_email)s\">obrnete na podporo za Zulip</a>."
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
@@ -2044,11 +1521,11 @@ msgstr ""
 "href=\"mailto:%(support_email)s\">obrnete na skrbnike tega strežnika Zulip</"
 "a>."
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 msgid "This organization has been deactivated."
 msgstr "Ta organizacija je bila deaktivirana."
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -2058,7 +1535,7 @@ msgstr ""
 "%(support_email)s\">stopite v stik s podporo Zulip</a>, da jo ponovno "
 "aktivirate."
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
@@ -2067,7 +1544,7 @@ msgstr ""
 "Če si član organizacije in želiš izvedeti, zakaj je bila deaktivirana, se "
 "obrni neposredno na skrbnike organizacije."
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -2078,15 +1555,15 @@ msgstr ""
 "%(support_email)s\">kontaktirate skrbnike tega strežnika Zulip</a> za "
 "ponovno aktivacijo."
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr "Dokončaj prijavo v namizno aplikacijo"
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr "Dokončaj namizno prijavo"
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
@@ -2094,93 +1571,92 @@ msgstr ""
 "Uporabite spletni brskalnik za dokončanje prijave, nato se vrnite sem in "
 "prilepite svoj prijavni žeton."
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr "Prilepi žeton sem"
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr "Dokončaj"
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr "Napačen žeton."
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr "Žeton sprejet.  Prijavljam vas…"
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr "Prijavite se v namizno aplikacijo"
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 "Kopirajte ta prijavni žeton in se vrnite v aplikacijo Zulip za dokončanje "
 "prijave:"
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "Kopiraj"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr "Nato lahko zaprete to okno."
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr "Ali pa nadaljujte v brskalniku."
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr "Anonimni uporabnik"
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr "Lastniki"
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "Skrbniki"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr "Moderatorji"
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr "Gostujoči uporabniki"
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "Običajni uporabniki"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr "Posreduj e-pošto na e-poštni račun"
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "Zapri"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "Posodobi"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr "Zulip"
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr "Povzetek"
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
@@ -2188,17 +1664,17 @@ msgid ""
 msgstr ""
 "Čestitamo, ustvarili ste novo organizacijo Zulip: <b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr "Dobrodošli v Zulip!"
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr "Pridružili ste se organizaciji Zulip <b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
@@ -2207,36 +1683,36 @@ msgstr ""
 "Za prijavo v spletne, <a href=\"%(apps_page_link)s\">mobilne in namizne</a> "
 "aplikacije Zulip boste uporabili naslednje podatke:"
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr "URL organizacije: %(organization_url)s"
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr "Vaše uporabniško ime: %(ldap_username)s"
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr "Za prijavo uporabite svoj račun LDAP"
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr "E-pošta vašega računa: %(email)s"
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr "Pojdi v organizacijo"
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
@@ -2245,7 +1721,7 @@ msgstr ""
 "Če ste novi v Zulipu, si oglejte naš <a "
 "href=\"%(getting_user_started_link)s\">uvodni vodnik</a>!"
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2256,7 +1732,7 @@ msgstr ""
 "href=\"%(getting_organization_started_link)s\">premik vaše organizacije v "
 "Zulip</a>."
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
@@ -2265,28 +1741,28 @@ msgstr ""
 "Vprašanja? <a href=\"mailto:%(support_email)s\">Pišite nam</a> — z veseljem "
 "vam bomo pomagali!"
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr "%(realm_name)s v Zulipu: Podrobnosti vaše nove organizacije"
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr "%(realm_name)s v Zulipu: Podrobnosti vašega novega računa"
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr "Čestitamo, ustvarili ste novo organizacijo Zulip: %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr "Pridružili ste se organizaciji Zulip %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
@@ -2295,7 +1771,7 @@ msgstr ""
 "Za prijavo v spletne, mobilne in namizne aplikacije Zulip "
 "(%(apps_page_link)s) boste uporabili naslednje podatke:"
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
@@ -2304,7 +1780,7 @@ msgstr ""
 "Če ste novi v Zulipu, si oglejte naš uvodni vodnik "
 "(%(getting_user_started_link)s)!"
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
@@ -2313,18 +1789,18 @@ msgstr ""
 "Imamo tudi vodnik za premik vaše organizacije v Zulip "
 "(%(getting_organization_started_link)s)."
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 "Vprašanja? Pišite nam na %(support_email)s — z veseljem vam bomo pomagali!"
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2333,17 +1809,17 @@ msgstr ""
 "Če imate kakršna koli vprašanja, se obrnite na skrbnike tega Zulip strežnika "
 "na %(support_email)s."
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr "Živjo,"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2354,12 +1830,12 @@ msgstr ""
 "predstavitvenemu računu organizacije Zulip na %(realm_url)s. Za potrditev in "
 "nastavitev gesla za ta račun kliknite spodaj:"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr "Potrdi in nastavi geslo"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2368,14 +1844,14 @@ msgstr ""
 "Če te spremembe niste zahtevali, nas nemudoma kontaktirajte na "
 "%(support_email)s."
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 #, fuzzy
 #| msgid "Verify your new email address for your demo Zulip organization"
 msgid "Verify your email address for your Zulip demo organization"
 msgstr "Potrdite svoj nov e-poštni naslov za svojo demo organizacijo Zulip"
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2384,8 +1860,8 @@ msgstr ""
 "Če te spremembe niste zahtevali, nas nemudoma kontaktirajte na "
 "<%(support_email)s>."
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2396,33 +1872,33 @@ msgstr ""
 "%(realm_url)s iz %(old_email)s v %(new_email)s. Za potrditev te spremembe "
 "kliknite spodaj:"
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr "Potrdi spremembo e-pošte"
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr "Potrdite svoj nov e-poštni naslov za %(organization_host)s"
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr "Zahtevali ste novo organizacijo Zulip:"
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr "Vrsta organizacije: %(organization_type)s"
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr "Nedavno ste se prijavili v Zulip. Super!"
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
@@ -2430,33 +1906,33 @@ msgstr ""
 "Kliknite spodnji gumb za ustvarjanje organizacije in registracijo računa. "
 "Navedene podatke boste lahko pozneje po potrebi uredili."
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr "Kliknite spodnji gumb za dokončanje registracije."
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr "Dokončaj registracijo"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr "Ustvarite svojo organizacijo Zulip"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr "Aktivirajte svoj račun Zulip"
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr "Kliknite spodnjo povezavo za dokončanje registracije."
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
@@ -2465,20 +1941,20 @@ msgstr ""
 "Imate vprašanja ali povratne informacije? Pišite nam na %(support_email)s — "
 "z veseljem vam bomo pomagali!"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr "Upravljaj nastavitve e-pošte"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr "Odjavi se od trženjskih e-poštnih sporočil"
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
@@ -2487,17 +1963,17 @@ msgstr ""
 "Vaš račun Zulip na <a href=\"%(realm_url)s\">%(realm_url)s</a> je bil "
 "deaktiviran in se ne boste več mogli prijaviti."
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr "Skrbniki so podali naslednji komentar:"
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr "Obvestilo o deaktivaciji računa na %(realm_name)s"
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
@@ -2506,11 +1982,11 @@ msgstr ""
 "Vaš račun Zulip na %(realm_url)s je bil deaktiviran in se ne boste več mogli "
 "prijaviti."
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr "Novi kanali"
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2520,7 +1996,7 @@ msgstr ""
 "Imate %(new_messages_count)s novih sporočil in %(new_streams_count)s novih "
 "kanalov v <a href=\"%(realm_url)s\">%(realm_name)s</a>."
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
@@ -2529,7 +2005,7 @@ msgstr ""
 "Imate %(new_messages_count)s novih sporočil v <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
@@ -2538,8 +2014,8 @@ msgstr ""
 "V <a href=\"%(realm_url)s\">%(realm_name)s</a> je %(new_streams_count)s "
 "novih kanalov."
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because your organization <a "
@@ -2551,8 +2027,8 @@ msgstr ""
 "class=\"content_disabled_help_link\" href=\"%(help_url)s\">skrije vsebino "
 "sporočil</a>."
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to <a "
@@ -2563,22 +2039,22 @@ msgstr ""
 "class=\"content_disabled_help_link\" href=\"%(help_url)s\">skrij vsebino "
 "sporočil</a> v e-poštnih obvestilih."
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr ""
 "<a href=\"%(realm_url)s\">Prijavite se</a> v Zulip in nadoknadite zamujeno."
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr "Odjavi se od e-poštnih povzetkov"
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr "Povzetek Zulip za %(realm_name)s"
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2587,18 +2063,18 @@ msgstr ""
 "Imate %(new_messages_count)s novih sporočil in %(new_streams_count)s novih "
 "kanalov v %(realm_name)s."
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr "Imate %(new_messages_count)s novih sporočil v %(realm_name)s."
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr "V %(realm_name)s je %(new_streams_count)s novih kanalov."
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because your organization hides "
@@ -2609,8 +2085,8 @@ msgstr ""
 "organizacija onemogočila prikazovanje vsebine sporočil v e-poštnih "
 "obvestilih. Za več podrobnosti glejte %(hide_content_url)s."
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to hide "
@@ -2620,32 +2096,30 @@ msgstr ""
 "prikazovanje vsebine sporočil v e-poštnih obvestilih. Za več podrobnosti "
 "glejte %(help_url)s ."
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr "Prijavite se v Zulip in nadoknadite zamujeno: %(organization_url)s."
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr "Upravljaj nastavitve e-pošte:"
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr "Odjavi se od e-poštnih povzetkov:"
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr "Plavajoča riba"
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr "Hvala za vašo zahtevo!"
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
@@ -2654,8 +2128,7 @@ msgstr ""
 "Vaš e-poštni naslov %(email)s ima račune v naslednjih organizacijah Zulip "
 "Cloud:"
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
@@ -2664,7 +2137,7 @@ msgstr ""
 "Vaš e-poštni naslov %(email)s ima račune v naslednjih organizacijah Zulip, "
 "ki jih gosti %(external_host)s:"
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
@@ -2673,19 +2146,15 @@ msgstr ""
 "Če imate težave s prijavo, lahko <a "
 "href=\"%(help_reset_password_link)s\">ponastavite svoje geslo</a>."
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr "Zahtevali ste seznam računov Zulip za ta e-poštni naslov."
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr "Na žalost ni bilo najdenih nobenih računov Zulip Cloud."
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
@@ -2694,7 +2163,7 @@ msgstr ""
 "Na žalost ni bilo najdenih nobenih računov v organizacijah Zulip, ki jih "
 "gosti %(external_host)s."
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2705,27 +2174,24 @@ msgstr ""
 "pošto ali <a href =\"%(help_logging_in_link)s\">poskusite na drug način</a> "
 "najti svoj račun."
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 "Če te zahteve ne prepoznate, lahko to e-poštno sporočilo varno prezrete."
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr "Vaši računi Zulip"
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr "Ni bilo najdenih nobenih računov Zulip"
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr "Če imate težave s prijavo, lahko ponastavite svoje geslo."
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
@@ -2734,12 +2200,12 @@ msgstr ""
 "Lahko preverite račune z drugo e-pošto (%(find_accounts_link)s) ali "
 "poskusite na drug način najti svoj račun (%(help_logging_in_link)s)."
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr "Živjo,"
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
@@ -2748,19 +2214,19 @@ msgstr ""
 "%(referrer_name)s želi, da se jim pridružite v Zulipu &mdash; orodju za "
 "timsko komunikacijo, zasnovanem za produktivnost."
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr "Za začetek kliknite spodnji gumb."
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 "%(referrer_full_name)s vas je povabil, da se pridružite "
 "%(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
@@ -2769,17 +2235,17 @@ msgstr ""
 "%(referrer_full_name)s (%(referrer_email)s) želi, da se jim pridružite v "
 "Zulipu -- orodju za timsko komunikacijo, zasnovanem za produktivnost."
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr "Za začetek kliknite spodnjo povezavo."
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr "Ponovno živjo,"
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
@@ -2788,13 +2254,13 @@ msgstr ""
 "To je prijazen opomnik, da vas %(referrer_name)s želi pridružiti v Zulipu "
 "&mdash; orodju za timsko komunikacijo, zasnovanem za produktivnost."
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr "To je zadnji opomnik, ki ga boste prejeli za to povabilo."
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
@@ -2803,12 +2269,12 @@ msgstr ""
 "To povabilo poteče v dveh dneh. Če poteče, boste morali zaprositi "
 "%(referrer_name)s za novo."
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr "Opomnik: Pridružite se %(referrer_name)s pri %(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2819,7 +2285,7 @@ msgstr ""
 "pridružiti v Zulipu -- orodju za timsko komunikacijo, zasnovanem za "
 "produktivnost."
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2828,7 +2294,7 @@ msgstr ""
 "Če imate kakršna koli vprašanja, se obrnite na skrbnike tega strežnika Zulip "
 "na <a href=\"mailto:%(email)s\">%(email)s</a>."
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
@@ -2837,22 +2303,20 @@ msgstr ""
 "Imate vprašanja ali povratne informacije? <a href=\"mailto:"
 "%(email)s\">Pišite nam</a> — z veseljem vam bomo pomagali!"
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr "To prejemate, ker ste bili osebno omenjeni."
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr "To prejemate, ker je bil omenjen @%(mentioned_user_group_name)s."
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
@@ -2861,8 +2325,8 @@ msgstr ""
 "To prejemate, ker so bili vsi udeleženci teme omenjeni v #%(channel_name)s > "
 "%(topic_name)s."
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
@@ -2870,15 +2334,15 @@ msgstr ""
 "To prejemate, ker imate omogočena obvestila o splošnih omembah za teme, ki "
 "jih spremljate."
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr "To prejemate, ker so bili vsi omenjeni v #%(channel_name)s."
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
@@ -2886,8 +2350,8 @@ msgstr ""
 "To prejemate, ker imate omogočena e-poštna obvestila za teme, ki jih "
 "spremljate."
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
@@ -2895,7 +2359,7 @@ msgid ""
 msgstr ""
 "To prejemate, ker imate omogočena e-poštna obvestila za #%(channel_name)s."
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2906,7 +2370,7 @@ msgstr ""
 "href=\"%(narrow_url)s\">oglejte si ga v %(realm_name)s Zulipu</a> ali <a "
 "href=\"%(notif_url)s\">upravljajte nastavitve e-pošte </a>."
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
@@ -2915,7 +2379,7 @@ msgstr ""
 "<a href=\"%(narrow_url)s\">Oglejte si ali odgovorite v %(realm_name)s "
 "Zulipu</a> ali <a href=\"%(notif_url)s\">upravljajte nastavitve e-pošte</a>."
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
@@ -2924,7 +2388,7 @@ msgstr ""
 "<a href=\"%(narrow_url)s\">Odgovorite v %(realm_name)s Zulipu</a> ali <a "
 "href=\"%(notif_url)s\">upravljajte nastavitve e-pošte</a>."
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
@@ -2933,43 +2397,43 @@ msgstr ""
 "Ne odgovarjajte na to e-pošto. Ta Zulip strežnik ni nastavljen za sprejem "
 "dohodnih sporočil (<a href=\"%(url)s\">pomoč</a>)."
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr "Skupinska neposredna sporočila z %(direct_message_group_display_name)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr "Neposredna sporočila z %(sender_str)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr "[rešeno] #%(channel_name)s > %(topic_name)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr "Nova sporočila"
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 "Odgovorite neposredno na to e-poštno sporočilo ali si ga oglejte v "
 "%(realm_name)s Zulipu:"
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr "Oglejte si ali odgovorite v %(realm_name)s Zulipu:"
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr "Odgovorite v %(realm_name)s Zulipu:"
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
@@ -2977,7 +2441,7 @@ msgstr ""
 "Ne odgovarjajte na to e-pošto. Ta Zulip strežnik ni nastavljen za sprejem "
 "dohodnih sporočil. Pomoč:"
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2988,22 +2452,22 @@ msgstr ""
 "%(new_email)s. Če niste zahtevali te spremembe, nas nemudoma kontaktirajte "
 "na %(support_email)s."
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr "Lep pozdrav,"
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr "Ekipa Zulip"
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr "E-pošta Zulip spremenjena za %(realm_name)s"
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -3014,7 +2478,7 @@ msgstr ""
 "%(new_email)s. Če niste zahtevali te spremembe, nas nemudoma kontaktirajte "
 "na <%(support_email)s>."
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
@@ -3022,46 +2486,46 @@ msgstr ""
 "Organizacija: %(organization_url)s Čas: %(login_time)s E-pošta: "
 "%(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr "Zaznali smo nedavno prijavo v naslednji Zulip račun."
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr "Organizacija: %(organization_link)s"
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr "E-pošta: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr "Čas: %(login_time)s"
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr "Naprava: %(device_browser)s na %(device_os)s."
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr "Naslov IP: %(device_ip)s"
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr "Če ste to bili vi, vam ni treba narediti ničesar."
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3072,31 +2536,31 @@ msgstr ""
 "vas prosimo, da nemudoma <a href=\"%(reset_link)s\">ponastavite svoje geslo</"
 "a> ali nas kontaktirate na %(support_email)s."
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr "Lep pozdrav,"
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr "Ekipa za varnost pri Zulipu"
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr "Odjavi se od obvestil o prijavi"
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr "Nova prijava iz %(device_browser)s na %(device_os)s"
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr "Organizacija: %(organization_url)s"
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3107,7 +2571,7 @@ msgstr ""
 "prosimo, ponastavite svoje geslo na %(reset_link)s ali nas nemudoma "
 "kontaktirajte na %(support_email)s."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -3118,7 +2582,7 @@ msgstr ""
 "Za začetek lahko uporabite naš <a "
 "href=\"%(get_organization_started)s\">vodnik za prehod na Zulip</a>."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
@@ -3126,7 +2590,7 @@ msgstr ""
 "V nasprotnem primeru je tukaj nekaj nasvetov, ki jih pogosto slišimo od "
 "strank pri ocenjevanju <i>katerega koli</i> izdelka za timski klepet:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
@@ -3135,12 +2599,12 @@ msgstr ""
 "<a href=\"%(invite_users)s\"><b>Povabite svoje sodelavce</b></a>, da "
 "raziskujejo z vami in delijo svoje edinstvene poglede."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr "Za klepet o svojih vtisih uporabite samo aplikacijo."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -3152,7 +2616,7 @@ msgstr ""
 "resnično doživite, kako bo nova aplikacija za klepet pomagala vaši ekipi pri "
 "komunikaciji."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -3163,21 +2627,21 @@ msgstr ""
 "komunikacije</a> in upamo, da bodo ti nasveti pomagali vaši ekipi izkusiti "
 "ga v akciji."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr "Odjavi se od pozdravnih e-poštnih sporočil za %(realm_name)s"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr "Izbira aplikacije za klepet za vašo ekipo"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
@@ -3185,7 +2649,7 @@ msgstr ""
 "Če ste se že odločili uporabljati Zulip za vašo organizacijo, dobrodošli! Za "
 "začetek lahko uporabite naš vodič za selitev v Zulip."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
@@ -3193,7 +2657,7 @@ msgstr ""
 "V nasprotnem primeru je tukaj nekaj nasvetov, ki jih pogosto slišimo od "
 "strank pri ocenjevanju katerega koli izdelka za timski klepet:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
@@ -3201,7 +2665,7 @@ msgstr ""
 "Povabite svoje sodelavce, da raziskujejo z vami in delijo svoje edinstvene "
 "poglede."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
@@ -3211,7 +2675,7 @@ msgstr ""
 "klepetalnike. To je edini način, da resnično doživite, kako bo nova "
 "aplikacija za klepet pomagala vaši ekipi pri komunikaciji."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
@@ -3219,8 +2683,8 @@ msgstr ""
 "Zulip je zasnovan za omogočanje učinkovite komunikacije in upamo, da bodo ti "
 "nasveti pomagali vaši ekipi izkusiti ga v akciji."
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
@@ -3230,78 +2694,78 @@ msgstr ""
 "ustreza vašim potrebam. Oglejte si ta vodič o ključnih funkcijah Zulipa za "
 "organizacije, kot je vaša!"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr "Ogled vodnika Zulip za podjetja"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr "Ogled vodnika Zulip za odprtokodne projekte"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr "Ogled vodnika Zulip za izobraževanje"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr "Ogled vodnika Zulip za raziskave"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr "Ogled vodnika Zulip za dogodke in konference"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr "Ogled vodnika Zulip za neprofitne organizacije"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr "Ogled vodnika Zulip za skupnosti"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr "Vodnik Zulip za podjetja"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr "Vodnik Zulip za odprtokodne projekte"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr "Vodnik Zulip za izobraževanje"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr "Vodnik Zulip za raziskave"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr "Vodnik Zulip za dogodke in konference"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr "Vodnik Zulip za neprofitne organizacije"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr "Vodnik Zulip za skupnosti"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
 msgstr ""
 "Tukaj je nekaj nasvetov za organizacijo vaših pogovorov v Zulipu s temami."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
@@ -3309,8 +2773,8 @@ msgstr ""
 "V Zulipu <b>kanali</b> določajo, kdo prejme sporočilo. <b>Teme</b> pa "
 "povedo, o čem je sporočilo."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
@@ -3319,12 +2783,12 @@ msgstr ""
 "sporočilo boste videli v kontekstu, ne glede na to, koliko različnih razprav "
 "poteka."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr "Kanali in teme v aplikaciji Zulip"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3335,11 +2799,11 @@ msgstr ""
 "način nova pogovorna nit ne bo prekinila tekočih razprav. Za dober naslov "
 "teme razmislite o dokončanju stavka: \"Hej, lahko govoriva o …?\""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr "Primeri kratkih tem"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3352,17 +2816,17 @@ msgstr ""
 "href=\"%(rename_topics_link)s\">preimenovati teme</a> ali celo <a "
 "href=\"%(move_channels_link)s\">premakniti temo v drug kanal</a>."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr "Pojdi v Zulip"
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr "Ohranite svoje pogovore organizirane s temami"
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
@@ -3370,7 +2834,7 @@ msgstr ""
 "V Zulipu kanali določajo, kdo prejme sporočilo. Teme povedo, o čem je "
 "sporočilo."
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3383,8 +2847,8 @@ msgstr ""
 "(%(rename_topics_link)s) ali celo premakniti temo v drug kanal "
 "(%(move_channels_link)s)."
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
@@ -3393,15 +2857,15 @@ msgstr ""
 "Nekdo (morda vi) je zahteval novo geslo za vaš Zulipov račun %(email)s na "
 "%(realm_url)s."
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr "Kliknite spodnji gumb za ponastavitev gesla."
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr "Ponastavi geslo"
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3412,18 +2876,18 @@ msgstr ""
 "Obrnite se na skrbnika organizacije, da <a href=\"%(help_link)s\">reaktivira "
 "vaš račun</a>."
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr "V tej organizaciji Zulip nimate računa."
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr "Imate aktivne račune v naslednjih organizacijah."
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
@@ -3431,23 +2895,23 @@ msgstr ""
 "Lahko se poskusite prijaviti ali ponastaviti geslo v zgornjih "
 "organizaciji(ah)."
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 "Če dejavnosti ne prepoznate, lahko to e-poštno sporočilo brez skrbi prezrete."
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr "Zahteva za ponastavitev gesla za %(realm_name)s"
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr "Kliknite spodnjo povezavo za ponastavitev gesla."
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
@@ -3456,7 +2920,7 @@ msgstr ""
 "Prej ste imeli račun na %(realm_url)s, vendar je bil deaktiviran. Lahko se "
 "obrnete na skrbnika organizacije, da ponovno aktivira vaš račun."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3467,7 +2931,7 @@ msgstr ""
 "neplačanih računov prestavljena na brezplačni paket Zulip Cloud . Neplačani "
 "računi so bili razveljavljeni."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
@@ -3476,7 +2940,7 @@ msgstr ""
 "Za nadaljevanje na standardnem načrtu Zulip Cloud ponovno nadgradite tako, "
 "da obiščete %(upgrade_url)s."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
@@ -3485,8 +2949,8 @@ msgstr ""
 "Če mislite, da je bila to napaka ali potrebujete več podrobnosti, nas "
 "kontaktirajte na %(support_email)s."
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "You have deactivated your Zulip organization, %(realm_name)s, on "
@@ -3498,8 +2962,8 @@ msgstr ""
 "Deaktivirali ste svojo organizacijo Zulip, %(realm_name)s, dne "
 "%(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "Your Zulip organization, %(realm_name)s, was deactivated by "
@@ -3511,8 +2975,8 @@ msgstr ""
 "Vašo organizacijo Zulip, %(realm_name)s, je deaktiviral "
 "%(deactivating_owner)s dne %(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "Your Zulip organization, %(realm_name)s, was deactivated on "
@@ -3524,8 +2988,8 @@ msgstr ""
 "Vaša organizacija Zulip, %(realm_name)s, je bila deaktivirana dne "
 "%(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
@@ -3534,8 +2998,8 @@ msgstr ""
 "Deaktivirali ste svojo organizacijo Zulip, %(realm_name)s, dne "
 "%(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
@@ -3544,8 +3008,8 @@ msgstr ""
 "Vašo organizacijo Zulip, %(realm_name)s, je deaktiviral "
 "%(deactivating_owner)s dne %(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
@@ -3554,14 +3018,14 @@ msgstr ""
 "Vaša organizacija Zulip, %(realm_name)s, je bila deaktivirana dne "
 "%(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr "Vsi podatki, povezani s to organizacijo, so bili trajno izbrisani."
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
@@ -3570,8 +3034,8 @@ msgstr ""
 "Vsi podatki, povezani s to organizacijo, bodo trajno izbrisani dne "
 "%(deletion_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
@@ -3579,19 +3043,19 @@ msgstr ""
 "Če imate kakršna koli vprašanja ali pomisleke, odgovorite na to e-poštno "
 "sporočilo čim prej kot mogoče."
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr "Vaša organizacija Zulip %(realm_name)s je bila deaktivirana"
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr "Dragi nekdanji skrbniki %(realm_name)s,"
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "One of your administrators requested reactivation of the previously "
@@ -3603,8 +3067,8 @@ msgstr ""
 "Eden od vaših skrbnikov je zahteval ponovno aktivacijo prej deaktivirane "
 "organizacije Zulip, gostovane na %(realm_url)s."
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
@@ -3613,16 +3077,16 @@ msgstr ""
 "Eden od vaših skrbnikov je zahteval ponovno aktivacijo prej deaktivirane "
 "organizacije Zulip, gostovane na %(realm_url)s."
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr "Kliknite spodnji gumb za ponovno aktivacijo vaše organizacije."
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr "Ponovno aktiviraj organizacijo"
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
@@ -3630,21 +3094,21 @@ msgstr ""
 "Če je bila zahteva napačna, lahko ne storite ničesar in ta povezava bo "
 "potekla čez 24 ur."
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Reactivate your Zulip organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "Ponovno aktivirajte svojo organizacijo Zulip"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr "Ponovno aktivirajte svojo organizacijo Zulip"
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr "Kliknite spodnjo povezavo za ponovno aktivacijo vaše organizacije."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3653,18 +3117,18 @@ msgstr ""
 "Vi ali nekdo v vašem imenu je zahteval prijavno povezavo za upravljanje "
 "Zulipovega načrta za <b>%(remote_server_hostname)s</b>."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 msgid "Click the button below to log in."
 msgstr "Kliknite spodnji gumb za prijavo."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr "Ta povezava bo potekla čez %(validity_in_hours)s ur."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
@@ -3673,11 +3137,11 @@ msgstr ""
 "Vprašanja? <a href=\"%(billing_help_link)s\">Izvedite več</a> ali "
 "kontaktirajte %(billing_contact_email)s."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr "Prijavite se v upravljanje načrta Zulip"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3686,12 +3150,12 @@ msgstr ""
 "Vi ali nekdo v vašem imenu je zahteval prijavno povezavo za upravljanje "
 "Zulipovega načrta za %(remote_server_hostname)s."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr "Kliknite spodnjo povezavo za prijavo."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
@@ -3700,7 +3164,7 @@ msgstr ""
 "Vprašanja? Izvedite več na %(billing_help_link)s ali kontaktirajte "
 "%(billing_contact_email)s."
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
@@ -3709,16 +3173,16 @@ msgstr ""
 "Kliknite spodnji gumb, da potrdite svojo e-pošto in se prijavite v "
 "upravljanje načrta Zulip za <b>%(remote_realm_host)s</b>."
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr "Potrdi in se prijavi"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr "Potrdi e-pošto za upravljanje načrta Zulip"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
@@ -3727,7 +3191,7 @@ msgstr ""
 "Kliknite spodnjo povezavo, da potrdite svojo e-pošto in se prijavite v "
 "upravljanje načrta Zulip za %(remote_realm_host)s."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
@@ -3736,7 +3200,7 @@ msgstr ""
 "Vaša zahteva za sponzorstvo Zulipa je bila odobrena! Vaša organizacija je "
 "bila nadgrajena na <a href=\"%(plans_link)s\">Zulip Community načrt</a>."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
@@ -3745,12 +3209,12 @@ msgstr ""
 "Če bi lahko <a href=\"%(link_to_zulip)s\">Zulip navedli kot sponzorja na "
 "svoji spletni strani</a>, bi bili zelo hvaležni!"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr "Sponzorstvo načrta skupnosti odobreno za %(billing_entity)s!"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
@@ -3758,7 +3222,7 @@ msgstr ""
 "Vaša zahteva za sponzorstvo Zulipa je bila odobrena! Vaša organizacija je "
 "bila nadgrajena na Zulip Community načrt."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
@@ -3766,22 +3230,22 @@ msgstr ""
 "Če bi lahko Zulip navedli kot sponzorja na svoji spletni strani, bi bili "
 "zelo hvaležni!"
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr "Najdi svoje račune"
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr "Najdi svoje račune Zulip"
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 "E-poštna sporočila poslana! Naslovi, vneseni na prejšnji strani, so navedeni "
 "spodaj:"
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
@@ -3790,7 +3254,7 @@ msgstr ""
 "Če ne prejmete e-pošte, lahko <a href=\"%(current_url)s\">poiščete račune za "
 "drug e-poštni naslov</a>."
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
@@ -3798,7 +3262,7 @@ msgstr ""
 "Vnesite svoj e-poštni naslov, da prejmete e-poštno sporočilo z URL-ji za vse "
 "organizacije Zulip Cloud, v katerih imate aktivne račune."
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
@@ -3806,7 +3270,7 @@ msgstr ""
 "Vnesite svoj e-poštni naslov, da prejmete e-poštno sporočilo z URL-ji za vse "
 "organizacije Zulip na tem strežniku, v katerih imate aktivne račune."
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
@@ -3814,216 +3278,216 @@ msgstr ""
 "Če ste pozabili tudi geslo, ga lahko <a href=\"/help/change-your-"
 "password\">ponastavite</a>."
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr "E-poštni naslov"
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "Najdi račune"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr "Izdelek"
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr "Zakaj Zulip"
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr "Funkcije"
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr "Načrti in cene"
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Zulip Cloud status"
 msgid "Zulip Cloud"
 msgstr "Stanje Zulip Cloud"
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr "Samostojno gostovanje"
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr "Varnost"
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "Integracije"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr "Namizne in mobilne aplikacije"
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr "Nova organizacija"
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr "Rešitve"
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr "Posel"
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr "Izobraževanje"
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr "Raziskave"
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr "Dogodki in konference"
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr "Odprtokodni projekti"
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr "Skupnosti"
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr "Zgodbe strank"
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr "Odprte skupnosti"
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr "Viri"
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr "Uvod"
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr "Center za pomoč"
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr "Klepet skupnosti"
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr "Partnerji"
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr "Stanje Zulip Cloud"
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr "Prehod na Zulip"
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr "Namestitev strežnika Zulip"
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr "Nadgradnja strežnika Zulip"
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr "Prispevanje"
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr "Vodnik za prispevanje"
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr "Razvojna skupnost"
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr "Prevajanje"
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr "GitHub"
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr "O nas"
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr "Ekipa"
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "Zgodovina"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr "Vrednote"
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr "Delovna mesta"
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr "Blog"
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr "Podprite Zulip"
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr "Mastodon"
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Values"
 msgid "Bluesky"
 msgstr "Vrednote"
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr "Poganja <a href=\"https://zulip.com\">Zulip</a>"
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr "Pogoji storitve"
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr "Pravilnik o zasebnosti"
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr "Pripisi spletnega mesta"
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr "Več kot %(integrations_count_display)s izvornih integracij."
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 #, fuzzy
 #| msgid ""
 #| "And hundreds more through <a href=\"/integrations/doc/zapier\">Zapier</a> "
@@ -4035,51 +3499,47 @@ msgstr ""
 "In na stotine več prek <a href=\"/integrations/doc/zapier\">Zapier</a> in <a "
 "href=\"/integrations/doc/ifttt\">IFTTT</a>."
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr "Išči integracije"
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr "Integracije po meri"
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr "Dohodni spletni kljuki"
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr "Interaktivni boti"
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr "REST API"
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr "Neveljavna e-pošta"
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr "E-pošta ni dovoljena"
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr "E-poštni naslov, s katerim se poskušate prijaviti, ni veljaven."
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4090,7 +3550,7 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>, ne dovoljuje prijav z e-poštnimi "
 "naslovi z vašo e-poštno domeno."
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4101,7 +3561,7 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>, ne dovoljuje prijav z začasnimi e-"
 "poštnimi naslovi."
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4112,24 +3572,24 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>, ne dovoljuje prijav z e-poštnimi "
 "naslovi, ki vsebujejo \"+\"."
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr "Prosimo, prijavite se z veljavnim e-poštnim naslovom."
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr "Prosimo, prijavite se z dovoljenim e-poštnim naslovom."
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr "Organizacija ni bila najdena"
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr "Na <b>%(current_url)s</b> ni organizacije Zulip."
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -4140,7 +3600,7 @@ msgstr ""
 "seznam svojih računov Zulip Cloud </a> ali <a href=\"mailto:"
 "%(support_email)s\">stopite v stik s podporo Zulip </a>."
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -4151,7 +3611,7 @@ msgstr ""
 "seznam svojih računov</a> na tem strežniku ali <a href=\"mailto:"
 "%(support_email)s\">stopite v stik s skrbniki tega strežnika Zulip </a>."
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
@@ -4160,60 +3620,60 @@ msgstr ""
 "<a href=\"%(current_url)s/serverlogin/\">Kliknite tukaj</a> za dostop do "
 "upravljanja načrta za vaš strežnik Zulip."
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr "Neveljavna ali potekla prijavna seja"
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr "Neveljavna ali potekla prijavna seja."
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr "Prijavite se v Zulip"
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 "S tem e-poštnim naslovom ste se že registrirali. Prosimo, prijavite se "
 "spodaj."
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr "E-pošta ali uporabniško ime"
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "Uporabniško ime"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr "Ste pozabili geslo?"
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr "Prijavite se z %(identity_provider)s"
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr "Ogled brez računa"
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 "Še nimate računa? Za pridružitev tej organizaciji potrebujete povabilo."
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr "Ni na voljo nobenih licenc"
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr "Organizacija trenutno ne more sprejeti novih članov"
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
@@ -4223,7 +3683,7 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>, ker so vse licence Zulip Cloud v "
 "uporabi."
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
@@ -4231,19 +3691,19 @@ msgstr ""
 "Prosimo, obrnite se na osebo, ki vas je povabila, in jo prosite, naj poveča "
 "število licenc, nato poskusite znova."
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr "Preskoči na glavno vsebino"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr "Napaka poddomene za preverjanje pristnosti"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr "Poddomena za preverjanje pristnosti"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -4257,25 +3717,24 @@ msgstr ""
 "zataknili tukaj med poskusom prijave, je to najverjetneje napaka strežnika "
 "ali napačna konfiguracija."
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 #, fuzzy
 #| msgid "No organization found"
 msgid "Demo organizations disabled"
 msgstr "Organizacija ni bila najdena"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr "Potrebna je posodobitev"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 "Uporabljate staro različico namizne aplikacije Zulip, ki ni več podprta."
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
@@ -4283,21 +3742,20 @@ msgstr ""
 "Funkcija samodejnega posodabljanja v tej stari različici namizne aplikacije "
 "Zulip ne deluje več."
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr "Prenesite najnovejšo izdajo."
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr "Presegli ste omejitev, kako pogosto lahko uporabnik izvede to dejanje."
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr "Zahtevana je povezava za ustvarjanje organizacije"
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -4309,12 +3767,11 @@ msgstr ""
 "readthedocs.io/en/stable/production/multiple-organizations."
 "html\">dokumentacijo</a> o ustvarjanju nove organizacije."
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr "Povezava za ustvarjanje organizacije je potekla ali je neveljavna"
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
@@ -4322,11 +3779,11 @@ msgstr ""
 "Žal to ni veljavna povezava za ustvarjanje organizacije. Prosimo, <a href=\"/"
 "new/\">pridobite novo povezavo</a> in poskusite znova."
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr "Nepričakovana registracija strežnika Zulip"
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -4337,17 +3794,16 @@ msgstr ""
 "strežnika Zulip. Prosimo, <a href=\"mailto:%(support_email)s\">kontaktirajte "
 "podporo Zulip</a> za pomoč pri reševanju te težave."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr "Nepodprt brskalnik"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr "%(browser_name)s ni podprt s strani Zulipa."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
@@ -4356,7 +3812,7 @@ msgstr ""
 "Zulip podpira <a href=\"%(supported_browsers_page_link)s\">sodobne "
 "brskalnike</a> kot so Firefox, Chrome in Edge."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
@@ -4364,21 +3820,20 @@ msgstr ""
 "Uporabite lahko tudi <a href=\"%(apps_page_link)s\">namizno aplikacijo "
 "Zulip</a>."
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr "Račun je deaktiviran"
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 msgid "Finalize organization import"
 msgstr "Dokončajte uvoz organizacije"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 msgid "Organization import completed!"
 msgstr "Uvoz organizacije zaključen!"
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -4389,56 +3844,55 @@ msgstr ""
 "potrdili z Zulipom (<strong>%(verified_email)s</strong>). Izberite račun, s "
 "katerim želite povezati svoj e-poštni naslov."
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 msgid "Select your account"
 msgstr "Izberite svoj račun"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Create new account"
 msgstr "Ustvarite svoj račun"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr "Organizacija uspešno ponovno aktivirana"
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr "Vaša organizacija je bila uspešno ponovno aktivirana."
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr ""
 "Povezava za ponovno aktivacijo organizacije je potekla ali je neveljavna"
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr ""
 "Povezava za ponovno aktivacijo organizacije je potekla ali ni veljavna."
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr "Prijavite se v svojo organizacijo"
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr "vasa-organizacija"
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr "Ne poznate URL-ja vaše organizacije?"
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr "Poiščite svojo organizacijo."
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr "Naprej"
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4449,11 +3903,11 @@ msgstr ""
 "href=\"%(org_creation_link)s\">Ustvarite novo organizacijo</a>, če je še "
 "nimate."
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 msgid "Self-hosting Zulip?"
 msgstr "Gostite Zulip sami?"
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4463,11 +3917,11 @@ msgstr ""
 "href=\"%(self_hosted_login_help)s\">prijaviš za upravljanje paketov in "
 "obračunavanja.</a>"
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr "Ponastavite geslo"
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
@@ -4475,62 +3929,62 @@ msgstr ""
 "Ste pozabili geslo? Ni problema, na e-poštni naslov, s katerim ste se "
 "prijavili, bomo poslali povezavo za ponastavitev gesla."
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr "Pošlji povezavo za ponastavitev"
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr "Nastavite novo geslo"
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "Potrdi geslo"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr ""
 "Oprostite, povezava, ki ste jo navedli, je neveljavna ali je bila že "
 "uporabljena."
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr "Novo geslo uspešno nastavljeno"
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr "Nastavili ste novo geslo!"
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr "Prosimo, <a href=\"%(login_url)s\">prijavite se</a> z novim geslom."
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr "E-poštno sporočilo za ponastavitev gesla poslano"
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr "Ponastavitev gesla poslana!"
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr "Čez nekaj minut preverite svojo e-pošto, da dokončate postopek."
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr "Uvoz iz Slacka"
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr "Potek uvoza"
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr "Preverjanje stanja uvoza…"
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4538,7 +3992,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4551,15 +4005,15 @@ msgstr ""
 "rel=\"noopener noreferrer\" target=\"_blank\">tem navodilom</a>, da "
 "pridobite <strong>žeton OAuth za uporabnika bota</strong>."
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr "Žeton OAuth za uporabnika bota Slack"
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr "Naložite svojo izvozno datoteko iz Slacka"
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
@@ -4569,17 +4023,17 @@ msgstr ""
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">tem navodilom</a>, da "
 "pridobite izvoz zgodovine sporočil iz Slacka."
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 #, fuzzy
 #| msgid "Start import"
 msgid "Start upload"
 msgstr "Začni uvoz"
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr "Naložena izvozna datoteka"
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 #, fuzzy
 #| msgid ""
 #| "Nobody in this Zulip organization will be able to see this email address."
@@ -4587,24 +4041,24 @@ msgid "Who will be allowed to see other users' email addresses?"
 msgstr ""
 "Nihče v tej organizaciji Zulip ne bo mogel videti tega e-poštnega naslova."
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr "Začni uvoz"
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
@@ -4612,7 +4066,7 @@ msgstr ""
 "Ali pa <span id=\"cancel-slack-import\" tabindex=\"0\">ustvari organizacijo</"
 "span> brez uvoza podatkov."
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4620,7 +4074,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4628,21 +4082,21 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr "Izberite račun za preverjanje pristnosti"
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr "<h1 class=\"get-started\">Izberite račun</h1>"
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 "Vaš račun GitHub ima tudi nepreverjene e-poštne naslove, povezane z njim."
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
@@ -4650,15 +4104,15 @@ msgstr ""
 "Če želite enega od teh uporabiti za prijavo v Zulip, ga morate najprej <a "
 "href=\"https://github.com/settings/emails\">preveriti pri GitHubu.</a>"
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr "Napaka pri odjavi e-pošte"
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr "Neznana zahteva za odjavo e-pošte"
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
@@ -4666,7 +4120,7 @@ msgstr ""
 "Živjo! Videti je, da ste poskušali preklicati naročnino na nekaj, vendar ne "
 "prepoznamo URL-ja."
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4676,12 +4130,11 @@ msgstr ""
 "Preverite, ali imate celoten URL, in poskusite znova ali nam <a "
 "href=\"mailto:%(support_email)s\">pošljite e-pošto</a> in to bomo uredili !"
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr "Nastavitve e-pošte posodobljene"
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
@@ -4690,7 +4143,7 @@ msgstr ""
 "Uspešno ste se odjavili od e-poštnih sporočil Zulip %(subscription_type)s za "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
@@ -4699,51 +4152,50 @@ msgstr ""
 "To spremembo lahko razveljavite ali pregledate svoje nastavitve v <a "
 "href=\"%(realm_url)s/#settings/notifications\">nastavitvah obvestil</a>."
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr "Neveljavno preslikavanje vrstnega reda."
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr "Vprašanja in razprava o uporabi Zulipa."
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr "Eksperimentirajte z Zulipom tukaj. :test_tube:"
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr "Za pogovore v celotni ekipi"
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr "prijave"
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr "{user} se je pridružil tej organizaciji."
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr "{user} je sprejel vaše povabilo, da se pridruži Zulipu!"
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 "Ni mogoče aktivirati začasnega računa; namesto tega prosite uporabnika, naj "
 "se registrira."
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 #, fuzzy
 #| msgid "Cannot deactivate user group in use."
 msgid "Cannot reactivate a deleted user"
 msgstr "Ni mogoče deaktivirati uporabniške skupine v uporabi."
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
@@ -4751,48 +4203,47 @@ msgstr ""
 "Nimate dovoljenja za spreminjanje tega polja. Za posodobitev se obrnite na "
 "skrbnika."
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr "ID polja {id} ni bil najden."
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr "Neveljavno ime privzete skupine kanalov '{group_name}'"
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 "Ime privzete skupine kanalov je predolgo (omejitev: {max_length} znakov)"
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr "Ime privzete skupine kanalov '{group_name}' vsebuje znake NULL (0x00)."
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr "Neveljavna privzeta skupina kanalov {group_name}"
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 "'{channel_name}' je privzet kanal in ga ni mogoče dodati v '{group_name}'"
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr "Privzeta skupina kanalov '{group_name}' že obstaja"
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
@@ -4801,7 +4252,7 @@ msgstr ""
 "Kanal '{channel_name}' je že prisoten v privzeti skupini kanalov "
 "'{group_name}'"
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
@@ -4809,12 +4260,12 @@ msgid ""
 msgstr ""
 "Kanal '{channel_name}' ni prisoten v privzeti skupini kanalov '{group_name}'"
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr "Ta privzeta skupina kanalov se že imenuje '{group_name}'"
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
@@ -4822,7 +4273,7 @@ msgstr ""
 "Da bi zaščitil uporabnike, Zulip omejuje število povabil, ki jih lahko "
 "pošljete v enem dnevu. Ker ste dosegli omejitev, povabila niso bila poslana."
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
@@ -4830,77 +4281,77 @@ msgstr ""
 "Vaš račun je preveč nov, da bi lahko pošiljali povabila za to organizacijo. "
 "Obrnite se na skrbnika organizacije ali bolj izkušenega uporabnika."
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 "Nekaterih e-poštnih sporočil ni bilo mogoče potrditi, zato nismo poslali "
 "nobenih povabil."
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr "Nikogar nismo mogli povabiti."
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr "Ničesar ni treba spremeniti"
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr "Neposrednih sporočil ni mogoče premakniti v kanale."
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr "Neposredna sporočila ne morejo imeti tem."
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr "Neveljaven propagate_mode brez urejanja teme"
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr "Splošnega klepeta ni mogoče označiti kot rešenega"
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr "Vsebine sporočila ni mogoče spremeniti med menjavo kanala"
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr "Pripomočkov ni mogoče urejati."
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr "Vaša organizacija je izklopila urejanje sporočil"
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr "Nimate dovoljenja za urejanje tega sporočila"
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr "Časovna omejitev za urejanje tega sporočila je potekla"
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr "{user} je to temo označil kot rešeno."
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr "{user} je to temo označil kot nerešeno."
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr "To temo je {user} premaknil v {new_location}."
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr "Sporočilo je {user} premaknil iz te teme v {new_location}."
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
@@ -4909,18 +4360,18 @@ msgstr ""
 "{changed_messages_count} sporočil je {user} premaknil iz te teme v "
 "{new_location}."
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr "To temo je {user} premaknil sem iz {old_location}."
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 msgstr "[Sporočilo]({message_link}) je {user} premaknil sem iz {old_location}."
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
@@ -4928,67 +4379,64 @@ msgid ""
 msgstr ""
 "{changed_messages_count} sporočil je {user} premaknil sem iz {old_location}."
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to resolve topics in this channel."
 msgstr "Nimate dovoljenja za razreševanje tem v tem kanalu."
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr "Časovna omejitev za urejanje teme tega sporočila je potekla."
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr "Nimate dovoljenja za premikanje tega sporočila"
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr "Časovna omejitev za urejanje kanala tega sporočila je potekla"
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr "Neveljavna zastavica: '{flag}'"
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr "Zastavice ni mogoče urejati: '{flag}'"
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr "Neveljavna operacija zastavice sporočila: '{operation}'"
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr "Neveljavno sporočilo(a)"
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr "Sporočila ni mogoče prikazati"
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr "Pričakovan je bil natanko en kanal"
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr "Neveljaven podatkovni tip za kanal"
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr "Neveljaven podatkovni tip za prejemnike"
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 "Seznami prejemnikov lahko vsebujejo e-poštne naslove ali ID-je uporabnikov, "
 "vendar ne obojega."
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
@@ -4997,7 +4445,7 @@ msgstr ""
 "Vaš bot {bot_identity} je poskušal poslati sporočilo na ID kanala "
 "{channel_id}, vendar kanal s tem ID-jem ne obstaja."
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -5008,7 +4456,7 @@ msgstr ""
 "vendar ta kanal ne obstaja. Kliknite [tukaj]({new_channel_link}), da ga "
 "ustvarite."
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
@@ -5017,30 +4465,30 @@ msgstr ""
 "Vaš bot {bot_identity} je poskušal poslati sporočilo v kanal {channel_name}. "
 "Kanal obstaja, vendar nima naročnikov."
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr "Nimate dovoljenja za dostop do nekaterih prejemnikov."
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr "Pripomočki: programer API je poslal neveljavno vsebino JSON"
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr "Pripomočki: {error_msg}"
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, fuzzy, python-brace-format
 #| msgid "{user_name} created the following channels: {new_channels}."
 msgid "{user} has made the following changes to your account."
 msgstr "{user_name} je ustvaril naslednje kanale: {new_channels}."
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5048,25 +4496,23 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr "Emoji po meri s tem imenom že obstaja."
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr "Neveljavna oblika slike"
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr "Urejen seznam ne sme vsebovati podvojenih povezovalnikov"
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr "Urejen seznam mora natančno enkrat našteti vse obstoječe povezovalnike"
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
@@ -5075,42 +4521,42 @@ msgstr ""
 "Če želite uporabiti to metodo preverjanja pristnosti, morate nadgraditi na "
 "načrt {required_upgrade_plan_name}."
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 "Neveljavna metoda preverjanja pristnosti: {name}. Veljavne metode so: "
 "{methods}"
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 "Metoda preverjanja pristnosti {name} ni na voljo v vašem trenutnem načrtu."
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr "Kanal za zahteve moderiranja mora biti zaseben."
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr "Shranjeni odrezek ne obstaja."
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr "Načrtovano sporočilo je bilo že poslano"
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 #, fuzzy
 #| msgid "Reminder does not exist"
 msgid "Reminder could not be sent."
 msgstr "Opomnika ni mogoče najti"
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr "Sporočila ni bilo mogoče poslati ob načrtovanem času."
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
@@ -5119,38 +4565,38 @@ msgstr ""
 "Sporočilo, ki ste ga načrtovali za {delivery_datetime}, ni bilo poslano "
 "zaradi naslednje napake:"
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr "[Ogled načrtovanih sporočil](#scheduled)"
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr "Kanal je že deaktiviran"
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr "Kanal #**{channel_name}** je bil arhiviran."
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr "Kanal trenutno ni deaktiviran"
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr "Kanal z imenom {channel_name} že obstaja"
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr "Kanal je zaseben in nima naročnikov"
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr "Kanal #**{channel_name}** je bil ponovno aktiviran."
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
@@ -5159,7 +4605,7 @@ msgstr ""
 "{user} je spremenil [dovoljenja za dostop]({help_link}) za ta kanal iz "
 "**{old_policy}** v **{new_policy}**."
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -5172,41 +4618,39 @@ msgstr ""
 "* **Staro**: {old_setting_description}\n"
 "* **Novo**: {new_setting_description}\n"
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 "{user_name} je preimenoval kanal {old_channel_name} v {new_channel_name}."
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr "Brez opisa."
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr "{user} je spremenil opis za ta kanal."
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr "Star opis"
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr "Nov opis"
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr "Za vedno"
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr "{number_of_days} dni"
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
@@ -5215,11 +4659,11 @@ msgstr ""
 "Sporočila v tem kanalu bodo zdaj samodejno izbrisana {number_of_days} dni po "
 "pošiljanju."
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr "Sporočila v tem kanalu bodo zdaj shranjena za vedno."
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -5235,26 +4679,26 @@ msgstr ""
 "\n"
 "{summary_line}"
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr "Samodejno"
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr "Tema *{empty_topic_display_name}* je dovoljena"
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr "Brez teme *{empty_topic_display_name}*"
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr "Dovoljena je samo tema *{empty_topic_display_name}*"
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
@@ -5263,73 +4707,63 @@ msgstr ""
 "{user_name} je spremenil nastavitev »Dovoli objavljanje v temi *splošni "
 "klepet*?« iz {old_topics_policy} v {new_topics_policy}."
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr "Na to sporočilo ne morete pripeti podsporočila."
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr "Neveljaven ID uporabnika {user_id}"
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr "Uporabniška skupina '{group_name}' že obstaja."
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr "Nezadostno dovoljenje"
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr "Ta API ni na voljo za dohodeče spletne kaveljne bote."
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr "Račun ni povezan s to poddomeno"
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr "Ta končna točka ne sprejema zahtev botov."
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr "Mora biti skrbnik strežnika"
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr "Ta končna točka zahteva osnovno preverjanje pristnosti HTTP."
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr "Neveljavna glava avtorizacije za osnovno preverjanje pristnosti"
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr "Manjkajoča glava avtorizacije za osnovno preverjanje pristnosti"
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr "Boti spletnih kaveljnov lahko dostopajo samo do spletnih kaveljnov"
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr "Napačna e-pošta ali geslo."
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
@@ -5338,54 +4772,53 @@ msgstr ""
 "Vaš račun {username} je bil deaktiviran. Prosimo, obrnite se na skrbnika "
 "organizacije, da ga ponovno aktivira."
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr "Geslo je prešibko."
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr "Poddomena mora imeti dolžino 3 ali več."
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr "Poddomena se ne more začeti ali končati z znakom '-'."
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr "Poddomena lahko vsebuje samo male črke, številke in znake '-'."
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr "Poddomena je že v uporabi. Prosimo, izberite drugo."
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr "Poddomena je rezervirana. Prosimo, izberite drugo."
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr "Prosimo, uporabite svoj pravi e-poštni naslov."
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr ""
 "Organizacija, ki se ji poskušate pridružiti z uporabo {email}, ne obstaja."
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr "Prosimo, zahtevajte povabilo za {email} od skrbnika organizacije."
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 "Ni se mogoče pridružiti organizaciji: preverjanje pristnosti z geslom ni "
 "omogočeno."
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
@@ -5394,11 +4827,11 @@ msgstr ""
 "Vaš e-poštni naslov, {email}, ni v eni od domen, ki so dovoljene za "
 "registracijo računov v tej organizaciji."
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr "E-poštni naslovi, ki vsebujejo +, v tej organizaciji niso dovoljeni."
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
@@ -5408,32 +4841,31 @@ msgstr ""
 "Zulip v uporabi. Prosimo, obrnite se na osebo, ki vas je povabila, in jo "
 "prosite, naj poveča število licenc, nato poskusite znova."
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr "Preverjeno, da ste človek!"
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr "Preverjanje, da niste bot…"
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 msgid "Challenges are not enabled."
 msgstr "Izzivi niso omogočeni."
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr "Preverjanje ni uspelo, poskusite znova."
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "Novo geslo"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr "Potrditev novega gesla"
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "You're making too many attempts to sign in. Try again in {seconds} "
@@ -5445,7 +4877,7 @@ msgstr ""
 "Prevečkrat poskušate se prijaviti. Poskusite znova čez {seconds} sekund ali "
 "se za pomoč obrnite na skrbnika organizacije."
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
@@ -5453,84 +4885,82 @@ msgstr ""
 "Vaše geslo je bilo onemogočeno, ker je prešibko. Ponastavite geslo, da "
 "ustvarite novega."
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr "Žeton"
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr "Nasvet: Vnesete lahko več e-poštnih naslovov, ločenih z vejicami."
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr "Prosimo, vnesite največ 10 e-poštnih naslovov."
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr "Te organizacije Zulip nismo mogli najti."
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr "Neveljavna e-pošta '{email}'"
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr "Manjkajoča tema"
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr "Ni mogoče poslati v več kanalov"
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr "Manjkajoč kanal"
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr "Sporočilo mora imeti prejemnike"
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr "Neveljavna vrsta sporočila"
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr "Neveljavna priponka"
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr "Pri brisanju priponke je prišlo do napake. Poskusite znova pozneje."
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr "Sporočilo mora imeti prejemnike!"
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name can't be empty."
 msgstr "Ime mape kanala ne sme biti prazno."
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr "Neveljaven znak v imenu mape kanala, na položaju {position}."
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr "Ime kanala je že v uporabi"
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 msgid "Invalid channel folder ID"
 msgstr "Neveljaven ID mape kanala"
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 msgid "Configure owner account email address."
 msgstr "Nastavite e-poštni naslov lastniškega računa."
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "\n"
@@ -5552,72 +4982,72 @@ msgstr ""
 "[preoblikovana v stalno organizacijo]"
 "({convert_demo_organization_help_url}).\n"
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a date"
 msgid "{var_name} is not Base64 encoded"
 msgstr "{var_name} ni datum"
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 #, fuzzy
 #| msgid "Invalid emoji code."
 msgid "Invalid `device_id`"
 msgstr "Neveljavna koda emojia."
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr "{service_name} povzetek"
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr "Domena ne sme biti prazna."
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr "Domena mora vsebovati vsaj eno piko (.)"
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr "Domena je predolga"
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr "Domena se ne sme začeti ali končati s piko (.)"
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr "Zaporedne pike '.' niso dovoljene."
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr "Poddomene se ne morejo začeti ali končati z znakom '-'."
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr "Domena lahko vsebuje samo črke, številke, pike '.' in vezaje '-'."
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr "Časovni žig ne sme biti negativen."
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr "Tema ne sme vsebovati ničelnih bajtov"
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr "Za sporočila kanala morate navesti natanko 1 ID kanala"
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr "Uporabnik je onemogočil sinhronizacijo osnutkov."
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr "Osnutek ne obstaja"
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5628,86 +5058,86 @@ msgstr ""
 "poštno obvestilo o sporočilu:\n"
 "{error_message}"
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr "E-pošta brez zadeve"
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr "Odprite Zulip, da vidite vsebino spojlerja"
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr "{service_name} obvestila"
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr "Neveljaven naslov."
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr "Zunaj vaše domene."
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr "E-poštni naslovi, ki vsebujejo +, niso dovoljeni."
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr "Rezervirano za sistemske bote."
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr "{email} že ima račun"
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr "Že ima račun."
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr "Račun je bil deaktiviran."
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr "Emoji '{emoji_name}' ne obstaja"
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr "Neveljaven emoji po meri."
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr "Neveljavno ime emojija po meri."
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr "Ta emoji po meri je bil deaktiviran."
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr "Neveljavna koda emojia."
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr "Neveljavno ime emojia."
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr "Neveljavna vrsta emojia."
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr "Mora biti skrbnik organizacije ali avtor emojija"
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr "Imena emojiev se morajo končati s črko ali števko."
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
@@ -5715,96 +5145,95 @@ msgstr ""
 "Imena emojiev morajo vsebovati samo male angleške črke, številke, presledke, "
 "vezaje in podčrtaje."
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr "Manjka ime emojija"
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr "Ni bilo mogoče dodeliti čakalne vrste dogodkov"
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr "Ni prijavljen: potrebna je avtentikacija API ali uporabniška seja"
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr "Kanal {channel_name} že obstaja"
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr "Kanal '{stream}' ne obstaja"
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr "Kanal z ID-jem '{stream_id}' ne obstaja"
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr "Nepodprta kombinacija parametrov: {parameters}"
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr "lastnik organizacije"
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr "uporabnik"
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr "Ni mogoče deaktivirati edinega {entity}."
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr "Neveljavna izjava za vključitev Markdown: {include_statement}"
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr "Napačno oblikovan JSON"
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr "Mora biti skrbnik organizacije"
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr "Mora biti lastnik organizacije"
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Must be an organization owner"
 msgid "Must be a bot user"
 msgstr "Mora biti lastnik organizacije"
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr "Vaše uporabniško ime ali geslo je napačno"
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr "Ta organizacija je bila deaktivirana"
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
@@ -5812,23 +5241,23 @@ msgstr ""
 "Registracija storitve potisnih obvestil za mobilne naprave za vaš strežnik "
 "je bila deaktivirana"
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr "Avtentikacija z geslom je v tej organizaciji onemogočena"
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr "Vaše geslo je bilo onemogočeno in ga je treba ponastaviti"
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr "Neveljaven ključ API"
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr "Napačno oblikovan ključ API"
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
@@ -5837,26 +5266,25 @@ msgstr ""
 "Dogodka '{event_type}' trenutno ne podpira spletni kavelj {webhook_name}; "
 "ignoriram ga"
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 "Ni mogoče razčleniti zahteve: Ali je {webhook_name} ustvaril ta dogodek?"
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr "Uporabnik ni avtenticiran"
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr "Neveljavna poddomena"
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr "Nimate dovoljenja za začetek pogovorov z neposrednimi sporočili."
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
@@ -5865,12 +5293,12 @@ msgstr ""
 "Pošiljanje sporočil v temo {empty_topic_display_name} v tem kanalu ni "
 "dovoljeno."
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr "V tem kanalu je dovoljena samo tema {empty_topic_display_name}."
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
@@ -5880,19 +5308,19 @@ msgstr ""
 "{empty_topic_display_name}. Razmislite o preimenovanju ali brisanju drugih "
 "tem."
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr "Neposredna sporočila so v tej organizaciji onemogočena."
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr "Ta pogovor ne vključuje nobenega uporabnika, ki bi ga lahko odobril."
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr "Dostop zavrnjen"
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
@@ -5901,15 +5329,15 @@ msgstr ""
 "Imate dovoljenje samo za premikanje {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} najnovejših sporočil v tej temi."
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr "Reakcija že obstaja."
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr "Reakcija ne obstaja."
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
@@ -5917,271 +5345,271 @@ msgstr ""
 "Vaša organizacija je registrirana na drugem strežniku Zulip. Za pomoč pri "
 "reševanju te težave se obrnite na podporo Zulip."
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr "Organizacija ni registrirana"
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr "Nimate dovoljenja za uporabo splošnih omemb kanalov v tem kanalu."
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr "Nimate dovoljenja za uporabo splošnih omemb tem v tej temi."
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr "'{field_name}' vrednost se ne ujema s pričakovano vrednostjo."
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr "'{setting_name}' mora biti sistemska uporabniška skupina."
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr "Ni mogoče deaktivirati uporabniške skupine v uporabi."
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr "Nimate dovoljenja za upravljanje tega kanala."
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr "Nimate dovoljenja za spreminjanje privzetih kanalov."
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr "E-pošta je že v uporabi."
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr "Načrtovani čas dostave mora biti v prihodnosti."
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr "Neveljaven bouncer_public_key"
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr "Zahteva je potekla"
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr "Neveljavna encrypted_push_registration"
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr "Strežnik ne uporablja storitve potisnih obvestil."
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Already has an account."
 msgid "Atlassian account ID"
 msgstr "Že ima račun."
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Behance username"
 msgstr "Napačno ime ali uporabniško ime"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Bitbucket username"
 msgstr "Uporabniško ime GitHub"
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Codeberg username"
 msgstr "Uporabniško ime Twitter"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Dribbble username"
 msgstr "Uporabniško ime GitHub"
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Facebook username"
 msgstr "Napačno ime ali uporabniško ime"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr "Uporabniško ime GitHub"
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "GitLab username"
 msgstr "Uporabniško ime GitHub"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Instagram username"
 msgstr "Uporabniško ime Twitter"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Mastodon"
 msgid "Mastodon profile"
 msgstr "Mastodon"
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Medium username"
 msgstr "Uporabniško ime GitHub"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Pinterest username"
 msgstr "Uporabniško ime Twitter"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Reddit username"
 msgstr "Uporabniško ime GitHub"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Snapchat username"
 msgstr "Uporabniško ime GitHub"
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Threads username"
 msgstr "Uporabniško ime Twitter"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "TikTok username"
 msgstr "Uporabniško ime Twitter"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Twitch username"
 msgstr "Uporabniško ime Twitter"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "Uporabniško ime"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr "Neveljavna vrsta zunanjega računa"
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr "Okvirji integracije"
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 msgid "Video calling"
 msgstr "Video klici"
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr "Neprekinjena integracija"
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr "Podpora strankam"
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr "Namestitev"
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr "Zabava"
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr "Komunikacija"
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr "Finančno"
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr "Človeški viri"
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr "Trženje"
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr "Razno"
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr "Spremljanje"
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr "Upravljanje projektov"
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr "Produktivnost"
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr "Nadzor različic"
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr "Sporočilo ne sme biti prazno"
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr "Sporočilo ne sme vsebovati ničelnih bajtov"
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr "Ni vam dovoljeno omenjati uporabniške skupine '{user_group_name}'."
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "{reporting_user_mention} reported a DM sent by {reported_user_mention} to "
@@ -6194,7 +5622,7 @@ msgstr ""
 "{reported_user_mention} poslal uporabnikom {recipient_mentions} in "
 "{last_user_mention}."
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "{reporting_user_mention} reported a DM sent by {reported_user_mention} to "
@@ -6207,7 +5635,7 @@ msgstr ""
 "{reported_user_mention} poslal uporabnikom {recipient_mentions} in "
 "{last_user_mention}."
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "{reporting_user_mention} reported a DM sent by {reported_user_mention} to "
@@ -6220,74 +5648,74 @@ msgstr ""
 "{reported_user_mention} poslal uporabnikom {recipient_mentions} in "
 "{last_user_mention}."
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid "{fullname}'s moderation requests"
 msgid "{fullname} moderation"
 msgstr "Zahteve za moderiranje od {fullname}"
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr "Neveljaven operator zožitve: {desc}"
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr "Neveljavna kombinacija operatorjev zožitve: {desc}"
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr "Podvojeni operatorji 'z'."
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr "Neveljaven operator 'z'"
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr "Manjkajoč argument 'sidro'."
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 #, fuzzy
 #| msgid "Missing 'anchor' argument."
 msgid "Missing 'anchor_date' argument."
 msgstr "Manjkajoč argument 'sidro'."
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr "Neveljavno sidro"
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr "Operator {operator} ni podprt."
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr "Operand {operand} ni podprt."
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 msgid "Navigation view does not exist."
 msgstr "Navigacijski pogled ne obstaja."
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr "Opomba od {admin_group_syntax}:"
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6298,7 +5726,7 @@ msgstr ""
 "Če želite izvedeti več, si oglejte naš [vodnik za uporabo Zulipa za razred]"
 "({getting_started_url})!\n"
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6309,7 +5737,7 @@ msgstr ""
 "Če želite izvedeti več, si oglejte naš [uvodni vodnik]"
 "({getting_started_url})!\n"
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6320,7 +5748,7 @@ msgstr ""
 "Imamo tudi vodnik za [nastavitev Zulipa za razred]"
 "({organization_setup_url}).\n"
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6331,7 +5759,7 @@ msgstr ""
 "Imamo tudi vodnik za [premik vaše organizacije v Zulip]"
 "({organization_setup_url}).\n"
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "\n"
@@ -6354,7 +5782,7 @@ msgstr ""
 "[preoblikovana v stalno organizacijo]"
 "({convert_demo_organization_help_url}).\n"
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
@@ -6364,7 +5792,7 @@ msgstr ""
 "Začel sem nekaj pogovorov, da vam pomagam začeti. Najdete\n"
 "jih lahko v svoji [Mapi Neprebrano](/#inbox).\n"
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6375,7 +5803,7 @@ msgstr ""
 "Vedno se lahko vrnete k videu [Dobrodošli v Zulip]"
 "({navigation_tour_video_url}) za hiter pregled aplikacije.\n"
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6400,7 +5828,7 @@ msgstr ""
 "{demo_organization_text}\n"
 "\n"
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
@@ -6410,7 +5838,7 @@ msgstr ""
 "[Mobilne in namizne aplikacije](/apps/) lahko [prenesete](/apps/).\n"
 "Zulip odlično deluje tudi v brskalniku.\n"
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -6422,7 +5850,7 @@ msgstr ""
 "(/help/change-your-profile-picture)\n"
 "in uredite svoje [podatke o profilu](/help/edit-your-profile).\n"
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -6441,7 +5869,7 @@ msgstr ""
 "izkušnjo Zulip\n"
 "v svojih [Nastavitvah](#settings/preferences).\n"
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6457,7 +5885,7 @@ msgstr ""
 "\n"
 "[Brskaj in se naroči na kanale]({settings_link}).\n"
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -6485,7 +5913,7 @@ msgstr ""
 "Oglejte si [Nedavne pogovore](#recent) za seznam tem, o katerih se\n"
 "razpravlja.\n"
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -6499,7 +5927,7 @@ msgstr ""
 "\n"
 "Pritisnite `?` kadar koli, da vidite [kratek vodič](#keyboard-shortcuts).\n"
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -6519,7 +5947,7 @@ msgstr ""
 "spojlerjih, globalnih\n"
 "časih in drugih možnostih..\n"
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6534,7 +5962,7 @@ msgstr ""
 "Oglejte si naš [Uvodni vodnik](/help/getting-started-with-zulip),\n"
 "ali brskajte po [centru za pomoč](/help/), da izveste več!\n"
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6545,7 +5973,7 @@ msgstr ""
 "Lahko klepetate z mano, kolikor želite! Za\n"
 "pomoč poskusite eno od naslednjih sporočil: {bot_commands}\n"
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6564,7 +5992,7 @@ msgstr ""
 "ali celo premakniti temo [v drug kanal]"
 "({move_content_another_channel_help_url}).\n"
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
@@ -6572,7 +6000,7 @@ msgstr ""
 "\n"
 ":point_right: Poskusite premakniti to sporočilo v drugo temo in nazaj.\n"
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6595,12 +6023,11 @@ msgstr ""
 "vrstici\n"
 "in zgoraj.\n"
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr "dobrodošli v Zulip!"
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -6612,7 +6039,7 @@ msgstr ""
 "v kontekstu,\n"
 "ne glede na to, koliko drugih pogovorov poteka.\n"
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
@@ -6622,7 +6049,7 @@ msgstr ""
 ":point_right: Ko ste pripravljeni, preverite [Neprebrano](/#inbox) za druge\n"
 "pogovore z neprebranimi sporočili.\n"
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -6634,7 +6061,7 @@ msgstr ""
 "kliknite\n"
 "gumb `+` zraven njegovega imena.\n"
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -6645,7 +6072,7 @@ msgstr ""
 "Označite svoj pogovor s temo. Razmislite o dokončanju stavka: »Hej,\n"
 "lahko poklepetamo o...?«\n"
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
@@ -6653,7 +6080,7 @@ msgstr ""
 "\n"
 ":point_right: Poskusite začeti nov pogovor v tem kanalu.\n"
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6664,7 +6091,7 @@ msgstr ""
 ":point_right:  Uporabite to temo, da preizkusite [funkcije sporočanja Zulipa]"
 "({format_message_help_url}).\n"
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6699,7 +6126,7 @@ msgstr ""
 "\n"
 "```\n"
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
@@ -6709,7 +6136,7 @@ msgstr ""
 "Ta tema **pozdravi** je odličen kraj, da rečete »živjo« :wave: svojim "
 "sodelavcem.\n"
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
@@ -6719,107 +6146,107 @@ msgstr ""
 ":point_right: Kliknite na to sporočilo, da začnete novo sporočilo v istem "
 "pogovoru.\n"
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr "premikanje sporočil"
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr "eksperimenti"
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr "začni pogovor"
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr "pozdravi"
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr "Neveljaven JSON v odgovoru"
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr "Neveljavna oblika odgovora"
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr "Prazen žeton ali žeton z neveljavno dolžino"
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr "Neveljaven žeton APNS"
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr ""
 "Neveljavna možnost GCM za strežnik za potisna obvestila: prioriteta "
 "{priority!r}"
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr "Neveljavne možnosti GCM za strežnik za potisna obvestila: {options}"
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr "Žeton ne obstaja"
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr "{full_name} je omenil @{user_group_name}:"
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr "{full_name} vas je omenil:"
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr "{full_name} je omenil vse:"
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "Novo sporočilo"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr "Testno obvestilo"
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr "To je testno obvestilo iz {realm_name} ({realm_url})."
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr "Naprava ni prepoznana"
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr "Naprava ni prepoznana s strani strežnika za potisna obvestila"
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr "Ni aktivne registrirane naprave za potisna obvestila"
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 "Prišlo je do omrežne napake pri povezovanju s storitvijo potisnih obvestil "
 "Zulip."
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 "Notranja napaka strežnika pri storitvi potisnih obvestil Zulip. Poskusite "
 "znova pozneje."
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
@@ -6827,13 +6254,13 @@ msgstr ""
 "Težava s konfiguracijo potisnih obvestil na strežniku. Obrnite se na "
 "skrbnika strežnika ali poskusite znova pozneje."
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 #, fuzzy
 #| msgid "Invalid API key"
 msgid "Invalid `push_key`"
 msgstr "Neveljaven ključ API"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
@@ -6842,32 +6269,30 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr "Neveljaven podatkovni tip za ID kanala"
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr "Uporabnik ni pooblaščen za to poizvedbo"
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr "'{email}' ne uporablja več Zulipa."
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr "Ne morete pošiljati neposrednih sporočil zunaj vaše organizacije."
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr "Največja dovoljena dolžina opomnika: {max_length} znakov"
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "You requested a reminder for the following direct message. Note:\n"
@@ -6879,13 +6304,13 @@ msgstr ""
 "Zahtevali ste opomnik za naslednje zasebno sporočilo. Opomba:\n"
 " > {note}"
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 #, fuzzy
 #| msgid "You requested a reminder for the following direct message."
 msgid "You requested a reminder for the following message."
 msgstr "Zahtevali ste opomnik za naslednje zasebno sporočilo."
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
@@ -6894,11 +6319,11 @@ msgstr ""
 "Zahtevali ste opomnik za naslednje zasebno sporočilo. Opomba:\n"
 " > {note}"
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr "Zahtevali ste opomnik za naslednje zasebno sporočilo."
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{user_silent_mention} [sent]({conversation_url}) a todo list."
 msgid ""
@@ -6906,14 +6331,14 @@ msgid ""
 "{topic_pretty_link}."
 msgstr "{user_silent_mention} je [poslal]({conversation_url}) seznam opravil."
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{user_silent_mention} [said]({conversation_url}):"
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr "{user_silent_mention} je [rekel]({conversation_url}):"
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{user_silent_mention} [sent]({conversation_url}) a todo list."
 msgid ""
@@ -6921,7 +6346,7 @@ msgid ""
 "{list_of_recipient_mentions}."
 msgstr "{user_silent_mention} je [poslal]({conversation_url}) seznam opravil."
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{user_silent_mention} [said]({conversation_url}):"
 msgid ""
@@ -6929,558 +6354,542 @@ msgid ""
 "{list_of_recipient_mentions}:"
 msgstr "{user_silent_mention} je [rekel]({conversation_url}):"
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{user_silent_mention} [sent]({conversation_url}) a todo list."
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr "{user_silent_mention} je [poslal]({conversation_url}) seznam opravil."
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{user_silent_mention} [sent]({conversation_url}) a todo list."
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr "{user_silent_mention} je [poslal]({conversation_url}) seznam opravil."
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 msgid "Reminder does not exist"
 msgstr "Opomnika ni mogoče najti"
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr "Napaka strežnika za potisna obvestila: {error}"
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr "Ne morem se odločiti med argumentoma '{var_name1}' in '{var_name2}'"
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr "Manjkajoč argument '{var_name}'"
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr "Napačna vrednost za '{var_name}': {bad_value}"
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr "Načrtovano sporočilo ne obstaja"
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr "{service_name} varnost računa"
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr "Privzet kanal ne more biti zaseben."
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr "Spletno javni kanali niso omogočeni."
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr "Nimate dovoljenja za objavljanje v tem kanalu."
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr "Niste pooblaščeni za pošiljanje v kanal '{channel_name}'"
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 #, fuzzy
 #| msgid "You don't have permission to resolve topics in this channel."
 msgid "You do not have permission to create new topics in this channel."
 msgstr "Nimate dovoljenja za razreševanje tem v tem kanalu."
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr "Neveljaven ID kanala"
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr "Neveljavno ime kanala '{channel_name}'"
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr "Kanal(i) ({channel_names}) ne obstajajo"
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr "Privzeta skupina kanalov z id-jem '{group_id}' ne obstaja."
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr "Ime kanala ne sme biti prazno."
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr "Ime kanala je predolgo (omejitev: {max_length} znakov)."
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr "Neveljaven znak v imenu kanala, na položaju {position}."
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr "Neveljaven znak v temi, na položaju {position}!"
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr "Podatki o naročnikih za ta kanal niso na voljo"
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr "Ni mogoče pridobiti naročnikov za zasebni kanal"
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr "Slike ni bilo mogoče dekodirati; ali ste naložili slikovno datoteko?"
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr "Velikost slike presega omejitev."
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr "Slika je poškodovana ali okrnjena"
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr "{var_name} ni logična vrednost"
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} does not have the expected format"
 msgstr "{var_name} nima pričakovanega formata"
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr "{var_name} ni datum"
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr "{var_name} ni slovar"
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr "Neveljaven {var_name}"
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr "Argument \"{argument}\" pri {var_name} je nepričakovan"
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr "{var_name} ni decimalno število"
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr "{var_name} je premajhen"
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr "{var_name} ni celo število"
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr "{var_name} ni veljaven JSON"
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr "{var_name} je prevelik"
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr "{var_name} ni seznam"
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr "{var_name} je predolg (omejitev: {max_length} znakov)"
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr "{var_name} je prekratek."
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr "{var_name} ni niz"
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr "{var_name} ima neveljavno obliko"
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr "{var_name} ni dolžine {length}"
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr "{var_name} je predolg (omejitev: {max_length} znakov)"
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr "{var_name} je predolg (omejitev: {max_length} znakov)"
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr "{var_name} ne sme biti prazen"
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr "Neveljaven {var_name}: {msg}"
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr "Polje {var_name} manjka: {msg}"
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr "Napačno oblikovana koristna vsebina"
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr "Ni na seznamu možnih vrednosti"
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr "Ni URL"
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr "Ni prepoznan časovni pas"
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr "{var_name} ni veljavna šestnajstiška barvna koda"
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr "Neveljaven {setting_name}"
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr "Nalaganje bi preseglo kvoto nalaganja vaše organizacije."
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr "Velikost slike presega omejitev"
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr "Uporabniška skupina je deaktivirana."
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr "Neveljavna uporabniška skupina"
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid user group ID: {group_id}"
 msgid "Invalid user group ID: {user_group_id}"
 msgstr "Neveljaven ID uporabniške skupine: {group_id}"
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr "Neveljavno ime sistemske skupine."
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr "Neveljaven ID uporabniške skupine: {group_id}"
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 "Nastavitve '{setting_name}' ni mogoče nastaviti na skupino 'role:internet'."
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 "Nastavitve '{setting_name}' ni mogoče nastaviti na skupino 'role:nobody'."
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 "Nastavitve '{setting_name}' ni mogoče nastaviti na skupino 'role:everyone'."
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 "Nastavitve '{setting_name}' ni mogoče nastaviti na skupino '{group_name}'."
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr "Ime uporabniške skupine ne sme biti prazno!"
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr "Ime uporabniške skupine ne sme presegati {max_length} znakov."
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr "Ime uporabniške skupine se ne more začeti z '{prefix}'."
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr "Odjemalec ni posredoval nobenih novih vrednosti."
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 "Odjemalec mora posredovati emoji_name, če posreduje emoji_code ali "
 "reaction_type."
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr "Ime je predolgo!"
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 msgid "Name must not be empty!"
 msgstr "Ime ne sme biti prazno!"
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr "Neveljavni znaki v imenu!"
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr "Neveljavna oblika!"
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr "V tej organizaciji so zahtevana edinstvena imena."
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr "Ime je že v uporabi."
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr "Napačno ime ali uporabniško ime"
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr "Neveljavna integracija '{integration_name}'."
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr "Manjkajoči konfiguracijski parametri: {keys}"
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr "Neveljavna vrednost {key} {value} ({error})"
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr "Neveljavni konfiguracijski podatki!"
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr "Neveljavna vrsta bota"
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr "Neveljavna vrsta vmesnika"
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr "Neveljaven ID uporabnika: {user_id}"
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr "Takšen bot ne obstaja"
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr "Takšen uporabnik ne obstaja"
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr "Uporabnik je deaktiviran"
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr "{item} ne sme biti prazen."
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr ""
 "{var_name} ima napačno dolžino {length}; morala bi biti {target_length}"
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a string"
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr "{var_name} ni niz"
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr "{container} bi moral imeti natanko {length} elementov"
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr "Ključ {key_name} manjka v {var_name}"
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr "Nepričakovani argumenti: {keys}"
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr "{var_name} ni dovoljena vrsta"
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr "{variable} != {expected_value} ({value} je napačna)"
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr "{var_name} ni URL"
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr "Vzorec URL mora vsebovati '%(username)s'."
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr "'{item}' ne sme biti prazen."
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr "Polje ne sme imeti podvojenih izbir."
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr "'{value}' ni veljavna izbira za '{field_name}'."
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr "{var_name} ni niz ali seznam celih števil"
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr "{var_name} ni niz ali celo število"
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr "{var_name} nima dolžine"
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr "{var_name} manjka"
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr "Neznana nastavitev 'PresetUrlOption': {config}"
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr "Manjka glava dogodka HTTP '{header}'"
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr "Algoritem '{algorithm}' ni podprt."
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
@@ -7488,153 +6897,153 @@ msgstr ""
 "Manjka skrivnost za webhook. Prosimo, nastavite `webhook_secret` ob "
 "ustvarjanju URL-ja."
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr "Preverjanje podpisa spletnega ključa (webhook) ni uspelo."
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr "V zcommandu bi morala biti vodilna poševnica."
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr "Takšnega ukaza ni: {command}"
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr "`zulip_update_announcements_stream` je nepričakovano deaktiviran."
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr "Napaka CSRF: {reason}"
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr "Napačna konfiguracija povratnega posrednika: {proxy_reason}"
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr "Neveljavni ID-ji uporabnikov: {invalid_ids}"
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr "Uporabnik z ID-jem {user_id} je deaktiviran"
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr "Uporabnik z ID-jem {user_id} je bot"
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr "Datum"
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr "Zunanji račun"
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr "Zaimki"
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr "Nihče"
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr "Polni člani"
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "Člani"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr "Vsi na internetu"
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Invalid characters in emoji name"
 msgid "Invalid auto-conversion field: empty field name."
 msgstr "Neveljavni znaki v imenu emojija"
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr "Skupina %(name)r v predlogi URL ni prisotna v vzorcu povezovalnika."
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr "Slab regularen izraz: {regex}"
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr "Neznana napaka regularnega izraza"
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr "Neveljavna predloga URL."
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid "Example input does not match the linkifier pattern."
 msgstr "Skupina %(name)r v predlogi URL ni prisotna v vzorcu povezovalnika."
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr "Skupina %(name)r v predlogi URL ni prisotna v vzorcu povezovalnika."
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr "Skupina %(name)r v vzorcu povezovalnika ni prisotna v predlogi URL."
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid ""
@@ -7642,7 +7051,7 @@ msgid ""
 "pattern."
 msgstr "Skupina %(name)r v predlogi URL ni prisotna v vzorcu povezovalnika."
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgid ""
@@ -7650,331 +7059,328 @@ msgid ""
 "template."
 msgstr "Skupina %(name)r v vzorcu povezovalnika ni prisotna v predlogi URL."
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr "Unicode emoji"
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "Emoji po meri"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr "Dodatni Zulip emoji"
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr "Neveljavni znaki v imenu emojija"
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr "Neveljavni znaki v jeziku pygments"
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr "Manjkajoča zahtevana spremenljivka \"code\" v predlogi URL"
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr "\"code\" bi morala biti edina spremenljivka v predlogi URL"
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr "peskovnik"
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr "splošno"
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr "dogodki kanala"
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr "Neželena pošta"
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr "Nadlegovanje"
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr "Neprimerna vsebina"
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr "Krši pravila skupnosti"
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr "Drug razlog"
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr "Posodobitve Zulip"
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr "Na voljo v Zulip Cloud Standard. Nadgradite za dostop."
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr "Na voljo v Zulip Cloud Plus. Nadgradite za dostop."
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr "Dovoli GIF-e z oceno G (Splošno občinstvo)"
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr "Dovoli GIF-e z oceno PG (Starševski nadzor)"
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr "Dovoli GIF-e z oceno PG-13 (Starševski nadzor - mlajši od 13 let)"
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr "Dovoli GIF-e z oceno R (Omejeno)"
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr "Spletno-javno"
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "Javno"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr "Zasebno, deljena zgodovina"
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr "Zasebno, zaščitena zgodovina"
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr "Skrbniki, moderatorji, člani in gostje"
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr "Skrbniki, moderatorji in člani"
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr "Skrbniki in moderatorji"
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr "Samo skrbniki"
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr "Neznan uporabnik"
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr "Lastnik organizacije"
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr "Skrbnik organizacije"
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr "Moderator"
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "Član"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "Gost"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr "Neznan IP naslov"
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr "neznan operacijski sistem"
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr "Neznan brskalnik"
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr "Manjkajoč argument 'queue_id'"
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr "Manjkajoč argument 'last_event_id'"
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr "Dogodek, novejši od {event_id}, je bil že očiščen!"
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr "Dogodek {event_id} ni bil v tej čakalni vrsti"
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr "Slab ID čakalne vrste dogodkov: {queue_id}"
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 msgid "Failed to generate challenge"
 msgstr "Generiranje izziva je spodletelo"
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr "Avtentikacija JWT ni omogočena za to organizacijo"
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr "V zahtevi ni bil posredovan noben spletni žeton JSON"
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr "Slab spletni žeton JSON"
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr "V zahtevkih spletnega žetona JSON ni navedene e-pošte"
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr "Zahtevana je poddomena"
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr "Geslo je napačno."
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr "Če želite arhivirati to mapo, morate iz nje odstraniti vse kanale."
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr "Glava User-Agent manjka v zahtevi"
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr "Oznaka ne sme biti prazna."
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr "Polje mora imeti vsaj eno izbiro."
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr "Vrsta polja ni podprta za prikaz v povzetku profila."
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 #, fuzzy
 #| msgid "Field type not supported for display in profile summary."
 msgid "Field type not supported for use for user matching."
 msgstr "Vrsta polja ni podprta za prikaz v povzetku profila."
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr "Neveljavna vrsta polja."
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr "V povzetku profila sta lahko prikazani samo 2 polji profila po meri."
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr "Polje s to oznako že obstaja."
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr "Privzetega polja po meri ni mogoče posodobiti."
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr "Končna točka ni na voljo v produkciji."
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr "DevAuthBackend ni omogočen."
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr "Neveljaven parameter '{key}' za anonimno zahtevo"
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr "Podatkovna zbirka je prazna"
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr "Ni mogoče poizvedovati po postgresql"
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr "Ni mogoče vzpostaviti povezave z rabbitmq"
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr "Ni mogoče poizvedovati po rabbitmq"
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr "Ni mogoče poizvedovati po redis"
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr "Ni mogoče pisati v memcached"
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr "Ni mogoče poizvedovati po memcached"
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr "Takšno povabilo ne obstaja"
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 #, fuzzy
 #| msgid "Invitation has already been revoked"
 msgid "Invitation already used or deactivated."
 msgstr "Povabilo je bilo že preklicano"
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr "Povabilo je bilo že preklicano"
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr "Neveljavna ID kanala {channel_id}. Povabila niso bila poslana."
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr "Nimate dovoljenja za naročanje drugih uporabnikov na kanale."
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr "Navesti morate vsaj en e-poštni naslov."
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
@@ -7982,100 +7388,98 @@ msgstr ""
 "Ker nekateri izmed teh naslovov že uporabljajo Zulip, jim povabila nismo "
 "poslali. Povabila smo poslali vsem ostalim!"
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr "Zgodovina urejanja sporočil je v tej organizaciji onemogočena"
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr "Nimate dovoljenja za brisanje tega sporočila"
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr "Časovna omejitev za brisanje tega sporočila je potekla"
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr "Sporočilo je že izbrisano"
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr "Zahtevanih je preveč sporočil (največ {max_messages})."
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr "Sidro je lahko izključeno samo na koncu obsega"
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr "Takšne teme ni '{topic}'"
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr "Potrebna je razlaga."
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 msgid "Message reporting is not enabled in this organization."
 msgstr "Poročanje o sporočilih v tej organizaciji ni omogočeno."
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr "Manjkajoč pošiljatelj"
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr "Zrcaljenje ni dovoljeno z ID-ji prejemnikov"
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr "Neveljavno zrcaljeno sporočilo"
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr "Funkcije umetne inteligence na tem strežniku niso omogočene."
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr "Dosežena je mesečna omejitev za kredite AI."
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr "V pogovoru ni sporočil za povzetek"
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr "Ni mogoče utišati samega sebe"
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr "Uporabnik je že utišan"
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr "Uporabnik ni utišan"
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr "Vgrajeni pogledi ne morejo imeti imena po meri."
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr "Prilagojeni pogledi morajo imeti veljavno ime."
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 msgid "Navigation view already exists."
 msgstr "Navigacijski pogled že obstaja."
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr "Neznan korak uvajanja: {onboarding_step}"
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -8086,343 +7490,342 @@ msgstr ""
 "Prosili ste, da si [video Dobrodošli v Zulip]({navigation_tour_video_url}) "
 "ogledate kasneje. Je zdaj primeren čas?\n"
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr "Prisotnost ni podprta za uporabnike botov."
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr "Ni podatkov o prisotnosti za {user_id_or_email}"
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr "Neveljavno stanje: {status}"
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 #, fuzzy
 #| msgid "You do not have permission to change default channels."
 msgid "You do not have permission to manage plans and billing."
 msgstr "Nimate dovoljenja za spreminjanje privzetih kanalov."
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr "Strežnik ne uporablja storitve potisnih obvestil"
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr "Napaka, ki jo je vrnil strežnik za potisna obvestila: {result}"
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr "Skrivnost preverjanja ni pripravljena"
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr ""
 "Prisoten mora biti vsaj eden od naslednjih argumentov: emoji_name, emoji_code"
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr "Potrdila o prebranem so v tej organizaciji onemogočena."
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr "Neveljaven jezik '{language}'"
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr "Omogočena mora biti vsaj ena metoda avtentikacije."
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr "Neveljaven video_chat_provider {video_chat_provider}"
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid giphy_rating {giphy_rating}"
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr "Neveljavna giphy_rating {giphy_rating}"
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr "Mora biti predstavitvena organizacija."
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 "Čas brisanja podatkov mora biti največ {max_allowed_days} dni v prihodnosti."
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 "Čas brisanja podatkov mora biti vsaj {min_allowed_days} dni v prihodnosti."
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr "Neveljavna domena: {error}"
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr "Domena {domain} je že del vaše organizacije."
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr "Ni bil najden noben vnos za domeno {domain}."
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr "Naložiti morate natanko eno datoteko."
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr "Samo skrbniki lahko preglasijo privzete emojije."
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr "Naložena datoteka je večja od dovoljene omejitve {max_size} MiB"
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 #, fuzzy
 #| msgid "JWT authentication is not enabled for this organization"
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr "Avtentikacija JWT ni omogočena za to organizacijo"
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr "Presežena omejitev hitrosti."
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr "Neveljaven ID izvoza podatkov"
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr "Izvoz je že izbrisan"
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr "Izvoz ni uspel, ničesar ni za izbrisati"
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr "Izvoz še vedno poteka"
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr "Naložiti morate natanko eno ikono."
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr "Povezovalnik ni bil najden."
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr "Naložiti morate natanko en logotip."
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid characters in pygments language"
 msgid "Invalid character in language: {character}"
 msgstr "Neveljavni znaki v jeziku pygments"
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid language '{language}'"
 msgid "Language '{language}' is not allowed."
 msgstr "Neveljaven jezik '{language}'"
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr "Neveljavno igrišče"
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr "Uvoza ni mogoče preklicati, ko se je že začel."
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr "Ni overjen"
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 msgid "Importing messages…"
 msgstr "Uvažanje sporočil…"
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr "Uvažanje podatkov o priponkah…"
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr "Uvažanje pretvorjenih podatkov iz Slacka…"
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr "Zaključevanje uvoza…"
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr "Končano!"
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr "Ni uporabnikov, ki bi ustrezali navedenemu e-poštnemu naslovu."
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "Your full name"
 msgid "Your name"
 msgstr "Vaše polno ime"
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr "Prejemnik je obvezen pri posodabljanju vrste načrtovanega sporočila."
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 "Tema je obvezna pri posodabljanju vrste načrtovanega sporočila v kanal."
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr "Neveljavna oblika zahteve"
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr "Neveljaven DSN"
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr "Zasebnih kanalov ni mogoče narediti privzetih."
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr "Posredovati morate \"new_description\" ali \"new_group_name\"."
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr ""
 "Neveljavna vrednost za \"op\". Določite eno izmed \"add\" ali \"remove\"."
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr "Neveljavni parametri"
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr "Zahtevan je dostop do vsebine kanala."
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr "Kanal že ima to ime."
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr "Ni nič za storiti. Določite vsaj eno izmed \"add\" ali \"delete\"."
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr "{user_full_name} vas je naročil na {channel_name}."
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr "{user_full_name} vas je naročil na naslednje kanale:"
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr "Ni mogoče dostopati do kanala ({channel_name})."
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr "{user_name} je ustvaril naslednje kanale: {new_channels}."
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr "{user_name} je ustvaril nov kanal {new_channels}."
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr "novi kanali"
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr "**Javno dostopen** kanal, ki ga je ustvaril {user_name}. **Opis:**"
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr "**Javni** kanal, ki ga je ustvaril {user_name}. **Opis:**"
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
@@ -8430,7 +7833,7 @@ msgstr ""
 "**Zasebni kanal s skupno zgodovino**, ki ga je ustvaril {user_name}. **Opis:"
 "**"
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
@@ -8439,26 +7842,26 @@ msgstr ""
 "**Zasebni kanal z zaščiteno zgodovino**, ki ga je ustvaril {user_name}. "
 "**Opis:**"
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr "{property} ni logična vrednost"
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr "Neznana lastnost naročnine: {property}"
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr "Ni naročen na ID kanala {channel_id}"
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr "Neveljaven json za podsporočilo"
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
@@ -8467,7 +7870,7 @@ msgstr ""
 "Datoteka je večja od največje velikosti nalaganja ({max_size} MiB), ki jo "
 "dovoljuje načrt vaše organizacije."
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
@@ -8476,7 +7879,7 @@ msgstr ""
 "Datoteka je večja od konfigurirane največje velikosti nalaganja tega "
 "strežnika ({max_size} MiB)."
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
@@ -8484,52 +7887,51 @@ msgid ""
 msgstr ""
 "Naložena datoteka presega največjo dovoljeno veliost ({max_file_size} MiB)."
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr "Uporabnik je onemogočil obvestila o tipkanju za sporočila kanala"
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr "Manjkajoč argument 'to'"
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr "Prazen seznam 'to'"
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr "Uporabnik je onemogočil obvestila o tipkanju za neposredna sporočila"
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr "<p>Ta datoteka ne obstaja ali je bila izbrisana.</p>"
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr "<p>Niste pooblaščeni za ogled te datoteke.</p>"
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr "Neveljaven žeton"
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr "Neveljavno ime datoteke"
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr "Navesti morate datoteko za nalaganje"
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr "Naenkrat lahko naložite samo eno datoteko"
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr "Ni bilo posredovanih nobenih novih podatkov"
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
@@ -8537,32 +7939,32 @@ msgstr ""
 "Ni nič za storiti. Določite vsaj eno izmed \"add\", \"delete\", "
 "\"add_subgroups\" ali \"delete_subgroups\"."
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr "{user_full_name} vas je dodal v skupino {group_name}."
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr "{user_full_name} vas je odstranil iz skupine {group_name}."
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr "Uporabnik {user_id} je že član te skupine"
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr "V tej uporabniški skupini ni člana '{user_id}'"
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr "Uporabniška skupina {group_id} je že podskupina te skupine."
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
@@ -8571,78 +7973,78 @@ msgstr ""
 "Uporabniška skupina {user_group_id} je že podskupina ene od posredovanih "
 "podskupin."
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr "Uporabniška skupina {group_id} ni podskupina te skupine."
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr "Spremembe avatarja so v tej organizaciji onemogočene."
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr "Spremembe e-poštnega naslova so v tej organizaciji onemogočene."
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr "Neveljaven default_language"
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr "Neveljaven zvok obvestila '{notification_sound}'"
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr "Neveljavno obdobje združevanja e-pošte: {seconds} sekund"
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr "Vaše geslo za Zulip se upravlja v LDAP"
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr "Napačno geslo!"
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, fuzzy, python-brace-format
 #| msgid "You're making too many attempts! Try again in {seconds} seconds."
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr "Naredili ste preveč poskusov! Poskusite znova čez {seconds} sekund."
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr "Novo geslo je prešibko!"
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr "Naložiti morate natanko en avatar."
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr "Tema ni utišana"
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr "Ni mogoče deaktivirati edinega lastnika organizacije"
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Nobody in this Zulip organization will be able to see this email address."
@@ -8650,27 +8052,27 @@ msgid "User is not allowed to delete other user's messages."
 msgstr ""
 "Nihče v tej organizaciji Zulip ne bo mogel videti tega e-poštnega naslova."
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 "Uporabnik ni pooblaščen za spreminjanje uporabniških e-poštnih naslovov"
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 "Dovoljenja lastnika ni mogoče odstraniti edinemu lastniku organizacije."
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr "Neveljaven nov e-poštni naslov."
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr "Napaka vrednosti nove e-pošte: {message}"
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
@@ -8683,26 +8085,26 @@ msgstr ""
 "konfiguriran.\n"
 "Obrnite se na skrbnika strežnika."
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 #, fuzzy
 #| msgid "Email is already in use."
 msgid "Email address already in use"
 msgstr "E-pošta je že v uporabi."
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr "Ni uspelo spremeniti lastnika, takšen uporabnik ne obstaja"
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr "Ni uspelo spremeniti lastnika, uporabnik je deaktiviran"
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr ""
 "Ni uspelo spremeniti lastnika, boti ne morejo imeti v lasti drugih botov"
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
@@ -8711,140 +8113,140 @@ msgstr ""
 "konfiguriran.\n"
 "Obrnite se na skrbnika strežnika."
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr "Vdelani boti niso omogočeni."
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr "Neveljavno ime vdelanega bota."
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr "Uporabnik ni pooblaščen za ustvarjanje uporabnikov"
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr "E-pošta '{email}' ni dovoljena v tej organizaciji"
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr "Začasni e-poštni naslovi v tej organizaciji niso dovoljeni"
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom access token"
 msgid "Invalid {provider_name} access token"
 msgstr "Neveljaven dostopni žeton za Zoom"
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} call"
 msgstr "Ni uspelo ustvariti klica Zoom"
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Zoom credentials have not been configured"
 msgid "{provider_name} credentials have not been configured"
 msgstr "Poverilnice za Zoom niso bile konfigurirane"
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom credentials"
 msgid "Invalid {provider_name} credentials"
 msgstr "Neveljavne poverilnice za Zoom"
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error connecting to the BigBlueButton server."
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr "Napaka pri povezovanju s strežnikom BigBlueButton."
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error authenticating to the BigBlueButton server."
 msgid "Error authenticating to the {provider_name} server"
 msgstr "Napaka pri avtentikaciji na strežniku BigBlueButton."
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "BigBlueButton server returned an unexpected error."
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr "Strežnik BigBlueButton je vrnil nepričakovano napako."
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom session identifier"
 msgid "Invalid {provider_name} session identifier"
 msgstr "Neveljaven identifikator seje Zoom"
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr "Neznana e-pošta uporabnika Zoom"
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} public room."
 msgstr "Ni uspelo ustvariti klica Zoom"
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr "Neveljaven podpis."
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{full_name}'s Zulip room"
 msgstr "{full_name} vas je omenil:"
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 "Projekti, ki uporabljajo tega ponudnika sistema za nadzor različic, niso "
 "podprti"
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr "Neveljavna koristna vsebina"
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr "Neznana zahteva spletnega kaveljna"
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr "Tema ne sme biti prazna"
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr "Vsebina ne sme biti prazna"
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr "Ni mogoče obravnavati koristne vsebine Jotform"
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr "Napačno oblikovan vnos JSON"
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr "Ključ dogodkov manjka v koristni vsebini"
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr "Napaka: parameter channels_map_to_topics, ki ni 0 ali 1"
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr "Neznano dejanje spletnega kaveljna WordPress: {hook}"
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
@@ -8853,76 +8255,76 @@ msgstr ""
 "Izvoz podatkov je zaključen. [Ogled in prenos izvozov]"
 "({export_settings_link})."
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr "Skrivnost preverjanja je potekla"
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr "Skrivnost preverjanja je neveljavna"
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr "Skrivnost preverjanja je napačno oblikovana"
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr "Skrivnost preverjanja je za drugo ime gostitelja"
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr "Neveljavna poddomena za strežnik za potisna obvestila"
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr "Potrditi je treba z veljavnim ključem API strežnika Zulip"
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr "Neveljaven UUID"
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr "Neveljavna vrsta žetona"
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 "{hostname} vsebuje neveljavne komponente (npr. pot, poizvedba, fragment)."
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr "{hostname} ni veljavno ime gostitelja"
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr "{hostname} še ni registriran"
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr "Napačen e-mail naslov administratorja serverja: {email_reason}"
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr "example.com ni veljavna email domena."
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr "{domain} je neveljavna, ker nima nobenih zapisov MX"
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr "{domain} ne obstaja"
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
@@ -8931,29 +8333,29 @@ msgstr ""
 "Dosežene so bile globalne omejitve nedavne uporabe te končne točke. Prosimo, "
 "poskusite znova kasneje ali se obrnite na {support_email} za pomoč."
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr "Za to ime gostitelja ni bila najdena nobena registracija"
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr "Gostitelj je poročal, da nima skrivnosti preverjanja."
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, fuzzy, python-brace-format
 #| msgid "Error response received from the host: {status_code}"
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr "Prejet odgovor o napaki od gostitelja: {status_code}"
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr "Manjkajoč ios_app_id"
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr "Manjkajoč user_id ali user_uuid"
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
@@ -8962,50 +8364,50 @@ msgstr ""
 "Vaš načrt ne dovoljuje pošiljanja potisnih obvestil. Razlog, ki ga je "
 "posredoval strežnik: {reason}"
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr "Vaš načrt ne dovoljuje pošiljanja potisnih obvestil."
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr "Neveljavna lastnost {property}"
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr "Neveljavna vrsta dogodka."
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr "Podatki niso v vrstnem redu."
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr "Zaznana je bila podvojena registracija."
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr "Napačno oblikovani podatki dnevnika revizije"
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr "Ponastaviti morate geslo."
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr "Manjkajoč parameter id_token"
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 #, fuzzy
 #| msgid "Missing id_token parameter"
 msgid "Missing idp param"
 msgstr "Manjkajoč parameter id_token"
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr "Neveljaven OTP"
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr "Ni mogoče hkrati uporabljati mobile_flow_otp in desktop_flow_otp."
 

--- a/locale/sr/LC_MESSAGES/django.po
+++ b/locale/sr/LC_MESSAGES/django.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 19:12+0000\n"
 "Last-Translator: Alex Vandiver <alexmv@zulip.com>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/zulip/django/sr/"
@@ -23,54 +23,54 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "Није дозвољено за госте"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "Неисправна организација"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr ""
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr ""
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr "Директне поруке"
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr "Групне директне поруке"
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr "Непознат назив графикона: {chart_name}"
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr ""
 "Време почетка је касније од времена завршетка. Почетак: {start}, Завршетак: "
 "{end}"
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr ""
 "Нема доступних података за аналитику. Молим вас контактирајте вашег "
 "администратора сервера."
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -83,7 +83,7 @@ msgstr ""
 "[деактивирајте неактивне кориснике]({deactivate_user_help_page_link}) да би "
 "сте омогућили приступ новим корисницима."
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -95,7 +95,7 @@ msgstr ""
 "({deactivate_user_help_page_link}) да би сте омогућили приступ више од "
 "једном кориснику."
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -107,7 +107,7 @@ msgstr ""
 "({deactivate_user_help_page_link}) да би сте омогућили приступ више од два "
 "корисника."
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -119,7 +119,7 @@ msgstr ""
 "({deactivate_user_help_page_link}) да би сте омогућили приступ више од три "
 "корисника."
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -128,28 +128,27 @@ msgid ""
 "({billing_page_link}) is greater than the current number of users."
 msgstr ""
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr ""
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr "Регистрација је деактивирана"
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr "Неисправан удаљени сервер."
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
@@ -158,7 +157,7 @@ msgstr ""
 "Морате купити лиценце за све активне кориснике у вашој организацији "
 "(минимално {min_licenses})."
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
@@ -167,62 +166,62 @@ msgstr ""
 "Фактуре са више од {max_licenses} лиценци не могу бити обрађене путем ове "
 "странице. Да би сте завршили надоградњу, молим вас контактирајте {email}."
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr "Није наведен начин плаћања у датотеци."
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr "{brand} се завршава за {last4}"
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr "Непознат начин плаћања. Молим вас контактирајте {email}."
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr "Десило се нешто непредвиђено. Молим вас контактирајте {email}."
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "Десило се нешто непредвиђено. Молим вас учитајте поново страницу."
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr ""
 "Десило се нешто непредвиђено. Молим вас сачекајте неколико секунди па "
 "покушајте поново."
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 "Молимо додајте кредитну картицу пре почетка бесплатног пробног периода."
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr "Молим вас додајте кредитну картицу да би сте заказали надоградњу."
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
 msgstr "Није могуће освежити план. План је истекао и замењен је новим планом."
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr "Није могуће освежити план. План је завршен."
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 "Није могуће изменити лиценцу у тренутном обрачунском периоду за бесплатан "
 "пробни план."
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
@@ -230,23 +229,23 @@ msgstr ""
 "Није могуће ручно освежавање лиценце. Ваш план је на аутоматском управљању "
 "лиценце."
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr "Ваш план већ има {licenses} лиценци у тренутном обрачунском периоду."
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr "Не можете да смањите лиценце у тренутном обрачунском периоду."
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
 msgstr ""
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
@@ -254,34 +253,34 @@ msgid ""
 msgstr ""
 "За ваш план је већ организована обнова са {licenses_at_next_renewal} лиценци."
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
 "billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr "Ништа за измену."
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr "Нема купца за ову организацију!"
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr "Сесија није пронађена"
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr "Сврха плаћања није пронађена"
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr ""
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -296,60 +295,58 @@ msgstr ""
 "Ако би сте могли да {begin_link}наведете Зулип као спонзора на вашем веб "
 "сајту{end_link}, били би смо вам много захвални!"
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr "Параметар 'потврђено' је неопходан"
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr "Истекао је приступни токен за наплату."
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr "Неисправан приступни токен за наплату."
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
 "{support_email}"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr "Кориснички налог још увек не постоји."
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr "Морате прихватити Услове сервиса да би сте наставили."
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 "Ова zulip_org_id није регистрована са Зулиповим системом за управљањем "
 "наплате."
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr "Неисправан zulip_org_key за ову zulip_org_id."
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr "Регистрација вашег сервера је деактивирана."
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "Грешка"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr "Страница није пронађена (404)"
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, fuzzy, python-format
 #| msgid ""
 #| "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd "
@@ -361,42 +358,41 @@ msgstr ""
 "Питања? <a href=\"mailto:%(support_email)s\">Контактирајте нас</a> — волели "
 "би смо да помогнемо!"
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr ""
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
 msgstr ""
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr ""
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
 msgstr ""
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr "Начин није дозвољен (405)"
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr "Интерна грешка сервера"
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
 msgstr ""
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -404,13 +400,13 @@ msgid ""
 "a> with any questions."
 msgstr ""
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, fuzzy, python-format
 #| msgid ""
 #| "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd "
@@ -422,144 +418,142 @@ msgstr ""
 "Питања? <a href=\"mailto:%(support_email)s\">Контактирајте нас</a> — волели "
 "би смо да помогнемо!"
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
 "href=\"%(troubleshooting_url)s\">Zulip server troubleshooting guide</a>."
 msgstr ""
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr "Аналитика за %(target_name)s | Зулип"
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 "Аналитика је у потпуности доступна 24 сата након креирања организације."
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr "Зулип аналитика за %(target_name)s"
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr "Организација укратко"
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr "Број корисника"
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr "Активно корисника за последњих 15 дана"
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr "Број гостију"
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr "Укупан број порука"
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr "Број порука за последњих 30 дана"
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr "Складиште датотека у употреби"
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "Активни корисници"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr "Дневно активни"
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr "Активни 15 дана"
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr "Укупно корисника"
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "Корисници"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr "Послате поруке према врсти примаоца"
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "Ја"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "Свако"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "Прошле недеље"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "Прошлог месеца"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "Прошле године"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "Све време"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr "Послате поруке у периоду"
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "Дневно"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "Недељно"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr "Кумулативно"
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "Људи"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "Ботови"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr "Прочитане поруке током времена"
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr "Послате поруке по клијенту"
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr "Последње освежавање"
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
@@ -567,15 +561,15 @@ msgstr ""
 "Потпуно освежавање свих графикона дешава се једном дневно. Графикон “Поруке "
 "послате током времена” се освежава на сат времена."
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr "Е-пошта је промењена"
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr "Е-пошта је промењена!"
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
@@ -584,48 +578,48 @@ msgstr ""
 "Ово потврђује да је адреса е-поште вашег Зулип налога промењена из "
 "%(old_email_html_tag)s у %(new_email_html_tag)s"
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr "Потврђивање ваше адресе е-поште"
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr "Не постоји веза потврде"
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr "Упс. Нисмо успели да пронађемо везу потврде у систему."
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr "Веза потврде је истекла или је деактивирана"
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr "Упс. Веза потврде је истекла или је деактивирана."
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr "Молим вас контактирајте администратора ваше организације за нову везу."
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr "Веза потврде је лоше формирана"
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr "Упс. Веза потврде је лоше формирана."
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
@@ -633,72 +627,55 @@ msgstr ""
 "Проверите да сте исправно ископирали везу у вашем прегледачу. Ако и даље "
 "долазите на ову страну, вероватно је то због наше грешке. Извињавамо се."
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr "Рачун"
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr "Затвори прозор"
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr "Заборави"
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "Откажи"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr "Потврди"
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr ""
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr "Статус наплате"
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr "Деактавирати регистрацију сервера?"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -709,19 +686,19 @@ msgid ""
 "server."
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -729,736 +706,246 @@ msgid ""
 "%(support_email)s'>contact support</a> with any questions."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr "Прекорачено је ограничење брзине"
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr "Прекорачено је ограничење брзине."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, fuzzy, python-format
 #| msgid "You can try again in %(retry_after)s seconds."
 msgid "You can try again in %(retry_after_string)s."
 msgstr "Можете да пробате поново за %(retry_after)s секунди."
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr "Надогради"
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr ""
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr "Отворите именик заједница"
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr "Филтрирај према категорији"
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "Све"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr "Категорије"
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr ""
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr "Зулип развојна заједница"
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr "Приступите као корисник"
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr "Приступите као самостални хостер"
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr "Приступите као доприноситељ"
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "Направите организацију"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr ""
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr "Самостално хостујте Зулип"
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr "Затражите спонзорство"
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr "Цена за образовне институције"
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr "Погледајте ценовник"
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr "Зулип за пословне кориснике"
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Zulip guide for open-source projects"
 msgid "Zulip for open source"
 msgstr "Зулипов водич за пројекте отвореног кода"
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Create your Zulip organization"
 msgid "Screenshot of Zulip conversation"
 msgstr "Направите вашу Зулип организацију"
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Messages sent over time"
 msgid "Message with code"
 msgstr "Послате поруке у периоду"
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr "Веза"
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr "Контактирајте подршку"
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr "Од"
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr "Организација"
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr "Наслов"
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr "Порука"
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr "Пошаљи"
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr "Хвала што сте нас контактирали"
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr "Хвала што сте нас контактирали!"
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr "Контактираћемо вас убрзо."
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
@@ -1466,13 +953,13 @@ msgstr ""
 "Можете пронаћи одговоре на често постављана питања у <a href=\"/help/"
 "\">Зулиповом центру за помоћ</a>."
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 #, fuzzy
 #| msgid "Getting started"
 msgid "Get started"
 msgstr "Први кораци"
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
@@ -1482,50 +969,49 @@ msgstr ""
 "href=\"https://zulip.com/policies/terms\">Зулипове Услове сервиса</a> да би "
 "сте наставили."
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr "Или, као алтернативу, користите један од ваших резервних телефона:"
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr "Као последње решење, можете искористити резервни токен:"
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr "Искористи резервни токен"
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr "Прихватите услове сервиса"
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr "Добродошли у Зулип"
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "Е-пошта"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr ""
 "Претплати ме на Зулипов нискофреквентни билтен (неколико е-порука годишње)."
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr "Настави"
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr "Потврдите адресу ваше е-поште"
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1536,7 +1022,7 @@ msgstr ""
 "class=\"user_email semi-bold\">%(email)s</span>) за е-поруку потврде од "
 "Зулипа."
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
@@ -1545,30 +1031,30 @@ msgstr ""
 "нежељеном поштом, ми је можемо <a href=\"#\" id=\"resend_email_link\">поново "
 "послати</a>."
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr ""
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
@@ -1576,39 +1062,38 @@ msgstr ""
 "Уколико се ова порука сама не уклони, покушајте <a class=\"reload-lnk\">да "
 "освежите</a> страницу."
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 "Грешка приликом учитавања Зулипа. Покушајте <a class=\"reload-lnk\">да "
 "освежите</a> страницу."
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr "Ниједан разговор се не поклапа са вашим филтерима."
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr "Приказ и даље учитава поруке."
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr "Учитај више"
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr "Завршен је видео позив"
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr "Сада можете затворити овај прозор."
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr "Грешка конфигурације"
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
@@ -1617,7 +1102,7 @@ msgstr ""
 "организацију. Користите EmailAuthBackend да би сте направили вашу "
 "организацију а затим покушајте поново."
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1625,199 +1110,192 @@ msgid ""
 "href=\"%(doc_url)s\">documentation</a>."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr "Налог није пронађен"
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr "Није пронађен Зулип налог."
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, fuzzy, python-format
 #| msgid "Your account email: %(email)s"
 msgid "No account found for %(email)s."
 msgstr "Е-пошта вашег налога: %(email)s"
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr "Пријавите се са другим налогом"
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr "Наставите на регистрацију"
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Must be a demo organization."
 msgid "Try Zulip in a demo organization"
 msgstr "Мора бити демонстративна организација."
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Try Zulip now"
 msgid "Try Zulip"
 msgstr "Пробајте Зулип сада"
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "Направите нову организацију"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr "Направите нову Зулип организацију"
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr "Упишите адресу ваше е-поште"
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr "Адреса ваше е-поште"
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr "Врста организације"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr "Језик организације"
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 #, fuzzy
 #| msgid "Private, shared history"
 msgid "Import chat history?"
 msgstr "Приватно, дељена историја"
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr "Назив организације"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "УРЛ организације"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr "Користите %(external_host)s"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "ОР"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "Региструјте се"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "Региструјте се у Зулип"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr "Потребна вам је позивница за приступ овој организацији."
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr "Региструјте се са %(identity_provider)s"
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr "Већ имате налог?"
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "Пријави се"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr "Подесите приватност адресе е-поште"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
@@ -1825,7 +1303,7 @@ msgstr ""
 "Зулип вам омогућава да контролишете које улоге у организацији могу да виде "
 "ваше адресе е-поште."
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
@@ -1833,11 +1311,11 @@ msgstr ""
 "Да ли желите да промените подешавања приватности ваше е-поште од "
 "предефинисаног подешавања за ову организацију?"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr "Ко може да приступи вашој адреси е-поште"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1848,14 +1326,14 @@ msgstr ""
 "configure-email-visibility\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">након што приступите</a>."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 "Администратори ове Зулип организације ће моћи да виде ову адресу е-поште."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
@@ -1863,92 +1341,91 @@ msgstr ""
 "Администратори и модератори ове Зулип организације ће моћи да виде ову "
 "адресу е-поште."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr "Нико у овој Зулип организацији неће моћи да види ову адресу е-поште."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 "Остали корисници ове Зулип организације ће моћи да виде ову адресу е-поште."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "Промени"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr "Регистрација"
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr "Направите вашу организацију"
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr "Направите ваш налог"
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr "<p>Унеисте детаље вашег налога да би сте завршили регистрацију.</p>"
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr "Ваша организација"
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr "Ваш налог"
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr "Не увозите подешавања"
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr "Увезите подешавања из постојећег Зулип налога"
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "Назив"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "Лозинка"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr "Унесите лозинку вашег LDAP/Активног директоријума."
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 "Ово се користи за апликације на телефону и остале алате који захтевају "
 "лозинку."
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr "Јачина лозинке"
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr "За шта сте заинтересовани?"
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
@@ -1957,22 +1434,22 @@ msgstr ""
 "Слажем се са <a href=\"%(root_domain_url)s/policies/terms\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">условима коришћења</a>."
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr "Искључена организација"
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr ""
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -1980,7 +1457,7 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid ""
@@ -1988,41 +1465,41 @@ msgid ""
 "deleted."
 msgstr "Ова организације је деактивирана"
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
 "inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
 "administrators</a> to inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid "This organization has been deactivated."
 msgstr "Ова организације је деактивирана"
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
 "%(support_email)s\">contact Zulip support</a> to reactivate it."
 msgstr ""
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, fuzzy, python-format
 #| msgid ""
 #| "If you have any questions, please contact this Zulip server's "
@@ -2035,15 +1512,15 @@ msgstr ""
 "Ако имате било каква питања, молим вас контактирајте администратора Зулип "
 "сервера на %(support_email)s."
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr "Завршите пријаву апликацијом на рачунару"
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr "Завршите пријаву на рачунару"
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
@@ -2051,93 +1528,92 @@ msgstr ""
 "Користите ваш веб прегледач да завршите пријављивање, затим се вратите овамо "
 "да налепите ваш токен за пријаву."
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr "Овде налепите токен"
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr "Заврши"
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr "Неисправан токен."
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr "Токен је прихваћен. Пријављујемо вас…"
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr "Пријавите се у апликацију на рачунару"
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 "Ископирајте овај токен за пријаву и вратите се у Зулип да би сте завршили "
 "пријављивање:"
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "Копирај"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr "Затим можете затворити овај прозор."
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr "Или, наставите у вашем прегледачу."
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr "Анонимни корисник"
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr "Власници"
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "Админстратори"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr "Модератори"
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr "Гости"
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "Обични корисници"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr "Проследите е-поруке на налог е-поште"
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "Затвори"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "Надогради"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr "Зулип"
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr "Сажми"
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
@@ -2145,17 +1621,17 @@ msgid ""
 msgstr ""
 "Честитамо, направили сте нову Зулип организацију: <b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr "Добродошли у Зулип!"
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr "Придружили сте се Зулип организацији <b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
@@ -2164,43 +1640,43 @@ msgstr ""
 "Користићете следеће податке за пријаву у Зулип на вебу, у апликацији за <a "
 "href=\"%(apps_page_link)s\">телефон и рачунар</a>:"
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr "Адреса организације: %(organization_url)s"
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr "Ваше корисничко име: %(ldap_username)s"
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr "Користите ваш LDAP налог за пријаву"
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr "Е-пошта вашег налога: %(email)s"
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr "Идите у организацију"
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
 "href=\"%(getting_user_started_link)s\">getting started guide</a>!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2208,7 +1684,7 @@ msgid ""
 "Zulip</a>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
@@ -2217,28 +1693,28 @@ msgstr ""
 "Питања? <a href=\"mailto:%(support_email)s\">Контактирајте нас</a> — волели "
 "би смо да помогнемо!"
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr "%(realm_name)s на Зулипу: Детаљи ваше нове организације"
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr "%(realm_name)s на Зулипу: Детаљи вашег новог налога"
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr "Честитамо, направили сте нову Зулип организацију: %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr "Приступили сте Зулип организацији %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
@@ -2247,32 +1723,32 @@ msgstr ""
 "Користићете следеће податке за пријаву у Зулип на вебу, у апликацији за "
 "телефон и рачунар (%(apps_page_link)s):"
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
 "(%(getting_user_started_link)s)!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
 "(%(getting_organization_started_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 "Питања? Контактирајте нас на %(support_email)s — волели би смо да помогнемо!"
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2281,17 +1757,17 @@ msgstr ""
 "Ако имате било каква питања, молим вас контактирајте администратора Зулип "
 "сервера на %(support_email)s."
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr "Здраво,"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2299,12 +1775,12 @@ msgid ""
 "password for this account, please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr "Потврди и подеси лозинку"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2313,15 +1789,15 @@ msgstr ""
 "Уколико нисте тражили ову промену, молим вас контактирајте нас моментално на "
 "%(support_email)s."
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 #, fuzzy
 #| msgid "Verify your new email address for your demo Zulip organization"
 msgid "Verify your email address for your Zulip demo organization"
 msgstr ""
 "Потврдите вашу нову адресу е-поште за вашу демонстративну Зулип организацију"
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2330,8 +1806,8 @@ msgstr ""
 "Уколико нисте тражили ову промену, молим вас контактирајте нас моментално на "
 "<%(support_email)s>."
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2339,33 +1815,33 @@ msgid ""
 "please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr "Потврдите промену е-поште"
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr "Потврдите вашу нову адресу е-поште за %(organization_host)s"
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr "Поднели сте захтев за новом Зулип организацијом:"
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr "Врста организације: %(organization_type)s"
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr "Недавно сте се регистровали на Зулип. Одлично!"
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
@@ -2373,33 +1849,33 @@ msgstr ""
 "Кликните на дугме испод да бисте креирали организацију и регистровали свој "
 "налог. Ако желите, моћи ћете да ажурирате информације изнад."
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr "Кликните на дугме испод да би сте завршили регистрацију."
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr "Завршите регистрацију"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr "Направите вашу Зулип организацију"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr "Активирајте ваш Зулип налог"
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr "Кликните на везу испод да би сте завршили регистрацију."
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
@@ -2408,48 +1884,48 @@ msgstr ""
 "Да ли имате питања или утисак који би сте поделили? Контактирајте нас на "
 "%(support_email)s — волели би смо да помогнемо!"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr "Управљајте поставкама е-поште"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr "Одјавите се од маркетиншких е-порука"
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
 "deactivated, and you will no longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr "Администратор је доставио следећи коментар:"
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr "Обавештење о деактивирању налога на %(realm_name)s"
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr ""
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2457,22 +1933,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because your organization has "
@@ -2488,8 +1964,8 @@ msgstr ""
 "<a class=\"content_disabled_help_link\" href=\"%(help_url)s\">приказ "
 "садржаја поруке у обавештењима е-порукама</a>."
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because you have disabled <a "
@@ -2504,40 +1980,40 @@ msgstr ""
 "class=\"content_disabled_help_link\" href=\"%(alert_notif_url)s\">приказ "
 "садржаја поруке у обавештењима е-порукама</a>."
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, fuzzy, python-format
 #| msgid "Click here to log in to Zulip and catch up."
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr "Кликните овде да се пријавите у Зулип и будете у току."
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr "Одјавите се са е-порука сажетка"
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr "Зулип сажетак за %(realm_name)s"
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2554,8 +2030,8 @@ msgstr ""
 "приказ садржаја поруке у обавештењима е-порукама.\n"
 "Погледајте %(hide_content_url)s за више детаља.\n"
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2571,42 +2047,39 @@ msgstr ""
 "садржаја поруке у обавештењима е-порукама.\n"
 "Погледајте %(alert_notif_url)s за више детаља.\n"
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, fuzzy, python-format
 #| msgid "Click here to log in to Zulip and catch up: %(organization_url)s."
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr ""
 "Кликните овде да се пријавите у Зулип и будете у току: %(organization_url)s."
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr "Управљајте поставкама е-поште:"
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr "Одјавите се са е-порука сажетка:"
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr "Пливајућа риба"
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr "Хвала на вашем захтеву!"
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
 "organizations:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
@@ -2615,33 +2088,29 @@ msgstr ""
 "Ваша адреса е-поште %(email)s има налоге у следећим Зулип организацијама "
 "које хостује %(external_host)s:"
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
 "href=\"%(help_reset_password_link)s\">reset your password</a>."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
 "%(external_host)s."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2649,38 +2118,35 @@ msgid ""
 "to find your account."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr "Ваши Зулип налози"
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
 "try another way to find your account (%(help_logging_in_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr "Здраво,"
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
@@ -2689,18 +2155,18 @@ msgstr ""
 "%(referrer_name)s жели да им се придружите на Зулипу &mdash; алату за "
 "комуникацију тимова дизајнираном за продуктивност."
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr "Да би сте почели, кликните на дугме испод."
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 "%(referrer_full_name)s вас је позвао да се придружите %(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
@@ -2709,17 +2175,17 @@ msgstr ""
 "%(referrer_full_name)s (%(referrer_email)s) жели да им се придружите на "
 "Зулипу -- алату за комуникацију тимова дизајнираном за продуктивност."
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr "Да би сте почели, кликните на везу испод."
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr "Здраво опет,"
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
@@ -2728,13 +2194,13 @@ msgstr ""
 "Ово је пријатељски подсетник да %(referrer_name)s жели да им се придружите "
 "на Зулипу &mdash; алату за комуникацију тимова дизајнираном за продуктивност."
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr "Ово је последњи подсетник који ћете добити за ову позивницу."
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
@@ -2743,12 +2209,12 @@ msgstr ""
 "Ова позивница истиче за два дана. Ако позивница истекне, мораћете замолити "
 "%(referrer_name)s за нову."
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr "Подсетник: Придружите се %(referrer_name)s на %(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2759,7 +2225,7 @@ msgstr ""
 "да им се придружите на Зулипу -- алату за комуникацију тимова дизајнираном "
 "за продуктивност."
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2768,7 +2234,7 @@ msgstr ""
 "Ако имате било каква питања, молим вас контактирајте администратора овог "
 "Зулип сервера на <a href=\"mailto:%(email)s\">%(email)s</a>."
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
@@ -2777,30 +2243,28 @@ msgstr ""
 "Да ли имате питања или утисак који би сте поделили? <a href=\"mailto:"
 "%(email)s\">Контактирајте нас</a> — волели би смо да помогнемо!"
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr "Примате ово јер сте били директно поменути."
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr "Примате ово јер је @%(mentioned_user_group_name)s био поменут."
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
 "#%(channel_name)s > %(topic_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
@@ -2808,15 +2272,15 @@ msgstr ""
 "Примате ово зато што сте омогућили обавештења за помињања путем посебног "
 "карактера за теме које пратите."
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
@@ -2824,15 +2288,15 @@ msgstr ""
 "Примате ово зато што сте омогућили обавештења путем е-поште за теме које "
 "пратите."
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2843,7 +2307,7 @@ msgstr ""
 "је у %(realm_name)s Зулипу</a>, или <a href=\"%(notif_url)s\">управљајте "
 "поставкама е-поште</a>."
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
@@ -2852,7 +2316,7 @@ msgstr ""
 "<a href=\"%(narrow_url)s\">Прегледајте или одговорите у %(realm_name)s "
 "Зулипу</a>, или <a href=\"%(notif_url)s\">управљајте поставкама е-поште</a>."
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
@@ -2861,7 +2325,7 @@ msgstr ""
 "<a href=\"%(narrow_url)s\">Одговорите у %(realm_name)s Зулипу</a>, или <a "
 "href=\"%(notif_url)s\">управљајте поставкама е-поште</a>."
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
@@ -2870,42 +2334,42 @@ msgstr ""
 "Не одговарајте на ову е-поруку. Овај Зулип сервер није подешен да прихвата "
 "долазне е-поруке (<a href=\"%(url)s\">помоћ</a>)."
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr "Групне ДП са %(direct_message_group_display_name)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr "ДП са %(sender_str)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr "Нове поруке"
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 "Одговори директно на ову е-поруку или је прегледај у %(realm_name)s Зулип:"
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr "Прегледај или одговори у %(realm_name)s Зулип:"
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr "Одговори у %(realm_name)s Зулип:"
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
@@ -2913,7 +2377,7 @@ msgstr ""
 "Не одговарајте на ову поруку. Овај Зулип сервер није подешен да прихвата "
 "долазне е-поруке. Помоћ:"
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2924,22 +2388,22 @@ msgstr ""
 "%(new_email)s. Ако ви нисте затражили ову промену, молим вас контактирајте "
 "на моментално на %(support_email)s."
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr "Све најбоље,"
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr "Зулип тим"
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr "Зулип е-пошта је промењена за %(realm_name)s"
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2950,7 +2414,7 @@ msgstr ""
 "%(new_email)s. Ако ви нисте затражили ову промену, молим вас контактирајте "
 "на моментално на <%(support_email)s>."
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
@@ -2958,46 +2422,46 @@ msgstr ""
 "Организација: %(organization_url)s Време: %(login_time)s Е-пошта: "
 "%(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr "Приметили смо недавну пријаву за следећи Зулип налог."
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr "Организација: %(organization_link)s"
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr "Е-пошта: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr "Време: %(login_time)s"
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr "Уређај: %(device_browser)s на %(device_os)s."
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr "ИП адреса: %(device_ip)s"
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr "Ако сте ово били ви, одлично! Не морате ништа друго да урадите."
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3008,31 +2472,31 @@ msgstr ""
 "угрожен, молим вас <a href=\"%(reset_link)s\">ресетујте вашу лозинку</a> или "
 "нас моментално контактирајте на %(support_email)s."
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr "Хвала,"
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr "Безбедност Зулипа"
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr "Одјавите се од обавештења о пријавама"
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr "Нова пријава са %(device_browser)s на %(device_os)s"
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr "Организација: %(organization_url)s"
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3043,7 +2507,7 @@ msgstr ""
 "угрожен, молим вас ресетујте вашу лозинку на %(reset_link)s или нас "
 "моментално контактирајте на %(support_email)s."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -3051,7 +2515,7 @@ msgid ""
 "Zulip</a> to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
@@ -3059,7 +2523,7 @@ msgstr ""
 "У супротном, ево неких савета које често добијамо од наших корисника за "
 "процену <i>било ког</i> производа за тимску комуникацију:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
@@ -3068,12 +2532,12 @@ msgstr ""
 "<a href=\"%(invite_users)s\"><b>Позовите чланове вашег тима</b></a> да би "
 "сте заједно истражили и поделили своје јединствено виђење."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr "Користите сами апликацију да би сте ћаскали о својим утисцима."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -3085,7 +2549,7 @@ msgstr ""
 "изистински искусите како ће нова апликација за ћаскање помоћи вашем тиму да "
 "комуницирате."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -3096,27 +2560,27 @@ msgstr ""
 "комуникацију</a>, и ми се надамо да ће ови савети помоћи вашем тиму да то "
 "искуси на делу."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr "Откажите претплату на е-поруке добродошлице за %(realm_name)s"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr "Бирање апликације за ћаскање за ваш тим"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
@@ -3124,7 +2588,7 @@ msgstr ""
 "У супротном, ево неких савета које често чујемо од потрошача за тестирање "
 "било ког производа за тимску комуникацију:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
@@ -3132,7 +2596,7 @@ msgstr ""
 "Позовите чланове вашег тима да би сте заједно истраживали и поделили са вама "
 "јединствене погледе."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
@@ -3142,7 +2606,7 @@ msgstr ""
 "којих других алата за ћаскање. Ово је једини начин да заиста доживите како "
 "нова апликација за ћаскање може помоћи вашем тиму у комуникацији."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
@@ -3150,8 +2614,8 @@ msgstr ""
 "Зулип је дизајниран да омогући ефикасну комуникацију, и надамо се да ће вам "
 "ови савети помоћи да то искусите у пракси."
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
@@ -3161,71 +2625,71 @@ msgstr ""
 "може најбоље да одговара вашим потребама. Погледајте овај водич за кључне "
 "Зулип функције за организације попут ваше!"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr "Погледај Зулипов водич за компаније"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr "Погледај Зулипов водич за пројекте отвореног кода"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr "Погледај Зулип водич за образовне"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr "Погледај Зулипов водич за истраживања"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr "Погледај Зулипов водич за догађаје и семинаре"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr "Погледај Зулипов водич за непрофитне организације"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr "Погледај Зулипов водич за заједнице"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr "Зулипов водич за компаније"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr "Зулипов водич за пројекте отвореног кода"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr "Зулип водич за образовне"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr "Зулипов водич за истраживање"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr "Зулипов водич за догађаје и семинаре"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr "Зулипов водич за непрофитне организације"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr "Зулипов водич за заједнице"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
@@ -3233,14 +2697,14 @@ msgstr ""
 "Ево неколико савета за одржавање ваших Зулип разговора организованим са "
 "темема."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
@@ -3249,12 +2713,12 @@ msgstr ""
 "поруку у контексту, без обзира колико различитих разговора се води "
 "истовремено."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3262,11 +2726,11 @@ msgid ""
 "about…?”"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr "Примери кратких тема"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3275,23 +2739,23 @@ msgid ""
 "href=\"%(move_channels_link)s\">move a topic to a different channel</a>."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr "Идите на Зулип"
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr "Одржавајте ваше разговоре организованим са темама"
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3300,23 +2764,23 @@ msgid ""
 "(%(move_channels_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
 "%(email)s on %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr "Кликните на дугме испод да ресетујете вашу лозинку."
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr "Поништи лозинку"
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3327,18 +2791,18 @@ msgstr ""
 "контактирати администратора организације да вам <a "
 "href=\"%(help_link)s\">поново активира налог</a>."
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr "Немате налог на тој Зулип организацији."
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr "Немате активне налоге у следећим организацији(ама)."
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
@@ -3346,31 +2810,31 @@ msgstr ""
 "Можете покушати пријаву или ресетовање ваше лозинке у организацији(ама) "
 "изнад."
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 "Ако не препознајете ову активност, можете безбедно да игноришете ову е-"
 "поруку."
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr "Захтев за ресетовањем лозинке за %(realm_name)s"
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr "Кликните на везу испод да би сте ресетовали лозинку."
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
 "You can contact an organization administrator to reactivate your account."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3381,7 +2845,7 @@ msgstr ""
 "Облак басплатан план због неплаћених фактура. Неплаћене фактуре проглашене "
 "ништавнима."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
@@ -3390,7 +2854,7 @@ msgstr ""
 "Да би сте наставили да користите Зулип Облак стандардни план, поново га "
 "унапредите тако што ћете отићи на %(upgrade_url)s."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
@@ -3399,8 +2863,8 @@ msgstr ""
 "Ако мислите да је ово грешка или вам је потребно више детаља, контактирајте "
 "нас на %(support_email)s."
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid "You've joined the Zulip organization %(realm_name)s."
 msgid ""
@@ -3408,145 +2872,145 @@ msgid ""
 "%(localized_date)s."
 msgstr "Приступили сте Зулип организацији %(realm_name)s."
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr "Драги бивши администратори на %(realm_name)s,"
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip demo organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr "Кликните на дугме испод да поновно активирате вашу организацију."
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr "Рекативирајте организацију"
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
 msgstr ""
 "Ако је захтев грешка, можете ово игнорисати и веза ће истећи за 24 часа."
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Reactivate your Zulip organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "Реактивирајте вашу Зулип организацију"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr "Реактивирајте вашу Зулип организацију"
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr "Кликните на везу испод да би сте реактивирали вашу организацију."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for <b>%(remote_server_hostname)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, fuzzy
 #| msgid "Click the link below to log in."
 msgid "Click the button below to log in."
 msgstr "Кликните на дугме испод да се пријавите."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr "Ова веза ће истећи за %(validity_in_hours)s сати."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
@@ -3555,23 +3019,23 @@ msgstr ""
 "Питања? <a href=\"%(billing_help_link)s\">Сазнајте више</a> или "
 "контактирајте %(billing_contact_email)s."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr "Пријавите се у Зулипово управљање планом"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for %(remote_server_hostname)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr "Кликните на дугме испод да се пријавите."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
@@ -3580,30 +3044,30 @@ msgstr ""
 "Питања? Сазнајте више на %(billing_help_link)s или контактирајте "
 "%(billing_contact_email)s."
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
 "management for <b>%(remote_realm_host)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr "Потврди и пријави се"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr "Потврди адресу е-поште за Зулипово управљање планом"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
 "management for %(remote_realm_host)s."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
@@ -3612,7 +3076,7 @@ msgstr ""
 "Ваш захтев за Зулип спонзорством је одобрен! Ваша организација је "
 "надограђена на <a href=\"%(plans_link)s\">Зулип Заједница план</a>."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
@@ -3621,12 +3085,12 @@ msgstr ""
 "Ако би сте могли <a href=\"%(link_to_zulip)s\">наведите Зулип као спонзора "
 "на вашем веб сајту</a>, то би нам заиста значило!"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
@@ -3634,260 +3098,260 @@ msgstr ""
 "Ваш захтев за Зулип спонзорством је одобрен! Ваша организација је "
 "надограђена на Зулип Заједница план."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
 msgstr ""
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr "Пронађите ваше налоге"
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr "Пронађите ваше Зулип налоге"
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
 "accounts for another email address</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr "Адреса е-поште"
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "Пронађи налоге"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr "Производ"
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr "Зашто Зулип"
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr "Могућности"
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr "Планови и ценовник"
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Zulip Cloud status"
 msgid "Zulip Cloud"
 msgstr "Статус Зулип Клауд-а"
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr "Самостално хостовање"
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr "Безбедност"
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "Интеграције"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr "Рачунар и мобилне апликације"
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr "Нова организација"
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr "Решења"
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr "Компанија"
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr "Образовна"
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr "Истраживачка"
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr "Догађаји и семинари"
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr "Пројекти отвореног кода"
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr "Заједнице"
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr "Приче наших клијената"
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr "Отвори заједнице"
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr "Ресурси"
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr "Први кораци"
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr "Центар помоћи"
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr "Ћаскање са заједницом"
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr "Статус Зулип Клауд-а"
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr "Инсталирање Зулип сервера"
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr "Надоградња Зулип сервера"
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr "Доприношење"
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr "Водич за доприношење"
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr "Заједница програмера"
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr "Превођење"
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr "GitHub"
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr "О нама"
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr "Тим"
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "Историја"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr "Вредности"
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr "Послови"
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr "Блог"
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr "Подржи Зулип"
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr "Mastodon"
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Values"
 msgid "Bluesky"
 msgstr "Вредности"
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr "Покреће <a href=\"https://zulip.com\">Зулип</a>"
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr "Услови коришћења"
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr "Политика приватности"
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr "Доприноси на веб сајту"
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr "Преко %(integrations_count_display)s изворних интеграција."
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 #, fuzzy
 #| msgid ""
 #| "And hundreds more through <a href=\"/integrations/doc/zapier\">Zapier</a> "
@@ -3899,51 +3363,47 @@ msgstr ""
 "И стотину више кроз <a href=\"/integrations/doc/zapier\">Zapier</a> и <a "
 "href=\"/integrations/doc/ifttt\">IFTTT</a>."
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr "Претражите интеграције"
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr "Прилагођене интеграције"
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr "Долазне веб закачке"
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr "Интерактивни ботови"
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr "REST API"
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr "Неисправна е-пошта"
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr "Е-пошта није дозвољена"
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr "Адреса е-поште којом покушавате да се региструјете није исправна."
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3951,7 +3411,7 @@ msgid ""
 "emails with your email domain."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3959,7 +3419,7 @@ msgid ""
 "disposable email addresses."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3967,24 +3427,24 @@ msgid ""
 "emails that contain \"+\"."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr "Молим вас региструјте се са исправном адресом е-поште."
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr "Молим вас региструјте се са дозвољеном адресом е-поште."
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3992,7 +3452,7 @@ msgid ""
 "%(support_email)s\">contact Zulip support</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -4000,91 +3460,91 @@ msgid ""
 "%(support_email)s\">contact this Zulip server's administrators</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
 "management for your Zulip server."
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr "Неисправна или истекла сесија"
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr "Неисправна или истекла сесија."
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr "Пријавите се у Зулип"
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr "Већ сте се регистровали са овом адресом е-поште. Пријавите се испод."
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr "Е-пошта или корисничко име"
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "Корисничко име"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr "Заборавили сте лозиннку?"
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr "Пријавите се са %(identity_provider)s"
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr "Прегледај без налога"
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 "Још увек немате налог? Морате бити позвани да би сте се придружили овој "
 "организацији."
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr "Нема доступних лиценци"
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr "Организација тренутно не може да прими нове чланове"
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> because all Zulip Cloud licenses are in use."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr "Проблем аутентификације поддомена"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr "Аутентификација поддомена"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -4093,44 +3553,42 @@ msgid ""
 "or misconfiguration."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 #, fuzzy
 #| msgid "New organization"
 msgid "Demo organizations disabled"
 msgstr "Нова организација"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr "Неопходно је унапређење"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr "Преузмите најновије издање."
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr "Неопходна је веза за прављење организације"
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -4138,22 +3596,21 @@ msgid ""
 "organization for more information."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr "Веза за прављење организације је истекла или је неисправна"
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -4161,49 +3618,47 @@ msgid ""
 "Zulip support</a> for assistance in resolving this issue."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr "Неподржан прегледач"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, fuzzy, python-format
 #| msgid "Presence is not supported for bot users."
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr "Присутност није подржана за бот кориснике."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
 "a> like Firefox, Chrome, and Edge."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr "Налог је деактивиран"
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Invalid organization"
 msgid "Finalize organization import"
 msgstr "Неисправна организација"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Organization type"
 msgid "Organization import completed!"
 msgstr "Врста организације"
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -4211,56 +3666,55 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Select your account"
 msgstr "Направите ваш налог"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Create new account"
 msgstr "Направите ваш налог"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr "Организација је успешно поновно активирана"
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr "Ваша организација је успешно реактивирана."
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr "Веза за поновно активирање организације је истекла или је неисправна"
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr "Веза за реактивацију организације је истекла или није исправна."
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr "Пријавите се у вашу организацију"
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr "Не знате адресу ваше организације?"
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr "Пронађите вашу организацију."
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr "Следеће"
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4268,24 +3722,24 @@ msgid ""
 "have one yet."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 #, fuzzy
 #| msgid "Self-host Zulip"
 msgid "Self-hosting Zulip?"
 msgstr "Самостално хостујте Зулип"
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">log in to manage plans and billing.</a>"
 msgstr ""
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr "Поново поставите вашу лозинку"
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
@@ -4293,64 +3747,64 @@ msgstr ""
 "Заборавили сте лозинку? Нема проблема, послаћемо везу за ресетовање лозинке "
 "на адресу ваше е-поште са којом сте се регистровали."
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr "Пошаљи везу за ресетовање"
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr "Постави нову лозинку"
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "Потврдите лозинку"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr ""
 "Извините, веза коју сте доставили је неисправна или је већ искоришћена."
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr "Нова лозинка је успешно постављена"
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr "Поставили сте нову лозинку!"
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr ""
 "Молим вас <a href=\"%(login_url)s\">пријавите се</a> са вашом новом лозинком."
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr "Послата је е-порука за ресетовање"
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr "Ресетовање лозинке је послато!"
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr "Проверите вашу е-пошту за неколико минута да би сте завршили процес."
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 #, fuzzy
 #| msgid "Export still in progress"
 msgid "Import progress"
 msgstr "Извоз је још увек у току"
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4358,7 +3812,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4367,60 +3821,60 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 #, fuzzy
 #| msgid ""
 #| "Nobody in this Zulip organization will be able to see this email address."
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr "Нико у овој Зулип организацији неће моћи да види ову адресу е-поште."
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4428,7 +3882,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4436,20 +3890,20 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr "Изаберите налог за аутентификацију"
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr "<h1 class=\"get-started\">Изаберите налог</h1>"
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr "Ваш GitHub налог има непотврђену адресу е-поште повезану са њим."
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
@@ -4457,15 +3911,15 @@ msgstr ""
 "Да би сте користили нешто од овога за пријаву у Зулип, прво морате <a "
 "href=\"https://github.com/settings/emails\">да је потврдите са GitHub-ом.</a>"
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr "Грешка одјаве е-поште"
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr "Захтев за отказивање претплате непознате е-поште"
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
@@ -4473,7 +3927,7 @@ msgstr ""
 "Здраво! Изгледа да сте покушали да откажете претплату са нечега, али не "
 "препознајемо адресу."
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4484,132 +3938,129 @@ msgstr ""
 "href=\"mailto:%(support_email)s\">нам пошаљите поруку</a> и ми ћемо ово "
 "одмах средити!"
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr "Подешавања е-поште су измењена"
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
 "href=\"%(realm_url)s/#settings/notifications\">notification settings</a>."
 msgstr ""
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr ""
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr ""
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr ""
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr ""
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr "регистрације"
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr ""
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr "{user} је прихватио ваш позив да се придружи Зулипу!"
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 #, fuzzy
 #| msgid "Cannot deactivate the only {entity}."
 msgid "Cannot reactivate a deleted user"
 msgstr "Није могуће деактивирати једино {entity}."
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr "ИД поље {id} није пронађено."
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr ""
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr ""
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr ""
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
@@ -4618,7 +4069,7 @@ msgstr ""
 "послати у једном дану. Зато што сте достигли ово ограничење, ниједна "
 "позивница није послата."
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
@@ -4626,77 +4077,77 @@ msgstr ""
 "Ваш налог је превише нов да би сте слали позивнице за ову организацију. "
 "Питајте администратора организације или дугогодишњег корисника."
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 "Неке адресе е-поште нису прошле проверу тако да нисмо послали ниједну "
 "позивницу."
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr "Нисмо успели никога да позовемо."
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr "Ништа за промену"
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr ""
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr "Директне поруке не могу имати теме."
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr ""
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr ""
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr "Виџети се не могу мењати."
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr "Ваша организација је искључила уређивање порука"
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr "Немате одобрење да уређујете ову поруку"
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr "Прошло је временско органичење за уређивање ове поруке"
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr "{user} је означио ову тему као решену."
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr "{user} је означио ову тему као нерешену."
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr "Ова тема је премештена у {new_location} од стране {user}."
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr "Порука је премештена из ове теме у {new_location} од стране {user}."
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
@@ -4705,18 +4156,18 @@ msgstr ""
 "{changed_messages_count} порука је премештено из ове теме у {new_location} "
 "од стране {user}."
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr "Ова тема је премештена овде из {old_location} од стране {user}."
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
@@ -4725,75 +4176,72 @@ msgstr ""
 "{changed_messages_count} порука је премештено овде из {old_location} од "
 "стране {user}."
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 #, fuzzy
 #| msgid "You don't have permission to delete this message"
 msgid "You don't have permission to resolve topics in this channel."
 msgstr "Немате дозволу да обришете ову поруку"
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr "Немате одобрење да преместите ову поруку"
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr ""
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr "Неисправна порука(е)"
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr "Није могуће приказати поруку"
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr "Неисправан тип података за примаоце"
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 "Списак прималаца може да садржи адресе е-поште или ИД корисника, али не оба."
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
 "but there is no channel with that ID."
 msgstr ""
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4801,36 +4249,36 @@ msgid ""
 "it."
 msgstr ""
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
 "The channel exists but does not have any subscribers."
 msgstr ""
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr ""
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr ""
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr "Виџети: {error_msg}"
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4838,64 +4286,62 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr "Већ постоји прилагођени емотикон са овим именом."
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
 "authentication method."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr ""
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr "Заказана порука је већ послата"
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder could not be sent."
 msgstr "Токен не постоји"
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr "Порука није могла бити послата у заказано време."
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
@@ -4904,45 +4350,45 @@ msgstr ""
 "Порука коју сте заказали за {delivery_datetime} није послата због следеће "
 "грешке:"
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr ""
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr ""
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr ""
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr ""
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr ""
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
 "**{old_policy}** to **{new_policy}**."
 msgstr ""
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -4951,51 +4397,49 @@ msgid ""
 "* **New**: {new_setting_description}\n"
 msgstr ""
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr "Нема описа."
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr ""
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr "Стари опис"
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr "Нови опис"
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr "Заувек"
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr ""
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 msgstr ""
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr ""
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -5006,99 +4450,89 @@ msgid ""
 "{summary_line}"
 msgstr ""
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr "Не можете прикачити потпоруку овој поруци."
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr ""
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr "Корисничка група '{group_name}' већ постоји."
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr "Недовољне дозволе"
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr ""
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr "Налог није повезан са овим поддоменом"
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr ""
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr "Мора бити администратор сервера"
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr ""
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr "Неисправно заглавље ауторизације за основну ауторизацију"
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr "Недостаје заглавље ауторизације за основну ауторизацију"
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr ""
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr ""
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
@@ -5107,53 +4541,52 @@ msgstr ""
 "Ваш налог {username} је деактивиран. Молим вас контактирајте администратора "
 "ваше организације да би сте га реактивирали."
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr "Лозинка је превише слаба."
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr "Поддомен мора бити дужине 3 или дужи."
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr "Поддомен не може почети са '-'."
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr "Поддомен може садржати само мала слова, бројеве и '-'."
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr "Поддомен је резервисан. Молим вас изаберите неки други."
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr "Молим вас користите вашу праву адресу е-поште."
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr ""
 "Не постоји организација којој покушавате да приступите користећи {email}."
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr ""
 "Молим вас затражите позивницу за {email} од администратора организације."
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
@@ -5162,11 +4595,11 @@ msgstr ""
 "Ваша адреса е-поште, {email}, није једна од домена којима је дозвољено да "
 "региструју налоге у овој организацији."
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr "Адресе е-поште које садрже + нису дозвољене у овој организацији."
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
@@ -5176,41 +4609,40 @@ msgstr ""
 "искоришћене. Молим вас контактирајте особу која вас је позвала и замолите их "
 "да повећају број лиценци, а затим покушате поново."
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 #, fuzzy
 #| msgid "Embedded bots are not enabled."
 msgid "Challenges are not enabled."
 msgstr "Интегрисани ботови нису омогућени."
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "Нова лозинка"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr "Потврда нове лозинке"
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "You're making too many attempts to sign in. Try again in "
 "{retry_after_string} or contact your organization administrator for help."
 msgstr ""
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
@@ -5218,91 +4650,89 @@ msgstr ""
 "Ваша лозинка је онемогућена јер је превише слаба. Ресетујте лозинку да би "
 "сте направили нову."
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr "Токен"
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr "Молим вас унесите највише 10 е-адреса."
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr "Нисмо могли да пронађемо ту Зулип организацију."
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr "Неисправна е-пошта '{email}'"
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr "Недостаје тема"
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr ""
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr ""
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr "Порука мора имати примаоце"
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr "Неисправан тип поруке"
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr "Неисправан прилог"
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr ""
 "Појавила се грешка при брисању прилога. МОлим вас покушајте поново касније."
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr "Порука мора имати примаоце!"
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Content can't be empty"
 msgid "Channel folder name can't be empty."
 msgstr "Садржај не може бити празан"
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Invalid data export ID"
 msgid "Invalid channel folder ID"
 msgstr "Неисправан ИД извоза података"
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 #, fuzzy
 #| msgid "Confirm your email address"
 msgid "Configure owner account email address."
 msgstr "Потврдите адресу ваше е-поште"
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| " Congratulations, you have created a new demo Zulip organization. Note "
@@ -5318,72 +4748,72 @@ msgstr ""
 "ће ова организација бити аутоматски обрисана након 30 дана. Сазнајте више о "
 "демонстративним организацијама овде: %(demo_organizations_help_link)s! "
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a date"
 msgid "{var_name} is not Base64 encoded"
 msgstr "{var_name} није датум"
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 #, fuzzy
 #| msgid "Invalid emoji code."
 msgid "Invalid `device_id`"
 msgstr "Неисправан код емотикона."
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr ""
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr "Домен не може бити празан."
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr "Домен мора садржати барем једну тачку (.)"
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr "Домен је предугачак"
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr "Домен не може почети или се завршити са тачком (.)"
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr "Повезане '.' нису дозвољене."
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr "Поддомен не може почети или се завршити са '-'."
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr "Домен може садржати само слова, бројеве, '.' и '-'."
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr "Временска ознака не може бити негативна."
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr "Тема не сме садржати нула бајтова"
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr "Корисник је онемогућио синхронизацију нацрта."
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr "Нацрт не постоји"
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5391,86 +4821,86 @@ msgid ""
 "{error_message}"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr "Отворите Зулип да би сте видели скривени садржај"
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr ""
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr "Неисправна адреса."
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr "Изван вашег домена."
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr "Адресе е-поште које садрже + нису дозвољене."
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr "Резервисано за системске ботове."
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr "{email} већ има налог"
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr "Већ има налог."
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr "Налог је деактивиран."
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr "Емотикон '{emoji_name}' не постоји"
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr "Неисправан прилагођени емотикон."
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr "Неисправно име прилагођеног емотикона."
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr "Прилагођени емотикон је деактивиран."
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr "Неисправан код емотикона."
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr "Неисправно име емотикона."
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr "Неисправан тип емотикона."
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr "Морате бити администратор организације или аутор емотикона"
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr "Имена емотикона морају се завршити са словом или цифром."
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
@@ -5478,97 +4908,96 @@ msgstr ""
 "Имена емотикона морају садржати само мала слова енглеског алфабета, цифре, "
 "размаке, цртице и доње цртице."
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr "Недостаје име емотикона"
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr ""
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr ""
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, fuzzy, python-brace-format
 #| msgid "User group '{group_name}' already exists."
 msgid "Channel '{channel_name}' already exists"
 msgstr "Корисничка група '{group_name}' већ постоји."
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr "власник организације"
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr "корисник"
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr "Није могуће деактивирати једино {entity}."
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr "Лоше формиран JSON"
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr "Морате бити администратор организације"
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr "Мора бити власник организације"
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Must be an organization owner"
 msgid "Must be a bot user"
 msgstr "Мора бити власник организације"
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr "Ваше корисничко име или лозинка нису исправни"
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr "Ова организације је деактивирана"
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
@@ -5576,457 +5005,456 @@ msgstr ""
 "Регистрација сервиса за слање обавештења на телефонима вашег сервера је "
 "деактивирана"
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr "Аутентификација лозинком је онемогућена у овој организацији"
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr "Ваша лозинка је онемогућена и неопходно је ресетовати је"
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr "Неисправан АПИ кључ"
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr "Лоше формиран АПИ кључ"
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
 "webhook; ignoring"
 msgstr ""
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 "Није могуће разлучити захтев: Да ли је {webhook_name} генерисао овај догађај?"
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr "Корисник није аутентификован"
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr "Неисправан поддомен"
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr "Директне поруке су онемогућене у овој организацији."
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr ""
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr "Приступ је одбијен"
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} most recent messages in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr "Реаговање већ постоји."
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr "Реакција не постоји."
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
 msgstr ""
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr ""
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr ""
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr ""
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr ""
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr "Време заказане доставе мора бити у будућности."
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Already has an account."
 msgid "Atlassian account ID"
 msgstr "Већ има налог."
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Behance username"
 msgstr "Лош назив или корисничко име"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Bitbucket username"
 msgstr "GitHub корисничко име"
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Codeberg username"
 msgstr "Twitter корисничко име"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Dribbble username"
 msgstr "GitHub корисничко име"
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Facebook username"
 msgstr "Лош назив или корисничко име"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr "GitHub корисничко име"
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "GitLab username"
 msgstr "GitHub корисничко име"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Instagram username"
 msgstr "Twitter корисничко име"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Mastodon"
 msgid "Mastodon profile"
 msgstr "Mastodon"
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Medium username"
 msgstr "GitHub корисничко име"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Pinterest username"
 msgstr "Twitter корисничко име"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Reddit username"
 msgstr "GitHub корисничко име"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Snapchat username"
 msgstr "GitHub корисничко име"
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Threads username"
 msgstr "Twitter корисничко име"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "TikTok username"
 msgstr "Twitter корисничко име"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Twitch username"
 msgstr "Twitter корисничко име"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "Корисничко име"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr "Неисправан тип екстерног налога"
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr "Оквир интеграција"
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 #, fuzzy
 #| msgid "Video call ended"
 msgid "Video calling"
 msgstr "Завршен је видео позив"
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr "Сталне интеграције"
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr "Корисничка подршка"
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr "Постављање"
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr "Забава"
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr "Комуникација"
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr "Финансијски"
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr "Људски ресурси"
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr "Маркетинг"
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr "Разно"
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr "Надгледање"
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr "Управљање пројектима"
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr "Продуктивност"
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr "Контрола верзија"
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr "Порука не може бити празна"
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr "Порука не сме садржати нула бајтова"
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{fullname} moderation"
 msgstr "{full_name} вас је поменуо:"
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr ""
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr ""
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr "Недостаје 'сидро' аргумент."
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 #, fuzzy
 #| msgid "Missing 'anchor' argument."
 msgid "Missing 'anchor_date' argument."
 msgstr "Недостаје 'сидро' аргумент."
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr "Неисправно сидро"
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr ""
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 #, fuzzy
 #| msgid "Confirmation link does not exist"
 msgid "Navigation view does not exist."
 msgstr "Не постоји веза потврде"
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6034,7 +5462,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6042,7 +5470,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6050,7 +5478,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6058,7 +5486,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| " Congratulations, you have created a new demo Zulip organization. Note "
@@ -6075,14 +5503,14 @@ msgstr ""
 "ће ова организација бити аутоматски обрисана након 30 дана. Сазнајте више о "
 "демонстративним организацијама овде: %(demo_organizations_help_link)s! "
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
 "them in your [Inbox](/#inbox).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6090,7 +5518,7 @@ msgid ""
 "({navigation_tour_video_url}) for a quick app overview.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6105,14 +5533,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -6120,7 +5548,7 @@ msgid ""
 "and edit your [profile information](/help/edit-your-profile).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -6131,7 +5559,7 @@ msgid ""
 "experience in your [Preferences](#settings/preferences).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6142,7 +5570,7 @@ msgid ""
 "[Browse and subscribe to channels]({settings_link}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -6159,7 +5587,7 @@ msgid ""
 "discussed.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -6168,7 +5596,7 @@ msgid ""
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -6180,7 +5608,7 @@ msgid ""
 "times, and more.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6190,7 +5618,7 @@ msgid ""
 "or browse the [help center](/help/) to learn more!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6198,7 +5626,7 @@ msgid ""
 "get help, try one of the following messages: {bot_commands}\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6210,13 +5638,13 @@ msgid ""
 "({move_content_another_channel_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6230,12 +5658,11 @@ msgid ""
 "and above.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr ""
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -6243,14 +5670,14 @@ msgid ""
 "no matter how many other conversations are going on.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
 "conversations with unread messages.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -6258,7 +5685,7 @@ msgid ""
 "the `+` button next to its name.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -6266,13 +5693,13 @@ msgid ""
 "can we chat about…?”\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6280,7 +5707,7 @@ msgid ""
 "({format_message_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6300,127 +5727,127 @@ msgid ""
 "```\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
 "teammates.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
 "conversation.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr ""
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr ""
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr ""
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr "Неиспарни JSON у одговору"
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr "Неисправан формат одговора"
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr "Празно или неисправна дужина токена"
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr "Неисправан APNS токен"
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr ""
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr "Токен не постоји"
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr "{full_name} је поменуо @{user_group_name}:"
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr "{full_name} вас је поменуо:"
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr "{full_name} је поменуо све:"
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "Нова порука"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr "Тестирај обавештење"
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr "Уређај није препознат"
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 #, fuzzy
 #| msgid "Invalid API key"
 msgid "Invalid `push_key`"
 msgstr "Неисправан АПИ кључ"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
@@ -6428,1120 +5855,1099 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr "Корисник није овлашћен за овај упит"
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr "'{email}' више не користи Зулип."
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr "Не можете слати директне поруке ван своје организације."
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr "{var_name} је предугачко (ограничење: {max_length} карактера)"
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder does not exist"
 msgstr "Токен не постоји"
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr ""
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr ""
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr "Недостаје '{var_name}' аргумент"
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr "Лоша вредност за '{var_name}': {bad_value}"
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr "Заказана порука не постоји"
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr ""
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr ""
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr ""
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 #, fuzzy
 #| msgid "You don't have permission to delete this message"
 msgid "You do not have permission to create new topics in this channel."
 msgstr "Немате дозволу да обришете ову поруку"
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr ""
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr ""
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr ""
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr ""
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr ""
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr "Величина слике превазилази ограничење."
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr "{var_name} није логичка вредност"
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} does not have a length"
 msgid "{var_name} does not have the expected format"
 msgstr "{var_name} не садржи дужину"
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr "{var_name} није датум"
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr "Неисправно {var_name}"
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr "{var_name} није децимална вредност"
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr "{var_name} је премало"
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr "{var_name} није цео број"
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr "{var_name} није исправан JSON"
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr "{var_name} је превелико"
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr "{var_name} није листа"
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr "{var_name} је предугачко (ограничење: {max_length} карактера)"
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr "{var_name} није текстуални садржај"
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr "{var_name} је предугачко (ограничење: {max_length} карактера)"
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr "{var_name} је предугачко (ограничење: {max_length} карактера)"
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr "{var_name} није исправан код хекс боје"
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr "Неисправно {setting_name}"
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr ""
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr ""
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr "Неисправна група корисника"
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid user group"
 msgid "Invalid user group ID: {user_group_id}"
 msgstr "Неисправна група корисника"
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr ""
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr ""
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr ""
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr "Клијент није проследио ниједну нову вредност."
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr "Име је предугачко!"
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 #, fuzzy
 #| msgid "Message must not be empty"
 msgid "Name must not be empty!"
 msgstr "Порука не може бити празна"
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr "Неисправан карактер у имену!"
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr "Неисправан формат!"
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr ""
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr ""
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr "Лош назив или корисничко име"
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr ""
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr ""
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr ""
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr "Неисправни подаци конфигурације!"
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr "Неисправан тип бота"
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr "Неисправан тип интерфејса"
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr ""
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr "Нема таквог бота"
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr "Нема таквог корисника"
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr "Корисник је декативиран"
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr "{item} не може бити празно."
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr ""
 "{var_name} нема исправну дужину {length}; требало би бити {target_length}"
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a string"
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr "{var_name} није текстуални садржај"
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr "{container} би требао имати тачно {length} ставки"
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr "{key_name} кључ недостаје из {var_name}"
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr ""
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr ""
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr "{variable} != {expected_value} ({value} је погрешно)"
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr "{var_name} није адреса"
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr "Шаблон адресе мора садржати '%(username)s'."
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr "'{item}' не може бити празно."
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr "Поље не сме садржати дуплиране изборе."
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr "'{value}' није исправан избор за '{field_name}'."
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr "{var_name} није текстуална вредност или листа целобројних вредности"
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr "{var_name} није текстуална вредност или листа целобројних вредности"
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr "{var_name} не садржи дужину"
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr "{var_name} недостаје"
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr "Недостаје HTTP заглавље догађаја '{header}'"
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr ""
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr ""
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr "CSRF грешка: {reason}"
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr "Екстерни налог"
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr "Заменице"
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr "Нико"
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr ""
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "Чланови"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr "Сви на интернету"
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Invalid characters in emoji name"
 msgid "Invalid auto-conversion field: empty field name."
 msgstr "Неисправан карактер у називу емотикона"
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr "Лош регуларни израз: {regex}"
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr "Непозната грешка регуларног израза"
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr "Неисправан УРЛ шаблон."
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 msgid "Example input does not match the linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in alternative URL template is not present in linkifier "
 "pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in linkifier pattern is not present in alternative URL "
 "template."
 msgstr ""
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr "Уникод емотикон"
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "Прилагођени емотикон"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr "Зулип додатни емотикон"
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr "Неисправан карактер у називу емотикона"
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr ""
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr ""
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr ""
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr ""
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr ""
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr "Доступно на Зулип Облак стандард. Надоградите за приступ."
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr ""
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr ""
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr ""
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr "Јавно доступно"
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "Јавно"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr "Приватно, дељена историја"
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr "Приватно, заштићена историја"
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr "Админи, модератори, чланови и гости"
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr "Админи, модератори и чланови"
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr "Админи и модератори"
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr "Само админи"
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr "Непознати корисник"
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr "Власник организације"
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr "Администратор организације"
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr "Модератор"
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "Члан"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "Гост"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr "Непозната IP адреса"
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr "непознати оперативни систем"
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr "Непознати прегледач"
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr "Недостаје 'queue_id' аргумент"
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr "Недостаје 'last_event_id' аргумент"
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr ""
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr ""
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 #, fuzzy
 #| msgid "Failed to create Zoom call"
 msgid "Failed to generate challenge"
 msgstr "Није успело успостављање Zoom позива"
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr ""
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr "Ниједан JSON веб токен није прослеђен у захтеву"
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr "Лош JSON веб токен"
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr ""
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr "Неопходан је поддомен"
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr "Лозинка није исправна."
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr "Недостаје заглавље корисничког агента у захтеву"
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr "Ознака не може бити празна."
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr "Поље мора садржати барем један избор."
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr "Тип поља није подржан за приказ у прегледу профила."
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 #, fuzzy
 #| msgid "Field type not supported for display in profile summary."
 msgid "Field type not supported for use for user matching."
 msgstr "Тип поља није подржан за приказ у прегледу профила."
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr "Неисправан тип поља."
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 "Само 2 прилагођена поља профила могу бити приказана у прегледу профила."
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr "Поље са том ознаком већ постоји."
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr "Предефинисано прилагођено поље не може бити измењено."
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr ""
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr ""
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr "База података је празна"
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr ""
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr ""
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr ""
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr ""
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr "Нема такве позивнице"
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 #, fuzzy
 #| msgid "Invitation has already been revoked"
 msgid "Invitation already used or deactivated."
 msgstr "Позивница је већ опозвана"
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr "Позивница је већ опозвана"
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr ""
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr "Морате навести барем једну адресу е-поште."
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
@@ -7549,108 +6955,106 @@ msgstr ""
 "Неке од ових адреса већ користе Зулип, тако да њима нисмо послали позивницу. "
 "Али зато јесмо послали свима осталима!"
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr "Историја измена порука је онемогућена у овој организацији"
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr "Немате дозволу да обришете ову поруку"
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr "Временско ограничење за брисање ове поруке је истекло"
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr "Порука је већ обрисана"
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr ""
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr "Сидро може бити изузето само на крају опсега"
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr "Нема такве теме '{topic}'"
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Organization creation link required"
 msgid "An explanation is required."
 msgstr "Неопходна је веза за прављење организације"
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Message edit history is disabled in this organization"
 msgid "Message reporting is not enabled in this organization."
 msgstr "Историја измена порука је онемогућена у овој организацији"
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr "Недостаје пошиљалац"
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr ""
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr ""
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr ""
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr ""
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr ""
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr "Није могуће утишати себе"
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr "Корисник је већ утишан"
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr "Корисник није утишан"
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 #, fuzzy
 #| msgid "{hostname} is not a valid hostname"
 msgid "Custom views must have a valid name."
 msgstr "{hostname} није исправно име за домаћина"
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 #, fuzzy
 #| msgid "Reaction already exists."
 msgid "Navigation view already exists."
 msgstr "Реаговање већ постоји."
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7658,473 +7062,471 @@ msgid ""
 "later. Is this a good time?\n"
 msgstr ""
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr "Присутност није подржана за бот кориснике."
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr ""
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 #, fuzzy
 #| msgid "You don't have permission to delete this message"
 msgid "You do not have permission to manage plans and billing."
 msgstr "Немате дозволу да обришете ову поруку"
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr ""
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr ""
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr ""
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr "Потврде читања су онемогућене у овој организацији."
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr "Неисправан језик '{language}'"
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr "Мора бити омогућен барем један начин аутентификације."
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr ""
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr ""
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr "Мора бити демонстративна организација."
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr "Неисправан домен: {error}"
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr "Домен {domain} је већ део ваше организације."
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr "Ниједан унос није пронађен за домен {domain}."
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr "Морате поставити тачно једну датотеку."
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr "Само администратори могу да препишу предефинисане емотиконе."
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr ""
 "Величина постављене датотеке је већа од дозвољеног ограничења од {max_size} "
 "MiB"
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 #, fuzzy
 #| msgid "Disposable email addresses are not allowed in this organization"
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr "Привремене адресе е-поште нису дозвољене у овој организацији"
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr "Прекорачен је лимит брзине."
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr "Неисправан ИД извоза података"
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr "Извоз је већ обрисан"
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr "Извоз није успео, нема шта обрисати"
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr "Извоз је још увек у току"
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr "Морате поставити тачно једну иконицу."
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr "Линкификатор није пронађен."
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr "Морате поставити тачно један лого."
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid characters in name!"
 msgid "Invalid character in language: {character}"
 msgstr "Неисправан карактер у имену!"
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid language '{language}'"
 msgid "Language '{language}' is not allowed."
 msgstr "Неисправан језик '{language}'"
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr "Неисправно игралиште"
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "User not authenticated"
 msgid "Unauthenticated"
 msgstr "Корисник није аутентификован"
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "Direct messages"
 msgid "Importing messages…"
 msgstr "Директне поруке"
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "Your email"
 msgid "Your name"
 msgstr "Адреса ваше е-поште"
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr "Прималац је обавезан при измени типа заказане поруке."
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr "Неисправан формат захтева"
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr "Неисправан DSN"
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr ""
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr "Морате навести \"new_description\" или \"new_group_name\"."
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr ""
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr "Неисправни параметри"
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr ""
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr ""
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr ""
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, fuzzy, python-brace-format
 #| msgid "{user_full_name} added you to the group {group_name}."
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr "{user_full_name} вас је додао у групу {group_name}."
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr ""
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr ""
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr ""
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
 "**"
 msgstr ""
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr ""
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr "Непознато својство претплате: {property}"
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr ""
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr "Неисправан json за потпоруку"
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr ""
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr "Недостаје 'за' аргумент"
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr "Празна 'за' листа"
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr "Корисник је онемогућио обавештење за куцкање за директне поруке"
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr "<p>Ова датотека не постоји или је обрисана.</p>"
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr "<p>Нисте овлашћени да прегледате ову датотеку.</p>"
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr "Неисправан токен"
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr "Неисправно име датотеке"
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr "Морате навести датотеку за постављање"
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr "Можете поставити само једну по једну датотеку"
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr "Нису достављени нови подаци"
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 msgstr ""
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr "{user_full_name} вас је додао у групу {group_name}."
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr "{user_full_name} вас је уклонио из групе {group_name}."
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr "Корисник {user_id} је већ члан ове групе"
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr "Нема члана '{user_id}' у овој корисничкој групи"
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr "Корисничка група {group_id} је већ подгрупа ове групе."
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
@@ -8132,104 +7534,104 @@ msgid ""
 msgstr ""
 "Корисничка група {user_group_id} је већ подгрупа једне од наведених подгрупа."
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr "Корисничка група {group_id} није подгрупа ове групе."
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr "Промена сличица није омогућена у овој организацији."
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr "Промена адресе е-поште је онемогућена у овој организацији."
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr "Неисправан default_language"
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr "Несиправан звук обавештења '{notification_sound}'"
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr ""
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr "Вашом Зулип лозинком се управља кроз LDAP"
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr "Погрешна лозинка!"
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, fuzzy, python-brace-format
 #| msgid "You're making too many attempts! Try again in {seconds} seconds."
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr "Покушавате превише често! Покушајте поново за {seconds} секунди."
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr "Нова лозинка је превише слаба!"
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr "Можете поставити тачно један аватар."
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr "Тема није утишана"
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr "Није могуће деактивирати јединог власника организације"
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Nobody in this Zulip organization will be able to see this email address."
 msgid "User is not allowed to delete other user's messages."
 msgstr "Нико у овој Зулип организацији неће моћи да види ову адресу е-поште."
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 "Дозволу власника није могуће уклонити од јединог власника организације."
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr ""
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr ""
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "No analytics data available. Please contact your server administrator."
@@ -8240,163 +7642,163 @@ msgstr ""
 "Нема доступних података за аналитику. Молим вас контактирајте вашег "
 "администратора сервера."
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 #, fuzzy
 #| msgid "Email address"
 msgid "Email address already in use"
 msgstr "Адреса е-поште"
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr "Није успела промена власника, не постоји тај корисник"
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr "Није успела промена власника, корисник је декативиран"
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr ""
 "Није успела промена власника, ботови не могу бити власници других ботова"
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 msgstr ""
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr "Интегрисани ботови нису омогућени."
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr "Неисправно име интегрисаног бота."
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr "Корисник није овлашћен да прави кориснике"
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr "Е-пошта '{email}' није дозвољена у овој организацији"
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr "Привремене адресе е-поште нису дозвољене у овој организацији"
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom access token"
 msgid "Invalid {provider_name} access token"
 msgstr "Неисправан Zoom приступни токен"
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} call"
 msgstr "Није успело успостављање Zoom позива"
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Zoom credentials have not been configured"
 msgid "{provider_name} credentials have not been configured"
 msgstr "Zoom креденцијали нису подешени"
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom credentials"
 msgid "Invalid {provider_name} credentials"
 msgstr "Неисправни Zoom креденцијали"
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error connecting to the BigBlueButton server."
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr "Грешка при повезивању са BigBlueButton сервером."
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error authenticating to the BigBlueButton server."
 msgid "Error authenticating to the {provider_name} server"
 msgstr "Грешка при аутентификацији са BigBlueButton сервером."
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "BigBlueButton server returned an unexpected error."
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr "BigBlueButton сервер је вратио неочекивану грешку."
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom session identifier"
 msgid "Invalid {provider_name} session identifier"
 msgstr "Неисправан Zoom идентификатор сесије"
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr ""
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} public room."
 msgstr "Није успело успостављање Zoom позива"
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr "Неисправан потпис."
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{full_name}'s Zulip room"
 msgstr "{full_name} вас је поменуо:"
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr "Пројекти који користе овај провајдер контроле верзија нису подржани"
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr ""
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr "Непознат захтев веб закачке"
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr "Тема не може бити празна"
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr "Садржај не може бити празан"
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr ""
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr "Лоше форматиран JSON унос"
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr ""
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr ""
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr ""
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
@@ -8405,153 +7807,153 @@ msgstr ""
 "Извоз ваших података је завршен. [Прегледај и преузми извоз]"
 "({export_settings_link})."
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr ""
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr ""
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr ""
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr ""
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr ""
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr "Морате потврдити за исправним АПИ кључем Зулип сервера"
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr "Неисправан UUID"
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr "Неисправна врста токена"
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr "{hostname} није исправно име за домаћина"
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr ""
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr ""
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr ""
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
 "try again later or reach out to {support_email} for assistance."
 msgstr ""
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr ""
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr ""
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr "Недостаје ios_app_id"
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr "Недостаје user_id или user_uuid"
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
 "server: {reason}"
 msgstr ""
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr ""
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr "Неисправно својство {property}"
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr "Неисправан тип догађаја."
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr "Подаци нису правилно сложени."
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr "Откривена је дуплирана регистрација."
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr ""
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr "Морате да ресетујете вашу лозинку."
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr ""
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 #, fuzzy
 #| msgid "Missing sender"
 msgid "Missing idp param"
 msgstr "Недостаје пошиљалац"
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr "Неисправан OTP"
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr ""
 

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 18:50+0000\n"
 "Last-Translator: Signar Kamparås <bolengejosiane@gmail.com>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/zulip/django/sv/"
@@ -20,50 +20,50 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "Ej tillåtet för gäster"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "ogiltig organisation"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr "Publika kanaler"
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr "Privata kanaler"
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr "Direktmeddelanden"
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr "Gruppera direktmeddelanden"
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr "Starttiden är senare än sluttiden. Start: {start}, Slut: {end}"
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr "Inga anlysdata tillgängliga. Var god kontakta serverns administratör."
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -72,7 +72,7 @@ msgid ""
 "users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -80,7 +80,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than one user to join."
 msgstr ""
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -88,7 +88,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than two users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -96,7 +96,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than three users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -105,148 +105,147 @@ msgid ""
 "({billing_page_link}) is greater than the current number of users."
 msgstr ""
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr ""
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr ""
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
 "(minimum {min_licenses})."
 msgstr ""
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
 "page. To complete the upgrade, please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr ""
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr ""
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "Något gick fel. Uppdatera sidan."
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr "Något gick fel. Vänta några sekunder och försök igen."
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr ""
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr ""
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
 msgstr ""
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
 msgstr ""
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
 "licenses."
 msgstr ""
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
 "billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr ""
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr ""
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr ""
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -256,100 +255,97 @@ msgid ""
 "we would really appreciate it!"
 msgstr ""
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
 "{support_email}"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr ""
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "Fel"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr ""
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
 "%(support_email)s\">contact support</a>."
 msgstr ""
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr ""
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
 msgstr ""
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr ""
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
 msgstr ""
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr ""
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr ""
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
 msgstr ""
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -357,290 +353,271 @@ msgid ""
 "a> with any questions."
 msgstr ""
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
 "a> for support."
 msgstr ""
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
 "href=\"%(troubleshooting_url)s\">Zulip server troubleshooting guide</a>."
 msgstr ""
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, fuzzy, python-format
 #| msgid "Zulip analytics for %(target_name)s"
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr "Zulip-analys for %(target_name)s"
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr "Zulip-analys for %(target_name)s"
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr ""
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr ""
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr ""
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr ""
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr ""
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr ""
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr ""
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "Aktiva användare"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr "Dagliga aktiviteter"
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr "Aktive senaste 15 dagarna"
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr "Totalt antal användare"
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "Användare"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr "Skickade meddelanden efter typ"
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "Jag"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "Alla"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "Senaste veckan"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "Senaste månaden"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "Senaste året"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "Alla"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr "Meddlendehistorik"
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "Dalig"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "Veckolig"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr "Kumulativ"
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "Människor"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "Botar"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr ""
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr "Meddelanden skickade från klient"
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr "Senaste uppdateringen"
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr "Mejladress ändrad!"
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
 "%(old_email_html_tag)s to %(new_email_html_tag)s"
 msgstr ""
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr ""
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
 msgstr ""
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr "Fakturering"
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr ""
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr ""
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -651,19 +628,19 @@ msgid ""
 "server."
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -671,790 +648,299 @@ msgid ""
 "%(support_email)s'>contact support</a> with any questions."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, python-format
 msgid "You can try again in %(retry_after_string)s."
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr ""
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr ""
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr ""
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr ""
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr ""
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr ""
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr ""
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr ""
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr ""
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "Skapa organisation"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr ""
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr ""
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr ""
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr ""
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 msgid "Zulip for open source"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Messages sent over time"
 msgid "Message with code"
 msgstr "Meddlendehistorik"
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
 msgstr ""
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 msgid "Get started"
 msgstr ""
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
 "continue."
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr "Alternativt kan du använda en reservtelefon:"
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr "Som sista möjlighet kan du använda ett återställningstoken:"
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr "Använd återställningstoken"
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "Mejl"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1462,78 +948,77 @@ msgid ""
 "from Zulip."
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
 msgstr ""
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr ""
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr ""
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr ""
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr ""
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr ""
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr ""
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr ""
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
 msgstr ""
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1541,210 +1026,203 @@ msgid ""
 "href=\"%(doc_url)s\">documentation</a>."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr "Inget Zulip-konto hittades."
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, python-format
 msgid "No account found for %(email)s."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr "Logga in med annat konto"
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr "Fortsätt till registreringen"
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Create a new Zulip organization"
 msgid "Try Zulip in a demo organization"
 msgstr "Skapa en ny Zulip-organisation"
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 msgid "Try Zulip"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "Skapa en ny organisation"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr "Skapa en ny Zulip-organisation"
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr "Skriv in din mejladress"
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid "Import chat history?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "Organisations-URL"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "ELLER"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "Gå med"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "Gå med i Zulip"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr "Du behöver en inbjudan för att ansluta till denna organisationen."
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr "Gå med %(identity_provider)s"
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "Logga In"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1752,125 +1230,124 @@ msgid ""
 "noreferrer\">after you join</a>."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "Ändra"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 #, fuzzy
 #| msgid "Click the button below to complete registration."
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr "Klicka på knappen nedan för att slutföra registreringen."
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr "Ditt konto"
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "Namn"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "Lösenord"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr ""
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">Terms of Service</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr "Avaktivera organisation"
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr ""
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -1878,45 +1355,45 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 msgid ""
 "This organization has been deactivated, and all organization data has been "
 "deleted."
 msgstr ""
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
 "inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
 "administrators</a> to inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 msgid "This organization has been deactivated."
 msgstr ""
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
 "%(support_email)s\">contact Zulip support</a> to reactivate it."
 msgstr ""
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -1924,165 +1401,164 @@ msgid ""
 "reactivate it."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "Kopiera"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "Administratörer"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr "Gästanvändare"
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "Vanliga anävndare"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "Stäng"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "Uppdatering"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr ""
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
 "<b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
 "href=\"%(apps_page_link)s\">mobile and desktop</a> apps:"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
 "href=\"%(getting_user_started_link)s\">getting started guide</a>!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2090,83 +1566,83 @@ msgid ""
 "Zulip</a>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
 "to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
 "desktop apps (%(apps_page_link)s):"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
 "(%(getting_user_started_link)s)!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
 "(%(getting_organization_started_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2174,32 +1650,32 @@ msgid ""
 "password for this account, please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "%(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 msgid "Verify your email address for your Zulip demo organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "<%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2207,113 +1683,113 @@ msgid ""
 "please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr "Bekräfta ändrad mejladress"
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr "Du gick nyligen med i Zuplip. Härligt!"
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr "Klicka på knappen nedan för att slutföra registreringen."
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr "Slutför registrering"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
 "— we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
 "deactivated, and you will no longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr ""
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2321,22 +1797,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because your organization <a "
@@ -2344,8 +1820,8 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to <a "
@@ -2353,39 +1829,39 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr ""
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because your organization hides "
@@ -2393,81 +1869,74 @@ msgid ""
 "details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to hide "
 "message content in email notifications. See %(help_url)s for more details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr ""
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr "Simmande fisk"
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
 "organizations:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
 "organizations hosted by %(external_host)s:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
 "href=\"%(help_reset_password_link)s\">reset your password</a>."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
 "%(external_host)s."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2475,97 +1944,94 @@ msgid ""
 "to find your account."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
 "try another way to find your account (%(help_logging_in_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
 "communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr ""
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
 "-- the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
 "Zulip &mdash; the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
 "to ask %(referrer_name)s for another one."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2573,72 +2039,70 @@ msgid ""
 "productivity."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at <a href=\"mailto:%(email)s\">%(email)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
 "%(email)s\">Contact us</a> — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
 "#%(channel_name)s > %(topic_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2646,68 +2110,68 @@ msgid ""
 "preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails (<a href=\"%(url)s\">help</a>)."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2715,22 +2179,22 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2738,52 +2202,52 @@ msgid ""
 "immediately at <%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2791,31 +2255,31 @@ msgid ""
 "contact us immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2823,7 +2287,7 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -2831,25 +2295,25 @@ msgid ""
 "Zulip</a> to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
 "with you and share their unique perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -2857,7 +2321,7 @@ msgid ""
 "experience how a new chat app will help your team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -2865,148 +2329,148 @@ msgid ""
 "action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
 "team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
 "organizations like yours!"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3014,11 +2478,11 @@ msgid ""
 "about…?”"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3027,23 +2491,23 @@ msgid ""
 "href=\"%(move_channels_link)s\">move a topic to a different channel</a>."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3052,23 +2516,23 @@ msgid ""
 "(%(move_channels_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
 "%(email)s on %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3076,46 +2540,46 @@ msgid ""
 "href=\"%(help_link)s\">reactivate your account</a>."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
 "You can contact an organization administrator to reactivate your account."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3123,543 +2587,539 @@ msgid ""
 "have been voided."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
 "to %(upgrade_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip demo organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip demo organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Deactivated organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "Avaktivera organisation"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for <b>%(remote_server_hostname)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, fuzzy
 #| msgid "Click the button below to complete registration."
 msgid "Click the button below to log in."
 msgstr "Klicka på knappen nedan för att slutföra registreringen."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for %(remote_server_hostname)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
 "management for <b>%(remote_realm_host)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
 "management for %(remote_realm_host)s."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the <a href=\"%(plans_link)s\">Zulip Community plan</a>."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
 "website</a>, we would really appreciate it!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
 msgstr ""
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
 "accounts for another email address</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr ""
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "Sök konton"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr ""
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr ""
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr ""
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 msgid "Zulip Cloud"
 msgstr ""
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr ""
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr ""
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "Integreringar"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr "Dator- och mobilappar"
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr ""
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr ""
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr ""
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr ""
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr ""
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr ""
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr ""
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr ""
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr ""
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr ""
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr ""
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr ""
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr "Hjälpcenter"
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr ""
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr ""
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr ""
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr ""
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr ""
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr ""
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr ""
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr ""
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr ""
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "Historia"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr ""
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr ""
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr ""
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr ""
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr ""
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 msgid "Bluesky"
 msgstr ""
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr ""
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr ""
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr ""
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 msgid ""
 "And hundreds more through <a href=\"/integrations/zapier\">Zapier</a> and <a "
 "href=\"/integrations/ifttt\">IFTTT</a>."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3667,7 +3127,7 @@ msgid ""
 "emails with your email domain."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3675,7 +3135,7 @@ msgid ""
 "disposable email addresses."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3683,24 +3143,24 @@ msgid ""
 "emails that contain \"+\"."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3708,7 +3168,7 @@ msgid ""
 "%(support_email)s\">contact Zulip support</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3716,89 +3176,89 @@ msgid ""
 "%(support_email)s\">contact this Zulip server's administrators</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
 "management for your Zulip server."
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr ""
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr ""
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr ""
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr ""
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr ""
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr ""
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr ""
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> because all Zulip Cloud licenses are in use."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -3807,44 +3267,42 @@ msgid ""
 "or misconfiguration."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 #, fuzzy
 #| msgid "Create organization"
 msgid "Demo organizations disabled"
 msgstr "Skapa organisation"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -3852,22 +3310,21 @@ msgid ""
 "organization for more information."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -3875,46 +3332,44 @@ msgid ""
 "Zulip support</a> for assistance in resolving this issue."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
 "a> like Firefox, Chrome, and Edge."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Invalid organization"
 msgid "Finalize organization import"
 msgstr "ogiltig organisation"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 msgid "Organization import completed!"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -3922,56 +3377,55 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Your account"
 msgid "Select your account"
 msgstr "Ditt konto"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create a new organization"
 msgid "Create new account"
 msgstr "Skapa en ny organisation"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr ""
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -3979,81 +3433,81 @@ msgid ""
 "have one yet."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 msgid "Self-hosting Zulip?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">log in to manage plans and billing.</a>"
 msgstr ""
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr ""
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
 msgstr ""
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr ""
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr ""
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr ""
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr ""
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr ""
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4061,7 +3515,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4070,57 +3524,57 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr ""
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4128,7 +3582,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4136,40 +3590,40 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4177,300 +3631,294 @@ msgid ""
 "away!"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
 "href=\"%(realm_url)s/#settings/notifications\">notification settings</a>."
 msgstr ""
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr ""
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr ""
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr ""
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr ""
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr ""
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr ""
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr ""
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 msgid "Cannot reactivate a deleted user"
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr ""
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr ""
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr ""
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr ""
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
 msgstr ""
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
 msgstr ""
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr ""
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr ""
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr ""
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr ""
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr ""
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr ""
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr ""
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr ""
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr ""
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr ""
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
 "{new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
 "{user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to resolve topics in this channel."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr ""
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr ""
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr ""
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr ""
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr ""
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
 "but there is no channel with that ID."
 msgstr ""
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4478,36 +3926,36 @@ msgid ""
 "it."
 msgstr ""
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
 "The channel exists but does not have any subscribers."
 msgstr ""
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr ""
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr ""
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr ""
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4515,107 +3963,105 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
 "authentication method."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr ""
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 msgid "Reminder could not be sent."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
 "the following error:"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr ""
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr ""
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr ""
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr ""
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr ""
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
 "**{old_policy}** to **{new_policy}**."
 msgstr ""
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -4624,51 +4070,49 @@ msgid ""
 "* **New**: {new_setting_description}\n"
 msgstr ""
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr ""
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr ""
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr ""
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr ""
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr ""
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr ""
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 msgstr ""
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr ""
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -4679,285 +4123,271 @@ msgid ""
 "{summary_line}"
 msgstr ""
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr ""
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr ""
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr ""
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr ""
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr ""
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr ""
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr ""
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr ""
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr ""
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr ""
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr ""
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
 "organization administrator to reactivate it."
 msgstr ""
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr ""
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr ""
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr ""
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr ""
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr ""
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr ""
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr ""
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
 "to register for accounts in this organization."
 msgstr ""
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr ""
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 msgid "Challenges are not enabled."
 msgstr ""
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "Nytt lösenord"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr ""
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "You're making too many attempts to sign in. Try again in "
 "{retry_after_string} or contact your organization administrator for help."
 msgstr ""
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
 msgstr ""
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr ""
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr ""
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr ""
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr ""
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr ""
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr ""
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr ""
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr ""
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr ""
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr ""
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr ""
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name can't be empty."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 msgid "Invalid channel folder ID"
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 #, fuzzy
 #| msgid "Enter your email address"
 msgid "Configure owner account email address."
 msgstr "Skriv in din mejladress"
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4966,69 +4396,69 @@ msgid ""
 "organization]({convert_demo}).\n"
 msgstr ""
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, python-brace-format
 msgid "{var_name} is not Base64 encoded"
 msgstr ""
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 msgid "Invalid `device_id`"
 msgstr ""
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr ""
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr ""
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr ""
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr ""
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr ""
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr ""
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr ""
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr ""
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr ""
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr ""
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5036,597 +4466,595 @@ msgid ""
 "{error_message}"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr ""
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr ""
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr ""
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr ""
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr ""
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr ""
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr ""
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr ""
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr ""
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr ""
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr ""
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr ""
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr ""
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
 msgstr ""
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr ""
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr ""
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr ""
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr ""
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr ""
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr ""
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr ""
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr ""
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 msgid "Must be a bot user"
 msgstr ""
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr ""
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr ""
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr ""
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
 "webhook; ignoring"
 msgstr ""
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr ""
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr ""
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr ""
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr ""
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} most recent messages in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr ""
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr ""
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
 msgstr ""
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr ""
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr ""
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr ""
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr ""
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr ""
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Find accounts"
 msgid "Atlassian account ID"
 msgstr "Sök konton"
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 msgid "Behance username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 msgid "Bitbucket username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 msgid "Codeberg username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 msgid "Dribbble username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 msgid "Facebook username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 msgid "GitLab username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 msgid "Instagram username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 msgid "Mastodon profile"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 msgid "Medium username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 msgid "Pinterest username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 msgid "Reddit username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 msgid "Snapchat username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 msgid "Threads username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 msgid "TikTok username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 msgid "Twitch username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 msgid "X username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr ""
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr ""
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 #, fuzzy
 #| msgid "Billing"
 msgid "Video calling"
 msgstr "Fakturering"
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr ""
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr ""
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr ""
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr ""
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr ""
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr ""
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr ""
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr ""
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr ""
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr ""
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr ""
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr ""
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr ""
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr ""
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "{fullname} moderation"
 msgstr ""
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr ""
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr ""
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor_date' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr ""
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 msgid "Navigation view does not exist."
 msgstr ""
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5634,7 +5062,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5642,7 +5070,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5650,7 +5078,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5658,7 +5086,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5668,14 +5096,14 @@ msgid ""
 "a permanent organization]({convert_demo_organization_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
 "them in your [Inbox](/#inbox).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5683,7 +5111,7 @@ msgid ""
 "({navigation_tour_video_url}) for a quick app overview.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5698,14 +5126,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -5713,7 +5141,7 @@ msgid ""
 "and edit your [profile information](/help/edit-your-profile).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -5724,7 +5152,7 @@ msgid ""
 "experience in your [Preferences](#settings/preferences).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5735,7 +5163,7 @@ msgid ""
 "[Browse and subscribe to channels]({settings_link}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -5752,7 +5180,7 @@ msgid ""
 "discussed.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -5761,7 +5189,7 @@ msgid ""
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -5773,7 +5201,7 @@ msgid ""
 "times, and more.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5783,7 +5211,7 @@ msgid ""
 "or browse the [help center](/help/) to learn more!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5791,7 +5219,7 @@ msgid ""
 "get help, try one of the following messages: {bot_commands}\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5803,13 +5231,13 @@ msgid ""
 "({move_content_another_channel_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5823,12 +5251,11 @@ msgid ""
 "and above.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr ""
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -5836,14 +5263,14 @@ msgid ""
 "no matter how many other conversations are going on.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
 "conversations with unread messages.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -5851,7 +5278,7 @@ msgid ""
 "the `+` button next to its name.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -5859,13 +5286,13 @@ msgid ""
 "can we chat about…?”\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5873,7 +5300,7 @@ msgid ""
 "({format_message_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5893,1324 +5320,1301 @@ msgid ""
 "```\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
 "teammates.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
 "conversation.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr ""
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr ""
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr ""
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr ""
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "Nytt meddelande"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 msgid "Invalid `push_key`"
 msgstr ""
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr ""
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr ""
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr ""
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 msgid "Reminder does not exist"
 msgstr ""
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr ""
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr ""
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr ""
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr ""
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr ""
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr ""
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr ""
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr ""
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 msgid "You do not have permission to create new topics in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr ""
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr ""
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr ""
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr ""
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr ""
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr ""
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} does not have the expected format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr ""
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr ""
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr ""
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {user_group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr ""
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr ""
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr ""
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr ""
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr ""
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 msgid "Name must not be empty!"
 msgstr ""
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr ""
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr ""
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr ""
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr ""
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr ""
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr ""
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr ""
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr ""
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr ""
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr ""
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr ""
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr ""
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr ""
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr ""
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr ""
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr ""
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr ""
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr ""
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr ""
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr ""
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr ""
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr ""
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr ""
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr ""
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr ""
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr ""
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr ""
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr ""
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr ""
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr ""
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr ""
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr ""
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr ""
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr ""
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr ""
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "Medlemmar"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr ""
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: empty field name."
 msgstr ""
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr ""
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr ""
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 msgid "Example input does not match the linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in alternative URL template is not present in linkifier "
 "pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in linkifier pattern is not present in alternative URL "
 "template."
 msgstr ""
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr ""
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "egna emoji"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr ""
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr ""
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr ""
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr ""
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr ""
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr ""
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr ""
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr ""
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr ""
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr ""
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "Publik"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr ""
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr ""
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr ""
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr ""
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr ""
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr "Bara admins"
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr ""
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr ""
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr ""
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr ""
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr ""
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr ""
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr ""
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr ""
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr ""
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr ""
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 msgid "Failed to generate challenge"
 msgstr ""
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr ""
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr ""
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr ""
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr ""
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr ""
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr ""
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for use for user matching."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr ""
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr ""
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr ""
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr ""
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr ""
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr ""
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr ""
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr ""
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 msgid "Invitation already used or deactivated."
 msgstr ""
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr ""
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr ""
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr ""
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
 msgstr ""
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr ""
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr ""
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr ""
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr ""
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr ""
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr ""
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr ""
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr ""
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "You need an invitation to join this organization."
 msgid "Message reporting is not enabled in this organization."
 msgstr "Du behöver en inbjudan för att ansluta till denna organisationen."
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr ""
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr ""
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr ""
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr ""
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr ""
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr ""
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr ""
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr ""
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr ""
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 msgid "Navigation view already exists."
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7218,561 +6622,559 @@ msgid ""
 "later. Is this a good time?\n"
 msgstr ""
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr ""
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr ""
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 msgid "You do not have permission to manage plans and billing."
 msgstr ""
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr ""
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr ""
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr ""
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr ""
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr ""
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr ""
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr ""
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr ""
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr ""
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr ""
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr ""
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 #, fuzzy
 #| msgid "You need an invitation to join this organization."
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr "Du behöver en inbjudan för att ansluta till denna organisationen."
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr ""
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr ""
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr ""
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr ""
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr ""
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr ""
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr ""
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Invalid character in language: {character}"
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Language '{language}' is not allowed."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr ""
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr ""
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "Direct messages"
 msgid "Importing messages…"
 msgstr "Direktmeddelanden"
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 msgid "Your name"
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr ""
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr ""
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr ""
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr ""
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr ""
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr ""
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr ""
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr ""
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr ""
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr ""
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr ""
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr ""
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr ""
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
 "**"
 msgstr ""
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr ""
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr ""
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr ""
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr ""
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr ""
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr ""
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr ""
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr ""
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr ""
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr ""
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr ""
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr ""
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr ""
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 msgstr ""
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr ""
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr ""
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
 "subgroups."
 msgstr ""
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr ""
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr ""
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr ""
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr ""
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr ""
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr ""
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr ""
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr ""
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr ""
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr ""
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 msgid "User is not allowed to delete other user's messages."
 msgstr ""
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr ""
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr ""
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "No analytics data available. Please contact your server administrator."
@@ -7781,301 +7183,301 @@ msgid ""
 "Please contact your server administrator."
 msgstr "Inga anlysdata tillgängliga. Var god kontakta serverns administratör."
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 msgid "Email address already in use"
 msgstr ""
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr ""
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr ""
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr ""
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 msgstr ""
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr ""
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr ""
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr ""
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr ""
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr ""
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} access token"
 msgstr ""
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} call"
 msgstr ""
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} credentials have not been configured"
 msgstr ""
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} credentials"
 msgstr ""
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr ""
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error authenticating to the {provider_name} server"
 msgstr ""
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr ""
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} session identifier"
 msgstr ""
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr ""
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} public room."
 msgstr ""
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr ""
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{full_name}'s Zulip room"
 msgstr ""
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr ""
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr ""
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr ""
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr ""
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr ""
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr ""
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr ""
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr ""
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr ""
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
 "({export_settings_link})."
 msgstr ""
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr ""
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr ""
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr ""
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr ""
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr ""
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr ""
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr ""
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr ""
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr ""
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr ""
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr ""
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr ""
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
 "try again later or reach out to {support_email} for assistance."
 msgstr ""
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr ""
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr ""
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr ""
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr ""
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
 "server: {reason}"
 msgstr ""
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr ""
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr ""
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr ""
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr ""
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr ""
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr ""
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr ""
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr ""
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 msgid "Missing idp param"
 msgstr ""
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr ""
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr ""
 

--- a/locale/ta/LC_MESSAGES/django.po
+++ b/locale/ta/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 19:08+0000\n"
 "Last-Translator: Anders Kaseorg <andersk@mit.edu>\n"
 "Language-Team: Tamil <https://hosted.weblate.org/projects/zulip/django/ta/>\n"
@@ -19,51 +19,51 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "விருந்தினர் பயனர்களுக்கு அனுமதிக்கப்படவில்லை"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "தவறான அமைப்பு"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr "அனைத்து தகவலரங்கங்கள்"
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr "தனிப்பட்ட செய்தி"
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr "நேரடி செய்தி"
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr "தனிப்பட்ட செய்தி"
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr "விளக்கப்படத்திற்கான சேனலைக் காணவில்லை: {chart_name}"
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr "அறியப்படாத விளக்கப்படம் பெயர்: {chart_name}"
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr "தொடக்க நேரம் இறுதி நேரத்தை விட தாமதமானது. தொடக்க: {start}, முடிவு: {end}"
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr ""
 "பகுப்பாய்வு தரவு எதுவும் கிடைக்கவில்லை. உங்கள் சேவையக நிர்வாகியை தொடர்பு கொள்ளவும்."
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -76,7 +76,7 @@ msgstr ""
 "({billing_page_link}) அல்லது [செயலற்ற பயனர்களை செயலிழக்கச் செய்யுங்கள்]"
 "({deactivate_user_help_page_link})."
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -87,7 +87,7 @@ msgstr ""
 "அனுமதிக்க நீங்கள் [உரிமங்களின் எண்ணிக்கையை அதிகரிக்கலாம்]({billing_page_link}) அல்லது "
 "[செயலற்ற பயனர்களை செயலிழக்கச் செய்யுங்கள்]({deactivate_user_help_page_link})."
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -98,7 +98,7 @@ msgstr ""
 "அதிகரிக்கலாம்]({billing_page_link}) அல்லது [செயலற்ற பயனர்களை செயலிழக்கச் செய்யலாம்]"
 "({deactivate_user_help_page_link}) இரண்டு பயனர்களுக்கு மேல் சேர அனுமதிக்கலாம்."
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -109,7 +109,7 @@ msgstr ""
 "அதிகரிக்கலாம்]({billing_page_link}) அல்லது [செயலற்ற பயனர்களை செயலிழக்கச் செய்யுங்கள்]"
 "({deactivate_user_help_page_link}) மூன்று பயனர்களுக்கு மேல் சேர அனுமதிக்கலாம்."
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -122,29 +122,28 @@ msgstr ""
 "பட்டியலிடல் காலத்திற்கான உரிமங்களின் எண்ணிக்கை]({billing_page_link}) தற்போதைய "
 "பயனர்களின் எண்ணிக்கையை விட அதிகமாக இருப்பதை உறுதிப்படுத்திக் கொள்ளுங்கள்."
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr "உங்கள் நிறுவனத்திற்கு போதுமான சூலிப் உரிமங்கள் இல்லை. அழைப்புகள் அனுப்பப்படவில்லை."
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
 msgstr ""
 "விருந்தினர் பயனரின் பங்கை மாற்ற உங்கள் நிறுவனத்திற்கு போதுமான சூலிப் உரிமங்கள் இல்லை."
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr "பதிவு செயலிழக்கப்படுகிறது"
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr ""
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
@@ -153,7 +152,7 @@ msgstr ""
 "உங்கள் நிறுவனத்தில் உள்ள அனைத்து செயலில் உள்ள பயனர்களுக்கும் நீங்கள் உரிமங்களை வாங்க வேண்டும் "
 "(குறைந்தபட்சம் {min_licenses})."
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
@@ -162,42 +161,42 @@ msgstr ""
 "{max_licenses} உரிமங்களை விட அதிகமான விலைப்பட்டியல் இந்த பக்கத்திலிருந்து செயலாக்க "
 "முடியாது. மேம்படுத்தலை முடிக்க, தயவுசெய்து {email} ஐ தொடர்பு கொள்ளவும்."
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr "கோப்பில் கட்டண முறை இல்லை."
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr "{brand} {last4} இல் முடிவடைகிறது"
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr "அறியப்படாத கட்டண முறை. தயவுசெய்து {email} ஐ தொடர்பு கொள்ளவும்."
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr "ஏதோ தவறு நடந்தது. தயவுசெய்து {email} ஐ தொடர்பு கொள்ளவும்."
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "ஏதோ தவறு நடந்தது. பக்கத்தை மீண்டும் ஏற்றவும்."
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr "ஏதோ தவறு நடந்தது. தயவுசெய்து சில வினாடிகள் காத்திருந்து மீண்டும் முயற்சிக்கவும்."
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr "உங்கள் இலவச சோதனையைத் தொடங்குவதற்கு முன் கடன் கார்டைச் சேர்க்கவும்."
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr "மேம்படுத்தலை திட்டமிட கடன் கார்டைச் சேர்க்கவும்."
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
@@ -205,17 +204,17 @@ msgstr ""
 "திட்டத்தை புதுப்பிக்க முடியவில்லை. திட்டம் காலாவதியானது மற்றும் புதிய திட்டத்துடன் "
 "மாற்றப்பட்டுள்ளது."
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr "திட்டத்தை புதுப்பிக்க முடியவில்லை. திட்டம் முடிந்தது."
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 "இலவச சோதனை திட்டத்திற்கான தற்போதைய பட்டியலிடல் காலத்தில் உரிமங்களை புதுப்பிக்க முடியாது."
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
@@ -223,18 +222,18 @@ msgstr ""
 "உரிமங்களை கைமுறையாக புதுப்பிக்க முடியவில்லை. உங்கள் திட்டம் தானியங்கி உரிம நிர்வாகத்தில் "
 "உள்ளது."
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr ""
 "உங்கள் திட்டம் ஏற்கனவே தற்போதைய பட்டியலிடல் காலத்தில் {licenses} உரிமங்களில் உள்ளது."
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr "தற்போதைய பட்டியலிடல் காலத்தில் நீங்கள் உரிமங்களைக் குறைக்க முடியாது."
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
@@ -242,7 +241,7 @@ msgstr ""
 "தரமிறக்கப்படும் ஒரு திட்டத்திற்கான அடுத்த பட்டியலிடல் சுழற்சிக்கான உரிமங்களை மாற்ற "
 "முடியாது."
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
@@ -251,7 +250,7 @@ msgstr ""
 "உங்கள் திட்டம் ஏற்கனவே {licenses_at_next_renewal} உரிமத்துடன் புதுப்பிக்க "
 "திட்டமிடப்பட்டுள்ளது."
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
@@ -260,27 +259,27 @@ msgstr ""
 "அடுத்த பட்டியலிடல் காலத்திற்கு நீங்கள் ஏற்கனவே {licenses_at_next_renewal} உரிமங்களை "
 "வாங்கியுள்ளீர்கள்."
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr "மாற்ற எதுவும் இல்லை."
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr ""
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr "அமர்வு காணப்படவில்லை"
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr "கட்டண நோக்கம் கிடைக்கவில்லை"
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr "Bass stripe_session_id அல்லது stripe_invoice_id"
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, fuzzy, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -295,20 +294,19 @@ msgstr ""
 "உங்கள் வலைத்தளத்தில் {end_link on இல் ஒரு ச்பான்சராக {emoji} பட்டியல் சூலிப் முடிந்தால், "
 "நாங்கள் அதை மிகவும் பாராட்டுகிறோம்!"
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr "'உறுதிப்படுத்தப்பட்ட' அளவுரு தேவை"
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr "பட்டியலிடல் அணுகல் கிள்ளாக்கு காலாவதியானது."
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr "தவறான பட்டியலிடல் அணுகல் கிள்ளாக்கு."
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
@@ -317,81 +315,79 @@ msgstr ""
 "சேவையகத்திற்கும் சாம்ராச்யத்திற்கும் இடையில் பட்டியலிடல் தரவை சரிசெய்ய முடியவில்லை. "
 "{support_email} ஐ தொடர்பு கொள்ளவும்"
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr "பயனர் கணக்கு இன்னும் இல்லை."
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr "தொடர பணி விதிமுறைகளை நீங்கள் ஏற்க வேண்டும்."
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 "இந்த zulip_org_id சூலிப்பின் பட்டியலிடல் மேலாண்மை அமைப்பில் பதிவு செய்யப்படவில்லை."
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr "இந்த zulip_org_id க்கு தவறான ZULIP_ORG_KEY."
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr "உங்கள் சேவையக பதிவு செயலிழக்கப்பட்டது."
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "பிழை"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr "பக்கம் கிடைக்கவில்லை (404)"
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
 "%(support_email)s\">contact support</a>."
 msgstr ""
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr "அணுகல் தடைசெய்யப்பட்டுள்ளது (403)"
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
 msgstr ""
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr ""
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
 msgstr ""
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr "முறை அனுமதிக்கப்படவில்லை (405)"
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr "உள் சேவையக பிழை"
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
 msgstr ""
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -399,157 +395,155 @@ msgid ""
 "a> with any questions."
 msgstr ""
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
 "a> for support."
 msgstr ""
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
 "href=\"%(troubleshooting_url)s\">Zulip server troubleshooting guide</a>."
 msgstr ""
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr ""
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 "அமைப்பு உருவாக்கம் 24 மணி நேரத்திற்குப் பிறகு பகுப்பாய்வு முழுமையாக கிடைக்கிறது."
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr "%(target_name)s க்கான சூலிப் பகுப்பாய்வு"
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr ""
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr "பயனர்களின் எண்ணிக்கை"
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr "கடந்த 15 நாட்களில் பயனர்கள் செயலில் உள்ளனர்"
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr "விருந்தினர்களின் எண்ணிக்கை"
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr "செய்திகளின் மொத்த எண்ணிக்கை"
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr "கடந்த 30 நாட்களில் செய்திகளின் எண்ணிக்கை"
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr "பயன்பாட்டில் கோப்பு சேமிப்பு"
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "செயலில் உள்ள பயனர்கள்"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr "நாள்தோறும் செயல்கள்"
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr "15 நாள் செயல்கள்"
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr "மொத்த பயனர்கள்"
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "பயனர்கள்"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr "பெறுநர் வகை அனுப்பிய செய்திகள்"
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "நான்"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "எல்லோரும்"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "கடந்த வாரம்"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "கடந்த மாதம்"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "கடந்த ஆண்டு"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "எல்லா நேரமும்"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr "காலப்போக்கில் அனுப்பப்பட்ட செய்திகள்"
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "தினசரி"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "வாராந்திர"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr "ஒட்டுமொத்த"
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "மனிதர்கள்"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "போட்"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr "காலப்போக்கில் வாசிக்கப்பட்ட செய்திகள்"
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr "கிளையன்ட் அனுப்பிய செய்திகள்"
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr "கடைசி புதுப்பிப்பு"
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
@@ -558,64 +552,64 @@ msgstr ""
 "“காலப்போக்கில் அனுப்பப்பட்ட செய்திகள்” வரைபடம் ஒரு மணி நேரத்திற்கு ஒரு முறை "
 "புதுப்பிக்கப்படும்."
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr "மின்னஞ்சல் மாற்றப்பட்டது"
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr "மின்னஞ்சல் மாற்றப்பட்டது!"
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
 "%(old_email_html_tag)s to %(new_email_html_tag)s"
 msgstr ""
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr "உங்கள் மின்னஞ்சல் முகவரியை உறுதிப்படுத்துகிறது"
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr "உறுதிப்படுத்தல் இணைப்பு இல்லை"
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr ""
 "அச்சச்சோ. கணினியில் உங்கள் உறுதிப்படுத்தல் இணைப்பை எங்களால் கண்டுபிடிக்க முடியவில்லை."
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr "உறுதிப்படுத்தல் இணைப்பு காலாவதியானது அல்லது செயலிழக்கப்பட்டது"
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr "அச்சச்சோ. The confirmation இணைப்பு has காலாவதியான or been deactivated."
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr "புதிய இணைப்புக்கு உங்கள் நிறுவன நிர்வாகியை தொடர்பு கொள்ளவும்."
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr "உறுதிப்படுத்தல் இணைப்பு தவறாக"
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr "அச்சச்சோ. உறுதிப்படுத்தல் இணைப்பு தவறாக உள்ளது."
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
@@ -623,72 +617,55 @@ msgstr ""
 "உங்கள் உலாவியில் இணைப்பை சரியாக நகலெடுத்துள்ளீர்கள் என்பதை உறுதிப்படுத்திக் கொள்ளுங்கள். "
 "நீங்கள் இன்னும் இந்தப் பக்கத்தை சந்திக்கிறீர்கள் என்றால், அது எங்கள் தவறு. மன்னிக்கவும்."
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr "பட்டியலிடல்"
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr "மூடு மேலேஅடுக்கு"
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr "பரவாயில்லை"
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr "தரமிறக்குதல்"
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "கைவிடு"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr "உறுதிப்படுத்து"
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr "இரத்து"
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr "பட்டியலிடல் நிலை"
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr "சேவையக பதிவை செயலிழக்கச் செய்யவா?"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr "திட்ட மேலாண்மை கிடைக்கவில்லை"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -699,19 +676,19 @@ msgid ""
 "server."
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -719,798 +696,307 @@ msgid ""
 "%(support_email)s'>contact support</a> with any questions."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr "விகித வரம்பு மீறியது"
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr "விகித வரம்பு மீறியது."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, fuzzy, python-format
 msgid "You can try again in %(retry_after_string)s."
 msgstr "நீங்கள் மீண்டும் %(Retry_fter) வினாடிகளில் முயற்சி செய்யலாம்."
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr "மேம்படுத்தல்"
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr "விலைப்பட்டியல் அனுப்பி இலவச சோதனையைத் தொடங்கவும்"
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr "விலைப்பட்டியல் அனுப்பவும்"
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr "திறந்த சமூகங்கள் அடைவு"
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr "வகை மூலம் வடிகட்டவும்"
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "அனைத்தும்"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr "வகைகள்"
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr "தனிப்பட்ட செய்தி"
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr "வரம்பற்றது"
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr "10 எம்பி வரை கோப்புகள்"
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr "1 சிபி வரை கோப்புகள்"
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr "ஆதரிக்கப்பட்டது"
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr "தன்வய நிர்வகிக்கப்படுகிறது"
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr "10 பயனர்களைக் கொண்ட நிறுவனங்களுக்கு"
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr "25 பயனர்கள் குறைந்தபட்சம்"
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr "கிடைக்கவில்லை"
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr "சூலிப் மேம்பாட்டு சமூகம்"
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr "பயனராக சேரவும்"
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr "சுய-ஓச்ட்டாக சேரவும்"
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr "பங்களிப்பாளராக சேரவும்"
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "அமைப்பை உருவாக்கவும்"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr "ஒரு டெமோ கிடைக்கும்"
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr "தன்வய புரவலன் சூலிப்"
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr "ச்பான்சர்சிப்பைக் கோருங்கள்"
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr "கல்வி விலை"
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr "விலையைக் காண்க"
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr "வணிகத்திற்கான சூலிப்"
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Zulip guide for open-source projects"
 msgid "Zulip for open source"
 msgstr "திறந்த மூல திட்டங்களுக்கான சூலிப் வழிகாட்டி"
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "start a conversation"
 msgid "Screenshot of Zulip conversation"
 msgstr "உரையாடலைத் தொடங்கவும்"
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Messages sent over time"
 msgid "Message with code"
 msgstr "காலப்போக்கில் அனுப்பப்பட்ட செய்திகள்"
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr "இணைப்பு"
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr "தொடர்பு உதவி"
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr "இருந்து"
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr "அமைப்பு"
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr "பொருள்"
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr "தனிப்பட்ட செய்தி"
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr "சமர்ப்பிக்கவும்"
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr "எங்களைத் தொடர்பு கொண்டதற்கு நன்றி"
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr "எங்களைத் தொடர்பு கொண்டதற்கு நன்றி!"
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr "நாங்கள் விரைவில் உங்களுடன் தொடர்பில் இருப்போம்."
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
 msgstr ""
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 #, fuzzy
 #| msgid "Getting started"
 msgid "Get started"
 msgstr "அமைப்புகள்"
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
 "continue."
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr "அல்லது, மாற்றாக, உங்கள் காப்பு தொலைபேசிகளில் ஒன்றைப் பயன்படுத்தவும்:"
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr "கடைசி முயற்சியாக, நீங்கள் காப்புப்பிரதி கிள்ளாக்கைப் பயன்படுத்தலாம்:"
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr "காப்பு கிள்ளாக்கைப் பயன்படுத்துங்கள்"
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr "பணி விதிமுறைகளை ஏற்றுக்கொள்ளுங்கள்"
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr "சுலிப்பு"
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "மின்னஞ்சல்"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr ""
 "சூலிப்பின் குறைந்த போக்குவரத்து செய்திமடலுக்கு (வருடத்திற்கு சில மின்னஞ்சல்கள்) என்னை "
 "குழுசேரவும்."
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr "தொடரவும்"
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr "உங்கள் மின்னஞ்சல் முகவரியை உறுதிப்படுத்தவும்"
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1520,7 +1006,7 @@ msgstr ""
 "உங்கள் பதிவை முடிக்க, சூலிப்பிலிருந்து உறுதிப்படுத்தல் மின்னஞ்சலுக்கு உங்கள் மின்னஞ்சல் "
 "கணக்கை (<span class=\"user_email semi-bold\">%(email)s</span>) சரிபார்க்கவும்."
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
@@ -1528,30 +1014,30 @@ msgstr ""
 "உங்கள் இன்பாக்ச் அல்லது ச்பேம் கோப்புறையில் உறுதிப்படுத்தல் மின்னஞ்சலை நீங்கள் காணவில்லை என்றால், "
 "நாங்கள் <a href=\"#\" id=\"resend_email_link\">அதை மறுபரிசீலனை செய்யலாம்</a>."
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr "{org_name} | இன் பொது பார்வை சூலிப் குழு அரட்டை"
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, fuzzy, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr "உள்நுழையாமல் {org_name in இல் பொதுவில் அணுகக்கூடிய சேனல்களை உலாவுக."
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
@@ -1559,43 +1045,42 @@ msgstr ""
 "இந்த செய்தி விலகிச் செல்லவில்லை என்றால், <a class=\"reload-lnk\">மீண்டும் ஏற்றுதல்</a> "
 "பக்கத்தை முயற்சிக்கவும்."
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr "சூலிப் ஏற்றுவதில் பிழை. <a class=\"reload-lnk\">மீண்டும் ஏற்றுதல்</a> பக்கம்."
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr "உங்கள் வடிப்பான்களுடன் எந்த உரையாடல்களும் பொருந்தவில்லை."
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr "இந்த பார்வை இன்னும் செய்திகளை ஏற்றுகிறது."
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr "மேலும் ஏற்றவும்"
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr "வீடியோ அழைப்பு முடிந்தது"
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr "நீங்கள் இப்போது இந்த சாளரத்தை மூடலாம்."
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr "உள்ளமைவு பிழை"
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
 msgstr ""
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1603,83 +1088,81 @@ msgid ""
 "href=\"%(doc_url)s\">documentation</a>."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr "கணக்கு காணப்படவில்லை"
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr "சூலிப் கணக்கு காணப்படவில்லை."
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, python-format
 msgid "No account found for %(email)s."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr "மற்றொரு கணக்கில் உள்நுழைக"
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr "பதிவுசெய்தல்"
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Create your Zulip organization"
 msgid "Try Zulip in a demo organization"
 msgstr "உங்கள் சூலிப் அமைப்பை உருவாக்கவும்"
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Why Zulip"
 msgid "Try Zulip"
 msgstr "ஏன் சூலிப்"
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "புதிய அமைப்பை உருவாக்கவும்"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr "புதிய சூலிப் அமைப்பை உருவாக்கவும்"
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr "உங்கள் மின்னஞ்சல் முகவரியை உள்ளிடவும்"
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr "உங்கள் மின்னஞ்சல்"
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr "சூலிப் பற்றி நீங்கள் முதலில் எப்படி கேள்விப்பட்டீர்கள்?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
@@ -1687,114 +1170,109 @@ msgstr ""
 "நீங்கள் ஒரு திட்டத்திற்கு பதிவுசெய்தால் மட்டுமே இந்த மதிப்பு பயன்படுத்தப்படுகிறது, இந்த "
 "விசயத்தில் அது சூலிப் குழுவுக்கு அனுப்பப்படும்."
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr "ஒரு விருப்பத்தைத் தேர்ந்தெடுக்கவும்"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr "தயவுசெய்து விவரிக்கவும்"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr "விளம்பரத்தை எங்கே பார்த்தீர்கள்?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr "ஒன்றைத் தேர்ந்தெடுக்கவும்"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr "நிறுவன வகை"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid "Import chat history?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr "அமைப்பு பெயர்"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "அமைப்பு URL"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr "%(external_host)s பயன்படுத்தவும்"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "அல்லது"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "பதிவு செய்க"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "சூலிப்பிற்கு பதிவுபெறுக"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr "இந்த அமைப்பில் சேர உங்களுக்கு அழைப்பு தேவை."
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, fuzzy, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr "%(அடையாளம்_ முன்னணி) கள் மூலம் பதிவு செய்க"
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr "ஏற்கனவே ஒரு கணக்கு இருக்கிறதா?"
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "புகுபதிகை செய்"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr "மின்னஞ்சல் முகவரி தனியுரிமையை உள்ளமைக்கவும்"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
@@ -1802,7 +1280,7 @@ msgstr ""
 "நிறுவனத்தில் எந்த பாத்திரங்கள் உங்கள் மின்னஞ்சல் முகவரியைக் காண முடியும் என்பதைக் "
 "கட்டுப்படுத்த சூலிப் உங்களை அனுமதிக்கிறது."
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
@@ -1810,11 +1288,11 @@ msgstr ""
 "இந்த நிறுவனத்திற்கான இயல்புநிலை உள்ளமைவிலிருந்து உங்கள் மின்னஞ்சலுக்கான தனியுரிமை "
 "அமைப்பை மாற்ற விரும்புகிறீர்களா?"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr "உங்கள் மின்னஞ்சல் முகவரியை யார் அணுகலாம்"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1824,103 +1302,102 @@ msgstr ""
 "இந்த அமைப்பை <a href=\"%(root_domain_url)s/help/configure-email-visibility\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">நீங்கள் சேர்ந்த பிறகு</a>."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr "இந்தச் சூலிப் அமைப்பில் யாரும் இந்த மின்னஞ்சல் முகவரியைக் காண முடியாது."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "மாற்றம்"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr "பதிவு"
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr "உங்கள் நிறுவனத்தை உருவாக்கவும்"
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr "உங்கள் கணக்கை உருவாக்கவும்"
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr "உங்கள் கணக்கு"
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr "அமைப்புகளை இறக்குமதி செய்ய don & rsquo;"
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr "தற்போதுள்ள சூலிப் கணக்கிலிருந்து அமைப்புகளை இறக்குமதி செய்யுங்கள்"
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr "முழு பெயர்"
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "பெயர்"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr "உங்கள் கணக்கு சூலிப்பில் காட்டப்படும்."
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "கடவுச்சொல்"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr "உங்கள் LDAP/செயலில் உள்ள அடைவு கடவுச்சொல்லை உள்ளிடவும்."
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 "இது மொபைல் பயன்பாடுகள் மற்றும் கடவுச்சொல் தேவைப்படும் பிற கருவிகளுக்கு "
 "பயன்படுத்தப்படுகிறது."
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr "கடவுச்சொல் வலிமை"
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr "நீங்கள் எதில் ஆர்வமாக உள்ளீர்கள்?"
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
@@ -1929,22 +1406,22 @@ msgstr ""
 "<a href=\"%(root_domain_url)s/policies/terms\" target=\"_blank\" "
 "rel=\"noopener noreferrer\">பணி விதிமுறைகள்</a>."
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr "செயலிழக்கச் செய்யப்பட்ட அமைப்பு"
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr ""
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -1952,45 +1429,45 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 msgid ""
 "This organization has been deactivated, and all organization data has been "
 "deleted."
 msgstr ""
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
 "inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
 "administrators</a> to inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 msgid "This organization has been deactivated."
 msgstr ""
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
 "%(support_email)s\">contact Zulip support</a> to reactivate it."
 msgstr ""
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -1998,15 +1475,15 @@ msgid ""
 "reactivate it."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr "டெச்க்டாப் பயன்பாட்டு உள்நுழைவை முடிக்கவும்"
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr "டெச்க்டாப் உள்நுழைவை முடிக்கவும்"
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
@@ -2014,110 +1491,109 @@ msgstr ""
 "உள்நுழைவதை முடிக்க உங்கள் வலை உலாவியைப் பயன்படுத்தவும், பின்னர் உங்கள் உள்நுழைவு டோக்கனில் "
 "ஒட்ட இங்கே திரும்பி வாருங்கள்."
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr "இங்கே கிள்ளாக்கு ஒட்டவும்"
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr "முடிக்க"
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr "தவறான கிள்ளாக்கு."
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr "கிள்ளாக்கு ஏற்றுக்கொள்ளப்பட்டது. உங்களை பதிவுசெய்கிறது…"
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr "டெச்க்டாப் பயன்பாட்டில் உள்நுழைக"
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 "இந்த உள்நுழைவு கிள்ளாக்கை நகலெடுத்து, உள்நுழைவதை முடிக்க உங்கள் சூலிப் பயன்பாட்டிற்கு "
 "திரும்பவும்:"
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "நகல்"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr "நீங்கள் இந்த சாளரத்தை மூடலாம்."
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr "அல்லது, உங்கள் உலாவியில் தொடரவும்."
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr "அநாமதேய பயனர்"
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr "உரிமையாளர்கள்"
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "நிர்வாகிகள்"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr "மதிப்பீட்டாளர்கள்"
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr "விருந்தினர் பயனர்கள்"
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "சாதாரண பயனர்கள்"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr "மின்னஞ்சல்களை மின்னஞ்சல் கணக்கிற்கு அனுப்பவும்"
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "மூடு"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "புதுப்பிப்பு"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr "சுலிப்பு"
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr "செரிமானம்"
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
 "<b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr "சுலிப்புக்கு வரவேற்கிறேன்"
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
@@ -2126,36 +1602,36 @@ msgstr ""
 "Zulip வலையில் உள்நுழைய பின்வரும் தகவலைப் பயன்படுத்துவீர்கள், <a href = "
 "\"%(apps_page_link)s\"> மொபைல் மற்றும் டெச்க்டாப் </a> பயன்பாடுகள்:"
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr "உங்கள் பயனர்பெயர்: %(ldap_username)s"
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr "உள்நுழைய உங்கள் LDAP கணக்கைப் பயன்படுத்தவும்"
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr "உங்கள் கணக்கு மின்னஞ்சல்: %(email)s"
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
@@ -2164,7 +1640,7 @@ msgstr ""
 "நீங்கள் சூலிப்பிற்கு புதியவராக இருந்தால், எங்கள் <a href = "
 "\"%(getting_user_started_link)s\"> தொடங்குதல் வழிகாட்டி </a>!"
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2174,7 +1650,7 @@ msgstr ""
 "<a href=\"%(getting_organization_started_link)s\">உங்கள் நிறுவனத்தை சூலிப்பிற்கு "
 "நகர்த்துவதற்கான வழிகாட்டியும் எங்களிடம் உள்ளது</a>."
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
@@ -2183,29 +1659,29 @@ msgstr ""
 "கேள்விகள்? <a href = \"mailto:%(support_email)s\"> எங்களை தொடர்பு கொள்ளுங்கள் </a> "
 "- நாங்கள் உதவ விரும்புகிறோம்!"
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr "சூலிப்பில் %(realm_name)s: உங்கள் புதிய அமைப்பு விவரங்கள்"
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr "ZULIP இல் %(realm_name)s: உங்கள் புதிய கணக்கு விவரங்கள்"
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr ""
 "வாழ்த்துக்கள், நீங்கள் ஒரு புதிய சூலிப் அமைப்பை உருவாக்கியுள்ளீர்கள்: %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr "நீங்கள் சூலிப் அமைப்பில் %(realm_name)s சேர்ந்துள்ளீர்கள்."
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
@@ -2214,7 +1690,7 @@ msgstr ""
 "சூலிப் வலை, மொபைல் மற்றும் டெச்க்டாப் பயன்பாடுகளில் (%(apps_page_link)s) உள்நுழைய "
 "பின்வரும் தகவலைப் பயன்படுத்துவீர்கள்:"
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
@@ -2223,24 +1699,24 @@ msgstr ""
 "நீங்கள் சூலிப்பிற்கு புதியவராக இருந்தால், எங்கள் தொடங்குதல் வழிகாட்டியைப் பாருங்கள் "
 "(%(getting_user_started_link)s)!"
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
 "(%(getting_organization_started_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr "Questions? தொடர்பு us at %(support_email)s — we'd love பெறுநர் help!"
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, fuzzy, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2249,17 +1725,17 @@ msgstr ""
 "உங்களிடம் ஏதேனும் கேள்விகள் இருந்தால், தயவுசெய்து இந்த சூலிப் சேவையக நிர்வாகியை %(ஆதரவு "
 "மின்னஞ்சல்) தொடர்பு கொள்ளவும்."
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr "ஆய்,"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, fuzzy, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2270,12 +1746,12 @@ msgstr ""
 "எங்களுக்கு கோரிக்கை கிடைத்தது. இந்த புதுப்பிப்பை உறுதிப்படுத்தவும், இந்த கணக்கிற்கான "
 "கடவுச்சொல்லை அமைக்கவும், கீழே சொடுக்கு செய்க:"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr "கடவுச்சொல்லை உறுதிப்படுத்துக"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2284,14 +1760,14 @@ msgstr ""
 "இந்த மாற்றத்தை நீங்கள் கோரவில்லை என்றால், தயவுசெய்து எங்களை உடனடியாக %(support_email)s "
 "இல் தொடர்பு கொள்ளவும்."
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 #, fuzzy
 #| msgid "Verify your new email address for your demo Zulip organization"
 msgid "Verify your email address for your Zulip demo organization"
 msgstr "உங்கள் டெமோ சூலிப் அமைப்புக்கான புதிய மின்னஞ்சல் முகவரியை சரிபார்க்கவும்"
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2300,8 +1776,8 @@ msgstr ""
 "If you did not request this change, please தொடர்பு us உடனடியாக at "
 "<%(support_email)s>."
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2312,33 +1788,33 @@ msgstr ""
 "%(new_email)s வரை மாற்றுவதற்கான கோரிக்கையை நாங்கள் பெற்றோம். இந்த மாற்றத்தை "
 "உறுதிப்படுத்த, கீழே சொடுக்கு செய்க:"
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr "மின்னஞ்சல் மாற்றத்தை உறுதிப்படுத்தவும்"
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr "உங்கள் புதிய மின்னஞ்சல் முகவரியை %(organization_host)s சரிபார்க்கவும்"
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr "நீங்கள் அண்மைக் காலத்தில் சூலிப்பிற்கு பதிவு செய்துள்ளீர்கள். அருமை!"
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
@@ -2346,33 +1822,33 @@ msgstr ""
 "அமைப்பை உருவாக்க கீழே உள்ள பொத்தானைக் சொடுக்கு செய்து உங்கள் கணக்கை பதிவு செய்யுங்கள். "
 "நீங்கள் விரும்பினால் மேலே உள்ள தகவல்களை நீங்கள் புதுப்பிக்க முடியும்."
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr "பதிவை முடிக்க கீழே உள்ள பொத்தானைக் சொடுக்கு செய்க."
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr "Complete registration"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr "உங்கள் சூலிப் அமைப்பை உருவாக்கவும்"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr "உங்கள் சூலிப் கணக்கை செயல்படுத்தவும்"
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr "பதிவு செய்ய கீழே உள்ள இணைப்பைக் சொடுக்கு செய்க."
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
@@ -2381,48 +1857,48 @@ msgstr ""
 "பகிர்வதற்கு உங்களுக்கு கேள்விகள் அல்லது கருத்து இருக்கிறதா? எங்களை %(support_email)s "
 "இல் தொடர்பு கொள்ளவும் - நாங்கள் உதவ விரும்புகிறோம்!"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr "மின்னஞ்சல் விருப்பங்களை நிர்வகிக்கவும்"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
 "deactivated, and you will no longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr "நிர்வாகிகள் பின்வரும் கருத்தை வழங்கினர்:"
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr "கணக்கின் அறிவிப்பு %(realm_name)s"
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr "புதிய சேனல்கள்"
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2430,22 +1906,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because your organization <a "
@@ -2453,8 +1929,8 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to <a "
@@ -2462,39 +1938,39 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr ""
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr "%(realm_name)s சூலிப் டைசச்ட்"
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because your organization hides "
@@ -2502,40 +1978,38 @@ msgid ""
 "details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to hide "
 "message content in email notifications. See %(help_url)s for more details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr "மின்னஞ்சல் விருப்பங்களை நிர்வகிக்கவும்:"
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr ""
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr "நீச்சல் மீன்"
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr "உங்கள் கோரிக்கைக்கு நன்றி!"
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
@@ -2544,8 +2018,7 @@ msgstr ""
 "உங்கள் மின்னஞ்சல் முகவரி %(email)s பின்வரும் சூலிப் முகில் அமைப்புகளுடன் கணக்குகளைக் "
 "கொண்டுள்ளது:"
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, fuzzy, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
@@ -2554,7 +2027,7 @@ msgstr ""
 "உங்கள் மின்னஞ்சல் முகவரி %(email)s %(வெளிப்புற_ஓச்ட்) வழங்கிய பின்வரும் சூலிப் "
 "அமைப்புகளுடன் கணக்குகளைக் கொண்டுள்ளது:"
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
@@ -2563,19 +2036,15 @@ msgstr ""
 "உள்நுழைவதில் சிக்கல் இருந்தால், நீங்கள் <a href = \"%(help_reset_password_link)s\"> "
 "உங்கள் கடவுச்சொல்லை மீட்டமைக்கலாம் </a>."
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr "இந்த மின்னஞ்சல் முகவரிக்கு சூலிப் கணக்குகளின் பட்டியலை நீங்கள் கோரியுள்ளீர்கள்."
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr "எதிர்பாராதவிதமாக, சூலிப் முகில் கணக்குகள் எதுவும் காணப்படவில்லை."
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
@@ -2584,7 +2053,7 @@ msgstr ""
 "எதிர்பாராதவிதமாக, %(external_host)s வழங்கும் சூலிப் அமைப்புகளில் கணக்குகள் எதுவும் "
 "காணப்படவில்லை."
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2595,28 +2064,25 @@ msgstr ""
 "மின்னஞ்சலுடன், அல்லது <a href = \"%(help_logging_in_link)s\"> வேறு வழியில் "
 "முயற்சிக்கவும் </a> உங்கள் கணக்கைக் கண்டுபிடிக்க."
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 "இந்த கோரிக்கையை நீங்கள் அங்கீகரிக்கவில்லை என்றால், இந்த மின்னஞ்சலை நீங்கள் பாதுகாப்பாக "
 "புறக்கணிக்கலாம்."
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr "உங்கள் சூலிப் கணக்குகள்"
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr "சூலிப் கணக்குகள் எதுவும் கிடைக்கவில்லை"
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr "உள்நுழைவதில் சிக்கல் இருந்தால், உங்கள் கடவுச்சொல்லை மீட்டமைக்கலாம்."
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
@@ -2626,12 +2092,12 @@ msgstr ""
 "அல்லது உங்கள் கணக்கைக் கண்டுபிடிக்க வேறு வழியை முயற்சிக்கவும் "
 "(%(help_logging_in_link)s)."
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr "ஆய்,"
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
@@ -2640,17 +2106,17 @@ msgstr ""
 "%(referrer_name)s நீங்கள் அவர்களுடன் சூலிப் & mdash இல் சேர விரும்புகின்றன; "
 "உற்பத்தித்திறனுக்காக வடிவமைக்கப்பட்ட குழு தொடர்பு கருவி."
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr "தொடங்க, கீழே உள்ள பொத்தானைக் சொடுக்கு செய்க."
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr "%(referrer_full_name)s உங்களை %(referrer_realm_name)sேர அழைத்துள்ளன"
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
@@ -2659,17 +2125,17 @@ msgstr ""
 "%(referrer_full_name)s (%(referrer_email)s) நீங்கள் அவர்களுடன் சூலிப்பில் சேர "
 "வேண்டும் - உற்பத்தித்திறனுக்காக வடிவமைக்கப்பட்ட குழு தகவல்தொடர்பு கருவி."
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr "தொடங்க, கீழே உள்ள இணைப்பைக் சொடுக்கு செய்க."
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr "ஆய் மீண்டும்,"
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, fuzzy, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
@@ -2678,13 +2144,13 @@ msgstr ""
 "இது ஒரு நட்புரீதியான நினைவூட்டலாகும், %(குறிப்புரர்_பேம்) நீங்கள் அவர்களுடன் சூலிப் & "
 "mdash இல் சேர விரும்புகிறது; உற்பத்தித்திறனுக்காக வடிவமைக்கப்பட்ட குழு தொடர்பு கருவி."
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr "இந்த அழைப்பிற்கு நீங்கள் பெறும் கடைசி நினைவூட்டல் இதுதான்."
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
@@ -2693,12 +2159,12 @@ msgstr ""
 "இந்த அழைப்பு இரண்டு நாட்களில் காலாவதியாகிறது. அழைப்பிதழ் காலாவதியாகிவிட்டால், நீங்கள் "
 "%(referrer_name)s ஐ இன்னொன்றைக் கேட்க வேண்டும்."
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr "நினைவூட்டல்: %(referrer_name)s இல் %(referrer_realm_name)s இல் சேரவும்"
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2709,7 +2175,7 @@ msgstr ""
 "அவர்களுடன் சூலிப்பில் சேர விரும்புகிறது - உற்பத்தித்திறனுக்காக வடிவமைக்கப்பட்ட குழு "
 "தொடர்பு கருவி."
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2718,7 +2184,7 @@ msgstr ""
 "உங்களிடம் ஏதேனும் கேள்விகள் இருந்தால், தயவுசெய்து இந்த சூலிப் சேவையகத்தின் நிர்வாகிகளை <a "
 "href = \"mailto:%(email)s\">%(email)s </a> இல் தொடர்பு கொள்ளவும்."
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
@@ -2727,23 +2193,21 @@ msgstr ""
 "பகிர்வதற்கு உங்களுக்கு கேள்விகள் அல்லது கருத்து இருக்கிறதா? <a href = \"mailto:"
 "%(email)s\"> எங்களை தொடர்பு கொள்ளுங்கள் </a> - நாங்கள் உதவ விரும்புகிறோம்!"
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr "நீங்கள் தனிப்பட்ட முறையில் குறிப்பிடப்பட்டதால் இதைப் பெறுகிறீர்கள்."
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr ""
 "நீங்கள் இதைப் பெறுகிறீர்கள், ஏனெனில் @%(mentioned_user_group_name)s குறிப்பிடப்பட்டுள்ளன."
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
@@ -2752,8 +2216,8 @@ msgstr ""
 "நீங்கள் இதைப் பெறுகிறீர்கள், ஏனெனில் அனைத்து தலைப்பு பங்கேற்பாளர்களும் # %(channel_name)s> "
 "%(topic_name)s குறிப்பிடப்பட்டுள்ளனர்."
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
@@ -2761,15 +2225,15 @@ msgstr ""
 "நீங்கள் பின்பற்றும் தலைப்புகளுக்கு காடு அட்டை குறிப்பு அறிவிப்புகள் இயக்கப்பட்டிருப்பதால் "
 "நீங்கள் இதைப் பெறுகிறீர்கள்."
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr "எல்லோரும் #%(channel_name)s இல் குறிப்பிடப்பட்டுள்ளதால் நீங்கள் இதைப் பெறுகிறீர்கள்."
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
@@ -2777,8 +2241,8 @@ msgstr ""
 "நீங்கள் பின்பற்றும் தலைப்புகளுக்கு மின்னஞ்சல் அறிவிப்புகள் இயக்கப்பட்டிருப்பதால் இதைப் "
 "பெறுகிறீர்கள்."
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
@@ -2786,7 +2250,7 @@ msgid ""
 msgstr ""
 "#%(channel_name)s க்கு மின்னஞ்சல் அறிவிப்புகள் இயக்கப்பட்டிருப்பதால் இதைப் பெறுகிறீர்கள்."
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2797,7 +2261,7 @@ msgstr ""
 "இதை%(realm_name)s zulip </a>, அல்லது <a href = \"%(notif_url)s\"> மின்னஞ்சல் "
 "விருப்பங்களை நிர்வகிக்கவும் </a>."
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
@@ -2806,7 +2270,7 @@ msgstr ""
 "<a href = \"%(narrow_url)s\">%(realm_name)s zulip </a>, அல்லது <a href = "
 "\"%(notif_url)s\"> மின்னஞ்சல் விருப்பங்களை நிர்வகிக்கவும் </a>."
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
@@ -2815,55 +2279,55 @@ msgstr ""
 "<a href = \"%(narrow_url)s\"> பதில்%(realm_name)s zulip </a>, அல்லது <a href = "
 "\"%(notif_url)s\"> மின்னஞ்சல் விருப்பங்களை நிர்வகிக்கவும் </a>."
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails (<a href=\"%(url)s\">help</a>)."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr "%(sender_str)s உடன் dms"
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr "[resolved] #%(channel_name)s > %(topic_name)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr "தனிப்பட்ட செய்தி"
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 "இந்த மின்னஞ்சலுக்கு நேரடியாக பதிலளிக்கவும், அல்லது அதை %(realm_name)s zulip இல் காண்க:"
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr "%(realm_name)s zulip இல் காண்க அல்லது பதிலளிக்கவும்:"
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr "பதில் %(realm_name)s zulip:"
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2874,22 +2338,22 @@ msgstr ""
 "மாற்றப்பட்டது. இந்த மாற்றத்தை நீங்கள் கோரவில்லை என்றால், தயவுசெய்து எங்களை உடனடியாக "
 "%(support_email)s இல் தொடர்பு கொள்ளவும்."
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr "சிறந்த,"
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr "சுலிப்பு"
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr "சூலிப் மின்னஞ்சல் %(realm_name)s மாற்றப்பட்டது"
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2900,52 +2364,52 @@ msgstr ""
 "மாற்றப்பட்டது. இந்த மாற்றத்தை நீங்கள் கோரவில்லை என்றால், தயவுசெய்து எங்களை உடனடியாக "
 "<%(support_email)s> இல் தொடர்பு கொள்ளவும்."
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr "பின்வரும் சூலிப் கணக்கிற்கான அண்மைக் கால உள்நுழைவை நாங்கள் கவனித்தோம்."
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr "மின்னஞ்சல்: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, fuzzy, python-format
 msgid "Time: %(login_time)s"
 msgstr "நேரம்: %(உள்நுழைவு_ நேரம்) கள்"
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr "சாதனம்: %(device_browser)s இல் %(device_os)s."
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr "ஐபி முகவரி: %(device_ip)s"
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr "இது நீங்கள் என்றால், பெரியது! நீங்கள் செய்ய வேண்டிய வேறு எதுவும் இல்லை."
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2957,31 +2421,31 @@ msgstr ""
 "உங்கள் கடவுச்சொல்லை மீட்டமைக்கவும் </a> அல்லது உடனடியாக எங்களை %(support_email)s இல் "
 "தொடர்பு கொள்ளவும்."
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr "நன்றி,"
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr "சூலிப் பாதுகாப்பு"
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr "%(device_browser)s இல் புதிய உள்நுழைவு %(device_os)s"
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2989,7 +2453,7 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -3000,7 +2464,7 @@ msgstr ""
 "வரவேற்கிறோம்! தொடங்குவதற்கு எங்கள் <a href = \"%(get_organization_started)s\"> "
 "வழிகாட்டியைப் பயன்படுத்தலாம் </a> தொடங்குவதற்கு."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
@@ -3008,7 +2472,7 @@ msgstr ""
 "இல்லையெனில், <i> ஏதேனும் </i> குழு அரட்டை தயாரிப்பு மதிப்பீடு செய்வதற்காக "
 "வாடிக்கையாளர்களிடமிருந்து நாங்கள் அடிக்கடி கேட்கும் சில ஆலோசனைகள் இங்கே:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
@@ -3017,12 +2481,12 @@ msgstr ""
 "<a href = \"%(invite_users)s\"> <b> உங்கள் குழு உறுப்பினர்களை அழைக்கவும் </b> </a> "
 "உங்களுடன் ஆராய்ந்து அவர்களின் தனித்துவமான முன்னோக்குகளைப் பகிர்ந்து கொள்ள."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr "உங்கள் பதிவைப் பற்றி அரட்டையடிக்க பயன்பாட்டைப் பயன்படுத்தவும்."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -3033,7 +2497,7 @@ msgstr ""
 "a> வேறு எந்த அரட்டை கருவிகளையும் பயன்படுத்தாமல். உங்கள் குழு தொடர்பு கொள்ள ஒரு புதிய "
 "அரட்டை பயன்பாடு எவ்வாறு உதவும் என்பதை உண்மையாக அனுபவிப்பதற்கான ஒரே வழி இதுதான்."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -3044,21 +2508,21 @@ msgstr ""
 "வடிவமைக்கப்பட்டுள்ளது, மேலும் இந்த உதவிக்குறிப்புகள் உங்கள் குழு அதை அனுபவிக்க உதவும் "
 "என்று நாங்கள் நம்புகிறோம்."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr "உங்கள் குழுவிற்கான அரட்டை பயன்பாட்டைத் தேர்ந்தெடுப்பது"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
@@ -3066,7 +2530,7 @@ msgstr ""
 "உங்கள் நிறுவனத்திற்கு சூலிப்பைப் பயன்படுத்த நீங்கள் ஏற்கனவே முடிவு செய்திருந்தால், "
 "வரவேற்கிறோம்! தொடங்குவதற்கு சூலிப்பிற்கு செல்ல எங்கள் வழிகாட்டியைப் பயன்படுத்தலாம்."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
@@ -3074,7 +2538,7 @@ msgstr ""
 "இல்லையெனில், எந்தவொரு குழு அரட்டை தயாரிப்பையும் மதிப்பிடுவதற்கு "
 "வாடிக்கையாளர்களிடமிருந்து நாங்கள் அடிக்கடி கேட்கும் சில ஆலோசனைகள் இங்கே:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
@@ -3082,7 +2546,7 @@ msgstr ""
 "உங்களுடன் ஆராய்ந்து அவர்களின் தனித்துவமான முன்னோக்குகளைப் பகிர்ந்து கொள்ள உங்கள் குழு "
 "உறுப்பினர்களை அழைக்கவும்."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
@@ -3092,7 +2556,7 @@ msgstr ""
 "இயக்கவும். உங்கள் குழு தொடர்பு கொள்ள ஒரு புதிய அரட்டை பயன்பாடு எவ்வாறு உதவும் என்பதை "
 "உண்மையாக அனுபவிப்பதற்கான ஒரே வழி இதுதான்."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
@@ -3100,8 +2564,8 @@ msgstr ""
 "திறமையான தகவல்தொடர்புக்கு செயல்படுத்த சூலிப் வடிவமைக்கப்பட்டுள்ளது, மேலும் இந்த "
 "உதவிக்குறிப்புகள் உங்கள் குழு அதை செயலில் அனுபவிக்க உதவும் என்று நம்புகிறோம்."
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
@@ -3111,77 +2575,77 @@ msgstr ""
 "முடியும் என்பதைக் கண்டறிய நாங்கள் உங்களுக்கு உதவ விரும்புகிறோம். உங்களைப் போன்ற "
 "நிறுவனங்களுக்கான முக்கிய சூலிப் அம்சங்களுக்கு இந்த வழிகாட்டியைப் பாருங்கள்!"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr "வணிகங்களுக்கான சூலிப் வழிகாட்டியைக் காண்க"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr "திறந்த மூல திட்டங்களுக்கான சூலிப் வழிகாட்டியைக் காண்க"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr "கல்விக்கான சூலிப் வழிகாட்டியைக் காண்க"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr "ஆராய்ச்சிக்கான சூலிப் வழிகாட்டியைக் காண்க"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr "நிகழ்வுகள் மற்றும் மாநாடுகளுக்கான சூலிப் வழிகாட்டியைக் காண்க"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr "இலாப நோக்கற்ற நிறுவனத்திற்கான சூலிப் வழிகாட்டியைக் காண்க"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr "சமூகங்களுக்கான சூலிப் வழிகாட்டியைக் காண்க"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr "வணிகங்களுக்கான சூலிப் வழிகாட்டி"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr "திறந்த மூல திட்டங்களுக்கான சூலிப் வழிகாட்டி"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr "ஆராய்ச்சிக்கான சூலிப் வழிகாட்டி"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr "நிகழ்வுகள் மற்றும் மாநாடுகளுக்கான சூலிப் வழிகாட்டி"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr "இலாப நோக்கற்ற நிறுவனத்திற்கான சூலிப் வழிகாட்டி"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr "சமூகங்களுக்கான சூலிப் வழிகாட்டி"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
 msgstr "உங்கள் சூலிப் உரையாடல்களை தலைப்புகளுடன் ஒழுங்கமைக்க சில குறிப்புகள் இங்கே."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
@@ -3189,8 +2653,8 @@ msgstr ""
 "சூலிப்பில், <b> சேனல்கள் </b> யாருக்கு செய்தி கிடைக்கிறது என்பதை தீர்மானிக்கவும். <b> "
 "தலைப்புகள் </b> செய்தி என்ன என்பதை உங்களுக்குச் சொல்லுங்கள்."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
@@ -3198,12 +2662,12 @@ msgstr ""
 "தலைப்புகளைப் பயன்படுத்தி, நீங்கள் ஒரு நேரத்தில் ஒரு உரையாடலைப் படிக்கலாம். எத்தனை வெவ்வேறு "
 "விவாதங்கள் நடந்து கொண்டிருந்தாலும், ஒவ்வொரு செய்தியையும் சூழலில் நீங்கள் காண்பீர்கள்."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr "சூலிப் பயன்பாட்டில் சேனல்கள் மற்றும் தலைப்புகள்"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3215,11 +2679,11 @@ msgstr ""
 "தலைப்பு பெயருக்கு, வாக்கியத்தை முடிப்பதைப் பற்றி சிந்தியுங்கள்: “ஏய், நாம் அரட்டை "
 "அடிக்கலாமா…?”"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr "குறுகிய தலைப்புகளின் எடுத்துக்காட்டுகள்"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3232,17 +2696,17 @@ msgstr ""
 "நகர்த்துவது</a>, <a href=\"%(rename_topics_link)s\">தலைப்புகளை மறுபெயரிடுங்கள்</"
 "a>, அல்லது <a href=\"%(move_channels_link)s\">...</a>."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr "சூலிப்பிற்குச் செல்லுங்கள்"
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr "உங்கள் உரையாடல்களை தலைப்புகளுடன் ஒழுங்கமைக்கவும்"
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
@@ -3250,7 +2714,7 @@ msgstr ""
 "சூலிப்பில், யாருக்கு செய்தி கிடைக்கிறது என்பதை சேனல்கள் தீர்மானிக்கின்றன. செய்தி என்ன "
 "என்பதை தலைப்புகள் உங்களுக்குக் கூறுகின்றன."
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, fuzzy, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3263,8 +2727,8 @@ msgstr ""
 "எளிதானது, தலைப்புகளை மறுபெயரிடுவது (%(remace_topics_link)), அல்லது ஒரு தலைப்பை "
 "வேறு சேனலுக்கு (%(move_channels_link)) நகர்த்துவது எளிது."
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
@@ -3273,15 +2737,15 @@ msgstr ""
 "யாரோ (ஒருவேளை நீங்கள்) Zulip கணக்கு %(email)s இல் %(realm_url)s க்கு புதிய "
 "கடவுச்சொல்லைக் கோரினர்."
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr "உங்கள் கடவுச்சொல்லை மீட்டமைக்க கீழே உள்ள பொத்தானைக் சொடுக்கு செய்க."
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr "கடவுச்சொல்"
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3292,18 +2756,18 @@ msgstr ""
 "செயலிழக்கப்பட்டது. நீங்கள் ஒரு நிறுவன நிர்வாகியை <a href = \"%(help_link)s\"> உங்கள் "
 "கணக்கை மீண்டும் செயல்படுத்தலாம் </a>."
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr "அந்த சூலிப் அமைப்பில் உங்களிடம் கணக்கு இல்லை."
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr "பின்வரும் நிறுவனத்தில் (கள்) செயலில் கணக்குகள் உள்ளன."
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
@@ -3311,24 +2775,24 @@ msgstr ""
 "மேலே உள்ள நிறுவனத்தில் (கள்) உங்கள் கடவுச்சொல்லில் உள்நுழைய அல்லது மீட்டமைக்க முயற்சி "
 "செய்யலாம்."
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 "இந்தச் செயல்பாட்டை நீங்கள் அங்கீகரிக்கவில்லை என்றால், இந்த மின்னஞ்சலை நீங்கள் பாதுகாப்பாக "
 "புறக்கணிக்கலாம்."
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr "கடவுச்சொல் மீட்டமைப்பு %(realm_name)s"
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr "உங்கள் கடவுச்சொல்லை மீட்டமைக்க கீழே உள்ள இணைப்பைக் சொடுக்கு செய்க."
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
@@ -3337,7 +2801,7 @@ msgstr ""
 "நீங்கள் முன்பு %(realm_url)s ஒரு கணக்கு வைத்திருந்தீர்கள், ஆனால் அது செயலிழக்கப்பட்டது. "
 "உங்கள் கணக்கை மீண்டும் செயல்படுத்த ஒரு நிறுவன நிர்வாகியை தொடர்பு கொள்ளலாம்."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3345,22 +2809,22 @@ msgid ""
 "have been voided."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
 "to %(upgrade_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "You have deactivated your Zulip organization, %(realm_name)s, on "
@@ -3371,8 +2835,8 @@ msgid ""
 msgstr ""
 "%(realm_name)s உங்கள் சூலிப் அமைப்பு, %(localized_date)s செயலிழக்கச் செய்துள்ளீர்கள்."
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
@@ -3381,8 +2845,8 @@ msgstr ""
 "உங்கள் சூலிப் அமைப்பு, %(realm_name)s, %(deactivating_owner)s மீது %(செயலிழக்கச் "
 "செய்யும்_வ்லர்) எச் மூலம் செயலிழக்கப்பட்டது."
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "Your Zulip organization, %(realm_name)s, was deactivated on "
@@ -3392,8 +2856,8 @@ msgid ""
 "%(localized_date)s."
 msgstr "உங்கள் சூலிப் அமைப்பு, %(realm_name)s, %(localized_date)s செயலிழக்கப்பட்டன."
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
@@ -3401,8 +2865,8 @@ msgid ""
 msgstr ""
 "%(realm_name)s உங்கள் சூலிப் அமைப்பு, %(localized_date)s செயலிழக்கச் செய்துள்ளீர்கள்."
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
@@ -3411,22 +2875,22 @@ msgstr ""
 "உங்கள் சூலிப் அமைப்பு, %(realm_name)s, %(deactivating_owner)s மீது %(செயலிழக்கச் "
 "செய்யும்_வ்லர்) எச் மூலம் செயலிழக்கப்பட்டது."
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr "உங்கள் சூலிப் அமைப்பு, %(realm_name)s, %(localized_date)s செயலிழக்கப்பட்டன."
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr "இந்த அமைப்புடன் தொடர்புடைய அனைத்து தரவும் நிரந்தரமாக நீக்கப்பட்டுள்ளன."
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
@@ -3434,8 +2898,8 @@ msgid ""
 msgstr ""
 "இந்த நிறுவனத்துடன் தொடர்புடைய அனைத்து தரவும் %(deletion_date)s நிரந்தரமாக நீக்கப்படும்."
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
@@ -3443,19 +2907,19 @@ msgstr ""
 "உங்களிடம் ஏதேனும் கேள்விகள் அல்லது கவலைகள் இருந்தால், தயவுசெய்து இந்த மின்னஞ்சலுக்கு "
 "விரைவில் பதிலளிக்கவும்."
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr "உங்கள் சூலிப் அமைப்பு %(realm_name)s செயலிழக்கின்றன"
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr "%(realm_name)s அன்புள்ள முன்னாள் நிர்வாகிகள்,"
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "One of your administrators requested reactivation of the previously "
@@ -3467,8 +2931,8 @@ msgstr ""
 "உங்கள் நிர்வாகிகளில் ஒருவர், முன்னர் செயலிழக்கச் செய்யப்பட்ட சூலிப் அமைப்பை %(realm_url)s "
 "இல் நடத்தினார்."
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
@@ -3477,16 +2941,16 @@ msgstr ""
 "உங்கள் நிர்வாகிகளில் ஒருவர், முன்னர் செயலிழக்கச் செய்யப்பட்ட சூலிப் அமைப்பை %(realm_url)s "
 "இல் நடத்தினார்."
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr "உங்கள் நிறுவனத்தை மீண்டும் செயல்படுத்த கீழே உள்ள பொத்தானைக் சொடுக்கு செய்க."
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr "அமைப்பு என்பதை மீண்டும் செயல்படுத்தவும்"
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
@@ -3494,21 +2958,21 @@ msgstr ""
 "கோரிக்கை பிழையாக இருந்தால், நீங்கள் எந்த நடவடிக்கையும் எடுக்க முடியாது, இந்த இணைப்பு 24 "
 "மணி நேரத்தில் காலாவதியாகும்."
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Reactivate your Zulip organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "உங்கள் சூலிப் அமைப்பை மீண்டும் செயல்படுத்தவும்"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr "உங்கள் சூலிப் அமைப்பை மீண்டும் செயல்படுத்தவும்"
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr "உங்கள் நிறுவனத்தை மீண்டும் செயல்படுத்த கீழே உள்ள இணைப்பைக் சொடுக்கு செய்க."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3517,18 +2981,18 @@ msgstr ""
 "நீங்கள், அல்லது உங்கள் சார்பாக யாராவது, <b>%(remote_server_hostname)s </b> க்கான "
 "சூலிப் திட்டத்தை நிர்வகிக்க இணைப்பில் உள்நுழைகுமாறு கோரியுள்ளீர்கள்."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 msgid "Click the button below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, fuzzy, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr "இந்த இணைப்பு %(செல்லுபடியாகும்_இன்_ஓர்ச்) மணிநேரங்களில் காலாவதியாகும்."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
@@ -3537,11 +3001,11 @@ msgstr ""
 "கேள்விகள்? <a href = \" %(billing_help_link)s\"> மேலும் அறிக </a> அல்லது "
 "%(billing_contact_email)s தொடர்பு கொள்ளவும்."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr "சூலிப் திட்ட நிர்வாகத்தில் உள்நுழைக"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3550,12 +3014,12 @@ msgstr ""
 "நீங்கள் அல்லது உங்கள் சார்பாக யாராவது, %(remote_server_hostname)s சூலிப் திட்டத்தை "
 "நிர்வகிக்க இணைப்பில் ஒரு பதிவைக் கோரியுள்ளீர்கள்."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr "உள்நுழைய கீழே உள்ள இணைப்பைக் சொடுக்கு செய்க."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
@@ -3564,23 +3028,23 @@ msgstr ""
 "கேள்விகள்? %(billing_help_link)s அல்லது தொடர்பு %(billing_contact_email)s "
 "ஆகியவற்றில் மேலும் அறிக."
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
 "management for <b>%(remote_realm_host)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr "கடவுச்சொல்லை உறுதிப்படுத்துக"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr "சூலிப் திட்ட நிர்வாகத்திற்கான மின்னஞ்சலை உறுதிப்படுத்தவும்"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
@@ -3589,7 +3053,7 @@ msgstr ""
 "உங்கள் மின்னஞ்சலை உறுதிப்படுத்த கீழேயுள்ள இணைப்பைக் சொடுக்கு செய்து, "
 "%(remote_realm_host)s சூலிப் திட்ட நிர்வாகத்தில் உள்நுழைக."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
@@ -3598,7 +3062,7 @@ msgstr ""
 "சூலிப் ச்பான்சர்சிப்பிற்கான உங்கள் கோரிக்கை அங்கீகரிக்கப்பட்டுள்ளது! உங்கள் அமைப்பு <a href = "
 "\"%(plans_link)s\"> சூலிப் சமூகத் திட்டம் </a> க்கு மேம்படுத்தப்பட்டுள்ளது."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
@@ -3607,12 +3071,12 @@ msgstr ""
 "நீங்கள் <a href=\"%(link_to_zulip)s\">உங்கள் வலைத்தளத்தில் ஒரு ச்பான்சராக சூலிப்பை "
 "பட்டியலிட முடிந்தால்</a>, நாங்கள் அதை மிகவும் பாராட்டுகிறோம்!"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr "சமூகத் திட்ட ச்பான்சர்சிப் %(billing_entity)s ஒப்புதல் அளித்தது!"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
@@ -3620,7 +3084,7 @@ msgstr ""
 "சூலிப் ச்பான்சர்சிப்பிற்கான உங்கள் கோரிக்கை அங்கீகரிக்கப்பட்டுள்ளது! உங்கள் அமைப்பு சூலிப் சமூக "
 "திட்டத்திற்கு மேம்படுத்தப்பட்டுள்ளது."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
@@ -3628,27 +3092,27 @@ msgstr ""
 "உங்கள் வலைத்தளத்தில் சூலிப்பை ஒரு ச்பான்சராக பட்டியலிட முடிந்தால், நாங்கள் அதை மிகவும் "
 "பாராட்டுகிறோம்!"
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr "உங்கள் கணக்குகளைக் கண்டறியவும்"
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr "உங்கள் சூலிப் கணக்குகளைக் கண்டறியவும்"
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
 "accounts for another email address</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
@@ -3656,7 +3120,7 @@ msgstr ""
 "உங்களிடம் செயலில் உள்ள கணக்குகள் உள்ள அனைத்து சூலிப் முகில் அமைப்புகளுக்கும் முகவரி களுடன் "
 "மின்னஞ்சலைப் பெற உங்கள் மின்னஞ்சல் முகவரியை உள்ளிடவும்."
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
@@ -3664,7 +3128,7 @@ msgstr ""
 "உங்களிடம் செயலில் உள்ள கணக்குகள் உள்ள இந்த சேவையகத்தில் உள்ள அனைத்து சூலிப் அமைப்புகளுக்கும் "
 "முகவரி களுடன் மின்னஞ்சலைப் பெற உங்கள் மின்னஞ்சல் முகவரியை உள்ளிடவும்."
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
@@ -3672,266 +3136,262 @@ msgstr ""
 "உங்கள் கடவுச்சொல்லையும் மறந்துவிட்டால், நீங்கள் <a href = \"/உதவி/மாற்ற-உங்கள்-பாச்வேர்ட்\"> "
 "மீட்டமைக்கலாம் </a>."
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr "மின்னஞ்சல்"
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "கணக்குகளைக் கண்டறியவும்"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr "தயாரிப்பு"
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr "ஏன் சூலிப்"
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr "நற்பொருத்தங்கள்"
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr "திட்டங்கள் & விலை"
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Zulip Cloud status"
 msgid "Zulip Cloud"
 msgstr "சூலிப் முகில் நிலை"
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr "அமைப்புகள்"
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr "பாதுகாப்பு"
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "ஒருங்கிணைப்புகள்"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr "டெச்க்டாப் & மொபைல் பயன்பாடுகள்"
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr "புதிய அமைப்பு"
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr "தீர்வுகள்"
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr "வணிகம்"
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr "கல்வி"
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr "ஆராய்ச்சி"
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr "நிகழ்வுகள் மற்றும் மாநாடுகள்"
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr "திறந்த மூல திட்டங்கள்"
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr "சமூகங்கள்"
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr "வாடிக்கையாளர் கதைகள்"
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr "திறந்த சமூகங்கள்"
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr "வளங்கள்"
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr "அமைப்புகள்"
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr "உதவி நடுவண்"
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr "சமூக அரட்டை"
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr "சூலிப் முகில் நிலை"
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr "சுலிப்பு"
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr "சூலிப் சேவையகத்தை நிறுவுதல்"
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr "சூலிப் சேவையகத்தை மேம்படுத்துதல்"
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr "பங்களிப்பு"
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr "பங்களிப்பு வழிகாட்டி"
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr "மேம்பாட்டு சமூகம்"
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr "மொழிபெயர்ப்பு"
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr "கிரப்"
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr "எங்களைப் பற்றி"
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr "அணி"
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "வரலாறு"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr "மதிப்புகள்"
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr "வேலைகள்"
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr "வலைப்பதிவு"
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr "சூலிப்பை ஆதரிக்கவும்"
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr "மாச்டோடன்"
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr "சென்டர்"
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Values"
 msgid "Bluesky"
 msgstr "மதிப்புகள்"
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr "<a href=\"https://zulip.com\">Zulip</a> ஆல் இயக்கப்படுகிறது"
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr "பணி விதிமுறைகள்"
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr "தனியுரிமைக் கொள்கை"
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr "வலைத்தள பண்புக்கூறுகள்"
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr "மேல் %(integrations_count_display)s சொந்த ஒருங்கிணைப்புகள்."
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 msgid ""
 "And hundreds more through <a href=\"/integrations/zapier\">Zapier</a> and <a "
 "href=\"/integrations/ifttt\">IFTTT</a>."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr "ஒருங்கிணைப்புகளைத் தேடுங்கள்"
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr "தனிப்பயன் ஒருங்கிணைப்புகள்"
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr "உள்வரும் வெப்ஊக்குகள்"
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr "ஊடாடும் போட்கள்"
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr "REST பநிஇ"
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr "தவறான மின்னஞ்சல்"
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr "மின்னஞ்சல் அனுமதிக்கப்படவில்லை"
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr "நீங்கள் பதிவுபெற முயற்சிக்கும் மின்னஞ்சல் முகவரி செல்லுபடியாகாது."
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3941,7 +3401,7 @@ msgstr ""
 "நீங்கள் சேர முயற்சிக்கும் அமைப்பு, <a href = \"%(realm_url)s\">%(realm_name)s </a>, "
 "உங்கள் மின்னஞ்சல் களத்துடன் மின்னஞ்சல்களைப் பயன்படுத்தி கையொப்பங்களை அனுமதிக்காது."
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3951,7 +3411,7 @@ msgstr ""
 "நீங்கள் சேர முயற்சிக்கும் அமைப்பு, <a href = \"%(realm_url)s\">%(realm_name)s </a>, "
 "செலவழிப்பு மின்னஞ்சல் முகவரிகளைப் பயன்படுத்தி கையொப்பங்களை அனுமதிக்காது."
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3961,24 +3421,24 @@ msgstr ""
 "நீங்கள் சேர முயற்சிக்கும் அமைப்பு, <a href = \"%(realm_url)s\">%(realm_name)s </a>, "
 "\"+\" கொண்ட மின்னஞ்சல்களைப் பயன்படுத்தி கையொப்பங்களை அனுமதிக்காது."
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr "சரியான மின்னஞ்சல் முகவரியைப் பயன்படுத்தி பதிவுபெறுக."
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr "அனுமதிக்கப்பட்ட மின்னஞ்சல் முகவரியைப் பயன்படுத்தி பதிவுபெறுக."
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr "<b>%(current_url)s </b> இல் சூலிப் அமைப்பு இல்லை."
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3989,7 +3449,7 @@ msgstr ""
 "கண்டுபிடி/\"> உங்கள் சூலிப் முகில் கணக்குகளின் பட்டியலைப் பெறுங்கள் </a>, அல்லது <a href "
 "= \"mailto:%(support_email)s\"> தொடர்பு சூலிப் உதவி </a>."
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -4001,7 +3461,7 @@ msgstr ""
 "href = \"mailto:%(support_email)s\"> இந்த சூலிப் சேவையகத்தின் நிர்வாகிகள் </a> ஐ "
 "தொடர்பு கொள்ளவும்."
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
@@ -4010,57 +3470,57 @@ msgstr ""
 "<a href = \"%(current_url)s/serverlogin/\"> உங்கள் சூலிப் சேவையகத்திற்கான திட்ட "
 "நிர்வாகத்தை அணுக இங்கே சொடுக்கு செய்க </a>."
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr "தவறான அல்லது காலாவதியான உள்நுழைவு அமர்வு"
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr "தவறான அல்லது காலாவதியான உள்நுழைவு அமர்வு."
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr "சூலிப்பில் உள்நுழைக"
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr "இந்த மின்னஞ்சல் முகவரியில் நீங்கள் ஏற்கனவே பதிவு செய்துள்ளீர்கள். கீழே உள்நுழைக."
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr "மின்னஞ்சல் அல்லது பயனர்பெயர்"
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "பயனர்பெயர்"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr "உங்கள் கடவுச்சொல்லை மறந்துவிட்டீர்களா?"
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, fuzzy, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr "%உடன் உள்நுழைக (அடையாளம்_ ப்ரோவிடர்) கள்"
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr "கணக்கு இல்லாமல் காண்க"
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr "இன்னும் கணக்கு இல்லையா? இந்த அமைப்பில் சேர நீங்கள் அழைக்கப்பட வேண்டும்."
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr "உரிமங்கள் எதுவும் கிடைக்கவில்லை"
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr "அமைப்பு இப்போது புதிய உறுப்பினர்களை ஏற்க முடியாது"
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
@@ -4069,7 +3529,7 @@ msgstr ""
 "புதிய உறுப்பினர்கள் தற்போது <a href = \"%(realm_url)s\">%(realm_name)s </a> சேர "
 "முடியாது, ஏனெனில் அனைத்து சூலிப் முகில் உரிமங்களும் பயன்பாட்டில் உள்ளன."
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
@@ -4077,19 +3537,19 @@ msgstr ""
 "உங்களை அழைத்த நபரைத் தொடர்புகொண்டு, உரிமங்களின் எண்ணிக்கையை அதிகரிக்கச் சொல்லுங்கள், பின்னர் "
 "மீண்டும் முயற்சிக்கவும்."
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr "முக்கிய உள்ளடக்கத்திற்கு செல்லவும்"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr "அங்கீகார துணை டொமைன் பிழை"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr "அங்கீகார துணை டொமைன்"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -4098,44 +3558,42 @@ msgid ""
 "or misconfiguration."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 #, fuzzy
 #| msgid "New organization"
 msgid "Demo organizations disabled"
 msgstr "புதிய அமைப்பு"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr "புதுப்பிப்பு தேவை"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr "அண்மைக் கால வெளியீட்டைப் பதிவிறக்கவும்."
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -4143,22 +3601,21 @@ msgid ""
 "organization for more information."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr "அமைப்பு உருவாக்கும் இணைப்பு காலாவதியானது அல்லது தவறானது"
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr "எதிர்பாராத சூலிப் சேவையக பதிவு"
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -4166,44 +3623,42 @@ msgid ""
 "Zulip support</a> for assistance in resolving this issue."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr "ஆதரிக்கப்படாத உலாவி"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
 "a> like Firefox, Chrome, and Edge."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr "கணக்கு செயலிழக்கப்படுகிறது"
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 msgid "Finalize organization import"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 msgid "Organization import completed!"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -4211,54 +3666,53 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 msgid "Select your account"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Create new account"
 msgstr "உங்கள் கணக்கை உருவாக்கவும்"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr "அமைப்பு வெற்றிகரமாக மீண்டும் செயல்படுத்தப்பட்டது"
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr "உங்கள் அமைப்பு வெற்றிகரமாக மீண்டும் செயல்படுத்தப்பட்டுள்ளது."
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr "அமைப்பு மீண்டும் செயல்படுத்தும் இணைப்பு காலாவதியானது அல்லது தவறானது"
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr "அமைப்பு மீண்டும் செயல்படுத்தும் இணைப்பு காலாவதியானது அல்லது செல்லுபடியாகாது."
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr "உங்கள் நிறுவனத்தில் உள்நுழைக"
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr "நிர்வாகிகள்"
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr "உங்கள் நிறுவன முகவரி தெரியாதா?"
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr "உங்கள் நிறுவனத்தைக் கண்டறியவும்."
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr "அடுத்த"
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4266,24 +3720,24 @@ msgid ""
 "have one yet."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 #, fuzzy
 #| msgid "Self-host Zulip"
 msgid "Self-hosting Zulip?"
 msgstr "தன்வய புரவலன் சூலிப்"
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">log in to manage plans and billing.</a>"
 msgstr ""
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr "உங்கள் கடவுச்சொல்லை மீட்டமைக்கவும்"
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
@@ -4291,62 +3745,62 @@ msgstr ""
 "உங்கள் கடவுச்சொல்லை மறந்துவிட்டீர்களா? எந்த பிரச்சனையும் இல்லை, நீங்கள் பதிவுசெய்த "
 "மின்னஞ்சலுக்கு உங்கள் கடவுச்சொல்லை மீட்டமைக்க ஒரு இணைப்பை அனுப்புவோம்."
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr "மீட்டமை இணைப்பை அனுப்பவும்"
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr "கடவுச்சொல்"
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "கடவுச்சொல்லை உறுதிப்படுத்துக"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr "மன்னிக்கவும், நீங்கள் வழங்கிய இணைப்பு தவறானது அல்லது ஏற்கனவே பயன்படுத்தப்பட்டுள்ளது."
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr ""
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr "கடவுச்சொல்"
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr ""
 "தயவுசெய்து <a href = \"%(login_url)s\"> உங்கள் புதிய கடவுச்சொல்லுடன் </a> இல் "
 "உள்நுழைக."
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr "கடவுச்சொல் மீட்டமை மின்னஞ்சல் அனுப்பப்பட்டது"
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr "கடவுச்சொல் மீட்டமைப்பு அனுப்பப்பட்டது!"
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr "செயல்முறையை முடிக்க சில நிமிடங்களில் உங்கள் மின்னஞ்சலைச் சரிபார்க்கவும்."
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr ""
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4354,7 +3808,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4363,60 +3817,60 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 #, fuzzy
 #| msgid ""
 #| "Nobody in this Zulip organization will be able to see this email address."
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr "இந்தச் சூலிப் அமைப்பில் யாரும் இந்த மின்னஞ்சல் முகவரியைக் காண முடியாது."
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4424,7 +3878,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4432,34 +3886,34 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr "அங்கீகாரத்திற்கான கணக்கைத் தேர்ந்தெடுக்கவும்"
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr "அறியப்படாத மின்னஞ்சல் குழுவிலக கோரிக்கை"
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
@@ -4467,7 +3921,7 @@ msgstr ""
 "ஆய்! நீங்கள் எதையாவது குழுவிலக முயற்சித்ததாகத் தெரிகிறது, ஆனால் நாங்கள் முகவரி ஐ "
 "அடையாளம் காணவில்லை."
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4478,69 +3932,67 @@ msgstr ""
 "href = \"mailto:%(support_email)s\"> எங்களுக்கு மின்னஞ்சல் அனுப்புங்கள் </a>, இதை "
 "நாங்கள் ச்கொயர் விலக்குவோம்!"
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr "மின்னஞ்சல் அமைப்புகள் புதுப்பிக்கப்பட்டன"
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
 "href=\"%(realm_url)s/#settings/notifications\">notification settings</a>."
 msgstr ""
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr "தவறான ஆர்டர் மேப்பிங்."
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr "சூலிப் பயன்படுத்துவது பற்றிய கேள்விகள் மற்றும் விவாதம்."
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr "சூலிப்புடன் இங்கே ஆய்வு செய்யுங்கள். : test_tube:"
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr "குழு அளவிலான உரையாடல்களுக்கு"
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr "கையொப்பங்கள்"
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr ""
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr "{user} சூலிப்பில் சேர உங்கள் அழைப்பை ஏற்றுக்கொண்டார்!"
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 "ஒதுக்கிடக் கணக்கை செயல்படுத்த முடியாது; அதற்கு பதிலாக பதிவுபெற பயனரிடம் கேளுங்கள்."
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 #, fuzzy
 #| msgid "Cannot deactivate user group in use."
 msgid "Cannot reactivate a deleted user"
 msgstr "பயன்பாட்டில் உள்ள பயனர் குழுவை செயலிழக்க முடியாது."
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
@@ -4548,67 +4000,66 @@ msgstr ""
 "இந்த துறையை மாற்ற உங்களுக்கு இசைவு இல்லை. அதைப் புதுப்பிக்க நிர்வாகியைத் தொடர்பு "
 "கொள்ளுங்கள்."
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr "புலம் அடையாளம் {id} கிடைக்கவில்லை."
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr "இயல்புநிலை சேனல் குழு பெயர் மிக நீளமானது (வரம்பு: {max_length} எழுத்துக்கள்)"
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 "இயல்புநிலை சேனல் குழு பெயர் '{group_name}' சுழிய (0x00) எழுத்துக்களைக் கொண்டுள்ளது."
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr ""
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 "'{channel_name}' என்பது இயல்புநிலை சேனல் மற்றும் '{group_name}' இல் சேர்க்க முடியாது"
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr "இயல்புநிலை சேனல் குழு '{group_name}' ஏற்கனவே உள்ளது"
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr "சேனல் '{channel_name}' ஏற்கனவே இயல்புநிலை சேனல் குழுவில் '{group_name}'"
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr "சேனல் '{channel_name}' இயல்புநிலை சேனல் குழுவில் '{group_name}' இல் இல்லை"
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr ""
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
@@ -4616,7 +4067,7 @@ msgstr ""
 "பயனர்களைப் பாதுகாக்க, ஒரு நாளில் நீங்கள் அனுப்பக்கூடிய அழைப்புகளின் எண்ணிக்கையை சூலிப் "
 "கட்டுப்படுத்துகிறார். நீங்கள் வரம்பை எட்டியுள்ளதால், அழைப்புகள் எதுவும் அனுப்பப்படவில்லை."
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
@@ -4624,75 +4075,75 @@ msgstr ""
 "இந்த நிறுவனத்திற்கான அழைப்புகளை அனுப்ப உங்கள் கணக்கு மிகவும் புதியது. ஒரு நிறுவன "
 "நிர்வாகி அல்லது அதிக பட்டறிவு வாய்ந்த பயனரிடம் கேளுங்கள்."
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr "சில மின்னஞ்சல்கள் சரிபார்க்கவில்லை, எனவே நாங்கள் எந்த அழைப்பிதழையும் அனுப்பவில்லை."
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr "எங்களால் யாரையும் அழைக்க முடியவில்லை."
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr "மாற்ற எதுவும் இல்லை"
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr "தனிப்பட்ட செய்தி"
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr "தனிப்பட்ட செய்தி"
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr "தலைப்பு திருத்தம் இல்லாமல் தவறான பிரச்சாரம்_மோட்"
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr "பொது அரட்டையை தீர்க்கப்பட்டதாகக் குறிக்க முடியாது"
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr "சேனலை மாற்றும்போது செய்தி உள்ளடக்கத்தை மாற்ற முடியாது"
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr "விட்செட்களை திருத்த முடியாது."
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr "உங்கள் அமைப்பு செய்தி திருத்துதல் முடக்கப்பட்டுள்ளது"
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr "இந்த செய்தியைத் திருத்த உங்களுக்கு இசைவு இல்லை"
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr "இந்த செய்தியைத் திருத்துவதற்கான கால காலநீடிப்பு கடந்துவிட்டது"
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, fuzzy, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr "{பயனர் this இந்த தலைப்பை தீர்க்கப்பட்டதாகக் குறித்தார்."
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, fuzzy, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr "{பயனர் the இந்த தலைப்பை தீர்க்கப்படாதது என்று குறித்தார்."
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, fuzzy, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr "இந்த தலைப்பு {{{பயனர் by ஆல் {new_location that க்கு மாற்றப்பட்டது."
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr "இந்த தலைப்பிலிருந்து {new_location} க்கு {user} க்கு ஒரு செய்தி நகர்த்தப்பட்டது."
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, fuzzy, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
@@ -4701,19 +4152,19 @@ msgstr ""
 "{changed_messages_count} செய்திகள் இந்த தலைப்பிலிருந்து {new_location} {பயனர் by "
 "க்கு மாற்றப்பட்டன."
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr "இந்த தலைப்பு {old_location} இலிருந்து {user} மூலம் இங்கே நகர்த்தப்பட்டது."
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 msgstr ""
 "[A message]({message_link}) was moved here இருந்து {old_location} by {user}."
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
@@ -4722,66 +4173,63 @@ msgstr ""
 "{changed_messages_count} செய்திகள் {old_location} இலிருந்து {user} ஆல் இங்கே "
 "நகர்த்தப்பட்டன."
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to resolve topics in this channel."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr "இந்த செய்தியின் தலைப்பைத் திருத்துவதற்கான கால காலநீடிப்பு கடந்துவிட்டது."
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr "இந்த செய்தியை நகர்த்த உங்களுக்கு இசைவு இல்லை"
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr "இந்த செய்தியின் சேனலைத் திருத்துவதற்கான கால காலநீடிப்பு கடந்துவிட்டது"
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr "கொடி திருத்த முடியாதது: '{flag}'"
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr "தவறான செய்தி (கள்)"
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr "செய்தியை வழங்க முடியவில்லை"
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr "சரியாக ஒரு சேனல் எதிர்பார்க்கப்படுகிறது"
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr "பெறுநர்களுக்கு தவறான தரவு வகை"
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 "பெறுநரின் பட்டியல்களில் மின்னஞ்சல்கள் அல்லது பயனர் ஐடிகள் இருக்கலாம், ஆனால் இரண்டும் இல்லை."
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, fuzzy, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
@@ -4790,7 +4238,7 @@ msgstr ""
 "உங்கள் போட் {bot_identity the சேனல் அடையாளம் {சேனல்_ஐடி பெறுநர் க்கு ஒரு செய்தியை "
 "அனுப்ப முயற்சித்தது, ஆனால் அந்த ஐடியுடன் சேனல் இல்லை."
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4801,7 +4249,7 @@ msgstr ""
 "முயற்சித்தது, ஆனால் அந்த சேனல் இல்லை. அதை உருவாக்க [இங்கே]({new_channel_link}) "
 "என்பதைக் சொடுக்கு செய்க."
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, fuzzy, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
@@ -4810,30 +4258,30 @@ msgstr ""
 "உங்கள் போட் {bot_identity the சேனல் {சேனல்_பேம் பெறுநர் க்கு ஒரு செய்தியை அனுப்ப "
 "முயற்சித்தது. சேனல் உள்ளது, ஆனால் எந்த சந்தாதாரர்களும் இல்லை."
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr "பெறுநர்களில் சிலரை அணுக உங்களுக்கு இசைவு இல்லை."
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr "விட்செட்டுகள்: பநிஇ புரோகிராமர் தவறான சாதொபொகு உள்ளடக்கத்தை அனுப்பினார்"
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr "விட்செட்டுகள்: {error_msg}"
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, fuzzy, python-brace-format
 #| msgid "{user_name} created the following channels: {new_channels}."
 msgid "{user} has made the following changes to your account."
 msgstr "{user_name} பின்வரும் சேனல்களை உருவாக்கியது: {new_channels}."
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4841,26 +4289,24 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr "இந்த பெயருடன் தனிப்பயன் ஈமோசி ஏற்கனவே உள்ளது."
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr "ஆர்டர் செய்யப்பட்ட பட்டியலில் நகல் இணைப்பு இருக்கக்கூடாது"
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 "ஆர்டர் செய்யப்பட்ட பட்டியல் தற்போதுள்ள அனைத்து இணைப்பாளர்களையும் ஒரு முறை கணக்கிட வேண்டும்"
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
@@ -4869,37 +4315,37 @@ msgstr ""
 "இந்த அங்கீகார முறையைப் பயன்படுத்த {required_upgrade_plan_name} திட்டத்திற்கு நீங்கள் "
 "மேம்படுத்த வேண்டும்."
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr "தவறான அங்கீகார முறை: {name}. செல்லுபடியாகும் முறைகள்: {methods}"
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, fuzzy, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr "அங்கீகார முறை {பெயர் your உங்கள் தற்போதைய திட்டத்தில் கிடைக்கவில்லை."
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr "மிதமான கோரிக்கை சேனல் தனிப்பட்டதாக இருக்க வேண்டும்."
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr "சேமித்த துணுக்கை இல்லை."
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr "திட்டமிடப்பட்ட செய்தி ஏற்கனவே அனுப்பப்பட்டது"
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 msgid "Reminder could not be sent."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr "திட்டமிடப்பட்ட நேரத்தில் செய்தியை அனுப்ப முடியவில்லை."
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, fuzzy, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
@@ -4908,38 +4354,38 @@ msgstr ""
 "பின்வரும் பிழையின் காரணமாக {devient_datetime க்கு க்கு நீங்கள் திட்டமிட்ட செய்தி "
 "அனுப்பப்படவில்லை:"
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr "[திட்டமிடப்பட்ட செய்திகளைக் காண்க](#scheduled)"
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr "சேனல் ஏற்கனவே செயலிழக்கப்படுகிறது"
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr ""
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr "சேனல் தற்போது செயலிழக்கவில்லை"
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr "சேனல் {channel_name} ஏற்கனவே உள்ளது"
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr "சேனல் தனிப்பட்டது மற்றும் சந்தாதாரர்கள் இல்லை"
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr ""
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, fuzzy, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
@@ -4948,7 +4394,7 @@ msgstr ""
 "Cannel இந்த சேனலுக்கான [அணுகல் அனுமதிகள்]({help_link}) ஐ **{old_policy}** "
 "இலிருந்து **{new_policy}** க்கு மாற்றியது."
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -4961,41 +4407,39 @@ msgstr ""
 "* ** பழையது**: {old_setting_description}\n"
 "* ** புதிய**: {new_setting_description}\n"
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 "{user_name} என மறுபெயரிடப்பட்ட சேனல் {old_channel_name} {new_channel_name}."
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr "விளக்கம் இல்லை."
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, fuzzy, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr "{பயனர் this இந்த சேனலுக்கான விளக்கத்தை மாற்றினார்."
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr "பழைய விளக்கம்"
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr "புதிய விளக்கம்"
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr "என்றென்றும்"
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr "{number_of_days} நாட்கள்"
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
@@ -5004,11 +4448,11 @@ msgstr ""
 "இந்த சேனலில் உள்ள செய்திகள் இப்போது தானாகவே நீக்கப்படும் {number_of_days} அவை "
 "அனுப்பப்பட்ட சில நாட்களுக்குப் பிறகு."
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr "இந்த சேனலில் உள்ள செய்திகள் இப்போது எப்போதும் தக்கவைக்கப்படும்."
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -5024,99 +4468,89 @@ msgstr ""
 "\n"
 "{summary_line}"
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr "இந்த செய்திக்கு நீங்கள் ஒரு சமர்ப்பிப்பை இணைக்க முடியாது."
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr ""
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr "பயனர் குழு '{group_name}' ஏற்கனவே உள்ளது."
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr "போதிய இசைவு"
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr "உள்வரும் வெப்ஊக் போட்களுக்கு இந்த பநிஇ கிடைக்கவில்லை."
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr "கணக்கு இந்த துணை டொமைனுடன் தொடர்புடையது அல்ல"
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr "இந்த இறுதிப்புள்ளி போட் கோரிக்கைகளை ஏற்காது."
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr "சேவையக நிர்வாகியாக இருக்க வேண்டும்"
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr "இந்த இறுதிப்புள்ளிக்கு HTTP அடிப்படை ஏற்பு தேவைப்படுகிறது."
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr "அடிப்படை அங்கீகாரத்திற்கான தவறான அங்கீகார தலைப்பு"
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr "அடிப்படை அங்கீகாரத்திற்கான அங்கீகார தலைப்பு இல்லை"
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr "வெப்ஊக் போட்கள் வெப்ஊக்குகளை மட்டுமே அணுக முடியும்"
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr "கடவுச்சொல்"
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
@@ -5125,51 +4559,50 @@ msgstr ""
 "உங்கள் கணக்கு {username} செயலிழக்கப்பட்டது. அதை மீண்டும் செயல்படுத்த உங்கள் நிறுவன "
 "நிர்வாகியை தொடர்பு கொள்ளவும்."
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr "கடவுச்சொல் மிகவும் பலவீனமாக உள்ளது."
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr "துணை டொமைன் 3 அல்லது அதற்கு மேற்பட்ட நீளம் இருக்க வேண்டும்."
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr "துணை டொமைன் ஒரு '-' உடன் தொடங்கவோ முடிவடையவோ முடியாது."
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr "சப் டொமைனில் சிறிய எழுத்துக்கள், எண்கள் மற்றும் '-எச் மட்டுமே இருக்க முடியும்."
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr "துணை டொமைன் ஏற்கனவே பயன்பாட்டில் உள்ளது. வேறு ஒன்றைத் தேர்வுசெய்க."
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr "துணை டொமைன் ஒதுக்கப்பட்டுள்ளது. வேறு ஒன்றைத் தேர்வுசெய்க."
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr "உங்கள் உண்மையான மின்னஞ்சல் முகவரியைப் பயன்படுத்தவும்."
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, fuzzy, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr "{மின்னஞ்சல் the ஐப் பயன்படுத்தி நீங்கள் சேர முயற்சிக்கும் அமைப்பு இல்லை."
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, fuzzy, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr "நிறுவன நிர்வாகியிடமிருந்து {மின்னஞ்சல் பெறுநர் க்கு அழைப்பைக் கோருங்கள்."
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
@@ -5178,11 +4611,11 @@ msgstr ""
 "உங்கள் மின்னஞ்சல் முகவரி, {email}, இந்த நிறுவனத்தில் கணக்குகளுக்கு பதிவு செய்ய "
 "அனுமதிக்கப்பட்ட களங்களில் ஒன்றில் இல்லை."
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr "இந்த நிறுவனத்தில் + கொண்ட மின்னஞ்சல் முகவரிகள் அனுமதிக்கப்படவில்லை."
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
@@ -5192,32 +4625,31 @@ msgstr ""
 "பயன்பாட்டில் உள்ளன. உங்களை அழைத்த நபரைத் தொடர்புகொண்டு, உரிமங்களின் எண்ணிக்கையை அதிகரிக்கச் "
 "சொல்லுங்கள், பின்னர் மீண்டும் முயற்சிக்கவும்."
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 msgid "Challenges are not enabled."
 msgstr ""
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "புதிய கடவுச்சொல்"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr "புதிய கடவுச்சொல் உறுதிப்படுத்தல்"
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "You're making too many attempts to sign in. Try again in {seconds} "
@@ -5229,7 +4661,7 @@ msgstr ""
 "உள்நுழைய நீங்கள் பல முயற்சிகளை மேற்கொள்கிறீர்கள். மீண்டும் {seconds} வினாடிகளில் "
 "முயற்சிக்கவும் அல்லது உதவிக்கு உங்கள் நிறுவன நிர்வாகியை தொடர்பு கொள்ளவும்."
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
@@ -5237,85 +4669,83 @@ msgstr ""
 "உங்கள் கடவுச்சொல் மிகவும் பலவீனமாக இருப்பதால் முடக்கப்பட்டுள்ளது. புதிய ஒன்றை உருவாக்க "
 "உங்கள் கடவுச்சொல்லை மீட்டமைக்கவும்."
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr "கிள்ளாக்கு"
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 "உதவிக்குறிப்பு: அவற்றுக்கிடையே காற்புள்ளிகளுடன் பல மின்னஞ்சல் முகவரிகளை உள்ளிடலாம்."
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr "அதிகபட்சம் 10 மின்னஞ்சல்களை உள்ளிடவும்."
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr "அந்த சூலிப் அமைப்பை எங்களால் கண்டுபிடிக்க முடியவில்லை."
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr ""
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr "தலைப்பு இல்லை"
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr "பல சேனல்களுக்கு அனுப்ப முடியாது"
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr "சேனல் இல்லை"
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr "செய்தியில் பெறுநர்கள் இருக்க வேண்டும்"
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr "தவறான செய்தி வகை"
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr "தவறான இணைப்பு"
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr "இணைப்பை நீக்கும்போது பிழை ஏற்பட்டது. தயவுசெய்து பின்னர் மீண்டும் முயற்சிக்கவும்."
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr "செய்தியில் பெறுநர்கள் இருக்க வேண்டும்!"
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name can't be empty."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 msgid "Invalid channel folder ID"
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 msgid "Configure owner account email address."
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5324,72 +4754,72 @@ msgid ""
 "organization]({convert_demo}).\n"
 msgstr ""
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a date"
 msgid "{var_name} is not Base64 encoded"
 msgstr "{var_name} என்பது ஒரு தேதி அல்ல"
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 #, fuzzy
 #| msgid "Invalid emoji code."
 msgid "Invalid `device_id`"
 msgstr "தவறான ஈமோசி குறியீடு."
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr "{service_name} டைசச்ட்"
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr "டொமைன் காலியாக இருக்க முடியாது."
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr "டொமைன் குறைந்தது ஒரு புள்ளியைக் கொண்டிருக்க வேண்டும் (.)"
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr "டொமைன் மிக நீளமானது"
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr "டொமைன் ஒரு புள்ளியுடன் (.) தொடங்கவோ முடிக்கவோ முடியாது"
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr "தொடர்ச்சியாக '.' அனுமதிக்கப்படவில்லை."
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr "துணை டொமைன்கள் ஒரு '-' உடன் தொடங்கவோ முடிக்கவோ முடியாது."
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr "டொமைன் கடிதங்கள், எண்கள் மட்டுமே இருக்க முடியும். ' மற்றும் '-'ச்."
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr "நேர முத்திரை எதிர்மறையாக இருக்கக்கூடாது."
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr "தலைப்பில் சுழிய பைட்டுகள் இருக்கக்கூடாது"
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr "சேனல் செய்திகளுக்கு சரியாக 1 சேனல் ஐடியைக் குறிப்பிட வேண்டும்"
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr "பயனர் வரைவுகளை ஒத்திசைப்பதை முடக்கியுள்ளார்."
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr "வரைவு இல்லை"
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, fuzzy, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5400,86 +4830,86 @@ msgstr ""
 "அனுப்புவதில் பிழை பதில்: \n"
 "{channel_name}"
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr "எந்த விசயமும் இல்லாமல் மின்னஞ்சல்"
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr "ச்பாய்லர் உள்ளடக்கத்தைக் காண சூலிப் திறக்கவும்"
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr ""
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr "தவறான முகவரி."
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr "உங்கள் களத்திற்கு வெளியே."
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr "+ கொண்ட மின்னஞ்சல் முகவரிகள் அனுமதிக்கப்படவில்லை."
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr "கணினி போட்களுக்கு ஒதுக்கப்பட்டுள்ளது."
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr "{email} ஏற்கனவே ஒரு கணக்கு உள்ளது"
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr "ஏற்கனவே ஒரு கணக்கு உள்ளது."
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr "கணக்கு செயலிழக்கப்பட்டது."
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr "Emoji '{emoji_name}' இல்லை"
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr "தவறான தனிப்பயன் ஈமோசி."
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr "தவறான தனிப்பயன் ஈமோசி பெயர்."
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr "இந்த தனிப்பயன் ஈமோசி செயலிழக்கப்பட்டது."
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr "தவறான ஈமோசி குறியீடு."
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr "தவறான ஈமோசி பெயர்."
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr "தவறான ஈமோசி வகை."
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr "ஒரு நிறுவன நிர்வாகி அல்லது ஈமோசி எழுத்தாளராக இருக்க வேண்டும்"
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr "ஈமோசி பெயர்கள் ஒரு கடிதம் அல்லது இலக்கத்துடன் முடிவடைய வேண்டும்."
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
@@ -5487,119 +4917,118 @@ msgstr ""
 "ஈமோசி பெயர்களில் சிறிய ஆங்கில எழுத்துக்கள், இலக்கங்கள், இடங்கள், கோடுகள் மற்றும் "
 "அடிக்கோடிட்டுக் காட்டுதல் மட்டுமே இருக்க வேண்டும்."
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr "ஈமோசி பெயர் காணவில்லை"
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr "நிகழ்வு வரிசையை ஒதுக்க முடியவில்லை"
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr "உள்நுழையவில்லை: பநிஇ ஏற்பு அல்லது பயனர் அமர்வு தேவை"
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, fuzzy, python-brace-format
 #| msgid "Channel named {channel_name} already exists"
 msgid "Channel '{channel_name}' already exists"
 msgstr "சேனல் {channel_name} ஏற்கனவே உள்ளது"
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr "சேனல் '{stream}' இல்லை"
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr "அடையாளம் '{stream_id}' உடன் சேனல் இல்லை"
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr "ஆதரிக்கப்படாத அளவுரு சேர்க்கை: {parameters}"
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr "பயனர்"
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr "ஒரே {entity} ஐ செயலிழக்க முடியாது."
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr "தவறான மார்க் பேரூர் அறிக்கையை உள்ளடக்கியது: {include_statement}"
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr "தவறாக சாதொபொகு"
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr "ஒரு நிறுவன நிர்வாகியாக இருக்க வேண்டும்"
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr "ஒரு நிறுவன உரிமையாளராக இருக்க வேண்டும்"
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Must be an organization owner"
 msgid "Must be a bot user"
 msgstr "ஒரு நிறுவன உரிமையாளராக இருக்க வேண்டும்"
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr "உங்கள் பயனர்பெயர் அல்லது கடவுச்சொல் தவறானது"
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr "இந்த அமைப்பு செயலிழக்கப்பட்டது"
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr "உங்கள் சேவையகத்திற்கான மொபைல் புச் அறிவிப்பு பணி பதிவு செயலிழக்கப்பட்டது"
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr "இந்த நிறுவனத்தில் கடவுச்சொல் ஏற்பு முடக்கப்பட்டுள்ளது"
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr "உங்கள் கடவுச்சொல் முடக்கப்பட்டுள்ளது மற்றும் மீட்டமைக்கப்பட வேண்டும்"
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr "தவறான பநிஇ விசை"
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr "தவறாக பநிஇ விசை"
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
@@ -5608,56 +5037,55 @@ msgstr ""
 "'{event_type}' நிகழ்வு தற்போது {webhook_name} webhook ஆல் ஆதரிக்கப்படவில்லை; "
 "புறக்கணித்தல்"
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr "கோரிக்கையை பாகுபடுத்த முடியவில்லை: {webhook_name} இந்த நிகழ்வை உருவாக்கியதா?"
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr "தலைப்பு"
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr "தவறான சப்டொமைன்"
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr "நேரடி செய்தி உரையாடல்களைத் தொடங்க உங்களுக்கு இசைவு இல்லை."
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr "இந்த நிறுவனத்தில் நேரடி செய்திகள் முடக்கப்பட்டுள்ளன."
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr "இந்த உரையாடலில் அங்கீகரிக்கக்கூடிய எந்தவொரு பயனரும் இல்லை."
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr "அணுகல் மறுக்கப்பட்டது"
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, fuzzy, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
@@ -5666,15 +5094,15 @@ msgstr ""
 "இந்த தலைப்பில் மிக அண்மைக் கால செய்திகளை {total_messages_allowed_to_move}/{மொத்த "
 "செய்திகளை நகர்த்த உங்களுக்கு மட்டுமே இசைவு உள்ளது."
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr "எதிர்வினை ஏற்கனவே உள்ளது."
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr "எதிர்வினை இல்லை."
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
@@ -5682,361 +5110,361 @@ msgstr ""
 "உங்கள் அமைப்பு வேறு சூலிப் சேவையகத்தில் பதிவு செய்யப்பட்டுள்ளது. இந்த சிக்கலைத் தீர்ப்பதற்கான "
 "உதவிக்கு சூலிப் ஆதரவைத் தொடர்பு கொள்ளவும்."
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr ""
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr "இந்த சேனலில் சேனல் வைல்டு அட்டை குறிப்புகளைப் பயன்படுத்த உங்களுக்கு இசைவு இல்லை."
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 "இந்த தலைப்பில் வைல்டு அட்டை குறிப்பிடும் தலைப்பைப் பயன்படுத்த உங்களுக்கு இசைவு இல்லை."
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr ""
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr "'{setting_name}' ஒரு கணினி பயனர் குழுவாக இருக்க வேண்டும்."
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr "பயன்பாட்டில் உள்ள பயனர் குழுவை செயலிழக்க முடியாது."
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr "இந்த சேனலை நிர்வகிக்க உங்களுக்கு இசைவு இல்லை."
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr "இயல்புநிலை சேனல்களை மாற்ற உங்களுக்கு இசைவு இல்லை."
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr "மின்னஞ்சல் ஏற்கனவே பயன்பாட்டில் உள்ளது."
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr "திட்டமிடப்பட்ட விநியோக நேரம் எதிர்காலத்தில் இருக்க வேண்டும்."
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Already has an account."
 msgid "Atlassian account ID"
 msgstr "ஏற்கனவே ஒரு கணக்கு உள்ளது."
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Behance username"
 msgstr "மோசமான பெயர் அல்லது பயனர்பெயர்"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Bitbucket username"
 msgstr "பயனர்பெயர்"
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Codeberg username"
 msgstr "ட்விட்டர் பயனர்பெயர்"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Dribbble username"
 msgstr "பயனர்பெயர்"
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Facebook username"
 msgstr "மோசமான பெயர் அல்லது பயனர்பெயர்"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr "பயனர்பெயர்"
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "GitLab username"
 msgstr "பயனர்பெயர்"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Instagram username"
 msgstr "ட்விட்டர் பயனர்பெயர்"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Mastodon"
 msgid "Mastodon profile"
 msgstr "மாச்டோடன்"
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Medium username"
 msgstr "பயனர்பெயர்"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Pinterest username"
 msgstr "ட்விட்டர் பயனர்பெயர்"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Reddit username"
 msgstr "பயனர்பெயர்"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Snapchat username"
 msgstr "பயனர்பெயர்"
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Threads username"
 msgstr "ட்விட்டர் பயனர்பெயர்"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "TikTok username"
 msgstr "ட்விட்டர் பயனர்பெயர்"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Twitch username"
 msgstr "ட்விட்டர் பயனர்பெயர்"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "பயனர்பெயர்"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr "தவறான வெளிப்புற கணக்கு வகை"
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr "ஒருங்கிணைப்பு கட்டமைப்புகள்"
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 #, fuzzy
 #| msgid "Video call ended"
 msgid "Video calling"
 msgstr "வீடியோ அழைப்பு முடிந்தது"
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr "தொடர்ச்சியான ஒருங்கிணைப்பு"
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr "வாடிக்கையாளர் உதவி"
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr "வரிசைப்படுத்தல்"
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr "பொழுதுபோக்கு"
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr "தொடர்பு"
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr "பொருள்"
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr "மனித வளங்கள்"
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr "சந்தைப்படுத்தல்"
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr "மற்றவை"
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr "கண்காணிப்பு"
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr "திட்ட மேலாண்மை"
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr "உற்பத்தித்திறன்"
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr "பதிப்பு கட்டுப்பாடு"
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr "செய்தி காலியாக இருக்கக்கூடாது"
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr "செய்தியில் சுழிய பைட்டுகள் இருக்கக்கூடாது"
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr "பயனர் குழு '{user_group_name}' ஐக் குறிப்பிட உங்களுக்கு இசைவு இல்லை."
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 msgid "{fullname} moderation"
 msgstr "{full_name you நீங்கள் குறிப்பிட்டுள்ளார்:"
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr "தவறான குறுகிய ஆபரேட்டர்: {desc}"
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr "தவறான குறுகிய ஆபரேட்டர் சேர்க்கை: {desc}"
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr "ஆபரேட்டர்களுடன் 'நகல்."
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr ""
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr "'நங்கூரம்' வாதத்தைக் காணவில்லை."
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 #, fuzzy
 #| msgid "Missing 'anchor' argument."
 msgid "Missing 'anchor_date' argument."
 msgstr "'நங்கூரம்' வாதத்தைக் காணவில்லை."
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr "தவறான நங்கூரம்"
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr "ஆபரேட்டர் {operator} ஆதரிக்கப்படவில்லை."
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr "Operand {operand} ஆதரிக்கப்படவில்லை."
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 msgid "Navigation view does not exist."
 msgstr ""
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6047,7 +5475,7 @@ msgstr ""
 "மேலும் அறிய, எங்கள் [ஒரு வகுப்பு வழிகாட்டிக்கு சூலிப் பயன்படுத்துதல்]"
 "({getting_started_url}) ஐப் பாருங்கள்!\n"
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6057,7 +5485,7 @@ msgstr ""
 "\n"
 "மேலும் அறிய, எங்கள் [தொடங்குதல் வழிகாட்டி]({getting_started_url}) ஐப் பாருங்கள்!\n"
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6068,7 +5496,7 @@ msgstr ""
 "[ஒரு வகுப்பிற்கு சூலிப்பை அமைப்பதற்கான வழிகாட்டியும் எங்களிடம் உள்ளது]"
 "({organization_setup_url}).\n"
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6079,7 +5507,7 @@ msgstr ""
 "[உங்கள் நிறுவனத்தை சூலிப்பிற்கு நகர்த்துவதற்கான வழிகாட்டியும் எங்களிடம் உள்ளது]"
 "({organization_setup_url}).\n"
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6089,7 +5517,7 @@ msgid ""
 "a permanent organization]({convert_demo_organization_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
@@ -6099,7 +5527,7 @@ msgstr ""
 "தொடங்குவதற்கு உங்களுக்கு உதவ சில உரையாடல்களை நான் உதைத்தேன். நீங்கள் காணலாம் \n"
 "அவை உங்கள் [இன்பாக்சில்](/#inbox).\n"
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6110,7 +5538,7 @@ msgstr ""
 "விரைவான பயன்பாட்டு கண்ணோட்டத்திற்காக நீங்கள் எப்போதும் [வரவேற்பு சூலிப் வீடியோ]"
 "({navigation_tour_video_url}) க்கு வரலாம்.\n"
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, fuzzy, python-brace-format
 msgid ""
 "\n"
@@ -6134,7 +5562,7 @@ msgstr ""
 "{navigation_tour_video_text}\n"
 "\n"
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
@@ -6144,7 +5572,7 @@ msgstr ""
 "நீங்கள் [பதிவிறக்கம் மொபைல் மற்றும் டெச்க்டாப் பயன்பாடுகள்](/apps/) செய்யலாம். \n"
 "உலாவியில் சூலிப் நன்றாக வேலை செய்கிறார்.\n"
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 #, fuzzy
 msgid ""
 "\n"
@@ -6157,7 +5585,7 @@ msgstr ""
 "(#settings/profile) செல்லவும்\n"
 "உங்கள் [சுயவிவரத் தகவலை](/help/edit-your-profile) திருத்தவும்.\n"
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -6175,7 +5603,7 @@ msgstr ""
 "தனிப்பயனாக்கவும்\n"
 "உங்கள் [விருப்பங்களில்](#settings/preferences) பட்டறிவு.\n"
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, fuzzy, python-brace-format
 msgid ""
 "\n"
@@ -6192,7 +5620,7 @@ msgstr ""
 "\n"
 ".\n"
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -6222,7 +5650,7 @@ msgstr ""
 "[சமீபத்திய உரையாடல்கள்](#recent) தலைப்புகளின் பட்டியலைப் பாருங்கள் \n"
 "விவாதிக்கப்பட்டது.\n"
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -6237,7 +5665,7 @@ msgstr ""
 "\n"
 "[ஏமாற்றுத் தாள்](#keyboard-shortcuts) காண `?` எந்த நேரத்தையும் அழுத்தவும்.\n"
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -6257,7 +5685,7 @@ msgstr ""
 "உலகளாவிய\n"
 "நேரங்கள், மேலும் பல.\n"
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "\n"
@@ -6278,7 +5706,7 @@ msgstr ""
 "எங்கள் [தொடங்குதல் வழிகாட்டியைப் பெறுதல்](/help/getting-started-with-zulip),\n"
 "அல்லது மேலும் அறிய [உதவி மையம்](/help/) உலாவுக!\n"
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6289,7 +5717,7 @@ msgstr ""
 "நீங்கள் விரும்பும் அளவுக்கு என்னுடன் அரட்டையடிக்கலாம்! பெறுநர் \n"
 "உதவியைப் பெறுங்கள், பின்வரும் செய்திகளில் ஒன்றை முயற்சிக்கவும்: {bot_commands}\n"
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6301,7 +5729,7 @@ msgid ""
 "({move_content_another_channel_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
@@ -6309,7 +5737,7 @@ msgstr ""
 "\n"
 ": Point_Right: இந்த செய்தியை மற்றொரு தலைப்புக்கு நகர்த்த முயற்சிக்கவும்.\n"
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6331,12 +5759,11 @@ msgstr ""
 "#** {zulip_discussion_channel_name} ** சேனல், இடது பக்கப்பட்டியில் நீங்கள் காணலாம் \n"
 "மற்றும் மேலே.\n"
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr "சுலிப்பு"
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -6348,7 +5775,7 @@ msgstr ""
 "படிக்கலாம், \n"
 "வேறு எத்தனை உரையாடல்கள் நடந்து கொண்டாலும் சரி.\n"
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
@@ -6359,7 +5786,7 @@ msgstr ""
 "பாருங்கள்\n"
 "படிக்காத செய்திகளுடன் உரையாடல்கள்.\n"
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -6371,7 +5798,7 @@ msgstr ""
 "செய்க \n"
 "அதன் பெயருக்கு அடுத்த `+` பொத்தான்.\n"
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -6383,7 +5810,7 @@ msgstr ""
 "“ஏய், \n"
 "நாம் அரட்டை அடிக்கலாமா…? ”\n"
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
@@ -6391,7 +5818,7 @@ msgstr ""
 "\n"
 ": Point_Right: இந்த சேனலில் புதிய உரையாடலைத் தொடங்க முயற்சிக்கவும்.\n"
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6402,7 +5829,7 @@ msgstr ""
 ":point_right:  Use this topic பெறுநர் try out [Zulip's messaging features]"
 "({format_message_help_url}).\n"
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6437,7 +5864,7 @@ msgstr ""
 "\n"
 "`` `\n"
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
@@ -6447,7 +5874,7 @@ msgstr ""
 "இந்த ** வாழ்த்துக்கள் ** தலைப்பு “ஆய்” என்று சொல்ல ஒரு சிறந்த இடம்: அலை: உங்கள் "
 "அணியினருக்கு.\n"
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
@@ -6457,1233 +5884,1212 @@ msgstr ""
 ": Point_Right: அதே உரையாடலில் புதிய செய்தியைத் தொடங்க இந்த செய்தியைக் சொடுக்கு "
 "செய்க.\n"
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr "தனிப்பட்ட செய்தி"
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr "சோதனைகள்"
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr "உரையாடலைத் தொடங்கவும்"
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr "அமைப்புகள்"
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr "பதிலில் தவறான சாதொபொகு"
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr "வெற்று அல்லது தவறான நீள கிள்ளாக்கு"
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr "தவறான APNS கிள்ளாக்கு"
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr ""
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr "கிள்ளாக்கு இல்லை"
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr "{full_name} குறிப்பிடப்பட்டுள்ளது @{user_group_name}:"
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, fuzzy, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr "{full_name you நீங்கள் குறிப்பிட்டுள்ளார்:"
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr "{full_name} அனைவரையும் குறிப்பிட்டுள்ளார்:"
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "புதிய செய்தி"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr "இது {realm_name} ({realm_url}) இலிருந்து சோதனை அறிவிப்பாகும்."
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr "சாதனம் அங்கீகரிக்கப்படவில்லை"
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr "சாதனம் புச் பவுன்சரால் அங்கீகரிக்கப்படவில்லை"
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 #, fuzzy
 #| msgid "Server doesn't use the push notification service"
 msgid "Network error while connecting to Zulip push notification service."
 msgstr "சேவையகம் புச் அறிவிப்பு சேவையைப் பயன்படுத்தாது"
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 #, fuzzy
 #| msgid "Server doesn't use the push notification service"
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr "சேவையகம் புச் அறிவிப்பு சேவையைப் பயன்படுத்தாது"
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 #, fuzzy
 #| msgid "Invalid API key"
 msgid "Invalid `push_key`"
 msgstr "தவறான பநிஇ விசை"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr "இந்த வினவலுக்கு பயனர் ஏற்பு பெறவில்லை"
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr "'{email}' இனி சூலிப்பைப் பயன்படுத்துவதில்லை."
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr "உங்கள் நிறுவனத்திற்கு வெளியே நேரடி செய்திகளை அனுப்ப முடியாது."
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "Channel name too long (limit: {max_length} characters)."
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr "சேனல் பெயர் மிக நீளமானது (வரம்பு: {max_length} எழுத்துக்கள்)."
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 msgid "Reminder does not exist"
 msgstr ""
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr "அறிவிப்புகளை அழுத்துங்கள் பவுன்சர் பிழை: {error}"
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr "'{var_name1}' மற்றும் '{var_name2}' வாதங்களுக்கு இடையில் தீர்மானிக்க முடியாது"
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr "'{var_name}' வாதத்தைக் காணவில்லை"
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr "'{var_name}' க்கான மோசமான மதிப்பு: {bad_value}"
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr "திட்டமிடப்பட்ட செய்தி இல்லை"
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr "{service_name} கணக்கு பாதுகாப்பு"
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr "இயல்புநிலை சேனல் தனிப்பட்டதாக இருக்க முடியாது."
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr "வலை பொது சேனல்கள் இயக்கப்படவில்லை."
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr "இந்த சேனலில் இடுகையிட உங்களுக்கு இசைவு இல்லை."
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr "சேனலுக்கு '{channel_name}' க்கு அனுப்ப ஏற்பு இல்லை"
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 #, fuzzy
 #| msgid "You do not have permission to post in this channel."
 msgid "You do not have permission to create new topics in this channel."
 msgstr "இந்த சேனலில் இடுகையிட உங்களுக்கு இசைவு இல்லை."
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr ""
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr "சேனல் (கள்) ({channel_names}) இல்லை"
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr "அடையாளம் '{group_id}' உடன் இயல்புநிலை சேனல் குழு இல்லை."
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr "சேனல் பெயர் காலியாக இருக்க முடியாது."
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr "சேனல் பெயர் மிக நீளமானது (வரம்பு: {max_length} எழுத்துக்கள்)."
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr ""
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr "இந்த சேனலுக்கு சந்தாதாரர் தரவு கிடைக்கவில்லை"
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr "தனியார் சேனலுக்கான சந்தாதாரர்களை மீட்டெடுக்க முடியவில்லை"
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr "படத்தை டிகோட் செய்ய முடியவில்லை; படக் கோப்பை பதிவேற்றினீர்களா?"
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr "பட அளவு வரம்பை மீறுகிறது."
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr "படம் சிதைந்து அல்லது துண்டிக்கப்பட்டுள்ளது"
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, fuzzy, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr "{var_name a ஒரு பூலியன் அல்ல"
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} does not have the expected format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr "{var_name} என்பது ஒரு தேதி அல்ல"
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr "{var_name} என்பது ஒரு கட்டளை அல்ல"
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr "{Var_name at இல் \"{argument}\" எதிர்பாராதது"
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, fuzzy, python-brace-format
 msgid "{var_name} is not a float"
 msgstr "{var_name a ஒரு மிதவை அல்ல"
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr "{var_name} மிகவும் சிறியது"
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, fuzzy, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr "{var_name a ஒரு முழு எண் அல்ல"
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr "{var_name} செல்லுபடியாகும் சாதொபொகு அல்ல"
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr "{var_name} மிகப் பெரியது"
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr "{var_name} என்பது ஒரு பட்டியல் அல்ல"
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr "{var_name} மிக நீளமானது (வரம்பு: {max_length} எழுத்துக்கள்)"
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr "{var_name} மிகவும் குறுகியது."
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr "{var_name} என்பது ஒரு சரம் அல்ல"
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr "{var_name} தவறான வடிவத்தைக் கொண்டுள்ளது"
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr "{var_name} என்பது நீளம் அல்ல {length}"
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr "{var_name} மிக நீளமானது (வரம்பு: {max_length} எழுத்துக்கள்)"
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr "{var_name} மிக நீளமானது (வரம்பு: {max_length} எழுத்துக்கள்)"
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr "{var_name} காலியாக இருக்க முடியாது"
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr "{var_name} புலம் காணவில்லை: {msg}"
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr "தவறாக பேலோட்"
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr "சாத்தியமான மதிப்புகளின் பட்டியலில் இல்லை"
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr "ஒரு முகவரி அல்ல"
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr "அங்கீகரிக்கப்பட்ட நேர மண்டலம் அல்ல"
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr "{var_name} என்பது செல்லுபடியாகும் ஃச் வண்ணக் குறியீடு அல்ல"
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr "பதிவேற்றம் உங்கள் நிறுவனத்தின் பதிவேற்ற ஒதுக்கீட்டை விட அதிகமாக இருக்கும்."
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr "பட அளவு வரம்பை மீறுகிறது"
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr "பயனர் குழு செயலிழக்கப்படுகிறது."
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr "தவறான பயனர் குழு"
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid user group"
 msgid "Invalid user group ID: {user_group_id}"
 msgstr "தவறான பயனர் குழு"
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr ""
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr "'{setting_name}' அமைப்பை 'பங்கு: இணையம்' குழுவாக அமைக்க முடியாது."
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr "'{setting_name}' அமைப்பை 'பாத்திரம்: யாரும்' குழு என அமைக்க முடியாது."
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr "'{setting_name}' அமைப்பை 'பங்கு: எல்லோரும்' குழு என அமைக்க முடியாது."
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr "'{setting_name}' அமைப்பை '{group_name}' குழுவாக அமைக்க முடியாது."
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr "பயனர் குழு பெயர் காலியாக இருக்க முடியாது!"
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr "பயனர் குழு பெயர் {max_length} எழுத்துக்களை விட அதிகமாக இருக்கக்கூடாது."
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr "பயனர் குழு பெயர் '{prefix}' உடன் தொடங்க முடியாது."
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr "வாடிக்கையாளர் எந்த புதிய மதிப்புகளையும் கடக்கவில்லை."
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr "வாடிக்கையாளர் EMOJI_NAME ஐ கடந்து செல்ல வேண்டும்."
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr "பெயர் மிக நீண்டது!"
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 #, fuzzy
 #| msgid "Message must not be empty"
 msgid "Name must not be empty!"
 msgstr "செய்தி காலியாக இருக்கக்கூடாது"
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr "பெயரில் தவறான எழுத்துக்கள்!"
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr "தவறான வடிவம்!"
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr ""
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr "பெயர் ஏற்கனவே பயன்பாட்டில் உள்ளது."
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr "மோசமான பெயர் அல்லது பயனர்பெயர்"
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr ""
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr "உள்ளமைவு அளவுருக்களைக் காணவில்லை: {keys}"
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr ""
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr "தவறான உள்ளமைவு தரவு!"
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr "தவறான போட் வகை"
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr "தவறான இடைமுக வகை"
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr ""
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr "அத்தகைய போட் இல்லை"
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr "அத்தகைய பயனர் இல்லை"
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr "பயனர் செயலிழக்கப்படுகிறார்"
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr "{item} காலியாக இருக்க முடியாது."
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, fuzzy, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr "{var_name தவறான நீளம் {var_name}; {இலக்கு_ நீளமாக இருக்க வேண்டும்"
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a string"
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr "{var_name} என்பது ஒரு சரம் அல்ல"
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr "{container} சரியாக {length} உருப்படிகளைக் கொண்டிருக்க வேண்டும்"
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, fuzzy, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr "{key_name} key {var_name இருந்து இலிருந்து காணவில்லை"
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr "எதிர்பாராத வாதங்கள்: {keys}"
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, fuzzy, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr "{var_name a ஒரு அனுமதிக்கப்பட்ட_ வகை அல்ல"
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr "{variable}! = {expected_value} ({value} தவறு)"
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr "{var_name} என்பது முகவரி அல்ல"
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr "முகவரி வடிவத்தில் '%(username)s' இருக்க வேண்டும்."
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr "'{item}' காலியாக இருக்க முடியாது."
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr "புலத்தில் நகல் தேர்வுகள் இருக்கக்கூடாது."
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr "'{value}' '{field_name}' க்கு சரியான தேர்வு அல்ல."
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr "{var_name} என்பது ஒரு சரம் அல்லது முழு எண் பட்டியல் அல்ல"
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, fuzzy, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr "{var_name a ஒரு சரம் அல்லது முழு எண் அல்ல"
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr "{var_name} நீளம் இல்லை"
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr "{var_name} காணவில்லை"
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr "HTTP நிகழ்வு தலைப்பு '{header}'"
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr "ZCommand இல் ஒரு முன்னணி குறைப்பு இருக்க வேண்டும்."
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr "அத்தகைய கட்டளை இல்லை: {command}"
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 "`zulip_update_announcements_stream` எதிர்பாராத விதமாக செயலிழக்கப்படுகிறது."
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr "CSRF பிழை: {reason}"
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr "தலைகீழ் பதிலாள் தவறான கட்டமைப்பு: {proxy_reason}"
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, fuzzy, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr "அடையாளம் {user_id with உடன் பயனர் செயலிழக்கப்படுகிறார்"
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, fuzzy, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr "அடையாளம் {user_id with உடன் பயனர் ஒரு போட்"
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr "திகதி"
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr "வெளிப்புற கணக்கு"
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr "உச்சரிப்புகள்"
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr "யாரும்"
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr "முழு உறுப்பினர்கள்"
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "உறுப்பினர்கள்"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr "இணையத்தில் அனைவரும்"
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Invalid characters in emoji name"
 msgid "Invalid auto-conversion field: empty field name."
 msgstr "ஈமோசி பெயரில் தவறான எழுத்துக்கள்"
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr "முகவரி வார்ப்புருவில் குழு %(பெயர்) r இணைப்பு வடிவத்தில் இல்லை."
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr "மோசமான வழக்கமான வெளிப்பாடு: {regex}"
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr "அறியப்படாத வழக்கமான வெளிப்பாடு பிழை"
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 #, fuzzy
 msgid "Example input does not match the linkifier pattern."
 msgstr "முகவரி வார்ப்புருவில் குழு %(பெயர்) r இணைப்பு வடிவத்தில் இல்லை."
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr "முகவரி வார்ப்புருவில் குழு %(பெயர்) r இணைப்பு வடிவத்தில் இல்லை."
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr "குழு %(பெயர்) r இணைப்பு வடிவத்தில் முகவரி வார்ப்புருவில் இல்லை."
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 msgid ""
 "Group %(name)r in alternative URL template is not present in linkifier "
 "pattern."
 msgstr "முகவரி வார்ப்புருவில் குழு %(பெயர்) r இணைப்பு வடிவத்தில் இல்லை."
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 msgid ""
 "Group %(name)r in linkifier pattern is not present in alternative URL "
 "template."
 msgstr "குழு %(பெயர்) r இணைப்பு வடிவத்தில் முகவரி வார்ப்புருவில் இல்லை."
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr "யூனிகோட் ஈமோசி"
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "தனிப்பயன் ஈமோசி"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr "கூடுதல் ஈமோசி"
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr "ஈமோசி பெயரில் தவறான எழுத்துக்கள்"
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr "பிக்மென்ட் மொழியில் தவறான எழுத்துக்கள்"
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr "முகவரி வார்ப்புருவில் தேவையான மாறி \"குறியீடு\" ஐக் காணவில்லை"
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr "\"குறியீடு\" என்பது முகவரி வார்ப்புருவில் ஒரே மாறி இருக்க வேண்டும்"
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr "சாண்ட்பாக்ச்"
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr "பொது"
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr "சேனல் நிகழ்வுகள்"
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr "சூலிப் புதுப்பிப்புகள்"
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr "சூலிப் முகில் தரத்தில் கிடைக்கிறது. அணுகலை மேம்படுத்தவும்."
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr "சூலிப் முகில் பிளசில் கிடைக்கிறது. அணுகலை மேம்படுத்தவும்."
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr "GIFS மதிப்பிடப்பட்ட G (பொது பார்வையாளர்கள்) ஐ அனுமதிக்கவும்"
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr "GIFS மதிப்பிடப்பட்ட PG (பெற்றோர் வழிகாட்டுதல்) ஐ அனுமதிக்கவும்"
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 "GIFS மதிப்பிடப்பட்ட PG -13 ஐ அனுமதிக்கவும் (பெற்றோரின் வழிகாட்டுதல் - 13 க்கு கீழ்)"
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr "Gifs மதிப்பிடப்பட்ட R (தடைசெய்யப்பட்ட) அனுமதிக்கவும்"
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr "வலை வெளியீடு"
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "பொதுமக்கள்"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr "தனிப்பட்ட, பகிரப்பட்ட வரலாறு"
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr "தனியார், பாதுகாக்கப்பட்ட வரலாறு"
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr "நிர்வாகிகள், மதிப்பீட்டாளர்கள், உறுப்பினர்கள் மற்றும் விருந்தினர்கள்"
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr "நிர்வாகிகள், மதிப்பீட்டாளர்கள் மற்றும் உறுப்பினர்கள்"
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr "நிர்வாகிகள் மற்றும் மதிப்பீட்டாளர்கள்"
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr "நிர்வாகிகள் மட்டுமே"
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr "தெரியாத பயனர்"
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr ""
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr ""
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr "மதிப்பீட்டாளர்"
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "உறுப்பினர்"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "விருந்தினர்"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr "தெரியாத ஐபி முகவரி"
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr "அறியப்படாத இயக்க முறைமை"
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr "அறியப்படாத உலாவி"
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr "'Queue_id' வாதத்தைக் காணவில்லை"
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr "'Last_event_id' வாதத்தைக் காணவில்லை"
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, fuzzy, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr "{Event_id க்கு ஐ விட புதிய நிகழ்வு ஏற்கனவே கத்தரிக்கப்பட்டுள்ளது!"
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr "நிகழ்வு {event_id} இந்த வரிசையில் இல்லை"
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr "மோசமான நிகழ்வு வரிசை ஐடி: {queue_id}"
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 msgid "Failed to generate challenge"
 msgstr ""
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr ""
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr "சாதொபொகு வலை கிள்ளாக்கு கோரிக்கையில் இல்லை"
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr "மோசமான சாதொபொகு வலை கிள்ளாக்கு"
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr "சாதொபொகு வலை கிள்ளாக்கு உரிமைகோரல்களில் எந்த மின்னஞ்சலும் குறிப்பிடப்படவில்லை"
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr "துணை டொமைன் தேவை"
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr "கடவுச்சொல் தவறானது."
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr "கோரிக்கையிலிருந்து பயனர்-முகவர் தலைப்பு இல்லை"
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr "சிட்டை காலியாக இருக்க முடியாது."
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr "புலத்திற்கு குறைந்தது ஒரு தேர்வு இருக்க வேண்டும்."
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr "சுயவிவர சுருக்கத்தில் காட்சிக்கு புலம் வகை ஆதரிக்கப்படவில்லை."
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 #, fuzzy
 #| msgid "Field type not supported for display in profile summary."
 msgid "Field type not supported for use for user matching."
 msgstr "சுயவிவர சுருக்கத்தில் காட்சிக்கு புலம் வகை ஆதரிக்கப்படவில்லை."
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr "தவறான புல வகை."
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr "சுயவிவர சுருக்கத்தில் 2 தனிப்பயன் சுயவிவர புலங்களை மட்டுமே காட்ட முடியும்."
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr "அந்த லேபிளைக் கொண்ட ஒரு புலம் ஏற்கனவே உள்ளது."
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr "இயல்புநிலை தனிப்பயன் புலத்தை புதுப்பிக்க முடியாது."
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr "உற்பத்தியில் இறுதிப்புள்ளி கிடைக்கவில்லை."
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr "Devauthbackend இயக்கப்படவில்லை."
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr "அநாமதேய கோரிக்கைக்கு தவறான '{key}' அளவுரு"
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr "தரவுத்தளம் காலியாக உள்ளது"
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr "Postgresql ஐ வினவ முடியாது"
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr "முயலுடன் இணைக்க முடியாது"
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr "முயல் வினவலால் முடியாது"
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr "ரெடிசை வினவ முடியாது"
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr "மெம்காச் எழுத முடியாது"
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr "மெம்காச் வினவ முடியாது"
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr "அத்தகைய அழைப்பு இல்லை"
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 #, fuzzy
 #| msgid "Invitation has already been revoked"
 msgid "Invitation already used or deactivated."
 msgstr "அழைப்பிதழ் ஏற்கனவே ரத்து செய்யப்பட்டுள்ளது"
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr "அழைப்பிதழ் ஏற்கனவே ரத்து செய்யப்பட்டுள்ளது"
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr "தவறான சேனல் அடையாளம் {channel_id}. அழைப்புகள் எதுவும் அனுப்பப்படவில்லை."
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr "சேனல்களுக்கு மற்ற பயனர்களை குழுசேர உங்களுக்கு இசைவு இல்லை."
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr "நீங்கள் குறைந்தது ஒரு மின்னஞ்சல் முகவரியைக் குறிப்பிட வேண்டும்."
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
@@ -7691,100 +7097,98 @@ msgstr ""
 "அந்த முகவரிகளில் சில ஏற்கனவே சூலிப்பைப் பயன்படுத்துகின்றன, எனவே நாங்கள் அவர்களுக்கு "
 "அழைப்பை அனுப்பவில்லை. நாங்கள் அனைவருக்கும் அழைப்புகளை அனுப்பினோம்!"
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr "செய்தி திருத்து வரலாறு இந்த நிறுவனத்தில் முடக்கப்பட்டுள்ளது"
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr "இந்த செய்தியை நீக்க உங்களுக்கு இசைவு இல்லை"
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr "இந்த செய்தியை நீக்குவதற்கான கால காலநீடிப்பு கடந்துவிட்டது"
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr "செய்தி ஏற்கனவே நீக்கப்பட்டது"
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr "கோரப்பட்ட பல செய்திகள் (அதிகபட்சம் {max_messages})."
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr "நங்கூரத்தை வரம்பின் முடிவில் மட்டுமே விலக்க முடியும்"
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr "அத்தகைய தலைப்பு இல்லை '{topic}'"
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr ""
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 msgid "Message reporting is not enabled in this organization."
 msgstr ""
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr "அனுப்புநர் காணவில்லை"
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr "பெறுநர் பயனர் ஐடிகளுடன் அனுமதிக்கப்படவில்லை"
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr "தவறான பிரதிபலித்த செய்தி"
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr "இந்த சேவையகத்தில் AI நற்பொருத்தங்கள் இயக்கப்படவில்லை."
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr "AI வரவுகளுக்கு மாதாந்திர வரம்பை எட்டியது."
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr "சுருக்கமாக உரையாடலில் செய்திகள் இல்லை"
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr "சுயமாக முடக்க முடியாது"
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr "பயனர் ஏற்கனவே முடக்கியுள்ளார்"
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr "தலைப்பு"
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 msgid "Navigation view already exists."
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr "அறியப்படாத Onboarding_step: {onboarding_step}"
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7795,106 +7199,106 @@ msgstr ""
 "[Vervice zulip video]({navigation_tour_video_url}) ஐ பின்னர் பார்க்கும்படி "
 "கேட்டீர்கள். இது நல்ல நேரம்?\n"
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr "போட் பயனர்களுக்கு இருப்பு ஆதரிக்கப்படவில்லை."
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, fuzzy, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr "{User_id_or_email க்கு க்கான இருப்பு தரவு இல்லை"
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 #, fuzzy
 #| msgid "You do not have permission to change default channels."
 msgid "You do not have permission to manage plans and billing."
 msgstr "இயல்புநிலை சேனல்களை மாற்ற உங்களுக்கு இசைவு இல்லை."
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr "சேவையகம் புச் அறிவிப்பு சேவையைப் பயன்படுத்தாது"
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr "பிழை பவுன்சரால் திரும்பியது: {result}"
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr "சரிபார்ப்பு மறைபொருள் தயாரிக்கப்படவில்லை"
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr "பின்வரும் வாதங்களில் குறைந்தபட்சம் ஒன்று இருக்க வேண்டும்: EMOJI_NAME, EMOJI_CODE"
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr ""
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr ""
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr "குறைந்தது ஒரு அங்கீகார முறை இயக்கப்பட வேண்டும்."
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr "தவறான video_chat_provider {video_chat_provider}"
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr ""
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
@@ -7902,7 +7306,7 @@ msgstr ""
 "தரவு நீக்குதல் நேரம் எதிர்காலத்தில் அதிகபட்சம் {max_allowed_days} நாட்களில் இருக்க "
 "வேண்டும்."
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
@@ -7910,257 +7314,256 @@ msgstr ""
 "தரவு நீக்குதல் நேரம் எதிர்காலத்தில் குறைந்தபட்சம் {min_allowed_days} நாட்களாக இருக்க "
 "வேண்டும்."
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr ""
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr "டொமைன் {domain} ஏற்கனவே உங்கள் நிறுவனத்தின் ஒரு பகுதியாகும்."
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, fuzzy, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr "டொமைன் {டொமைன் க்கு க்கு நுழைவு எதுவும் கிடைக்கவில்லை."
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr "நீங்கள் சரியாக ஒரு கோப்பை பதிவேற்ற வேண்டும்."
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr "பதிவேற்றிய கோப்பு {max_size} mib இன் அனுமதிக்கப்பட்ட வரம்பை விட பெரியது"
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 #, fuzzy
 #| msgid "Disposable email addresses are not allowed in this organization"
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr "இந்த நிறுவனத்தில் செலவழிப்பு மின்னஞ்சல் முகவரிகள் அனுமதிக்கப்படவில்லை"
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr "விகித வரம்பை மீறியது."
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr "தவறான தரவு ஏற்றுமதி அடையாளம்"
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr "ஏற்றுமதி ஏற்கனவே நீக்கப்பட்டது"
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr "ஏற்றுமதி தோல்வியடைந்தது, நீக்க எதுவும் இல்லை"
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr "ஏற்றுமதி இன்னும் நடந்து கொண்டிருக்கிறது"
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr "நீங்கள் சரியாக ஒரு ஐகானைப் பதிவேற்ற வேண்டும்."
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr "இணைப்பு இல்லை."
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr "நீங்கள் சரியாக ஒரு லோகோவை பதிவேற்ற வேண்டும்."
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid characters in pygments language"
 msgid "Invalid character in language: {character}"
 msgstr "பிக்மென்ட் மொழியில் தவறான எழுத்துக்கள்"
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 msgid "Language '{language}' is not allowed."
 msgstr "{var_name a ஒரு அனுமதிக்கப்பட்ட_ வகை அல்ல"
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr ""
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr ""
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 msgid "Importing messages…"
 msgstr ""
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "Your full name"
 msgid "Your name"
 msgstr "முழு பெயர்"
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr "திட்டமிடப்பட்ட செய்தியின் வகையைப் புதுப்பிக்கும்போது பெறுநர் தேவை."
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr "திட்டமிடப்பட்ட செய்தி வகையை சேனலுக்கு புதுப்பிக்கும்போது தலைப்பு தேவை."
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr ""
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr ""
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr "தனியார் சேனல்களை இயல்புநிலையாக மாற்ற முடியாது."
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr "நீங்கள் \"புதிய_ விளக்கப்படம்\" அல்லது \"புதிய_ குழும_நேம்\" ஐ கடக்க வேண்டும்."
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr "\"OP\" க்கு தவறான மதிப்பு. \"சேர்\" அல்லது \"அகற்று\" ஒன்றைக் குறிப்பிடவும்."
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr ""
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr "சேனல் உள்ளடக்க அணுகல் தேவை."
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr "சேனலுக்கு ஏற்கனவே அந்த பெயர் உள்ளது."
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr "செய்ய எதுவும் இல்லை. குறைந்தபட்சம் \"சேர்\" அல்லது \"நீக்கு\" ஒன்றைக் குறிப்பிடவும்."
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr ""
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr "{user_full_name} பின்வரும் சேனல்களுக்கு உங்களை சந்தா செலுத்தியது:"
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr "சேனலை அணுக முடியவில்லை ({channel_name})."
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr "{user_name} பின்வரும் சேனல்களை உருவாக்கியது: {new_channels}."
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, fuzzy, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr "{user_name ஒரு புதிய சேனலை உருவாக்கியது {user_name}."
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr "புதிய சேனல்கள்"
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
 "**"
 msgstr ""
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, fuzzy, python-brace-format
 msgid "{property} is not a boolean"
 msgstr "{சொத்து a ஒரு பூலியன் அல்ல"
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr "அறியப்படாத சந்தா சொத்து: {property}"
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr ""
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr "சமர்ப்பிப்பதற்கு தவறான சாதொபொகு"
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
@@ -8169,7 +7572,7 @@ msgstr ""
 "உங்கள் நிறுவனத்தின் திட்டத்தால் அனுமதிக்கப்பட்ட அதிகபட்ச பதிவேற்ற அளவை ({max_size} mib) "
 "விட கோப்பு பெரியது."
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
@@ -8178,59 +7581,58 @@ msgstr ""
 "இந்த சேவையகத்தின் கட்டமைக்கப்பட்ட அதிகபட்ச பதிவேற்ற அளவை ({max_size} mib) விட கோப்பு "
 "பெரியது."
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr "சேனல் செய்திகளுக்கான தட்டச்சு அறிவிப்புகளை பயனர் முடக்கியுள்ளார்"
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr "'காணவில்லை' உரையாடல்"
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr "வெற்று 'to' பட்டியல்"
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr "நேரடி செய்திகளுக்கான தட்டச்சு அறிவிப்புகளை பயனர் முடக்கியுள்ளார்"
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr "<p> இந்த கோப்பு இல்லை அல்லது நீக்கப்பட்டது. </p>"
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr "<p> இந்த கோப்பைக் காண உங்களுக்கு ஏற்பு இல்லை. </p>"
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr "தவறான கிள்ளாக்கு"
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr "தவறான கோப்பு பெயர்"
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr "பதிவேற்ற ஒரு கோப்பை நீங்கள் குறிப்பிட வேண்டும்"
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr "நீங்கள் ஒரு நேரத்தில் ஒரு கோப்பை மட்டுமே பதிவேற்றலாம்"
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr "புதிய தரவு எதுவும் வழங்கப்படவில்லை"
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
@@ -8238,32 +7640,32 @@ msgstr ""
 "செய்ய எதுவும் இல்லை. \"சேர்\", \"நீக்கு\", \"add_subgroups\" அல்லது "
 "\"Delete_Subgroups\" ஆகியவற்றில் குறைந்தபட்சம் ஒன்றைக் குறிப்பிடவும்."
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr "{user_full_name} உங்களை குழுவில் சேர்த்தது {group_name}."
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr "{user_full_name} குழுவிலிருந்து உங்களை அகற்றியது {group_name}."
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr "பயனர் {user_id} ஏற்கனவே இந்த குழுவில் உறுப்பினராக உள்ளார்"
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr "இந்த பயனர் குழுவில் '{user_id}' எந்த உறுப்பினரும் இல்லை"
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr "பயனர் குழு {group_id} என்பது ஏற்கனவே இந்த குழுவின் துணைக்குழு ஆகும்."
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
@@ -8272,104 +7674,104 @@ msgstr ""
 "பயனர் குழு {user_group_id} என்பது ஏற்கனவே கடந்து வந்த துணைக்குழுக்களில் ஒன்றின் "
 "துணைக்குழுவாகும்."
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr "பயனர் குழு {group_id} இந்த குழுவின் துணைக்குழு அல்ல."
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr "இந்த அமைப்பில் அவதார் மாற்றங்கள் முடக்கப்பட்டுள்ளன."
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr "இந்த நிறுவனத்தில் மின்னஞ்சல் முகவரி மாற்றங்கள் முடக்கப்பட்டுள்ளன."
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr "தவறான இயல்புநிலை_ மொழி"
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr ""
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr "தவறான மின்னஞ்சல் தொகுத்தல் காலம்: {seconds} விநாடிகள்"
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr "உங்கள் சூலிப் கடவுச்சொல் LDAP இல் நிர்வகிக்கப்படுகிறது"
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr "தவறான கடவுச்சொல்!"
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, fuzzy, python-brace-format
 #| msgid "You're making too many attempts! Try again in {seconds} seconds."
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr ""
 "நீங்கள் பல முயற்சிகளை மேற்கொள்கிறீர்கள்! {seconds} விநாடிகளில் மீண்டும் முயற்சிக்கவும்."
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr "புதிய கடவுச்சொல் மிகவும் பலவீனமாக உள்ளது!"
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr "நீங்கள் சரியாக ஒரு அவதாரத்தை பதிவேற்ற வேண்டும்."
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr "தலைப்பு"
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr "ஒரே நிறுவன உரிமையாளரை செயலிழக்க முடியாது"
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Nobody in this Zulip organization will be able to see this email address."
 msgid "User is not allowed to delete other user's messages."
 msgstr "இந்தச் சூலிப் அமைப்பில் யாரும் இந்த மின்னஞ்சல் முகவரியைக் காண முடியாது."
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr "பயனர் மின்னஞ்சல்களை மாற்ற பயனர் ஏற்பு இல்லை"
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr "உரிமையாளர் அனுமதியை ஒரே நிறுவன உரிமையாளரிடமிருந்து அகற்ற முடியாது."
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr ""
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr "புதிய மின்னஞ்சல் மதிப்பு பிழை: {message}"
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
@@ -8381,25 +7783,25 @@ msgstr ""
 "போலி_எமெயில்_ டொமைன் சரியாக உள்ளமைக்கப்படும் வரை போட்களை உருவாக்க முடியாது. \n"
 "உங்கள் சேவையக நிர்வாகியை தொடர்பு கொள்ளவும்."
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 #, fuzzy
 #| msgid "Email is already in use."
 msgid "Email address already in use"
 msgstr "மின்னஞ்சல் ஏற்கனவே பயன்பாட்டில் உள்ளது."
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr "உரிமையாளரை மாற்றத் தவறிவிட்டது, அத்தகைய பயனர் இல்லை"
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr "உரிமையாளரை மாற்றத் தவறிவிட்டது, பயனர் செயலிழக்கப்படுகிறார்"
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr "உரிமையாளரை மாற்றத் தவறிவிட்டது, போட்ச் மற்ற போட்களை சொந்தமாக்க முடியாது"
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
@@ -8407,213 +7809,213 @@ msgstr ""
 "போலி_எமெயில்_ டொமைன் சரியாக உள்ளமைக்கப்படும் வரை போட்களை உருவாக்க முடியாது. \n"
 "உங்கள் சேவையக நிர்வாகியை தொடர்பு கொள்ளவும்."
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr "உட்பொதிக்கப்பட்ட போட்கள் இயக்கப்படவில்லை."
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr "தவறான உட்பொதிக்கப்பட்ட போட் பெயர்."
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr "பயனர்களை உருவாக்க பயனர் ஏற்பு இல்லை"
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr "இந்த நிறுவனத்தில் '{email}' அனுமதிக்கப்படவில்லை"
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr "இந்த நிறுவனத்தில் செலவழிப்பு மின்னஞ்சல் முகவரிகள் அனுமதிக்கப்படவில்லை"
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom access token"
 msgid "Invalid {provider_name} access token"
 msgstr "தவறான சூம் அணுகல் கிள்ளாக்கு"
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} call"
 msgstr "சூம் அழைப்பை உருவாக்கத் தவறிவிட்டது"
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Zoom credentials have not been configured"
 msgid "{provider_name} credentials have not been configured"
 msgstr "சூம் நற்சான்றிதழ்கள் கட்டமைக்கப்படவில்லை"
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom credentials"
 msgid "Invalid {provider_name} credentials"
 msgstr "தவறான சூம் நற்சான்றிதழ்கள்"
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error connecting to the BigBlueButton server."
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr "பிக் ப்ளூபட்டன் சேவையகத்துடன் இணைக்கும் பிழை."
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error authenticating to the BigBlueButton server."
 msgid "Error authenticating to the {provider_name} server"
 msgstr "பிக் ப்ளூபட்டன் சேவையகத்திற்கு அங்கீகாரத்தில் பிழை."
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "BigBlueButton server returned an unexpected error."
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr "BigblueButton சேவையகம் எதிர்பாராத பிழையை அளித்தது."
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom session identifier"
 msgid "Invalid {provider_name} session identifier"
 msgstr "தவறான சூம் அமர்வு அடையாளங்காட்டி"
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr "தெரியாத சூம் பயனர் மின்னஞ்சல்"
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} public room."
 msgstr "சூம் அழைப்பை உருவாக்கத் தவறிவிட்டது"
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr ""
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 msgid "{full_name}'s Zulip room"
 msgstr "{full_name you நீங்கள் குறிப்பிட்டுள்ளார்:"
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 "இந்த பதிப்பு கட்டுப்பாட்டு கணினி வழங்குநரைப் பயன்படுத்தும் திட்டங்கள் ஆதரிக்கப்படவில்லை"
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr "தவறான பேலோட்"
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr "அறியப்படாத வெப்ஊக் கோரிக்கை"
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr "தலைப்பு காலியாக இருக்க முடியாது"
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr "உள்ளடக்கம் காலியாக இருக்க முடியாது"
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr "சோட்ஃபார்ம் பேலோடைக் கையாள முடியவில்லை"
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr "தவறாக சாதொபொகு உள்ளீடு"
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr "நிகழ்வுகள் விசை பேலோடில் இருந்து இல்லை"
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr "பிழை: 0 அல்லது 1 ஐத் தவிர வேறு சேனல்கள்_மாப்_டோ_டோபிக்ச் அளவுரு"
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr "அறியப்படாத வேர்ட்பிரச் வெப்ஊக் செயல்: {hook}"
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, fuzzy, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
 "({export_settings_link})."
 msgstr "உங்கள் தரவு ஏற்றுமதி முடிந்தது. ."
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr "சரிபார்ப்பு மறைபொருள் காலாவதியானது"
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr "சரிபார்ப்பு மறைபொருள் தவறானது"
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr "சரிபார்ப்பு மறைபொருள் தவறாக உள்ளது"
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr "சரிபார்ப்பு மறைபொருள் வேறு ஓச்ட்பெயருக்கு"
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr "புச் அறிவிப்புகள் பவுன்சருக்கு தவறான சப்டொமைன்"
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr "செல்லுபடியாகும் சூலிப் சர்வர் பநிஇ விசையுடன் சரிபார்க்க வேண்டும்"
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr ""
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr "தவறான கிள்ளாக்கு வகை"
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr "{hostname} தவறான கூறுகளைக் கொண்டுள்ளது (எ.கா., பாதை, வினவல், துண்டு)."
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr "{hostname} என்பது சரியான ஓச்ட்பெயர் அல்ல"
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, fuzzy, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr "நிர்வாகிகள்"
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr "{domain} தவறானது, ஏனெனில் அதில் எந்த MX பதிவுகளும் இல்லை"
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr "{domain} இல்லை"
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, fuzzy, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
@@ -8623,29 +8025,29 @@ msgstr ""
 "தயவுசெய்து பின்னர் மீண்டும் முயற்சிக்கவும் அல்லது உதவிக்கு {support_email that ஐ "
 "அணுகவும்."
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr "இந்த ஓச்ட்பெயருக்கு பதிவு கிடைக்கவில்லை"
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr "சரிபார்ப்பு மறைபொருள் இல்லை என்று புரவலன் தெரிவித்துள்ளது."
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, fuzzy, python-brace-format
 #| msgid "Error response received from the host: {status_code}"
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr "ஓச்டிலிருந்து பெறப்பட்ட பிழை பதில்: {status_code}"
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr "IOS_APP_ID காணவில்லை"
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr "USER_ID அல்லது USER_UUID ஐக் காணவில்லை"
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
@@ -8654,50 +8056,50 @@ msgstr ""
 "புச் அறிவிப்புகளை அனுப்ப உங்கள் திட்டம் அனுமதிக்காது. சேவையகத்தால் வழங்கப்பட்ட காரணம்: "
 "{reason}"
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr "புச் அறிவிப்புகளை அனுப்ப உங்கள் திட்டம் அனுமதிக்காது."
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr ""
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr ""
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr "தரவு ஒழுங்கற்றது."
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr "நகல் பதிவு கண்டறியப்பட்டது."
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr "தவறாக தணிக்கை பதிவு தரவு"
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr "உங்கள் கடவுச்சொல்லை மீட்டமைக்க வேண்டும்."
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr "ஐடி_டோகன் அளவுரு இல்லை"
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 #, fuzzy
 #| msgid "Missing id_token parameter"
 msgid "Missing idp param"
 msgstr "ஐடி_டோகன் அளவுரு இல்லை"
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr "தவறான OTP"
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr ""
 "மொபைல்_ஃப்ளோ_ஓடிபி மற்றும் டெச்க்டாப்_ஃப்ளோ_ஓடிபி இரண்டையும் ஒன்றாகப் பயன்படுத்த முடியாது."

--- a/locale/tl/LC_MESSAGES/django.po
+++ b/locale/tl/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 19:44+0000\n"
 "Last-Translator: Alex Vandiver <alexmv@zulip.com>\n"
 "Language-Team: Tagalog <https://hosted.weblate.org/projects/zulip/django/tl/"
@@ -20,50 +20,50 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "Hindi pinapayagan ang mga panauhing tagagamit"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "Walang bisa na kapisanan"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr ""
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr ""
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr ""
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr ""
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -72,7 +72,7 @@ msgid ""
 "users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -80,7 +80,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than one user to join."
 msgstr ""
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -88,7 +88,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than two users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -96,7 +96,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than three users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -105,149 +105,148 @@ msgid ""
 "({billing_page_link}) is greater than the current number of users."
 msgstr ""
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr ""
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr ""
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
 "(minimum {min_licenses})."
 msgstr ""
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
 "page. To complete the upgrade, please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr ""
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr ""
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr "Hindi kilalang pamamaraan ng pambayad. Maaaring ipaalam {email}."
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr "May nangyaring masama. Ipaalam {email}."
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "May nangyaring masama. Maaaring buksan muli ang pahina."
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr ""
 "May nangyaring masama. Maaaring maghintay ng ilang segundo at subukan muli."
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr ""
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr ""
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
 msgstr ""
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
 msgstr ""
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
 "licenses."
 msgstr ""
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
 "billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr "Walang dapat baguhin."
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr "Walang mamimili para sa kapisanan!"
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr ""
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -257,100 +256,97 @@ msgid ""
 "we would really appreciate it!"
 msgstr ""
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
 "{support_email}"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr ""
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr ""
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr ""
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
 "%(support_email)s\">contact support</a>."
 msgstr ""
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr ""
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
 msgstr ""
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr ""
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
 msgstr ""
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr ""
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr ""
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
 msgstr ""
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -358,289 +354,270 @@ msgid ""
 "a> with any questions."
 msgstr ""
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
 "a> for support."
 msgstr ""
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
 "href=\"%(troubleshooting_url)s\">Zulip server troubleshooting guide</a>."
 msgstr ""
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr ""
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr ""
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr ""
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr ""
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr ""
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr ""
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr ""
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr ""
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr ""
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "Masugid na mga tagagamit"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr ""
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr ""
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr ""
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "Mga tagagamit"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr ""
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "Ako"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr ""
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr ""
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr ""
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr ""
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr ""
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr ""
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "Arawan"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr ""
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr ""
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "Mga Tao"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr ""
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr ""
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr ""
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr ""
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
 "%(old_email_html_tag)s to %(new_email_html_tag)s"
 msgstr ""
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr ""
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
 msgstr ""
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr "Paniningil"
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr ""
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr ""
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -651,19 +628,19 @@ msgid ""
 "server."
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -671,790 +648,299 @@ msgid ""
 "%(support_email)s'>contact support</a> with any questions."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, python-format
 msgid "You can try again in %(retry_after_string)s."
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr ""
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr ""
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr ""
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "Lahat"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr "Mga Kaurian"
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr ""
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr ""
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr "Sumali bilang tagagamit"
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr "Sumali bilang self-hoster"
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr "Sumali bilang tagapamahagi"
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr ""
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr ""
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr ""
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr ""
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr ""
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 msgid "Zulip for open source"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Create your Zulip organization"
 msgid "Screenshot of Zulip conversation"
 msgstr "Gumawa ng iyong Kapisanang Tulip"
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 msgid "Message with code"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
 msgstr ""
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 msgid "Get started"
 msgstr ""
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
 "continue."
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "Sulatroniko"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1462,78 +948,77 @@ msgid ""
 "from Zulip."
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
 msgstr ""
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr ""
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr ""
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr ""
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr ""
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr ""
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr ""
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr ""
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
 msgstr ""
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1541,210 +1026,203 @@ msgid ""
 "href=\"%(doc_url)s\">documentation</a>."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, python-format
 msgid "No account found for %(email)s."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Create your Zulip organization"
 msgid "Try Zulip in a demo organization"
 msgstr "Gumawa ng iyong Kapisanang Tulip"
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 msgid "Try Zulip"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid "Import chat history?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "Sumali"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "Papasok"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1752,123 +1230,122 @@ msgid ""
 "noreferrer\">after you join</a>."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "Baguhin"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr "Gumawa ng iyong bagong samahan"
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr "Gumawa ng iyong kwenta"
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "Kontrasenya"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr ""
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">Terms of Service</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr ""
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr ""
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -1876,7 +1353,7 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid ""
@@ -1884,41 +1361,41 @@ msgid ""
 "deleted."
 msgstr "Ang samahan ay napawalang bisa"
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
 "inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
 "administrators</a> to inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid "This organization has been deactivated."
 msgstr "Ang samahan ay napawalang bisa"
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
 "%(support_email)s\">contact Zulip support</a> to reactivate it."
 msgstr ""
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -1926,165 +1403,164 @@ msgid ""
 "reactivate it."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr "Lingid na tagagamit"
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr "Mga May-ari"
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "Mga Tagapamahala"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr "Mga Pangulo ng Talakayan"
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "Pangkaraniwan na tagagamit"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr ""
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr ""
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
 "<b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
 "href=\"%(apps_page_link)s\">mobile and desktop</a> apps:"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
 "href=\"%(getting_user_started_link)s\">getting started guide</a>!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2092,83 +1568,83 @@ msgid ""
 "Zulip</a>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
 "to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
 "desktop apps (%(apps_page_link)s):"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
 "(%(getting_user_started_link)s)!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
 "(%(getting_organization_started_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr "Pagbati,"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2176,34 +1652,34 @@ msgid ""
 "password for this account, please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "%(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 #, fuzzy
 #| msgid "Create your Zulip organization"
 msgid "Verify your email address for your Zulip demo organization"
 msgstr "Gumawa ng iyong Kapisanang Tulip"
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "<%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2211,113 +1687,113 @@ msgid ""
 "please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr "Tapusin ang layunin na sumali"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr "Gumawa ng iyong Kapisanang Tulip"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr "Buhayin ang iyong Kwenta sa Zulip"
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
 "— we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
 "deactivated, and you will no longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr ""
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2325,22 +1801,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because your organization <a "
@@ -2348,8 +1824,8 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to <a "
@@ -2357,39 +1833,39 @@ msgid ""
 "content</a> in email notifications."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr ""
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because your organization hides "
@@ -2397,82 +1873,75 @@ msgid ""
 "details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to hide "
 "message content in email notifications. See %(help_url)s for more details."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, fuzzy, python-format
 #| msgid "Log in to your organization"
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr "Pumasok sa iyong samahan"
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr ""
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
 "organizations:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
 "organizations hosted by %(external_host)s:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
 "href=\"%(help_reset_password_link)s\">reset your password</a>."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
 "%(external_host)s."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2480,97 +1949,94 @@ msgid ""
 "to find your account."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
 "try another way to find your account (%(help_logging_in_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
 "communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr ""
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
 "-- the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
 "Zulip &mdash; the team communication tool designed for productivity."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
 "to ask %(referrer_name)s for another one."
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2578,72 +2044,70 @@ msgid ""
 "productivity."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at <a href=\"mailto:%(email)s\">%(email)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
 "%(email)s\">Contact us</a> — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
 "#%(channel_name)s > %(topic_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2651,68 +2115,68 @@ msgid ""
 "preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails (<a href=\"%(url)s\">help</a>)."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2720,22 +2184,22 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2743,52 +2207,52 @@ msgid ""
 "immediately at <%(support_email)s>."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2796,31 +2260,31 @@ msgid ""
 "contact us immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr "Salamat,"
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr ""
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2828,7 +2292,7 @@ msgid ""
 "immediately at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -2836,25 +2300,25 @@ msgid ""
 "Zulip</a> to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
 "with you and share their unique perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -2862,7 +2326,7 @@ msgid ""
 "experience how a new chat app will help your team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -2870,148 +2334,148 @@ msgid ""
 "action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
 "team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
 "organizations like yours!"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3019,11 +2483,11 @@ msgid ""
 "about…?”"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr "Halimbawa ng mga maiikling paksa"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3032,23 +2496,23 @@ msgid ""
 "href=\"%(move_channels_link)s\">move a topic to a different channel</a>."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3057,23 +2521,23 @@ msgid ""
 "(%(move_channels_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
 "%(email)s on %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3081,46 +2545,46 @@ msgid ""
 "href=\"%(help_link)s\">reactivate your account</a>."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
 "You can contact an organization administrator to reactivate your account."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3128,541 +2592,537 @@ msgid ""
 "have been voided."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
 "to %(upgrade_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip demo organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip demo organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Create your Zulip organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "Gumawa ng iyong Kapisanang Tulip"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for <b>%(remote_server_hostname)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 msgid "Click the button below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for %(remote_server_hostname)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
 "management for <b>%(remote_realm_host)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
 "management for %(remote_realm_host)s."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the <a href=\"%(plans_link)s\">Zulip Community plan</a>."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
 "website</a>, we would really appreciate it!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
 msgstr ""
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
 "accounts for another email address</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr ""
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr ""
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr ""
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr ""
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr ""
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 msgid "Zulip Cloud"
 msgstr ""
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr ""
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr ""
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr ""
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr ""
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr ""
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr ""
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr ""
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr ""
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr ""
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr ""
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr ""
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr ""
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr ""
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr ""
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr ""
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr ""
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr ""
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr ""
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr ""
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr ""
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr ""
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr ""
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr ""
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr ""
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr ""
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr ""
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr ""
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr ""
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr ""
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr ""
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr ""
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr ""
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr ""
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 msgid "Bluesky"
 msgstr ""
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr ""
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr ""
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr ""
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 msgid ""
 "And hundreds more through <a href=\"/integrations/zapier\">Zapier</a> and <a "
 "href=\"/integrations/ifttt\">IFTTT</a>."
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr "Imbalidong sulatroniko"
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3670,7 +3130,7 @@ msgid ""
 "emails with your email domain."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3678,7 +3138,7 @@ msgid ""
 "disposable email addresses."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3686,24 +3146,24 @@ msgid ""
 "emails that contain \"+\"."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3711,7 +3171,7 @@ msgid ""
 "%(support_email)s\">contact Zulip support</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3719,89 +3179,89 @@ msgid ""
 "%(support_email)s\">contact this Zulip server's administrators</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
 "management for your Zulip server."
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr ""
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr "Papasok sa Zulip"
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr "Sulatroniko o pasokngalan"
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "Pasokngalan"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr "Nakalimutan ang iyong kontrasenya?"
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr "Pasok na may %(identity_provider)s"
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr ""
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> because all Zulip Cloud licenses are in use."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -3810,44 +3270,42 @@ msgid ""
 "or misconfiguration."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid "Demo organizations disabled"
 msgstr "Ang samahan ay napawalang bisa"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -3855,22 +3313,21 @@ msgid ""
 "organization for more information."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -3878,46 +3335,44 @@ msgid ""
 "Zulip support</a> for assistance in resolving this issue."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
 "a> like Firefox, Chrome, and Edge."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr "Ang kwenta ay napawalang bisa"
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Invalid organization"
 msgid "Finalize organization import"
 msgstr "Walang bisa na kapisanan"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 msgid "Organization import completed!"
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -3925,56 +3380,55 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Select your account"
 msgstr "Gumawa ng iyong kwenta"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Create new account"
 msgstr "Gumawa ng iyong kwenta"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr ""
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr "Pumasok sa iyong samahan"
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr "Hanapin ang iyong samahan."
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -3982,81 +3436,81 @@ msgid ""
 "have one yet."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 msgid "Self-hosting Zulip?"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">log in to manage plans and billing.</a>"
 msgstr ""
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr ""
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
 msgstr ""
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "Ilagay ang kontrasenya muli"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr ""
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr ""
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr ""
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr ""
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr ""
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4064,7 +3518,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4073,57 +3527,57 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr ""
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4131,7 +3585,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4139,40 +3593,40 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4180,302 +3634,296 @@ msgid ""
 "away!"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
 "href=\"%(realm_url)s/#settings/notifications\">notification settings</a>."
 msgstr ""
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr ""
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr ""
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr ""
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr ""
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr ""
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr ""
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr ""
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 msgid "Cannot reactivate a deleted user"
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr ""
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr ""
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr ""
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr ""
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
 msgstr ""
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
 msgstr ""
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr "Hindi maaaring anyayahin sinuman."
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr "Wala nang dapat baguhin"
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr ""
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr ""
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr ""
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr ""
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr ""
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr ""
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr "Ikaw ay walang sapat na pahintulot upang baguhin ang mensaheng ito"
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr ""
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
 "{new_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
 "{user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 #, fuzzy
 #| msgid "You don't have permission to edit this message"
 msgid "You don't have permission to resolve topics in this channel."
 msgstr "Ikaw ay walang sapat na pahintulot upang baguhin ang mensaheng ito"
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr ""
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr ""
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr "(Mga) Imbalidong Mensahe"
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr "Hindi maipakita ang mensahe"
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr ""
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
 "but there is no channel with that ID."
 msgstr ""
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4483,36 +3931,36 @@ msgid ""
 "it."
 msgstr ""
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
 "The channel exists but does not have any subscribers."
 msgstr ""
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr ""
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr ""
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr ""
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4520,109 +3968,107 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
 "authentication method."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr ""
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 #, fuzzy
 #| msgid "Draft does not exist"
 msgid "Reminder could not be sent."
 msgstr "Ang borador ay hindi mahanap"
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
 "the following error:"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr ""
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr ""
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr ""
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr ""
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr ""
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
 "**{old_policy}** to **{new_policy}**."
 msgstr ""
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -4631,51 +4077,49 @@ msgid ""
 "* **New**: {new_setting_description}\n"
 msgstr ""
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr ""
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr ""
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr ""
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr ""
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr ""
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr ""
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 msgstr ""
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr ""
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -4686,285 +4130,271 @@ msgid ""
 "{summary_line}"
 msgstr ""
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr ""
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr ""
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr ""
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr "Walang sapat na pahintulot"
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr ""
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr ""
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr ""
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr ""
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr ""
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr ""
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr ""
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr ""
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
 "organization administrator to reactivate it."
 msgstr ""
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr ""
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr ""
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr ""
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr ""
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr ""
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr ""
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr ""
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
 "to register for accounts in this organization."
 msgstr ""
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr ""
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 msgid "Challenges are not enabled."
 msgstr ""
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "Bagong kontrasenya"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr ""
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "You're making too many attempts to sign in. Try again in "
 "{retry_after_string} or contact your organization administrator for help."
 msgstr ""
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
 msgstr ""
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr ""
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr ""
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr ""
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr ""
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr "Nawawalang paksa"
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr ""
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr ""
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr "Ang mensahe ay kailangan magkaroon ng maraming taga-pagtanggap"
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr "Imbalidong tipo ng mensahe"
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr "Imbalidong nakakabit"
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr ""
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Content can't be empty"
 msgid "Channel folder name can't be empty."
 msgstr "Ang nilalalaman ay dapat may laman"
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 msgid "Invalid channel folder ID"
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 msgid "Configure owner account email address."
 msgstr ""
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4973,71 +4403,71 @@ msgid ""
 "organization]({convert_demo}).\n"
 msgstr ""
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, python-brace-format
 msgid "{var_name} is not Base64 encoded"
 msgstr ""
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 #, fuzzy
 #| msgid "Invalid email"
 msgid "Invalid `device_id`"
 msgstr "Imbalidong sulatroniko"
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr ""
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr "Ang larangan ay hindi maaaring kakab."
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr "Ang larangan ay dapat may isang tuldok man lang (.)"
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr "Ang larangan ay napakahaba"
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr ""
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr ""
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr ""
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr ""
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr ""
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr "Ang paksa ay dapat hindi maglaman ng walang bytes"
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr ""
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr "Ang borador ay hindi mahanap"
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5045,627 +4475,625 @@ msgid ""
 "{error_message}"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr ""
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr "Imbalidong pook ng tahanan."
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr "Labas ng iyong larangan."
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr "Mga tirahan ng sulatroniko na naglalaman ng + ay pinagbabawal."
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr ""
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr ""
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr "Mayroon nang kwenta."
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr "Ang kwenta ay pinawalang bisa."
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr ""
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr ""
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr ""
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr ""
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr ""
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr ""
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr ""
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr ""
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
 msgstr ""
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr ""
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr ""
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr ""
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr ""
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr "tagagamit"
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr ""
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr "Maling anyo ng JSON"
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr "Dapat ay tagapamahala ng samahan"
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr "Dapat ay may-ari ng samahan"
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Must be an organization owner"
 msgid "Must be a bot user"
 msgstr "Dapat ay may-ari ng samahan"
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr "Ang iyong pasokngalan o kontrasenya ay mali"
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr "Ang samahan ay napawalang bisa"
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr "Ang pagpapatunay sa kontrasenya ay pinawalang bisa sa samahan na ito"
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr "Ang iyong kontrasenya ay napawalang bisa at dapat nang baguhin"
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr "Imablidong susing API"
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr "Maling anyo na susing API"
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
 "webhook; ignoring"
 msgstr ""
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr "Imbalidong mababang larangan"
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr ""
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr ""
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr "Pinagbawalang pumasok"
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} most recent messages in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr ""
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr ""
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
 msgstr ""
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr ""
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr ""
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr ""
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr ""
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr ""
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Already has an account."
 msgid "Atlassian account ID"
 msgstr "Mayroon nang kwenta."
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Behance username"
 msgstr "Pangit na pangalan o pasokngalan"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 msgid "Bitbucket username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Codeberg username"
 msgstr "Pangit na pangalan o pasokngalan"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Dribbble username"
 msgstr "Sulatroniko o pasokngalan"
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Facebook username"
 msgstr "Pangit na pangalan o pasokngalan"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "GitLab username"
 msgstr "Sulatroniko o pasokngalan"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Instagram username"
 msgstr "Pangit na pangalan o pasokngalan"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 msgid "Mastodon profile"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Medium username"
 msgstr "Pangit na pangalan o pasokngalan"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Pinterest username"
 msgstr "Pangit na pangalan o pasokngalan"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Reddit username"
 msgstr "Sulatroniko o pasokngalan"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 msgid "Snapchat username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Threads username"
 msgstr "Pangit na pangalan o pasokngalan"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "TikTok username"
 msgstr "Sulatroniko o pasokngalan"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Twitch username"
 msgstr "Sulatroniko o pasokngalan"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "Pasokngalan"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr ""
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr ""
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 #, fuzzy
 #| msgid "Billing"
 msgid "Video calling"
 msgstr "Paniningil"
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr ""
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr "Ugnayang mamimili"
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr ""
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr "Libangan"
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr "Kalatas"
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr "Pinánsiyál"
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr ""
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr "Kawani para sa Bentahan"
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr "At iba pa"
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr ""
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr "Pangangasiwa sa proyekto"
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr ""
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr "Pamamahala ng bersyon"
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr ""
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr ""
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "{fullname} moderation"
 msgstr ""
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr ""
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr ""
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor_date' argument."
 msgstr ""
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr ""
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 #, fuzzy
 #| msgid "Draft does not exist"
 msgid "Navigation view does not exist."
 msgstr "Ang borador ay hindi mahanap"
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5673,7 +5101,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5681,7 +5109,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5689,7 +5117,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5697,7 +5125,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5707,14 +5135,14 @@ msgid ""
 "a permanent organization]({convert_demo_organization_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
 "them in your [Inbox](/#inbox).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5722,7 +5150,7 @@ msgid ""
 "({navigation_tour_video_url}) for a quick app overview.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5737,14 +5165,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -5752,7 +5180,7 @@ msgid ""
 "and edit your [profile information](/help/edit-your-profile).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -5763,7 +5191,7 @@ msgid ""
 "experience in your [Preferences](#settings/preferences).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5774,7 +5202,7 @@ msgid ""
 "[Browse and subscribe to channels]({settings_link}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -5791,7 +5219,7 @@ msgid ""
 "discussed.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -5800,7 +5228,7 @@ msgid ""
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -5812,7 +5240,7 @@ msgid ""
 "times, and more.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5822,7 +5250,7 @@ msgid ""
 "or browse the [help center](/help/) to learn more!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5830,7 +5258,7 @@ msgid ""
 "get help, try one of the following messages: {bot_commands}\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5842,13 +5270,13 @@ msgid ""
 "({move_content_another_channel_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5862,12 +5290,11 @@ msgid ""
 "and above.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr ""
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -5875,14 +5302,14 @@ msgid ""
 "no matter how many other conversations are going on.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
 "conversations with unread messages.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -5890,7 +5317,7 @@ msgid ""
 "the `+` button next to its name.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -5898,13 +5325,13 @@ msgid ""
 "can we chat about…?”\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5912,7 +5339,7 @@ msgid ""
 "({format_message_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5932,1335 +5359,1312 @@ msgid ""
 "```\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
 "teammates.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
 "conversation.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr ""
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr ""
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr ""
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr ""
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "Bagong mensahe"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 #, fuzzy
 #| msgid "Invalid API key"
 msgid "Invalid `push_key`"
 msgstr "Imablidong susing API"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr ""
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr ""
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr ""
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 #, fuzzy
 #| msgid "Draft does not exist"
 msgid "Reminder does not exist"
 msgstr "Ang borador ay hindi mahanap"
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr ""
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr ""
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr ""
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr ""
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr ""
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr ""
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr ""
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr ""
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 #, fuzzy
 #| msgid "You don't have permission to edit this message"
 msgid "You do not have permission to create new topics in this channel."
 msgstr "Ikaw ay walang sapat na pahintulot upang baguhin ang mensaheng ito"
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr ""
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr ""
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr ""
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr ""
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr ""
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr ""
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} does not have the expected format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid attachment"
 msgid "Invalid {setting_name}"
 msgstr "Imbalidong nakakabit"
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr ""
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr ""
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr ""
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {user_group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr ""
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr ""
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr ""
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr ""
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr "Ang pangalan ay napakahaba!"
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 #, fuzzy
 #| msgid "Content can't be empty"
 msgid "Name must not be empty!"
 msgstr "Ang nilalalaman ay dapat may laman"
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr ""
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr ""
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr ""
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr ""
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr "Pangit na pangalan o pasokngalan"
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr ""
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr ""
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr ""
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr ""
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr ""
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr ""
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr ""
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr ""
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr ""
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr ""
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr ""
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr ""
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr ""
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr ""
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr ""
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr ""
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr ""
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr ""
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr ""
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr ""
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr ""
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr ""
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr ""
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr ""
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr ""
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr ""
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr ""
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr ""
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr ""
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr "Walang sinuman"
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr ""
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "Mga Miyembro"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr ""
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: empty field name."
 msgstr ""
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr ""
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr ""
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 msgid "Example input does not match the linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in alternative URL template is not present in linkifier "
 "pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in linkifier pattern is not present in alternative URL "
 "template."
 msgstr ""
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr ""
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr ""
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr ""
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr ""
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr ""
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr ""
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr ""
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr ""
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr ""
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr ""
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr ""
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr ""
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr ""
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr ""
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr ""
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr ""
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr ""
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr "Mga Tagapamahala at Mga Pangulo ng Talakayan"
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr "Tanging Mga Tagapamahala lamang"
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr ""
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr ""
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr ""
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr "Pangulo ng Talakayan"
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "Miyembro"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr ""
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr ""
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr ""
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr ""
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr ""
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr ""
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 msgid "Failed to generate challenge"
 msgstr ""
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr ""
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr ""
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr "Maling JSON web token"
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr ""
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr ""
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr ""
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for use for user matching."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr ""
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr ""
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr ""
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr ""
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr ""
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr ""
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr ""
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr ""
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr ""
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid "Invitation already used or deactivated."
 msgstr "Ang samahan ay napawalang bisa"
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr ""
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr ""
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr ""
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
 msgstr ""
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr ""
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr ""
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr ""
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr ""
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr ""
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr ""
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr ""
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr ""
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Password authentication is disabled in this organization"
 msgid "Message reporting is not enabled in this organization."
 msgstr "Ang pagpapatunay sa kontrasenya ay pinawalang bisa sa samahan na ito"
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr "Nawawalang tagapagpadala"
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr ""
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr ""
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr ""
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr ""
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr ""
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr ""
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr ""
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr ""
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 msgid "Navigation view already exists."
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7268,863 +6672,861 @@ msgid ""
 "later. Is this a good time?\n"
 msgstr ""
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr ""
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr ""
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 #, fuzzy
 #| msgid "You don't have permission to edit this message"
 msgid "You do not have permission to manage plans and billing."
 msgstr "Ikaw ay walang sapat na pahintulot upang baguhin ang mensaheng ito"
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr ""
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr ""
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr ""
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr ""
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr ""
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr ""
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr ""
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr ""
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr ""
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr ""
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr ""
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 #, fuzzy
 #| msgid "Password authentication is disabled in this organization"
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr "Ang pagpapatunay sa kontrasenya ay pinawalang bisa sa samahan na ito"
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr ""
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr ""
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr ""
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr ""
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr ""
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr ""
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr ""
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Invalid character in language: {character}"
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Language '{language}' is not allowed."
 msgstr ""
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr ""
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr ""
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 msgid "Importing messages…"
 msgstr ""
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 msgid "Your name"
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr ""
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr ""
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr ""
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr ""
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr ""
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr ""
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr ""
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr ""
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr ""
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr ""
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr ""
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr ""
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr ""
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
 "**"
 msgstr ""
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr ""
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr ""
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr ""
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr ""
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr ""
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr ""
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr ""
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr ""
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr ""
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr ""
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr ""
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr ""
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr ""
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 msgstr ""
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr ""
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr ""
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
 "subgroups."
 msgstr ""
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr ""
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr ""
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr ""
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr ""
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr ""
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr ""
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr ""
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr ""
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr ""
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr ""
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr ""
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 msgid "User is not allowed to delete other user's messages."
 msgstr ""
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr ""
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr ""
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 msgid ""
 "Can't change bot email until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 msgstr ""
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 msgid "Email address already in use"
 msgstr ""
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr ""
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr ""
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr ""
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 msgstr ""
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr ""
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr ""
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr ""
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr ""
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr ""
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} access token"
 msgstr ""
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} call"
 msgstr ""
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} credentials have not been configured"
 msgstr ""
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} credentials"
 msgstr ""
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr ""
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error authenticating to the {provider_name} server"
 msgstr ""
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr ""
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} session identifier"
 msgstr ""
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr ""
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} public room."
 msgstr ""
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr ""
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{full_name}'s Zulip room"
 msgstr ""
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr ""
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr ""
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr "Dapat may nilalaman ang paksa"
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr "Ang nilalalaman ay dapat may laman"
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr ""
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr "Maling anyo ang binigay na JSON"
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr ""
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr ""
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr ""
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
 "({export_settings_link})."
 msgstr ""
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr ""
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr ""
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr ""
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr ""
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr ""
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr ""
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr ""
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr ""
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr ""
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr ""
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr ""
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr ""
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
 "try again later or reach out to {support_email} for assistance."
 msgstr ""
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr ""
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr ""
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr ""
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr ""
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
 "server: {reason}"
 msgstr ""
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr ""
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr ""
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr ""
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr ""
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr ""
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr ""
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr ""
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr ""
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 #, fuzzy
 #| msgid "Missing sender"
 msgid "Missing idp param"
 msgstr "Nawawalang tagapagpadala"
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr ""
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr ""
 

--- a/locale/tr/LC_MESSAGES/django.po
+++ b/locale/tr/LC_MESSAGES/django.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 19:47+0000\n"
 "Last-Translator: Alex Vandiver <alexmv@zulip.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/zulip/django/tr/"
@@ -31,52 +31,52 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "Misafir kullanıcılara izin verilmemektedir"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "Geçersiz organizasyon"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr "Açık kanallar"
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr "Özel kanallar"
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr "Direkt iletiler"
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr "Grup direkt iletileri"
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr "{chart_name}: grafiği için kanal yok"
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr "Bilinmeyen grafik ismi: {chart_name}"
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr ""
 "Başlangıç zamanı bitiş zamanında sonra. Başlangıç: {start}, Bitiş: {end}"
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr ""
 "Çözümleme verisi bulunmamaktadır. Lütfen sunucu yöneticinizle temasa geçiniz."
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -89,7 +89,7 @@ msgstr ""
 "artırın]({billing_page_link})  ve [atıl kullanıcıları devre dışı bırakın]"
 "({deactivate_user_help_page_link})."
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -101,7 +101,7 @@ msgstr ""
 "({billing_page_link}) veya [etkin olmayan kullanıcıları devre dışı "
 "bırakabilirsiniz]({deactivate_user_help_page_link})."
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -113,7 +113,7 @@ msgstr ""
 "({billing_page_link}) veya [etkin olmayan kullanıcıları devre dışı "
 "bırakabilirsiniz]({deactivate_user_help_page_link})."
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -125,7 +125,7 @@ msgstr ""
 "({billing_page_link}) veya [etkin olmayan kullanıcıları devre dışı "
 "bırakabilirsiniz]({deactivate_user_help_page_link})."
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -134,28 +134,27 @@ msgid ""
 "({billing_page_link}) is greater than the current number of users."
 msgstr ""
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr ""
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr "Kayıt devre dışı bırakıldı"
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr "Geçersiz uzak sunucu."
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
@@ -164,7 +163,7 @@ msgstr ""
 "Tüm aktif kullanıcılar için lisans satın almak zorundasınız (minimum "
 "{min_licenses})."
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
@@ -173,60 +172,60 @@ msgstr ""
 "{max_licenses} lisansından daha fazla lisansa sahip faturalar bu sayfadan "
 "işlenemez. Yükseltmeyi tamamlamak için lütfen {email} ile iletişime geçin."
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr "İşlenmiş bir ödeme yöntemi yok."
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr "{brand} {last4} içinde sonra eriyor"
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr "Bilinmeyen ödeme yöntemi. Lütfen {email} ile iletişime geçiniz."
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr "Bir sorun oluştu. Lütfen {email} ile iletişime geçiniz."
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "Bir sorun oluştu. Lütfen sayfayı yeniden yükleyiniz."
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr "Bir sorun oluştu. Lütfen birkaç saniye bekleyip yeniden deneyiniz."
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr "Ücretsiz denemenizi başlatmadan önce lütfen bir kredi kartı ekleyin."
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr "Lütfen yükseltme planlamak için bir kredi kartı ekleyin."
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
 msgstr ""
 "Plan yükseltilemedi. Plan tarihi geçmiş ve yeni bir plan ile değişmiştir."
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr "Plan yükseltilemedi. Plan bitmiştir."
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 "Ücretsiz deneme planı için geçerli faturalandırma döneminde lisanslar "
 "güncellenemiyor."
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
@@ -234,18 +233,18 @@ msgstr ""
 "Lisanslar manuel olarak yükseltilemedi. Planınız otomatik lisans "
 "yönetimindedir."
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr ""
 "Mevcut fatura döneminde planınız zaten {licenses} lisanslarında bulunuyor."
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr "Mevcut fatura döneminde lisansları azaltamazsınız."
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
@@ -253,7 +252,7 @@ msgstr ""
 "Düşürülen bir plan için bir sonraki faturalandırma döngüsü için lisanslar "
 "değiştirilemez."
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
@@ -262,7 +261,7 @@ msgstr ""
 "Planınızın {licenses_at_next_renewal} lisanslarıyla yenilenmesi zaten "
 "planlandı."
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
@@ -271,27 +270,27 @@ msgstr ""
 "Bir sonraki fatura dönemi için {licenses_at_next_renewal} lisanslarını zaten "
 "satın aldınız."
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr "Değişecek bir şey yok."
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr "Bu organizasyon için müşteri yok!"
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr "Oturum bulunamadı"
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr "Ödeme amacı bulunamadı"
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr "stripe_session_id veya stripe_invoice_id girin"
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -306,20 +305,19 @@ msgstr ""
 "Eğer {begin_link} Zulip'i web sitenizde sponsor olarak listeleyebilirseniz "
 "{end_link} gerçekten minnettar oluruz!"
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr "'onaylandı' parametresi gerekli"
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr "Ödeme erişim anahtarı süresi doldu."
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr "Geçersiz ödeme erişim anahtarı."
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
@@ -328,39 +326,38 @@ msgstr ""
 "Sunucu ile bölge arasındaki faturalandırma verileri mutabakatı sağlanamadı. "
 "Lütfen {support_email} ile iletişime geçin"
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr "Bu hesap henüz mevcut değil."
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr "Devam etmek için Hizmet Koşullarını kabul etmelisiniz."
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 "Bu zulip_org_id, Zulip'in faturalandırma yönetim sisteminde kayıtlı değil."
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr "Bu zulip_org_id için geçersiz zulip_org_key ."
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr "Sunucu kaydınız devre dışı bırakıldı."
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "Hata"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr "Sayfa bulunamadı (404)"
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, fuzzy, python-format
 #| msgid ""
 #| "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd "
@@ -372,42 +369,41 @@ msgstr ""
 "Sorularınız mı var? <a href=\"mailto:%(support_email)s\">Bize ulaşın</a> - "
 "yardımcı olmak isteriz!"
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr "Giriş engelli (403)"
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
 msgstr ""
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr ""
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
 msgstr ""
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr "Methoda izin verilmiyor (405)"
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr "Dahili sunucu hatası"
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
 msgstr ""
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -415,13 +411,13 @@ msgid ""
 "a> with any questions."
 msgstr ""
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, fuzzy, python-format
 #| msgid ""
 #| "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd "
@@ -433,145 +429,143 @@ msgstr ""
 "Sorularınız mı var? <a href=\"mailto:%(support_email)s\">Bize ulaşın</a> - "
 "yardımcı olmak isteriz!"
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
 "href=\"%(troubleshooting_url)s\">Zulip server troubleshooting guide</a>."
 msgstr ""
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr "%(target_name)s | Zulip için analitikler"
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 "Organizasyon oluşturulduktan itibaren 24 saat süreyle analitikler tam olarak "
 "açıktır."
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr "%(target_name)s için Zulip analitikleri"
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr "Organizasyon özeti"
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr "Kullanıcı sayısı"
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr "Son 15 günde aktif olan kullanıcılar"
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr "Misafir sayısı"
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr "Toplam ileti sayısı"
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr "Son 30 gündeki ileti sayısı"
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr "Dosya kullanımda"
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "Aktif kullanıcılar"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr "Günlük hareketler"
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr "15 günlük hareketler"
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr "Toplam kullanıcılar"
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "Kullanıcılar"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr "Alıcı türüne göre gönderilen iletiler"
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "Ben"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "Herkes"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "Geçen hafta"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "Geçen ay"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "Geçen sene"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "Tüm zaman"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr "Zaman içinde gönderilen iletiler"
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "Günlük"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "Haftalık"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr "Toplam"
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "İnsanlar"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "Botlar"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr "Zaman içinde okunan iletiler"
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr "İstemci türüne göre gönderilen iletiler"
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr "Son güncelleme"
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
@@ -579,15 +573,15 @@ msgstr ""
 "Tüm grafiklerin tam güncellemesi günde bir defa gerçekleşir. “Zaman içinde "
 "gönderilmiş iletileri” grafiği saatlik olarak güncellenir."
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr "E-posta değistirildi"
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr "E-posta değişti!"
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
@@ -596,48 +590,48 @@ msgstr ""
 "Bu, Zulip hesabınızın e-postasını %(old_email_html_tag)s dan "
 "%(new_email_html_tag)s a değiştirdiğinizi onaylar"
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr "E-posta adresiniz doğrulanıyor"
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr "Doğrulama bağlantısı mevcut değil"
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr "Eyvah! Onay bağlantınızı sistemde bulamadık."
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr "Doğrulama bağlantısının süresi doldu veya devre dışı bırakıldı"
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr "Eyvah! Bu onay linki geçerliliği dolmuş veya devre dışı bırakılmış."
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr "Yeni link için lütfen sistem yöneticisine başvurunuz."
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr "Doğrulama linki bozuk"
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr "Eyvah! Onay linki hatalı."
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
@@ -645,72 +639,55 @@ msgstr ""
 "Bağlantıyı tarayıcınıza doğru şekilde kopyaladığınızdan emin olun. Eğer hala "
 "bu sayfayla karşılaşıyorsanız, muhtemelen bizim hatamızdır. Üzgünüz."
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr "Faturalandırma"
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr "Modali Kapat"
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr "Boş ver"
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr "Düşür"
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "İptal"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr "Onayla"
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr "Yükseltmeyi iptal et"
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr "Ödeme durumu"
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr "Sunucu kaydını iptalet?"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr "Plan yönetimi açık değil"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -721,19 +698,19 @@ msgid ""
 "server."
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -741,736 +718,246 @@ msgid ""
 "%(support_email)s'>contact support</a> with any questions."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr "Limit aşıldı"
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr "Hız limiti aşıldı."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, fuzzy, python-format
 #| msgid "You can try again in %(retry_after)s seconds."
 msgid "You can try again in %(retry_after_string)s."
 msgstr "%(retry_after)s saniye içinde tekrar deneyebilirsiniz."
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr "Yükselt"
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr "Faturayı gönder ve ücretsiz denemeyi başlat"
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr "Fatura gönder"
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr "Açık topluluk rehberi"
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr "Kategorilere göre filtrele"
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "Hepsi"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr "Kategoriler"
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr "10.000 mesaj"
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr "Limitsiz"
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr "Desteklenen"
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr "Self-yönetim"
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr "En fazla 10 kullanıcısı olan kuruluşlar için"
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr "Minimum 25 kullanıcı"
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr "Uygun değil"
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr "Zulip geliştirici birliği"
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr "Kullanıcı olarak katıl"
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr "Kendi kendine ev sahibi olarak katılın"
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr "Katılımcı olarak katılın"
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "Organizasyon oluştur"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr ""
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr "Zulip'i kendi sunucunda kullan"
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr "Sponsorluk iste"
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr "Eğitim fiyatlandırması"
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr "Fiyatlandırmayı görüntüle"
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr "İş için Zulip"
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Zulip guide for open-source projects"
 msgid "Zulip for open source"
 msgstr "Açık kaynak projeler için Zulip rehberini görüntüle"
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Create your Zulip organization"
 msgid "Screenshot of Zulip conversation"
 msgstr "Zulip organizasyonunuzu oluşturun"
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Messages sent over time"
 msgid "Message with code"
 msgstr "Zaman içinde gönderilen iletiler"
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr "Link"
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr "Desteğe ulaş"
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr "Gönderen"
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr "Organizasyon"
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr "Konu"
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr "İleti"
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr "Gönder"
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr "Bize ulaştığıınız için teşekkürler"
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr "Bize ulaştığıınız için teşekkürler!"
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr "Yakın zamanda dönüş yapacağız."
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
@@ -1478,13 +965,13 @@ msgstr ""
 "Sık sorulan soruların yanıtlarını <a href=\"/help/\">Zulip yardım merkezi</"
 "a>'nde bulabilirsiniz."
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 #, fuzzy
 #| msgid "Getting started"
 msgid "Get started"
 msgstr "Başlarken"
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
@@ -1494,50 +981,49 @@ msgstr ""
 "lütfen <a href=\"https://zulip.com/policies/terms\">Zulip Hizmet Şartları</"
 "a>'nı kabul edin."
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr "veya alternatif olarak yedekleme telefonlarınızdan birini kullanınız:"
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr "Son çare olarak yedekleme anahtarını kullanabilirsiniz:"
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr "Yedekleme anahtarı kullan"
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr "Hizmet Koşullarını Kabul Et"
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr "Zulip'e hoşgeldiniz"
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "E-posta"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr ""
 "Zulip'in düşük trafikli haber bültenine abone olun (yılda birkaç e-posta)."
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr "Devam et"
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr "E-posta adresinizi doğrulayın"
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1548,7 +1034,7 @@ msgstr ""
 "posta hesabınızı (<span class=\"user_email semi-bold\">%(email)s</span>) "
 "kontrol edin."
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
@@ -1556,30 +1042,30 @@ msgstr ""
 "Eğer Gelen Kutusu veya Spam klasörünüzde doğrulama e-postası görmüyorsanız, "
 "<a href=\"#\" id=\"resend_email_link\">tekrar gönderebiliriz</a>."
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr ""
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
@@ -1587,39 +1073,38 @@ msgstr ""
 "Bu mesaj kaybolmazsa, sayfayı <a class=\"reload-lnk\">yeniden yüklemeyi</a> "
 "deneyin."
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 "Zulip yüklenirken hata oluştu. Sayfayı <a class=\"reload-lnk\">yeniden "
 "yüklemeyi</a> deneyin."
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr "Filtrelerinizle eşleşen konuşma yok."
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr "Bu görünüm hala mesajları yüklüyor."
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr "Daha fazla yükle"
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr "Video görüşmesi sonlandırıldı"
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr "Şimdi bu pencereyi kapatabilirsiniz."
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr "Ayar hatası"
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
@@ -1628,7 +1113,7 @@ msgstr ""
 "organizasyon. Lütfen oluşturmak için EmailAuthBackend kullanın ve sonra "
 "tekrar deneyin."
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1639,199 +1124,192 @@ msgstr ""
 "Anlık bildirimlerini yapılandırmak için lütfen <a "
 "href=\"%(doc_url)s\">dökümantasyonu</a> inceleyin."
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr "Hesap bulunamadı"
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr "Zulip hesabı bulunamadı."
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, fuzzy, python-format
 #| msgid "Your account email: %(email)s"
 msgid "No account found for %(email)s."
 msgstr "Hesap e-postanız: %(email)s"
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr "Başka bir hesap ile giriş yapın"
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr "Kayıt işlemine devam et"
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Must be a demo organization."
 msgid "Try Zulip in a demo organization"
 msgstr "Demo organizasyon olmalı."
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Try Zulip now"
 msgid "Try Zulip"
 msgstr "Şimdi Zulip'i deneyin"
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "Yeni bir organizasyon oluştur"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr "Yeni bir Zulip organizasyonu oluştur"
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr "E-posta adresinizi girin"
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr "E-postanız"
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr "Bir seçenek seçin"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr "Lütfen açıklayın"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr "Reklamı nerede gördünüz?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr "Hangi organizasyon?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr "Organizasyon tipi"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr "Organizasyon dili"
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 #, fuzzy
 #| msgid "Private, shared history"
 msgid "Import chat history?"
 msgstr "Özel, paylaşılan geçmiş"
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr "Organizasyon adı"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "Organizasyon URL'si"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr "%(external_host)s kullan"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "OR"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "Kayıt ol"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "Zulip'e kayıt olun"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr "Bu organizasyona katılmak için bir davetiyeye ihtiyacınız var."
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr "%(identity_provider)s ile kayıt oluştur"
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr "Zaten bir hesabınız var mı?"
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "Giriş"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr "E-posta adresi gizliliğini doğrulayın"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
@@ -1839,7 +1317,7 @@ msgstr ""
 "Zulip, kuruluştaki hangi rollerin e-posta adresinizi görüntüleyebileceğini "
 "kontrol etmenizi sağlar."
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
@@ -1847,11 +1325,11 @@ msgstr ""
 "E-postanızın gizlilik ayarını bu kuruluş için varsayılan yapılandırmadan "
 "değiştirmek istiyor musunuz?"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr "E-posta hesabınıza kimler erişebilir"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1862,13 +1340,13 @@ msgstr ""
 "target=\"_blank\" rel=\"noopener noreferrer\">katıldıktan sonra</a> da "
 "değiştirebilirsiniz."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr "Bu Zulip kuruluşunun yöneticileri bu e-posta adresini görebilecektir."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
@@ -1876,13 +1354,13 @@ msgstr ""
 "Bu Zulip organizasyonunun yöneticileri ve moderatörleri bu e-posta adresini "
 "görebileceklerdir."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 "Bu Zulip organizasyonundaki hiç kimse bu e-posta adresini göremeyecektir."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
@@ -1890,79 +1368,78 @@ msgstr ""
 "Bu Zulip organizasyonundaki diğer kullanıcılar bu e-posta adresini "
 "görebilecektir."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "Değiştir"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr "Kayıt"
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr "Organizasyon oluştur"
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr "Hesap oluştur"
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr "<p>Kaydı tamamlamak için hesap bilgilerinizi girin.</p>"
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr "Organizasyonunuz"
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr "Hesabınız"
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr "Ayarları içeri aktarma"
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr "Var olan Zulip hesabından ayarları içeri aktar"
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr "Tam adınız"
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "İsim"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr "Hesabınızın Zulip'te nasıl görüntüleneceğidir."
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "Parola"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr "LDAP/Active Directory parolanı gir."
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 "Bu, mobil uygulamalar ve bir parola gerektiren diğer araçlar için kullanılır."
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr "Parola kuvveti"
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr "Ne ile ilgisiniz?"
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
@@ -1971,22 +1448,22 @@ msgstr ""
 "<a href=\"%(root_domain_url)s/policies/terms\" target=\"_blank\" "
 "rel=\"noopener noreferrer\">Kullanım Şartları</a>'nı kabul ediyorum."
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr "Devre dışı organizasyon"
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr "Organizasyon taşındı"
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -1994,7 +1471,7 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid ""
@@ -2002,41 +1479,41 @@ msgid ""
 "deleted."
 msgstr "Bu organizasyon devre dışıdır"
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
 "inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
 "administrators</a> to inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid "This organization has been deactivated."
 msgstr "Bu organizasyon devre dışıdır"
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
 "%(support_email)s\">contact Zulip support</a> to reactivate it."
 msgstr ""
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, fuzzy, python-format
 #| msgid ""
 #| "If you have any questions, please contact this Zulip server's "
@@ -2049,15 +1526,15 @@ msgstr ""
 "Herhangi bir sorunuz varsa, lütfen bu Zulip sunucusunun yöneticileriyle "
 "%(support_email)s adresinden iletişime geçin."
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr "Masaüstü uygulama girişini sonlandırın"
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr "Masaüstü girişini bitir"
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
@@ -2065,93 +1542,92 @@ msgstr ""
 "Tarayıcınızı kullanarak giriş işlemini tamamlayın, sonra buraya giriş "
 "anahtarınızını yapıştırın."
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr "Anahtarı buraya yapıştırın"
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr "Bitir"
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr "Geçersiz anahtar."
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr "Anahtar kabul edildi. Giriş yapılıyor…"
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr "Masaüstü uygulamasına giriş yapın"
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 "Bu giriş anahtarını kopyalayın ve Zulip uygulamanıza geri dönerek giriş "
 "işlemini tamamlayın:"
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "Kopyala"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr "Bu pencereyi kapatabilirsiniz."
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr "veya , tarayıcı içinden devam edin."
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr "Anonim kullanıcı"
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr "Organizasyon Yöneticileri"
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "Yöneticiler"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr "Moderatörler"
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr "Misafir kullanıcı"
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "Normal kullanıcılar"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr "E-postaları bir e-posta hesabına yönlendirin"
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "Kapat"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "Güncelle"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr "Zulip"
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr "Digest"
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
@@ -2159,17 +1635,17 @@ msgid ""
 msgstr ""
 "Tebrikler, yeni bir Zulip oluşturdunuz organizasyon: <b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr "Zulip'e hoşgeldiniz!"
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr "Zulip organizasyonuna <b>%(realm_name)s</b> katıldınız."
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
@@ -2178,43 +1654,43 @@ msgstr ""
 "Zulip web, <a href=\"%(apps_page_link)s\">mobil ve masaüstü</a> "
 "uygulamalarına giriş yapmak için aşağıdaki bilgileri kullanacaksınız:"
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr "Organizasyon URL'si: %(organization_url)s"
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr "Kullanıcı adınız: %(ldap_username)s"
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr "LDAP hesabınızla giriş yapın"
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr "Hesap e-postanız: %(email)s"
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr "Organizasyona git"
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
 "href=\"%(getting_user_started_link)s\">getting started guide</a>!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2222,7 +1698,7 @@ msgid ""
 "Zulip</a>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
@@ -2231,28 +1707,28 @@ msgstr ""
 "Sorularınız mı var? <a href=\"mailto:%(support_email)s\">Bize ulaşın</a> - "
 "yardımcı olmak isteriz!"
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr "Zulip'te bulunan %(realm_name)s: Yeni organizasyon detaylar"
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr "Zulip'te bulunan %(realm_name)s: Yeni hesap detayların"
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr "Tebrikler, yeni bir Zulip organizasyonu oluşturdunuz: %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr "%(realm_name)s Zulip organizasyonuna katıldınız."
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
@@ -2261,33 +1737,33 @@ msgstr ""
 "Zulip web, mobil ve masaüstü uygulamalarına (%(apps_page_link)s) giriş "
 "yapmak için aşağıdaki bilgileri kullanacaksınız:"
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
 "(%(getting_user_started_link)s)!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
 "(%(getting_organization_started_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 "Sorularınız mı var? Bize %(support_email)s adresinden ulaşın - yardımcı "
 "olmak isteriz!"
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2296,17 +1772,17 @@ msgstr ""
 "Herhangi bir sorunuz varsa, lütfen bu Zulip sunucusunun yöneticileriyle "
 "%(support_email)s adresinden iletişime geçin."
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr "Merhaba,"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2314,12 +1790,12 @@ msgid ""
 "password for this account, please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr "Onay ve şifre belirle"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2328,14 +1804,14 @@ msgstr ""
 "Eğer bu isteği siz  yapmadıysanız lütfen bizimle %(support_email)s aracılığı "
 "ile iletişime geçiniz."
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 #, fuzzy
 #| msgid "Verify your new email address for your demo Zulip organization"
 msgid "Verify your email address for your Zulip demo organization"
 msgstr "Demo Zulip organizasyonunuz için yeni e-posta adresinizi doğrulayın"
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2344,8 +1820,8 @@ msgstr ""
 "Eğer bu isteği siz gerçekleştirmediyseniz, lütfen bizimle iletişime geçiniz "
 "<%(support_email)s>."
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2353,33 +1829,33 @@ msgid ""
 "please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr "E-posta değişikliğini onayla"
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr "Yeni e-posta adresinizi %(organization_host)s için doğrulayın"
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr "Yeni bir Zulip organizasyonu talep ettiniz:"
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr "Organizasyon tipi: %(organization_type)s"
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr "Yakın zaman Zulip için kayıt oldunuz. Harika!"
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
@@ -2387,33 +1863,33 @@ msgstr ""
 "Organizasyonu oluşturmak ve hesabınızı kaydetmek için aşağıdaki düğmeyi "
 "tıklayın. İsterseniz yukarıdaki bilgileri güncelleyebileceksiniz."
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr "Aşağıdaki linke tıklayarak kayıt işlemini tamamlayınız."
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr "Kayıt işlemini tamamla"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr "Zulip organizasyonunuzu oluşturun"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr "Zulip hesabını devreye al"
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr "Aşağıdaki linke tıklayarak kaydı tamamla."
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
@@ -2422,48 +1898,48 @@ msgstr ""
 "Paylaşmak istediğiniz sorularınız veya geri bildirimleriniz mi var? Bize "
 "%(support_email)s adresinden ulaşın - yardımcı olmak isteriz!"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr "E-posta ayarlarını yönet"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr "Pazarlama e-postaları aboneliğinden çık"
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
 "deactivated, and you will no longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr "Yöneticiler aşağıdaki yorumu yapmışlardır:"
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr "%(realm_name)s hesap devre dışı bırakma bildirimi"
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr "Yeni kanallar"
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2471,22 +1947,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because your organization has "
@@ -2502,8 +1978,8 @@ msgstr ""
 "class=\"content_disabled_help_link\" href=\"%(help_url)s\">e-posta "
 "bildirimlerinde ileti içeriği</a> özelliğini devre dışı bırakmıştır."
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because you have disabled <a "
@@ -2518,40 +1994,40 @@ msgstr ""
 "class=\"content_disabled_help_link\" href=\"%(alert_notif_url)s\">e-posta "
 "bildirimlerinde ileti içeriği </a> özelliğini devre dışı bıraktınız."
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, fuzzy, python-format
 #| msgid "Click here to log in to Zulip and catch up."
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr "Buraya tıklayarak Zulip'e giriş yap ve yakala."
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr "Haberdar e-postalarından çık"
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr "%(realm_name)s için Zulip bilgilendirmesi"
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2568,8 +2044,8 @@ msgstr ""
 "bildirimlerinde ileti içeriği özelliğini devre dışı bıraktı.\n"
 "Daha fazla detay için %(hide_content_url)s.\n"
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2585,34 +2061,32 @@ msgstr ""
 "içeriği özelliğini devre dışı bıraktınız.\n"
 "Daha fazla detay için %(alert_notif_url)s.\n"
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, fuzzy, python-format
 #| msgid "Click here to log in to Zulip and catch up: %(organization_url)s."
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr ""
 "Zulip'te oturum açmak ve yetişmek için buraya tıklayın: %(organization_url)s."
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr "E-posta ayarlarını yönet:"
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr "Haberdar e-postalarından çık:"
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr "Yüzen balık"
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr "Talebiniz için teşekkürler!"
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
@@ -2621,8 +2095,7 @@ msgstr ""
 "E-posta adresiniz %(email)s, aşağıdaki Zulip Cloud organizasyonlarında "
 "hesapları bulunmaktadır:"
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
@@ -2631,33 +2104,29 @@ msgstr ""
 "E-posta adresiniz %(email)siçin %(external_host)s tarafından barındırılan "
 "aşağıdaki Zulip organizasyonlarında hesap mevcut:"
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
 "href=\"%(help_reset_password_link)s\">reset your password</a>."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
 "%(external_host)s."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2665,38 +2134,35 @@ msgid ""
 "to find your account."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr "Zulip hesaplarınız"
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr "Zulip hesabı bulunamadı"
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr "Giriş yapmakta sorun yaşıyorsanız, şifrenizi sıfırlayabilirsiniz."
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
 "try another way to find your account (%(help_logging_in_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr "Merhaba,"
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
@@ -2705,18 +2171,18 @@ msgstr ""
 "%(referrer_name)sonlara Zulip'te ve mdash'de -üretkenlik için tasarlanmış "
 "ekip iletişim aracı.- katılmanızı istiyor."
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr "Başlamak için aşağıda ki butona basınız."
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 "%(referrer_full_name)s sizi %(referrer_realm_name)s'a katılmaya davet etti"
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
@@ -2725,17 +2191,17 @@ msgstr ""
 "%(referrer_full_name)s(%(referrer_email)s) senin Zulip'te - üretkenlik için "
 "tasarlanmış edilmiş ekip iletişim aracı- onlara katılmanı istiyor."
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr "Başlamak için aşağıdaki linke tıkla."
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr "Tekrar merhaba,"
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
@@ -2745,13 +2211,13 @@ msgstr ""
 "tasarlanmış ekip iletişim aracı- onlara katılmanızı isteğini bildiren bir "
 "hatırlatıcıdır."
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr "Bu davet için son hatırlatıcıdır."
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
@@ -2760,13 +2226,13 @@ msgstr ""
 "Bu davetiye iki gün içersinde sona eriyor. Eğer davetiye sona ererse, "
 "%(referrer_name)s'a başka bir tanesi için sorman gerekir."
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr ""
 "Hatırlatıcı: %(referrer_name)s'a %(referrer_realm_name)s üzerinden bağlan"
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2776,7 +2242,7 @@ msgstr ""
 "%(referrer_name)s(%(referrer_email)s) senin Zulip'e bağlanmanı istiyor -- "
 "üretkenlik için dizayn edilmiş takım komünikasyon aracı."
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2785,7 +2251,7 @@ msgstr ""
 "Herhangi bir sorunuz varsa, lütfen bu Zulip sunucusunun yöneticileriyle <a "
 "href=\"mailto:%(email)s\">%(email)s</a> adresinden iletişime geçin."
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
@@ -2794,30 +2260,28 @@ msgstr ""
 "Paylaşmak istediğiniz sorularınız veya geri bildirimleriniz mi var? <a "
 "href=\"mailto:%(email)s\">Bize ulaşın</a> - yardımcı olmak isteriz!"
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr "Bunu alıyorsunuz çünkü şahsen sizden bahsedildi."
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr "Bunu alıyorsunuz çünkü @%(mentioned_user_group_name)s dan bahsedildi."
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
 "#%(channel_name)s > %(topic_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
@@ -2825,15 +2289,15 @@ msgstr ""
 "Bunu alıyorsunuz çünkü takip ettiğiniz konular için joker söz bildirimlerini "
 "etkinleştirdiniz."
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
@@ -2841,15 +2305,15 @@ msgstr ""
 "Bunu alıyorsunuz çünkü takip ettiğiniz konular için e-posta bildirimlerini "
 "etkinleştirdiniz."
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2860,7 +2324,7 @@ msgstr ""
 "Zulip</a>'te görüntüleyin veya <a href=\"%(notif_url)s\">e-posta "
 "tercihlerini yönetin</a>."
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
@@ -2869,7 +2333,7 @@ msgstr ""
 "<a href=\"%(narrow_url)s\">%(realm_name)s Zulip</a>'te görüntüleyin veya "
 "yanıtlayın ya da <a href=\"%(notif_url)s\">e-posta tercihlerini yönetin</a>."
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
@@ -2878,7 +2342,7 @@ msgstr ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, veya <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
@@ -2887,42 +2351,42 @@ msgstr ""
 "Bu e-postaya cevap vermeyin. Bu Zulip sunucusu gelen e-postaları almak için "
 "ayarlanmadı (<a href=\"%(url)s\">yardım</a>)."
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr "%(direct_message_group_display_name)s ile olan Grup DM'leri"
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr "%(sender_str)s ile olan DM'ler"
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr "Yeni iletiler"
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 "Bu e-postayı doğrudan yanıtlayın veya %(realm_name)s Zulip'inde görüntüleyin:"
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr "%(realm_name)s Zulip'te görüntüleyin veya yanıtlayın:"
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr "%(realm_name)s Zulip içinde yanıtla:"
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
@@ -2930,7 +2394,7 @@ msgstr ""
 "Bu e-postaya cevap vermeyin. Bu Zulip sunucusu gelen e-postaları almak için "
 "ayarlanmadı. Yardım:"
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2941,22 +2405,22 @@ msgstr ""
 "değiştirildi. Bu değişikliği siz talep etmediyseniz, lütfen adresinden hemen "
 "bizimle %(support_email)s adresinden iletişime geçin."
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr "Saygılarımızla,"
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr "Zulip Takımı"
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr "%(realm_name)s için Zulip e-posta adresi değişti"
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2967,7 +2431,7 @@ msgstr ""
 "bildirisidir. Eğer bunu siz talep etmediyseniz lütfen bizimle iletişime "
 "geçiniz <%(support_email)s>."
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
@@ -2975,46 +2439,46 @@ msgstr ""
 "Organizasyon: %(organization_url)s Zaman: %(login_time)s E-posta: "
 "%(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr "Ekteki Zulip hesabı için az önce bir giriş tespit ettik."
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr "Organizasyon: %(organization_link)s"
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr "E-posta: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr "Zaman: %(login_time)s"
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr "Cihaz %(device_browser)s : %(device_os)s."
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr "IP Adresi: %(device_ip)s"
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr "Eğer bu siz idiyseniz harika! Başka birşey yapmanıza gerek yok."
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3026,31 +2490,31 @@ msgstr ""
 "yenileyin</a> veya hemen %(support_email)s adresinden bizimle iletişime "
 "geçin."
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr "Teşekkürler,"
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr "Zulip Güvenliği"
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr "Giriş bildirimleri aboneliğinden çık"
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr "Cihaz %(device_browser)s : %(device_os)s tarafından yeni giriş"
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr "Organizasyon: %(organization_url)s"
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3061,7 +2525,7 @@ msgstr ""
 "düşünüyorsanız lütfen parolanızı%(reset_link)s adresinden yenileyin veya "
 "%(support_email)s adresinden bizimle iletişime geçin."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -3069,7 +2533,7 @@ msgid ""
 "Zulip</a> to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
@@ -3077,7 +2541,7 @@ msgstr ""
 "Aksi takdirde, <i>herhangi</i> bir ekip sohbeti ürününü değerlendirmek için "
 "müşterilerden sıkça duyduğumuz bazı tavsiyeler aşağıda verilmiştir:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
@@ -3086,13 +2550,13 @@ msgstr ""
 "<a href=\"%(invite_users)s\"><b>Ekip arkadaşlarınızı</b></a> sizinle "
 "birlikte keşfetmeye ve benzersiz bakış açılarını paylaşmaya davet edin."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr ""
 "İzlenimleriniz hakkında sohbet etmek için uygulamanın kendisini kullanın."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -3104,7 +2568,7 @@ msgstr ""
 "uygulamasının ekibinizin iletişimine nasıl yardımcı olacağını gerçekten "
 "deneyimlemenin tek yolu budur."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -3115,27 +2579,27 @@ msgstr ""
 "tasarlanmıştır ve bu ipuçlarının ekibinizin bunu deneyimlemesine yardımcı "
 "olacağını umuyoruz."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr "%(realm_name)s için karşılama e-postaları aboneliğinden çıkın"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr "Ekibiniz için sohbet uygulamasını seçme"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
@@ -3143,7 +2607,7 @@ msgstr ""
 "Aksi takdirde, herhangi bir ekip sohbeti ürününü değerlendirmek için "
 "müşterilerden sık sık duyduğumuz bazı tavsiyeleri burada bulabilirsiniz:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
@@ -3151,7 +2615,7 @@ msgstr ""
 "Ekip arkadaşlarınızı sizinle birlikte keşfetmeye ve benzersiz bakış "
 "açılarını paylaşmaya davet edin."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
@@ -3161,7 +2625,7 @@ msgstr ""
 "yapın. Yeni bir sohbet uygulamasının ekibinizin iletişimine nasıl yardımcı "
 "olacağını gerçekten deneyimlemenin tek yolu budur."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
@@ -3169,8 +2633,8 @@ msgstr ""
 "Zulip, verimli iletişim sağlamak için tasarlanmıştır ve bu ipuçlarının "
 "ekibinizin bunu iş başında deneyimlemesine yardımcı olacağını umuyoruz."
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
@@ -3180,85 +2644,85 @@ msgstr ""
 "çalışabileceğini keşfetmenize yardımcı olmak isteriz. Sizinki gibi "
 "kuruluşlar için Zulip'in temel özelliklerine ilişkin bu kılavuza göz atın!"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr "İşletmeler için Zulip rehberini görüntüle"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr "Açık kaynaklı projeler için Zulip kılavuzunu görüntüleyin"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr "Eğitim için Zulip rehberini görüntüle"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr "Araştırma için Zulip rehberini görüntüle"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr "Etkinlikler ve konferanslar için Zulip rehberini görüntüleyin"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr "Kar amacı gütmeyenler için Zulip rehberini görüntüle"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr "Topluluklar için Zulip rehberini görüntüle"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr "İşletmeler için Zulip rehberi"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr "Açık kaynak projeler için Zulip rehberini görüntüle"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr "Eğitim için Zulip rehberi"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr "Araştırma için Zulip rehberi"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr "Etkinlikler ve konferanslar için Zulip rehberi"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr "Kar amacı gütmeyenler için Zulip rehberi"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr "Topluluklar için Zulip rehberi"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
 msgstr ""
 "Zulip konuşmalarınızı konu başlıklarıyla düzenli tutmak için bazı ipuçları."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
@@ -3267,12 +2731,12 @@ msgstr ""
 "farklı tartışma devam ediyor olursa olsun, her mesajı bağlam içinde "
 "görürsünüz."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr "Zulip uygulamasındaki kanallar ve konular"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3280,11 +2744,11 @@ msgid ""
 "about…?”"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr "Kısa konulardan örnekler"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3293,23 +2757,23 @@ msgid ""
 "href=\"%(move_channels_link)s\">move a topic to a different channel</a>."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr "Zulip'e git"
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr "Konuşmalarınızı konu başlıklarıyla düzenli tutun"
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3318,23 +2782,23 @@ msgid ""
 "(%(move_channels_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
 "%(email)s on %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr "Aşağıdaki butona tıklayarak parolanızı sıfırlayınız."
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr "Parola sıfırla"
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3345,18 +2809,18 @@ msgstr ""
 "dışı bırakıldı. Hesabınızı <a href=\"%(help_link)s\">yeniden etkinleştirmek</"
 "a> için bir organizasyon yöneticisiyle iletişime geçebilirsiniz."
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr "Bu Zulip organizasyonunda hesabınız bulunmamaktadır."
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr "Aşağıdaki organizasyon(lar) için aktif hesaplarınız bulunmaktadır."
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
@@ -3364,31 +2828,31 @@ msgstr ""
 "Yukarıda ki organizasyon(lar) a giriş yapmayı deneyebilir veya parolanızı "
 "sıfırlayabilirsiniz."
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 "Eğer bu eylemi hatırlamıyorsanız, bu e-postayı güvenle göz ardı "
 "edebilirsiniz."
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr "%(realm_name)s için parola sıfırlama talebi"
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr "Aşağıda ki linke tıklayarak parolanı sıfırla."
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
 "You can contact an organization administrator to reactivate your account."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3399,7 +2863,7 @@ msgstr ""
 "nedeniyle Zulip Cloud Ücretsiz planına düşürüldü. Ödenmemiş faturalar iptal "
 "edilmiştir."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
@@ -3408,7 +2872,7 @@ msgstr ""
 "Zulip Cloud Standard planına devam etmek için lütfen %(upgrade_url)sadresine "
 "giderek tekrar yükseltin."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
@@ -3417,8 +2881,8 @@ msgstr ""
 "Bunun bir hata olduğunu düşünüyorsanız veya daha fazla ayrıntıya ihtiyacınız "
 "varsa, lütfen bize %(support_email)s adresinden ulaşın."
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid "You've joined the Zulip organization %(realm_name)s."
 msgid ""
@@ -3426,104 +2890,104 @@ msgid ""
 "%(localized_date)s."
 msgstr "%(realm_name)s Zulip organizasyonuna katıldınız."
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr "Sayın %(realm_name)s eski yöneticileri,"
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip demo organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr "Aşağıdaki butona tıklayarak organizasyonu yeniden devreye sok."
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr "Organizasyonu yeniden devreye sok"
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
@@ -3531,21 +2995,21 @@ msgstr ""
 "Eğer bu istek bir hata ise, bir şey yapmanıza gerek yok. Bu link 24 saat "
 "içersinde devre dışı kalacaktır."
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Reactivate your Zulip organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "Zulip organizasyonunu yeniden aktive et"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr "Zulip organizasyonunu yeniden aktive et"
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr "Aşağıdaki linke tıklayarak organizasyonu yeniden aktif duruma getir."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3554,20 +3018,20 @@ msgstr ""
 "Ya siz ya da sizin adınıza birisi, <b>%(remote_server_hostname)s</b> için "
 "Zulip planını yönetmek üzere bir oturum açma bağlantısı talep etti."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, fuzzy
 #| msgid "Click the link below to log in."
 msgid "Click the button below to log in."
 msgstr "Giriş yapmak için aşağıdaki bağlantıya tıklayın."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr "Bu bağlantının süresi %(validity_in_hours)s saat içinde dolacaktır."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
@@ -3576,11 +3040,11 @@ msgstr ""
 "Sorularınız mı var? <a href=\"%(billing_help_link)s\">Daha fazla bilgi "
 "edinin</a> veya %(billing_contact_email)s ile iletişime geçin."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr "Zulip plan yönetimine giriş yapın"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3589,12 +3053,12 @@ msgstr ""
 "Siz ya da sizin adınıza birisi, %(remote_server_hostname)s için Zulip "
 "planını yönetmek üzere bir oturum açma bağlantısı talep etti."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr "Giriş yapmak için aşağıdaki bağlantıya tıklayın."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
@@ -3603,7 +3067,7 @@ msgstr ""
 "Sorularınız mı var? Daha fazla bilgi için %(billing_help_link)s adresini "
 "ziyaret edin veya %(billing_contact_email)s ile iletişime geçin."
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
@@ -3612,16 +3076,16 @@ msgstr ""
 "E-postanızı onaylamak ve <b>%(remote_realm_host)s</b> için Zulip plan "
 "yönetimine giriş yapmak için aşağıdaki düğmeyi tıklayın."
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr "Onayla ve giriş yap"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr "Zulip plan yönetimi için e-postayı onayla"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
@@ -3630,7 +3094,7 @@ msgstr ""
 "E-postanızı onaylamak ve %(remote_realm_host)s için Zulip plan yönetimine "
 "giriş yapmak için aşağıdaki bağlantıya tıklayın."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
@@ -3639,7 +3103,7 @@ msgstr ""
 "Zulip sponsorluk talebiniz onaylandı! Kuruluşunuz <a "
 "href=\"%(plans_link)s\">Zulip Topluluk planına</a> yükseltildi."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
@@ -3648,12 +3112,12 @@ msgstr ""
 "<a href=\"%(link_to_zulip)s\">Zulip'i web sitenizde sponsor olarak "
 "listeleyebilirseniz</a>, gerçekten minnettar oluruz!"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr "Topluluk planı sponsorluğu %(billing_entity)s için onaylandı!"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
@@ -3661,7 +3125,7 @@ msgstr ""
 "Zulip sponsorluk talebiniz onaylandı! Kuruluşunuz Zulip Topluluk planına "
 "yükseltildi."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
@@ -3669,20 +3133,20 @@ msgstr ""
 "Zulip'i web sitenizde sponsor olarak listeleyebilirseniz, gerçekten "
 "minnettar oluruz!"
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr "Hesaplarınızı bulun"
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr "Zulip hesaplarını bul"
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
@@ -3691,234 +3155,234 @@ msgstr ""
 "Bir e-posta almazsanız <a href=\"%(current_url)s\">başka bir e-posta "
 "adresine</a> ait hesapları bulabilirsiniz."
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr "E-posta adresi"
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "Hesapları bul"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr "Ürün"
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr "Neden Zulip"
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr "Özellikler"
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr "Planlar ve fiyatlar"
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Zulip Cloud status"
 msgid "Zulip Cloud"
 msgstr "Zulip Bulut durumu"
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr "Self-kurulum"
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr "Güvenlik"
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "Entegrasyonlar"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr "Masa üstü & mobil uygulamalar"
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr "Yeni organizasyon"
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr "Çözümler"
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr "İşletme"
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr "Eğitim"
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr "Araştırma"
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr "Etkinlikler ve konferanslar"
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr "Açık kaynak projeleri"
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr "Topluluklar"
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr "Müşteri hikayeleri"
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr "Açık Topluluklar"
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr "Kaynaklar"
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr "Başlarken"
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr "Yardım merkezi"
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr "Topluluk sohbeti"
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr "Zulip Bulut durumu"
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr "Zulip sunucusu yükleme"
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr "Zulip sunucusunu yükseltme"
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr "Geliştirme"
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr "Geliştirme rehberi"
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr "Geliştirme topluluğu"
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr "Tercüme"
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr "GitHub"
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr "Hakkımızda"
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr "Ekip"
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "Tarihçe"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr "Değerler"
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr "İş imkanları"
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr "Blog"
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr "Zulip'i Destekle"
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr "Mastodon"
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Values"
 msgid "Bluesky"
 msgstr "Değerler"
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr "<a href=\"https://zulip.com\">Zulip</a> tarafından desteklenmektedir"
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr "Hizmet koşulları"
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr "Gizlilik politikası"
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr "Website ilişkilendirmesi"
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr "%(integrations_count_display)s 'den fazla dahili entegrasyon."
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 #, fuzzy
 #| msgid ""
 #| "And hundreds more through <a href=\"/integrations/doc/zapier\">Zapier</a> "
@@ -3930,51 +3394,47 @@ msgstr ""
 "Ve yüzlercesi daha <a href=\"/integrations/doc/zapier\">Zapier</a> ve <a "
 "href=\"/integrations/doc/ifttt\">IFTTT</a> aracılığıyla."
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr "Arama entegrasyonları"
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr "Özel entegrasyonlar"
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr "Gelen webhooks"
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr "İnteraktif botlar"
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr "REST API"
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr "Geçersiz E-posta"
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr "Eposta'ya izin verilmiyor"
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr "Kaydolmaya çalıştığınız e-posta adresi geçerli değil."
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3982,7 +3442,7 @@ msgid ""
 "emails with your email domain."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3990,7 +3450,7 @@ msgid ""
 "disposable email addresses."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3998,24 +3458,24 @@ msgid ""
 "emails that contain \"+\"."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr "Lütfen geçerli bir e-posta adresi kullanarak kaydolun."
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr "Lütfen izin verilen bir e-posta adresi kullanarak kaydolun."
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -4023,7 +3483,7 @@ msgid ""
 "%(support_email)s\">contact Zulip support</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -4031,72 +3491,72 @@ msgid ""
 "%(support_email)s\">contact this Zulip server's administrators</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
 "management for your Zulip server."
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr "Geçersiz veya süresi dolmuş giriş oturumu"
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr "Geçersiz veya süresi dolmuş giriş oturumu."
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr "Zulip'e giriş yap"
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 "Bu E-posta adresiyle hali hazırda kayıtlısınız. Lütfen aşağıdan giriş yapın."
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr "E-posta veya kullanıcı adı"
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "Kullanıcı Adı"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr "Parolanızı mı unuttunuz?"
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr "%(identity_provider)s ile giriş yap"
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr "Hesap olmadan gör"
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr "Hesabınız yok mu? Bu organizasyona girmek için davet edilmelisiniz."
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr "Lisans uygun değil"
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr "Kuruluş şu anda yeni üye kabul edemiyor"
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> because all Zulip Cloud licenses are in use."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
@@ -4104,19 +3564,19 @@ msgstr ""
 "Lütfen sizi davet eden kişiyle iletişime geçin ve lisans sayısını "
 "artırmalarını isteyin, sonra tekrar deneyin."
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr "Ana içeriğe geç"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr "Subdomain kimlik doğrulama hatası"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr "Subdomain kimlik doğrulaması"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -4125,44 +3585,42 @@ msgid ""
 "or misconfiguration."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 #, fuzzy
 #| msgid "New organization"
 msgid "Demo organizations disabled"
 msgstr "Yeni organizasyon"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr "Güncelleme gerekli"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr "Son sürümü indir."
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr "Organizasyon oluşturma bağlantısı gerekli"
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -4170,22 +3628,21 @@ msgid ""
 "organization for more information."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr "Organizasyon oluşturma bağlantısının süresi doldu veya geçersiz"
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr "Beklenmeyen Zulip sunucu kaydı"
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, fuzzy, python-format
 #| msgid ""
 #| "Your organization is registered to a different Zulip server. Please "
@@ -4198,49 +3655,47 @@ msgstr ""
 "Kuruluşunuz farklı bir Zulip sunucusuna kayıtlı. Bu sorunu çözme konusunda "
 "yardım almak için lütfen Zulip destek ekibiyle iletişime geçin."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr "Desteklenmeyen tarayıcı"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, fuzzy, python-format
 #| msgid "Presence is not supported for bot users."
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr "Bot kullanıcılar için bağlantı durumu bilgisi desteklenmiyor"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
 "a> like Firefox, Chrome, and Edge."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr "Hesap devre dışı bırakıldı"
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Invalid organization"
 msgid "Finalize organization import"
 msgstr "Geçersiz organizasyon"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Organization moved"
 msgid "Organization import completed!"
 msgstr "Organizasyon taşındı"
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -4248,57 +3703,56 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Select your account"
 msgstr "Hesap oluştur"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Create new account"
 msgstr "Hesap oluştur"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr "Organizasyon başarılı bir şekilde yeniden aktif edildi"
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr "Organizasyonun başarılı bir şekilde yeniden aktif edilmiştir."
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr "Kuruluş yeniden etkinleştirme bağlantısının süresi doldu veya geçersiz"
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr ""
 "Organizasyon yeniden aktif etme bağlantısı sona erdi veya geçerli değil."
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr "Organizasyonuna giriş yap"
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr "Organizasyon URL'ni bilmiyor musun?"
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr "Organizasyonunu bul."
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr "Sonraki"
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4306,24 +3760,24 @@ msgid ""
 "have one yet."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 #, fuzzy
 #| msgid "Self-host Zulip"
 msgid "Self-hosting Zulip?"
 msgstr "Zulip'i kendi sunucunda kullan"
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">log in to manage plans and billing.</a>"
 msgstr ""
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr "Parolanızı sıfırlayın"
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
@@ -4331,63 +3785,63 @@ msgstr ""
 "Parolanızı mı unuttunuz? Hiç sorun değil, kayıt olmak için kullandığınız e-"
 "postanıza parolanızı sıfırlamak için bağlantı göndereceğiz."
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr "Sıfırlama linki gönder"
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr "Yeni bir parola belirleyin"
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "Parolayı teyid et"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr "Bu e-posta adresini zaten kaydetmişsiniz. Lutfen aşağıdan giriş yapın."
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr "Yeni parola başarıyla ayarlandı"
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr "Yeni bir parola ayarladınız!"
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr "Lütfen yeni parolanızla <a href=\"%(login_url)s\">giriş yapın</a>."
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr "Parola yenileme e-postası gönderildi"
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr "Parola sıfırlama gönderildi!"
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr ""
 "Bir kaç dakika içersinde işlemi sonlandırmak için e-postanı kontrol et."
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 #, fuzzy
 #| msgid "Export still in progress"
 msgid "Import progress"
 msgstr "Dışa aktarma hala devam ediyor"
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4395,7 +3849,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4404,30 +3858,30 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 #, fuzzy
 #| msgid ""
 #| "Nobody in this Zulip organization will be able to see this email address."
@@ -4435,30 +3889,30 @@ msgid "Who will be allowed to see other users' email addresses?"
 msgstr ""
 "Bu Zulip organizasyonundaki hiç kimse bu e-posta adresini göremeyecektir."
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4466,7 +3920,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4474,20 +3928,20 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr "Kimlik doğrulama için hesap seç"
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr "<h1 class=\"get-started\">Hesap seç </h1>"
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr "GitHub hesabınızda da onaylanmamış e-posta bulunmaktadır."
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
@@ -4495,15 +3949,15 @@ msgstr ""
 "Zulip'te oturum açarken için bunlardan birini kullanmak için önce <a "
 "href=\"https://github.com/settings/emails\">GitHub ile doğrulayın.</a>"
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr "Eposta abonelik sonlandırılması hatası"
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr "Bilinmeyen e-posta abonelikten çıkma isteği"
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
@@ -4511,7 +3965,7 @@ msgstr ""
 "Merhaba! Görünüşe göre bir şeyden aboneliğinizi iptal etmeye çalıştınız, "
 "ancak URL'yi tanımıyoruz."
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4522,134 +3976,131 @@ msgstr ""
 "veya <a href=\"mailto:%(support_email)s\">bize e-posta gönderin</a> ve bu "
 "sorunu çözelim!"
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr "E-posta ayarları güncellendi"
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
 "href=\"%(realm_url)s/#settings/notifications\">notification settings</a>."
 msgstr ""
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr "Geçersiz sıralama."
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr ""
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr ""
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr ""
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr "kaydolmalar"
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr "{user} bu organizasyona bağlandı."
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr "{user} Zulip'e katılma davetinizi kabul etti!"
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 "Yer tutucu bir hesap etkinleştirilemiyor; bunun yerine kullanıcıdan "
 "kaydolmasını isteyin."
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 #, fuzzy
 #| msgid "Cannot deactivate the only {entity}."
 msgid "Cannot reactivate a deleted user"
 msgstr "Tek {entity} devre dışı bırakılamaz."
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr "Field id {id} bulunamadı."
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr ""
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr ""
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr ""
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
@@ -4657,7 +4108,7 @@ msgstr ""
 "Kullanıcıları korumak için Zulip bir gün içinde gönderebileceğiniz davetiye "
 "sayısını sınırlar. Sınıra ulaştığınız için davetiye gönderilmedi."
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
@@ -4666,79 +4117,79 @@ msgstr ""
 "organizasyon yöneticisi veya daha uzun süreli bir başka kullanıcıdan yardım "
 "alınız."
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 #, fuzzy
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 "E-postaların bazıları doğrulanamadığından bu kisilere davetiye "
 "gönderilemedi. Geri kalan herkesin davetiyesi gönderildi!"
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr "Kimseyi davet edemedik."
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr "Değiştirilecek bir şey yok"
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr ""
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr "Doğrudan mesajların konuları olamaz."
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr "Konu düzenlemesi olmayan geçersiz propagate_mode"
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr ""
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr "Araçlar düzenlenemez."
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr "Organizasyonunuz ileti değiştirmeye izin vermiyor"
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr "Bu iletiyi düzenleme izniniz yok"
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr "İleti düzenleme için belirlenen zaman limiti geçmiştir"
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr "{user} bu konuyu çözüldü olarak işaretledi."
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr "{user} bu konuyu çözülmemiş olarak işaretledi."
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr "Bu konu {user} tarafından {new_location} konumuna taşındı."
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr ""
 "Bir mesaj {user} tarafından bu konudan {new_location} konumuna taşındı."
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
@@ -4747,13 +4198,13 @@ msgstr ""
 "{changed_messages_count} mesajları {user} tarafından bu konudan "
 "{new_location} 'a taşındı."
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr ""
 "Bu konu {user} tarafından {old_location} konumundan buraya taşınmıştır."
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
@@ -4761,7 +4212,7 @@ msgstr ""
 "[Bir mesaj]({message_link}) {user} tarafından {old_location} 'dan buraya "
 "taşındı."
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
@@ -4770,76 +4221,73 @@ msgstr ""
 "{changed_messages_count} mesajları {user} tarafından {old_location} 'dan "
 "buraya taşındı."
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 #, fuzzy
 #| msgid "You don't have permission to delete this message"
 msgid "You don't have permission to resolve topics in this channel."
 msgstr "Bu iletiyi silmek için geçerli yetkiniz bulunmamaktadır"
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr "Bu mesajın konusunu düzenlemek için zaman sınırı geçti."
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr "Bu iletiyi taşımak için yetkiniz yok"
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr ""
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr "Geçersiz bayrak: '{flag}'"
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr "Bayrak düzenlenemez: '{flag}'"
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr "Geçersiz mesaj bayrağı işlemi: '{operation}'"
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr "Geçersiz ileti(ler)"
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr "İleti gönderime hazırlanamadı"
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr "Tam olarak 1 kanal bekleniyordu"
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr "Kanal için geçersiz veri tipi"
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr "Alıcılar için geçersiz veri tipi"
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 "Alıcılar listesi e-posta veya kullanıcı ID içerebilir ama ikisi birden "
 "olamaz."
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
 "but there is no channel with that ID."
 msgstr ""
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4847,36 +4295,36 @@ msgid ""
 "it."
 msgstr ""
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
 "The channel exists but does not have any subscribers."
 msgstr ""
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr "Bazı alıcılara erişim izniniz yok."
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr "Eklentiler: API programıcısı yanlış JSON içeriği gönderdi"
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr "Widgetlar: {error_msg}"
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4884,26 +4332,24 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr "Bu isimle bir özel emoji hali hazırda mevcut."
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr "Sıralı liste yinelenen bağlayıcılar içermemelidir"
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 "Sıralı liste, mevcut tüm bağlayıcıları tam olarak bir kez sıralamalıdır"
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
@@ -4912,39 +4358,39 @@ msgstr ""
 "Bu giriş metodunu kullanabilmek için {required_upgrade_plan_name} planına "
 "yükseltmeniz gerekmektedir."
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr "Geçersiz giriş metodu: {name}. Geçerli metodlar: {methods}"
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr "Aktif planınız için {name} giriş metodu mevcut değil."
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr ""
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr "Zamanlanmış mesaj zaten gönderildi"
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder could not be sent."
 msgstr "Jeton (token) bulunamadı"
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr "Mesaj planlanan zamanda gönderilemedi."
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
@@ -4953,45 +4399,45 @@ msgstr ""
 "{delivery_datetime} için zamanladığınız mesaj aşağıdaki hata nedeniyle "
 "gönderilemedi:"
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr "[Zamanlanmış mesajları gör](#scheduled)"
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr "Kanal zaten devre dışı"
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr ""
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr "Kanal şu an da devre dışı değil"
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr ""
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr ""
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr ""
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
 "**{old_policy}** to **{new_policy}**."
 msgstr ""
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -5000,51 +4446,49 @@ msgid ""
 "* **New**: {new_setting_description}\n"
 msgstr ""
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr "Tanım yok."
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr ""
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr "Eski açıklama"
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr "Yeni açıklama"
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr "Sonsuza dek"
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr ""
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 msgstr ""
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr ""
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -5055,99 +4499,89 @@ msgid ""
 "{summary_line}"
 msgstr ""
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr "Bu iletiye bir alt ileti ekleyemezsiniz."
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr "{user_id} geçersiz kullanıcı kimliği"
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr "Kullanıcı grubu '{group_name}' zaten mevcut."
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr "Yetersiz izin"
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr "Bu API gelen webhook botlarına müsait değildir."
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr "Hesap bu alt alanla ilişkilendirilmedi"
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr "Bu endpoint bot istemlerini kabul etmiyor."
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr "Sunucu yöneticisi olmak zorunda"
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr "Bu endpoint için HTTP basic authentication gerekiyor."
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr "Basic auth için geçersiz doğrulama başlığı"
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr "Basit doğrulama için geçersiz doğrulama başlığı"
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr "Webhook botları yalnızca webhooklara ulaşabilirler"
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr ""
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
@@ -5156,54 +4590,53 @@ msgstr ""
 "Hesabınız {username} devre dışı bırakıldı. Yeniden etkinleştirmek için "
 "lütfen kuruluş yöneticinizle iletişime geçin."
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr "Şifre çok zayıf."
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr "Alt alan adı 3 veya daha fazla karakterden oluşmalıdır."
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr "Alt alan adının başında ve sonunda '-' bulunamaz."
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr ""
 "Alt alan adında sadece küçük harfler, rakamlar ve '-' işaretleri "
 "kullanılabilir."
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr "Alt alan adı rezerve edildi. Lütfen farklı bir tane seçin."
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr "Lütfen gercek e-posta adresinizi kullanın."
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr "{email} ile katılmak istediğiniz organizasyon mevcut değil."
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr ""
 "Lütfen organizasyon yöneticinizden {email} için bir davetiye isteyiniz."
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
@@ -5212,12 +4645,12 @@ msgstr ""
 "E-posta adresiniz, {email}, bu organizasyonda hesap oluşturmak için izin "
 "verilmiş alan adlarından birine ait değil."
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr ""
 "+ işareti içeren e-posta adreslerine bu organizasyonda izin verilmemektedir."
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
@@ -5227,34 +4660,33 @@ msgstr ""
 "katılamaz. Lütfen sizi davet eden kişiyle iletişime geçin ve lisans sayısını "
 "artırmasını isteyin, ardından tekrar deneyin."
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 #, fuzzy
 #| msgid "Embedded bots are not enabled."
 msgid "Challenges are not enabled."
 msgstr "Gömülü botlar etkin değil."
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "Yeni parola"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr "Yeni parola onayı"
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "You're making too many attempts to sign in. Try again in {seconds} "
@@ -5266,7 +4698,7 @@ msgstr ""
 "Oturum açmak için çok fazla deneme yapıyorsunuz. {seconds} içinde tekrar "
 "deneyin veya yardım için kuruluş yöneticinize başvurun."
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
@@ -5274,92 +4706,90 @@ msgstr ""
 "Şifreniz çok zayıf olduğundan dolayı devre dışı bırakılmıştır. Yeni bir tane "
 "oluşturmak için şifrenizi sıfırlayın."
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr "Anahtar"
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 "İpucu: Aralarına virgül koyarak birden fazla e-posta adresi girebilirsiniz."
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr "Lütfen en fazla 10 E-posta adresi giriniz."
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr "Zulip organizasyonunu bulamadık."
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr "Geçersiz e-posta '{email}'"
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr "Konu eksik"
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr "Birden fazla kanala gönderilemedi"
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr "Kayıp kanal"
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr "İletinin alıcıları olmalıdır"
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr "Geçersiz ileti türu"
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr "Geçersiz ek"
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr "Ek silinirken bir hata oluştu. Lütfen daha sonra tekrar deneyiniz."
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr "İleti alıcı içermelidir!"
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "User group name can't be empty!"
 msgid "Channel folder name can't be empty."
 msgstr "Kullanıcı grubu adı boş olamaz!"
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid character in topic, at position {position}!"
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr "Konuda, {position} konumunda geçersiz karakter!"
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Invalid data export ID"
 msgid "Invalid channel folder ID"
 msgstr "Geçersiz veri dışa aktarım ID'si"
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 #, fuzzy
 #| msgid "Confirm your email address"
 msgid "Configure owner account email address."
 msgstr "E-posta adresinizi doğrulayın"
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| " Congratulations, you have created a new demo Zulip organization. Note "
@@ -5376,72 +4806,72 @@ msgstr ""
 "organizasyonlar hakkında daha fazla bilgiyi buradan edinebilirsiniz: "
 "%(demo_organizations_help_link)s!"
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a date"
 msgid "{var_name} is not Base64 encoded"
 msgstr "{var_name} bir tarih değil"
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 #, fuzzy
 #| msgid "Invalid emoji code."
 msgid "Invalid `device_id`"
 msgstr "Geçersiz emoji kodu."
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr "{service_name} digest"
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr "Alan boş olamaz."
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr "Alan içinde en az bir nokta (.) olmalıdır"
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr "Alan adı çok uzun"
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr "Alanlar nokta ile başlayamaz ve bitemez"
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr "Ardışık '.' kullanılamaz."
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr "Alt alan adları '-' ile başlayamaz."
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr "Alan adlarında sadece harfler, rakamlar, \".\" ve \"-\" bulunabilir."
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr "Zaman bilgisi negatif olmamalıdır."
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr "Konu boş bayt içermemelidir"
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr "Kullanıcı, taslakları senkronize etmeyi devre dışı bıraktı."
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr "Taslak mevcut değil"
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5449,86 +4879,86 @@ msgid ""
 "{error_message}"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr "Zulip'i açarak verileri önceden izleyin"
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr "{service_name} bildirimleri"
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr "Geçersiz adres."
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr "Sizin alanınız dışında."
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr "+ işareti içeren e-posta adreslerine izin verilmemektedir."
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr "Sistem botları için ayrıldı."
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr "{email} bir hesaba sahip"
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr "Zaten bir hesabı var."
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr "Hesap devre dışı bırakıldı."
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr "Emoji '{emoji_name}' mevcut değil"
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr "Geçersiz özel emoji."
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr "Geçersiz özel emoji ismi."
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr "Bu özel emoji devre dışıdır."
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr "Geçersiz emoji kodu."
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr "Geçersiz emoji ismi."
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr "Geçersiz emoji türü."
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr "Organizasyon yöneticisi veya emoji tasarımcısı olmalı"
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr "Emoji adları bir harf veya rakamla bitmelidir."
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
@@ -5536,120 +4966,119 @@ msgstr ""
 "Emoji adları yalnızca küçük İngilizce harfler, rakamlar, boşluklar, tire ve "
 "alt çizgi içermelidir."
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr "Emoji adı eksik"
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr "Olay sırası atanamadı"
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr ""
 "Oturum açık değil: API kimlik doğrulaması veya kullanıcı oturumu gerekli"
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, fuzzy, python-brace-format
 #| msgid "User group '{group_name}' already exists."
 msgid "Channel '{channel_name}' already exists"
 msgstr "Kullanıcı grubu '{group_name}' zaten mevcut."
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr "organizasyon sahibi"
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr "kullanıcı"
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr "Tek {entity} devre dışı bırakılamaz."
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr "Geçersiz Markdown içerme durumu: {include_statement}"
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr "Hatalı biçimlendirilmiş JSON"
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr "Organizasyon yöneticisi olmalı"
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr "Organizasyon sahibi olmalı"
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Must be an organization owner"
 msgid "Must be a bot user"
 msgstr "Organizasyon sahibi olmalı"
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr "Kullanıcı adınız veya parolanız hatalı"
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr "Bu organizasyon devre dışıdır"
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr "Sunucunuz için mobil anlık bildirim hizmeti kaydı devre dışı bırakıldı"
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr "Bu organizasyonda parola doğrulaması devre dışı bırakıldı"
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr "Parolanız devre dışı bırakıldı ve sıfırlanması gerekiyor"
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr "Geçersiz API anahtarı"
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr "Hatalı API anahtarı"
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
@@ -5658,56 +5087,55 @@ msgstr ""
 "'{event_type}' olayı şu anda {webhook_name} webhook'u tarafından "
 "desteklenmiyor; yok sayılıyor"
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr "İstek ayrıştırılamıyor: Bu olayı {webhook_name} mi oluşturdu?"
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr "Kullanıcı giriş yapmadı"
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr "Geçersiz alt alan adı"
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr "Bu organizasyonda doğrudan mesajlar devre dışı bırakılmıştır."
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr ""
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr "Erişim engellendi"
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
@@ -5716,15 +5144,15 @@ msgstr ""
 "Yalnızca bu konudaki {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} en son iletileri taşıma iznine sahipsiniz."
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr "Tepki halihazırda mevcut."
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr "Tepki mevcut değil."
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
@@ -5732,365 +5160,365 @@ msgstr ""
 "Kuruluşunuz farklı bir Zulip sunucusuna kayıtlı. Bu sorunu çözme konusunda "
 "yardım almak için lütfen Zulip destek ekibiyle iletişime geçin."
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr "Organizasyon kayıtlı değil"
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr "Bu konuda konu joker karakterlerini kullanma izniniz yok."
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr ""
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr "'{setting_name}' bir sistem kullanıcı grubu olmalıdır."
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr ""
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr "Planlanan teslimat zamanı gelecekte olmalıdır."
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Server doesn't use the push notification service"
 msgid "Server is not configured to use push notification service."
 msgstr "Sunucu anlık bildirim servisi kullanmıyor"
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Already has an account."
 msgid "Atlassian account ID"
 msgstr "Zaten bir hesabı var."
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Behance username"
 msgstr "Kötü ad veya kullanıcı adı"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Bitbucket username"
 msgstr "Github kullanıcı adı"
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Codeberg username"
 msgstr "Twitter kullanıcı adı"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Dribbble username"
 msgstr "Github kullanıcı adı"
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Facebook username"
 msgstr "Kötü ad veya kullanıcı adı"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr "Github kullanıcı adı"
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "GitLab username"
 msgstr "Github kullanıcı adı"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Instagram username"
 msgstr "Twitter kullanıcı adı"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Mastodon"
 msgid "Mastodon profile"
 msgstr "Mastodon"
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Medium username"
 msgstr "Github kullanıcı adı"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Pinterest username"
 msgstr "Twitter kullanıcı adı"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Reddit username"
 msgstr "Github kullanıcı adı"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Snapchat username"
 msgstr "Github kullanıcı adı"
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Threads username"
 msgstr "Twitter kullanıcı adı"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "TikTok username"
 msgstr "Twitter kullanıcı adı"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Twitch username"
 msgstr "Twitter kullanıcı adı"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "Kullanıcı Adı"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr "Geçersiz dış hesap tipi"
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr "Entegrasyon yapıları"
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 #, fuzzy
 #| msgid "Video call ended"
 msgid "Video calling"
 msgstr "Video görüşmesi sonlandırıldı"
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr "Sürekli entegrasyon"
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr "Müşteri desteği"
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr "Sunucuya kurulum"
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr "Eğlence"
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr "İletişim"
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr "Finansal"
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr "İnsan kaynakları"
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr "Pazarlama"
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr "Çeşitli"
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr "Gözlemleme"
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr "Proje yönetimi"
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr "Üretkenlik"
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr "Versiyon kontrölü"
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr "İleti boş olmamalıdır"
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr "İleti boş bayt içermemelidir"
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{fullname} moderation"
 msgstr "{full_name} senden bahsetti:"
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr "Geçersiz süzme operatörü: {desc}"
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr ""
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr ""
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr "Eksik 'anchor' argümanı."
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 #, fuzzy
 #| msgid "Missing 'anchor' argument."
 msgid "Missing 'anchor_date' argument."
 msgstr "Eksik 'anchor' argümanı."
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr "Geçersiz öbek"
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr "{operator} operatörü desteklenmiyor."
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr ""
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 #, fuzzy
 #| msgid "Confirmation link does not exist"
 msgid "Navigation view does not exist."
 msgstr "Doğrulama bağlantısı mevcut değil"
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6098,7 +5526,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6106,7 +5534,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6114,7 +5542,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6122,7 +5550,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| " Congratulations, you have created a new demo Zulip organization. Note "
@@ -6140,14 +5568,14 @@ msgstr ""
 "organizasyonlar hakkında daha fazla bilgiyi buradan edinebilirsiniz: "
 "%(demo_organizations_help_link)s!"
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
 "them in your [Inbox](/#inbox).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6155,7 +5583,7 @@ msgid ""
 "({navigation_tour_video_url}) for a quick app overview.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6170,14 +5598,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -6185,7 +5613,7 @@ msgid ""
 "and edit your [profile information](/help/edit-your-profile).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -6196,7 +5624,7 @@ msgid ""
 "experience in your [Preferences](#settings/preferences).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6207,7 +5635,7 @@ msgid ""
 "[Browse and subscribe to channels]({settings_link}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -6224,7 +5652,7 @@ msgid ""
 "discussed.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -6233,7 +5661,7 @@ msgid ""
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -6245,7 +5673,7 @@ msgid ""
 "times, and more.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6255,7 +5683,7 @@ msgid ""
 "or browse the [help center](/help/) to learn more!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6263,7 +5691,7 @@ msgid ""
 "get help, try one of the following messages: {bot_commands}\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6275,13 +5703,13 @@ msgid ""
 "({move_content_another_channel_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6295,12 +5723,11 @@ msgid ""
 "and above.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr ""
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -6308,14 +5735,14 @@ msgid ""
 "no matter how many other conversations are going on.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
 "conversations with unread messages.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -6323,7 +5750,7 @@ msgid ""
 "the `+` button next to its name.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -6331,13 +5758,13 @@ msgid ""
 "can we chat about…?”\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6345,7 +5772,7 @@ msgid ""
 "({format_message_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6365,915 +5792,897 @@ msgid ""
 "```\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
 "teammates.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
 "conversation.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr ""
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr ""
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr ""
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr "Geçersiz JSON cevabı"
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr "Geçersiz cevap formatı"
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr "Boş veya geçersiz uzunluk belirteci"
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr "Geçersiz APNS token"
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr "Fedai için geçersiz GCM seçeneği: öncelik {priority!r}"
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr "Geçersiz GCM seçenekleri: {options}"
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr "Jeton (token) bulunamadı"
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr "{full_name}, @{user_group_name}'dan bahsetti:"
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr "{full_name} senden bahsetti:"
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr "{full_name} herkese bahsetti:"
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "Yeni mesaj"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr "Test bildirimi"
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr "Cihaz tanımlanamadı"
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr "Cihaz push bouncer tarafından tanınmıyor"
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 #, fuzzy
 #| msgid "Server doesn't use the push notification service"
 msgid "Network error while connecting to Zulip push notification service."
 msgstr "Sunucu anlık bildirim servisi kullanmıyor"
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 #, fuzzy
 #| msgid "Server doesn't use the push notification service"
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr "Sunucu anlık bildirim servisi kullanmıyor"
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 #, fuzzy
 #| msgid "Invalid API key"
 msgid "Invalid `push_key`"
 msgstr "Geçersiz API anahtarı"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr "Kullanıcı bu sorgu için yetkilendirilmemiş"
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr "'{email}' Zulip'i artık kullanmıyor."
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr "Kuruluşunuzun dışına doğrudan mesaj gönderemezsiniz."
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr "{var_name} çok uzun (limit: {max_length} karakter)"
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder does not exist"
 msgstr "Jeton (token) bulunamadı"
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr "Push bildirimleri bouncer hatası: {error}"
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr "'{var_name1}' ve '{var_name2}' argümanları arasında karar verilemedi"
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr "Eksik '{var_name}' argümanı"
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr "'{var_name}' için kötü değer : {bad_value}"
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr "Zamanlanmış mesaj mevcut değil"
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr "{service_name} hesap güvenliği"
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr ""
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr ""
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 #, fuzzy
 #| msgid "You don't have permission to delete this message"
 msgid "You do not have permission to create new topics in this channel."
 msgstr "Bu iletiyi silmek için geçerli yetkiniz bulunmamaktadır"
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr ""
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr ""
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr ""
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr ""
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr ""
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr "Konuda, {position} konumunda geçersiz karakter!"
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr "Resim dosyası açılamadı; resim dosyası mı yükledin?"
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr "Resim boyutu limiti aşmaktadır."
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr "{var_name} bir boolean değil"
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} does not have a length"
 msgid "{var_name} does not have the expected format"
 msgstr "{var_name} bir uzunluğu yok"
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr "{var_name} bir tarih değil"
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr "{var_name} bir dict değil"
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr "Geçersiz {var_name}"
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr "argüman \"{argument}\" at {var_name} beklenmedik"
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr "{var_name} küsuratlı değil"
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr "{var_name} çok küçük"
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr "{var_name} bir sayı değil"
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr "{var_name} geçerli bir JSON değil"
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr "{var_name} çok büyük"
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr "{var_name} bir liste değil"
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr "{var_name} çok uzun (limit: {max_length} karakter)"
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr "{var_name} çok kısa."
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr "{var_name} bir string değil"
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr "{var_name} çok uzun (limit: {max_length} karakter)"
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr "{var_name} çok uzun (limit: {max_length} karakter)"
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr "{var_name} boş olamaz"
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr "Geçersiz {var_name}: {msg}"
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr "Bozuk veri"
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr "{var_name} geçerli bir hex renk kodu değil"
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr "Geçersiz {setting_name}"
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr "Bu yükleme organizasyonunuzun yükleme hakkını aşıyor."
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr ""
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr ""
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr "Geçersiz kullanıcı grubu"
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid user group ID: {group_id}"
 msgid "Invalid user group ID: {user_group_id}"
 msgstr "Geçersiz kullanıcı grubu kimliği: {group_id}"
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr ""
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr "Geçersiz kullanıcı grubu kimliği: {group_id}"
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr "'{setting_name}' ayarı 'role:internet' grubuna ayarlanamaz."
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr "'{setting_name}' ayarı 'role:nobody' grubuna ayarlanamaz."
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr "'{setting_name}' ayarı 'role:everyone' grubuna ayarlanamaz."
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr "'{setting_name}' ayarı '{group_name}' grubuna ayarlanamaz."
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr "Kullanıcı grubu adı boş olamaz!"
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr "Kullanıcı grubu adı {max_length} karakterlerini aşamaz."
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr "Kullanıcı grubu adı '{prefix}' ile başlayamaz."
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr "Alıcı herhangi yeni bir değer göndermedi."
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 "İstemci, emoji_code veya reaction_type gönderdiğinde emoji_name de "
 "gönderilmelidir."
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr "İsim çok uzun!"
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 #, fuzzy
 #| msgid "Message must not be empty"
 msgid "Name must not be empty!"
 msgstr "İleti boş olmamalıdır"
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr "İsim'de geçersiz karakterler bulunuyor!"
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr "Geçersiz format!"
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr ""
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr ""
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr "Kötü ad veya kullanıcı adı"
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr "'{integration_name}' geçersiz etegrasyon."
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr "Eksik ayar parametreleri: {keys}"
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr "Geçersiz {key} değeri {value} ({error})"
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr "Geçersiz ayar verisi!"
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr "Geçersiz bot türü"
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr "Geçersiz arayüz türü"
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr "Geçersiz kullanıcı kimliği: {user_id}"
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr "Böyle bot yok"
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr "Böyle bir kullanıcı yok"
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr "Kullanıcı devre dışı bırakıldı"
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr "{item} boş geçilemez."
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr "{var_name} geçersiz uzunlukta {length};  {target_length} olmalı"
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a string"
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr "{var_name} bir string değil"
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr "{container} tam {length} parçaya sahip olmalı"
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr "{key_name} anahtarı buradan {var_name} eksik"
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr "Beklenmeyen değerler: {keys}"
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr "{var_name} allowed_type değil"
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr "{variable} != {expected_value} ({value} yanlış)"
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr "{var_name} bir URL değil"
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr "URL kalıbı '%(username)s' içermelidir."
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr "'{item}' boş geçilemez."
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr "Alanın yinelenen seçenekleri olmamalıdır."
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr "'{value}', '{field_name}' için uygun bir seçenek değil."
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr "{var_name} bir karakter ya da sayı listesi değil"
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr "{var_name} bir karakter ya da sayı değil"
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr "{var_name} bir uzunluğu yok"
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr "{var_name} eksik"
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr "HTTP olay başlığı '{header}' eksik"
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, fuzzy, python-brace-format
 #| msgid "Operator {operator} not supported."
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr "{operator} operatörü desteklenmiyor."
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr "zcommand sonunda '/' olmalı."
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr "Böyle bir komut yok: {command}"
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr "CSRF hatası: {reason}"
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr "Ters vekil sunucusu ayar eksiği: {proxy_reason}"
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr "ID {user_id} olan kullanıcı devre dışı bırakıldı"
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr "ID {user_id} olan kullanıcı bir bottur"
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr "Tarih"
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr "Dış hesap"
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr "Zamiler"
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr "Hiç kimse"
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr ""
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "Üyeler"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr "İnternetteki herkes"
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Invalid characters in emoji name"
 msgid "Invalid auto-conversion field: empty field name."
 msgstr "Emoji adında geçersiz karakterler"
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr "URL şablonundaki %(name)r grubu bağlayıcı deseninde mevcut değil."
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr "Kötü regex sorgusu: {regex}"
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr "Bilinmeyen  regular expression hatası"
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr "Geçersiz URL taslağı."
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid "Example input does not match the linkifier pattern."
 msgstr "URL şablonundaki %(name)r grubu bağlayıcı deseninde mevcut değil."
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr "URL şablonundaki %(name)r grubu bağlayıcı deseninde mevcut değil."
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr "Bağlayıcı desenindeki %(name)r grubu URL şablonunda mevcut değil."
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid ""
@@ -7281,7 +6690,7 @@ msgid ""
 "pattern."
 msgstr "URL şablonundaki %(name)r grubu bağlayıcı deseninde mevcut değil."
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgid ""
@@ -7289,333 +6698,330 @@ msgid ""
 "template."
 msgstr "Bağlayıcı desenindeki %(name)r grubu URL şablonunda mevcut değil."
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr "Unicode emoji"
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "Özel emoji"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr "Zulip ekstra emoji"
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr "Emoji adında geçersiz karakterler"
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr "Pygments dilinde hatalı karakterler"
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr "URL şablonunda gerekli \"code\" değişkeni eksik"
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr "URL şablonunda bulunan tek değişken \"code\" olmalıdır"
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr ""
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr ""
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr ""
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr "Zulip güncellemeleri"
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr "Zulip Cloud Standard'da mevcuttur. Erişmek için yükseltin."
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr "Zulip Cloud Plus'ta mevcuttur. Erişmek için yükseltin."
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr "GIF'lerin G (Genel izleyici) olarak derecelendirilmesine izin verin"
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr "PG (Ebeveyn rehberliği) dereceli GIF'lere izin ver"
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr "PG-13 (Ebeveyn rehberliği - 13 yaş altı) dereceli GIF'lere izin ver"
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr "R dereceli GIF'lere izin ver (Kısıtlı)"
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr "Web-public"
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "Genel"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr "Özel, paylaşılan geçmiş"
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr "Özel, korumalı geçmiş"
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr "Yöneticiler, moderatörler, üyeler ve misafirler"
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr "Yöneticiler, moderatörler ve üyeler"
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr "Yöneticiler ve moderatörler"
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr "Sadece yöneticiler"
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr "Bilinmeyen kullanıcı"
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr "Organizasyon sahibi"
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr "Organizasyon ymeticisi"
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr "Moderatör"
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "Üye"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "Misafir"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr "Bilinmeyen IP adresi"
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr "Bilinmeyen bir işletim sistemi"
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr "Bilinmeyen bir tarayıcı"
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr "'queue_id' argümanı eksik"
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr "'last_event_id' argümanı eksik"
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr "{event_id} olayından daha yeni bir olay kesildi!"
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr "{event_id} olayı bu sırada değildi"
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr "Hatalı olay kuyruğu kimliği: {queue_id}"
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 #, fuzzy
 #| msgid "Failed to create Zoom call"
 msgid "Failed to generate challenge"
 msgstr "Bir Zoom görüşmesi oluşturulamadı"
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr "JWT kimlik doğrulaması bu kuruluş için etkinleştirilmemiştir"
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr "İstekte JSON web belirteci yoktu"
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr "JSON web token hatalı"
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr "JSON web belirteci taleplerinde e-posta belirtilmemiş"
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr "Alt alan gerekli"
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr "Parola yanlış."
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr "İstekte User-Agent başlığı eksik"
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr "Başlık boş geçilemez."
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr "Alan en az bir seçenek içermelidir."
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr "Alan türü profil özetinde görüntülenmek için desteklenmiyor."
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 #, fuzzy
 #| msgid "Field type not supported for display in profile summary."
 msgid "Field type not supported for use for user matching."
 msgstr "Alan türü profil özetinde görüntülenmek için desteklenmiyor."
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr "Geçersiz alan türü."
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr "Profil özetinde yalnızca 2 özel profil alanı görüntülenebilir."
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr "Bu başlık zaten mevcut."
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr "Varsayılan özel alan güncellenemez."
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr "Uç sunucu yayınlanmış versiyonda mevcut değil."
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr "DevAuthBackend etkin değil."
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr "Anonim istek için geçersiz '{key}' parametresi"
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr "Veri tabanı boş"
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr "Postgresql sorgulanamıyor"
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr "Rabbitmq'ya bağlanılamıyor"
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr "Rabbitmq sorgulanamıyor"
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr "Redis sorgulanamıyor"
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr "Memcached'e yazılamadı"
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr "Memcached sorgulanamıyor"
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr "Böyle bir davetiye yok"
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 #, fuzzy
 #| msgid "Invitation has already been revoked"
 msgid "Invitation already used or deactivated."
 msgstr "Davet zaten iptal edildi"
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr "Davet zaten iptal edildi"
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr ""
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr "En az bir e-posta adresi belirtmelisiniz."
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
@@ -7623,108 +7029,106 @@ msgstr ""
 "Bu adreslerden bazıları zaten Zülip'i kullanıyor, bu yüzden onlara bir davet "
 "göndermedik. Diğer herkese davetiye gönderildi!"
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr "Bu organizasyonda ileti değiştirme tarihçesi tutulmuyor"
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr "Bu iletiyi silmek için geçerli yetkiniz bulunmamaktadır"
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr "Bu iletiyi silmek için belirlenen zaman limiti geçmiştir"
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr "İleti zaten silinmiş"
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr "Çok fazla mesaj talep edildi (maksimum {max_messages})."
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr "Çapa yalnızca aralığın bir ucunda hariç tutulabilir"
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr "'{topic}' böyle bir konu yok"
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Organization creation link required"
 msgid "An explanation is required."
 msgstr "Organizasyon oluşturma bağlantısı gerekli"
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Zephyr mirroring is not allowed in this organization"
 msgid "Message reporting is not enabled in this organization."
 msgstr "Bu organizasyonda Zephyr kopyalamaya (mirroring) izin verilmemektedir"
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr "Eksik gönderici"
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr "Aynalama, alıcı kullanıcı kimlikleri ile izin verilmemektedir"
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr "Geçersiz kopyalanmış ileti"
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr ""
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr ""
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr ""
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr "Kendini sessize alamazsın"
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr "Kullanıcı zaten sessiz"
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr "Kullanıcı sessize alınmamış"
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 #, fuzzy
 #| msgid "{hostname} is not a valid hostname"
 msgid "Custom views must have a valid name."
 msgstr "{hostname} geçerli bir ana bilgisayar adı değil"
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 #, fuzzy
 #| msgid "Reaction already exists."
 msgid "Navigation view already exists."
 msgstr "Tepki halihazırda mevcut."
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr "Bilinmeyen onboarding_step: {onboarding_step}"
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7732,477 +7136,475 @@ msgid ""
 "later. Is this a good time?\n"
 msgstr ""
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr "Bot kullanıcılar için bağlantı durumu bilgisi desteklenmiyor."
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr "{user_id_or_email} ait bir veri yok"
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr "Geçersiz durum: {status}"
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 #, fuzzy
 #| msgid "You don't have permission to delete this message"
 msgid "You do not have permission to manage plans and billing."
 msgstr "Bu iletiyi silmek için geçerli yetkiniz bulunmamaktadır"
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr "Sunucu anlık bildirim servisi kullanmıyor"
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr "Fedai tarafından döndürülen hata: {result}"
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr ""
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr "Aşağıdaki argümanların en az biri gerekli: emoji_name, emoji_code"
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr "Bu organizasyonda okuma makbuzları devre dışı bırakılmıştır."
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr "Geçersiz dil '{language}'"
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr "En az bir kimlik doğrulama yöntemi etkinleştirilmelidir."
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr "Geçersiz video görüşme sağlayıcısı {video_chat_provider}"
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid giphy_rating {giphy_rating}"
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr "Geçersiz giphy_rating {giphy_rating}"
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr "Demo organizasyon olmalı."
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr "Geçersiz ad: {error}"
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr "{domain} alanı zaten sizin organizasyonunuzun bir parçası."
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr "{domain} alanı için hiç kayıt bulunamadı."
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr "Bir ve yalnızca bir dosya yüklemelisiniz."
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr "Yalnızca yöneticiler varsayılan emojiyi geçersiz kılabilir."
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr "Yüklenen dosya izin verilen {max_size} sınırından daha büyük MiB"
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 #, fuzzy
 #| msgid "JWT authentication is not enabled for this organization"
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr "JWT kimlik doğrulaması bu kuruluş için etkinleştirilmemiştir"
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr "Kullanım sınırı aşıldı."
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr "Geçersiz veri dışa aktarım ID'si"
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr "Dışa aktarım zaten silinmiş"
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr "Dışa aktarma başarısız oldu, silinecek bir şey yok"
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr "Dışa aktarma hala devam ediyor"
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr "Tam olarak bir simge yüklemeniz gerekir."
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr "Linkifier bulunamadı."
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr "Sadece bir logo yükleyebilirsin."
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid characters in pygments language"
 msgid "Invalid character in language: {character}"
 msgstr "Pygments dilinde hatalı karakterler"
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid language '{language}'"
 msgid "Language '{language}' is not allowed."
 msgstr "Geçersiz dil '{language}'"
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr "Hatalı oyun alanı"
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "User not authenticated"
 msgid "Unauthenticated"
 msgstr "Kullanıcı giriş yapmadı"
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "Direct messages"
 msgid "Importing messages…"
 msgstr "Direkt iletiler"
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "Your full name"
 msgid "Your name"
 msgstr "Tam adınız"
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr "Zamanlanmış mesaj türü güncellenirken alıcı gereklidir."
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr "Geçersiz sorgu formatı"
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr "Geçersiz DSN"
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr ""
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr "\"new_description\" veya \"new_group_name\" değişkeni göndermelisiniz."
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr ""
 "\"op\" için seçilen değer geçersiz. Lütfen \"add\" veya \"remove\" "
 "değerlerinden birini seçiniz."
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr "Geçersiz tür parametresi"
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr ""
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr ""
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr ""
 "Gerçekleştirilecek bir eylem yok. Lütfen \"ekle\" veya \"sil\" işlemlerinden "
 "en az birini seçiniz."
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, fuzzy, python-brace-format
 #| msgid "{user_full_name} added you to the group {group_name}."
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr "{user_full_name} sizi {group_name} grubuna ekledi."
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr ""
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr ""
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr ""
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
 "**"
 msgstr ""
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr ""
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr "Bilinmeyen abonelik özelliği: {property}"
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr ""
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr "Alt bildirim için geçersiz JSON"
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr ""
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr "'kime' argümanı eksik"
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr "Boş 'to' listesi"
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr ""
 "Kullanıcı doğrudan mesajlar için yazma bildirimlerini devre dışı bıraktı"
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr "<p>Bu dosya mevcut değil veya silindi.</p>"
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr "<p>Bu dosyayı görüntülemeye yetkili değilsiniz.</p>"
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr "Geçersiz anahtar"
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr "Geçersiz dosya adı"
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr "Yüklenecek bir dosya belirtmelisiniz"
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr "Aynı anda yalnızca bir dosya yükleyebilirsiniz"
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr "Verilen yeni veri yok"
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 msgstr ""
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr "{user_full_name} sizi {group_name} grubuna ekledi."
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr "{user_full_name} sizi {group_name} grubundan çıkardı."
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr "{user_id} kullanıcısı hali hazırda bu grubun bir üyesi"
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr "Bu kullanıcı grubunda '{user_id}' üyesi yok"
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr "Kullanıcı grubu {group_id} zaten bu grubun bir alt grubudur."
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
@@ -8211,78 +7613,78 @@ msgstr ""
 "Kullanıcı grubu {user_group_id} zaten geçirilen alt gruplardan birinin alt "
 "grubudur."
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr "Kullanıcı grubu {group_id} bu grubun bir alt grubu değildir."
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr "Bu organizasyonda avatar değişiklikleri devre dışı bırakılmıştır."
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr "Bu organizasyonda e-posta adresi değişiklikleri devre dışı bırakıldı."
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr "Geçersiz default_language"
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr "'{notification_sound}' geçersiz bildirim sesi"
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr "Geçersiz e-posta gruplama süresi: {seconds} saniye"
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr "Zulip parolan LDAP tarafından yönetilmektedir"
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr "Yanlış parola!"
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, fuzzy, python-brace-format
 #| msgid "You're making too many attempts! Try again in {seconds} seconds."
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr "Çok fazla deneme yapıyorsunuz! {seconds} içinde tekrar deneyin."
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr "Yeni parola zayıf!"
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr "Tam olarak bir avatar resmi yüklemelisin."
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr "Konu sessize alınmadı"
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr "Sadece organizasyon sahibi devredışı bırakabilir"
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Nobody in this Zulip organization will be able to see this email address."
@@ -8290,25 +7692,25 @@ msgid "User is not allowed to delete other user's messages."
 msgstr ""
 "Bu Zulip organizasyonundaki hiç kimse bu e-posta adresini göremeyecektir."
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr "Yönetici yetkisi sunucudaki tek yöneticiden alınamaz."
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr ""
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr ""
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
@@ -8320,26 +7722,26 @@ msgstr ""
 "FAKE_EMAIL_DOMAIN doğru ayarlanana kadar bot oluşturulamaz.\n"
 "Lütfen sistem yöneticisi ile iletişim kurunuz."
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 #, fuzzy
 #| msgid "Email address"
 msgid "Email address already in use"
 msgstr "E-posta adresi"
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr "Bot sahibi değiştirme başarısız oldu. Böyle bir kullanıcı bulunmuyor"
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr "Bot sahibi değiştirmekte hata meydana geldi. Kullanıcı devre dışı"
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr ""
 "Bot sahibi değiştirme başarısız oldu. Botlar diğer botların sahibi olamaz"
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
@@ -8347,140 +7749,140 @@ msgstr ""
 "FAKE_EMAIL_DOMAIN doğru ayarlanana kadar bot oluşturulamaz.\n"
 "Lütfen sistem yöneticisi ile iletişim kurunuz."
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr "Gömülü botlar etkin değil."
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr "Geçersiz gömülü bot adı."
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr "Kullanıcının kullanıcı oluşturma yetkisi yok"
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr "'{email}' epostası bu organizasyona giremez"
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr ""
 "Bu organizasyonda tek kullanımlık E-posta adreslerinin kullanımına izin "
 "verilmemektedir"
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom access token"
 msgid "Invalid {provider_name} access token"
 msgstr "Geçersiz Zoom giriş tokeni"
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} call"
 msgstr "Bir Zoom görüşmesi oluşturulamadı"
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Zoom credentials have not been configured"
 msgid "{provider_name} credentials have not been configured"
 msgstr "Zoom bilgileri ayarlanmadı"
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom credentials"
 msgid "Invalid {provider_name} credentials"
 msgstr "Geçersiz Zoom kimlik bilgisi"
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error connecting to the BigBlueButton server."
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr "BigBlueButton sunucusuna bağlanırken hata oluştu."
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error authenticating to the BigBlueButton server."
 msgid "Error authenticating to the {provider_name} server"
 msgstr "BigBlueButton sunucusunun kimliği doğrulanırken hata oluştu."
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "BigBlueButton server returned an unexpected error."
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr "BigBlueButton sunucusu beklenmeyen bir hata döndürdü."
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom session identifier"
 msgid "Invalid {provider_name} session identifier"
 msgstr "Geçersiz Zoom oturum bilgisi"
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr ""
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} public room."
 msgstr "Bir Zoom görüşmesi oluşturulamadı"
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr "Geçersiz imza."
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{full_name}'s Zulip room"
 msgstr "{full_name} senden bahsetti:"
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr "Bu sürüm kontrol sistemi sağlayıcısını kullanan projeler desteklenmez"
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr "Geçersiz istek"
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr "Bilinmeyen webhook isteği"
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr "Konu boş olamaz"
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr "İçerik boş olamaz"
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr ""
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr "Hatalı biçimlendirilmiş JSON girişi"
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr "Olaylar anahtarı yükte eksik"
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr "Hata: channels_map_to_topics parametresi 0 veya 1'den farklı"
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr "Bilinmeyen WordPress web kancası eylemi: {hook}"
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
@@ -8489,103 +7891,103 @@ msgstr ""
 "Veri dışa aktarma işleminiz tamamlandı. [Dışa aktarımları görüntüle ve indir]"
 "({export_settings_link})."
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr ""
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr ""
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr ""
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr ""
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr "Push bildirimleri bouncer'ı için geçersiz alt alan"
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr "Geçerli Zulip sunucusu API anahtarı ile doğrulama yapmalısınız"
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr "Geçersiz UUID"
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr "Geçersiz jeton (token) türü"
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr "{hostname} geçerli bir ana bilgisayar adı değil"
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr ""
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr ""
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr ""
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
 "try again later or reach out to {support_email} for assistance."
 msgstr ""
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr ""
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr ""
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr "Eksik ios_app_id"
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr "Eksik user_id veya user_uuid"
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
@@ -8594,50 +7996,50 @@ msgstr ""
 "Planınız anlık bildirim göndermeye izin vermiyor. Sunucu tarafından verilen "
 "gerekçe: {reason}"
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr "Planınız anlık bildirim göndermeye izin vermiyor."
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr "Geçersiz özellik {property}"
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr "Geçersiz etkinlik tipi."
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr "Veri sırası doğru değil."
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr "Mükerrer kayıt tespit edildi."
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr "Bozuk denetim kütük verisi"
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr "Parolanızı sıfırlamanız gerekiyor."
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr "id_token parametresi eksik"
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 #, fuzzy
 #| msgid "Missing id_token parameter"
 msgid "Missing idp param"
 msgstr "id_token parametresi eksik"
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr "Geçersiz OTP"
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr "Aynı anda mobile_flow_otp ve desktop_flow_otp kullanılamaz."
 

--- a/locale/uk/LC_MESSAGES/django.po
+++ b/locale/uk/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 18:59+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/zulip/django/"
@@ -28,53 +28,53 @@ msgstr ""
 "(n % 100 >=11 && n % 100 <=14 )) ? 2: 3);\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "Не дозволено для гостьових користувачів"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "Неправильна організація"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr "Публічні канали"
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr "Приватні канали"
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr "Особисті повідомлення"
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr "Групувати особисті повідомлення"
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr "Відсутній канал для діаграми: {chart_name}"
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr "Невідома назва діаграми: {chart_name}"
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr ""
 "Час початку пізніше, ніж час закінчення. Початок: {start}, кінець: {end}"
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr ""
 "Аналітичні дані відсутні. Будь ласка, зв'яжіться зі своїм адміністратором "
 "сервера."
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -88,7 +88,7 @@ msgstr ""
 "({deactivate_user_help_page_link}), щоб дозволити приєднатися новим "
 "користувачам."
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -100,7 +100,7 @@ msgstr ""
 "неактивних користувачів]({deactivate_user_help_page_link}), щоб дозволити "
 "приєднатися більше ніж одному користувачу."
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -112,7 +112,7 @@ msgstr ""
 "неактивних користувачів]({deactivate_user_help_page_link}), щоб дозволити "
 "приєднатися більш ніж двум користувачам."
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -124,7 +124,7 @@ msgstr ""
 "неактивних користувачів]({deactivate_user_help_page_link}), щоб дозволити "
 "приєднатися більш ніж трьом користувачам."
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -137,7 +137,7 @@ msgstr ""
 "переконайтеся, що [кількість ліцензій на поточний та наступний розрахунковий "
 "період]({billing_page_link}) більша за поточну кількість користувачів."
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
@@ -145,7 +145,7 @@ msgstr ""
 "Ваша організація не має достатньої кількості ліцензій Zulip. Запрошення не "
 "надіслано."
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
@@ -153,16 +153,15 @@ msgstr ""
 "Ваша організація не має достатньої кількості ліцензій Zulip для зміни ролі "
 "гостьового користувача."
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr "Регістрація вимкнена"
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr "Невірний віддалений сервер."
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
@@ -171,7 +170,7 @@ msgstr ""
 "Вам необхідно придбати ліцензії для всіх активних користувачів вашої "
 "організації (мінімум {min_licenses})."
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
@@ -180,81 +179,81 @@ msgstr ""
 "Рахунки на більш ніж {max_licenses} ліцензій не можуть бути оброблені на цій "
 "сторінці. Для завершення апгрейду, будь ласка, зв'яжіться з {email}."
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr "Не вказано спосіб оплати."
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr "{brand} закінчується за {last4}"
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr "Невідомий спосіб оплати. Зверніться до {email}."
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr "Щось пішло не так. Зверніться до {email}."
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "Щось пішло не так. Перезавантажте сторінку."
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr ""
 "Щось пішло не так. Будь ласка, зачекайте кілька секунд і повторіть спробу."
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 "Будь ласка, вкажіть дані платіжної картки перед початком безкоштовного "
 "пробного використання."
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr "Будь ласка, вкажіть дані платіжної картки щоб запланувати оновлення."
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
 msgstr "Неможливо поновити тариф. Тарифний план закінчився і замінений новим."
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr "Неможливо поновити тариф. Тарифний план закінчився."
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 "Не вдається оновити ліцензії у поточному розрахунковому періоді для "
 "безкоштовного пробного тарифу."
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
 msgstr ""
 "Не можливо оновити ліцензії вручну. Ваш тариф на автоматичному керуванні."
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr ""
 "Ваш тариф вже включає {licenses} ліцензій у поточному розрахунковому періоді."
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr ""
 "Ви не можете зменшити кількість ліцензій у путочному розрахунковому періоді."
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
@@ -262,7 +261,7 @@ msgstr ""
 "Не вдається змінити ліцензії на наступний платіжний період для тарифу, "
 "рівень якого буде знижений."
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
@@ -271,7 +270,7 @@ msgstr ""
 "Ваш тариф вже заплановано до продовження на {licenses_at_next_renewal} "
 "ліцензій."
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
@@ -280,27 +279,27 @@ msgstr ""
 "Ви вже придбали ліцензії ({licenses_at_next_renewal}) на наступний "
 "розрахунковий період."
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr "Нема що змінювати."
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr "Ця організація не має клієнтів!"
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr "Сеансу не знайдено"
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr "Призначення платежу не знайдено"
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr "Передайте stripe_session_id або stripe_invoice_id"
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -315,20 +314,19 @@ msgstr ""
 "Якщо ви зможете {begin_link}вказати Zulip як спонсора на своєму веб-"
 "сайті{end_link}, ми будемо вам дуже вдячні!"
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr "Параметр 'підтверджено' є обов'язковим"
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr "Термін дії токена платіжного доступу минув."
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr "Недійсний токен платіжного доступу."
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
@@ -337,39 +335,38 @@ msgstr ""
 "Не вдалося узгодити платіжні дані між сервером та доменом. Зверніться до "
 "{support_email}"
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr "Обліковий запис користувача ще не створено."
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr "Щоб продовжити, ви повинні прийняти Умови використання."
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 "Цей zulip_org_id не зареєстровано у системі управління платежами Zulip."
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr "Невірний zulip_org_key для цього zulip_org_id."
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr "Реєстрація сервера відкликана."
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "Помилка"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr "Сторінку не знайдено (404)"
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
@@ -378,11 +375,11 @@ msgstr ""
 "Якщо ця помилка неочікувана, ви можете <a href=\"mailto:"
 "%(support_email)s\">звернутися до служби підтримки</a>."
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr "Доступ заборонено (403)"
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
@@ -390,11 +387,11 @@ msgstr ""
 "Ваш запит не вдалося виконати, оскільки ваш браузер не надіслав облікові "
 "дані, необхідні для автентифікації вашого доступу. Щоб вирішити цю проблему:"
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr "Переконайтеся, що ваш браузер дозволяє файли cookie для цього сайту."
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
@@ -402,16 +399,15 @@ msgstr ""
 "Перевірте налаштування конфіденційності браузера або розширення, які "
 "блокують заголовки Referer, і вимкніть їх для цього сайту."
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr "Метод заборонено (405)"
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr "Внутрішня помилка сервера"
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
@@ -419,7 +415,7 @@ msgstr ""
 "Щось пішло не так. Вибачте! Ми знаємо про проблему та працюємо над її "
 "виправленням. Zulip завантажиться автоматично, щойно знову запрацює."
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -431,7 +427,7 @@ msgstr ""
 "%(support_email)s\">зверніться до служби підтримки Zulip</a>, якщо у вас "
 "виникнуть запитання."
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
@@ -439,7 +435,7 @@ msgstr ""
 "Щось пішло не так. Вибачте! Zulip завантажиться автоматично, щойно знову "
 "запрацює."
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
@@ -448,7 +444,7 @@ msgstr ""
 "<a href=\"mailto:%(support_email)s\">Зверніться до адміністраторів цього "
 "сервера</a> для отримання підтримки."
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
@@ -458,138 +454,136 @@ msgstr ""
 "href=\"%(troubleshooting_url)s\">посібником з усунення несправностей сервера "
 "Zulip</a>."
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr "Аналітика для %(target_name)s | Zulip"
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 "Аналітика стане доступна повністю через 24 години після створення "
 "організації."
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr "Аналітика Zulip для %(target_name)s"
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr "Короткий опис організації"
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr "Кількість користувачів"
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr "Користувачі, активні протягом останніх 15 днів"
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr "Кількість гостей"
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr "Загальна кількість повідомлень"
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr "Кількість повідомлень за останні 30 днів"
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr "Файлове сховище у використанні"
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "Активні користувачі"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr "Денна активність"
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr "15 денна активність"
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr "Всього користувачів"
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "Користувачі"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr "Надіслані повідомлення за типом одержувача"
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "Я"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "Будь хто"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "Останній тиждень"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "Останній місяць"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "Останній рік"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "За весь час"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr "Повідомлення, надіслані протягом певного періоду"
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "Поденно"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "Потижнево"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr "Сукупно"
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "Люди"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "Боти"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr "Повідомлення, прочитані протягом певного періоду"
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr "Повідомлення відправлені клієнтом"
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr "Останнє оновлення"
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
@@ -597,15 +591,15 @@ msgstr ""
 "Повне оновлення всіх графіків відбувається раз на день. Графік "
 "“повідомлення, надіслані протягом певного періоду” оновлюється кожну годину."
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr "Адресу електронної пошти змінено"
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr "Адресу електронної пошти змінено!"
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
@@ -614,21 +608,21 @@ msgstr ""
 "Це підтверджує, що електронна адреса вашого облікового запису Zulip "
 "змінилася з %(old_email_html_tag)s на %(new_email_html_tag)s"
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr "Підтвердження вашої адреси електронної пошти"
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr "Посилання для підтвердження не існує"
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr "Ой. Ми не змогли знайти ваше посилання на підтвердження в системі."
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
@@ -637,31 +631,31 @@ msgstr ""
 "У будь-якому разі, напишіть нам на адресу %(support_email_html_tag)s, і ми "
 "незабаром вирішимо це питання."
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr ""
 "Термін дії посилання для підтвердження закінчився або його деактивовано"
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr ""
 "Ой. Термін дії посилання для підтвердження минув, або його було деактивовано."
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr ""
 "Будь ласка, зв’яжіться з адміністратором організації, щоб отримати нове "
 "посилання."
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr "Посилання для підтвердження має неправильний формат"
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr "Ой. Посилання для підтвердження сформоване неправильно."
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
@@ -669,72 +663,55 @@ msgstr ""
 "Переконайтеся, що ви правильно скопіювали посилання у браузер. Якщо ви все "
 "ще стикаєтесь із цією сторінкою, мабуть, це наша провина. Нам шкода."
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr "Платежі"
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr "Закрити модальне вікно"
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr "Неважливо"
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr "Даунґрейд"
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "Скасувати"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr "Підтвердити"
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr "Скасувати оновлення"
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr "Статус виставлення рахунку"
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr "Деактивувати реєстрацію сервера?"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr "Управління тарифом не доступне"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -751,7 +728,7 @@ msgstr ""
 "billing-management\">інструкціях з входу</a>, щоб адмініструвати план для "
 "вашого сервера Zulip."
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
@@ -760,7 +737,7 @@ msgstr ""
 "інші запитання, <a href=\"mailto:{{ support_email }}\">зверніться до служби "
 "підтримки</a>."
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
@@ -768,7 +745,7 @@ msgstr ""
 "Керування планом для цього сервера недоступне, оскільки принаймні одна "
 "організація, розміщена на цьому сервері, вже має активний план."
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -780,730 +757,240 @@ msgstr ""
 "<a href='mailto:%(support_email)s'>зверніться до служби підтримки</a>, якщо "
 "у вас виникнуть запитання."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr "Перевищено ліміт швидкості"
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr "Перевищено ліміт швидкості."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr "Ваш сервер перевищив ліміт частоти виконання цієї дії."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, fuzzy, python-format
 #| msgid "You can try again in %(retry_after)s seconds."
 msgid "You can try again in %(retry_after_string)s."
 msgstr "Ви можете спробувати ще раз через %(retry_after)s секунд."
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr "Оновлення"
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr "Надіслати рахунок-фактуру та розпочати безкоштовний пробний період"
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr "Надіслати рахунок-фактуру"
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr "Відкрити каталог спільнот"
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr "Фільтрувати за категорією"
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "Всі"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr "Категорії"
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr "10,000 повідомлень"
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr "Необмежений"
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr "Файли до 10 МБ"
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr "Файли до 1 ГБ"
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr "Підтримується"
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr "Самокерований"
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr "Для організацій з кількістю користувачів до 10"
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr "Мінімум 25 користувачів"
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr "Недоступно"
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr "Спільнота розробників Zulip"
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr "Зареєструватися як користувач"
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr "Приєднатися як самостійний хостинг"
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr "Приєднатися як автор"
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "Створити організацію"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr "Отримати демо"
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr "Самостійне розміщення Zulip"
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr "Запросити спонсорство"
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr "Ціна для навчальних закладів"
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr "Переглянути ціни"
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr "Zulip для бізнесу"
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 msgid "Zulip for open source"
 msgstr "Zulip для відкритого коду"
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr "Собака в окулярах з ноутбуком"
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation"
 msgstr "Скріншот розмови Zulip"
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr "Скріншот розмови Zulip з ботом-вартом"
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr "Знімок екрана папки \"Вхідні\" у Zulip"
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr "Відкритий ноутбук з книгою всередині"
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr "Складання головоломки двома руками"
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 msgid "Message with code"
 msgstr "Повідомлення з кодом"
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr "Блискавка"
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr "Посилання"
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr "Корабельне колесо"
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr "Звернутися в службу підтримки"
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr "Від"
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr "Організація"
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr "Тема"
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr "Повідомлення"
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr "Відправити"
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr "Дякуємо, що звернулися до нас"
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr "Дякуємо, що звернулися до нас!"
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr "Ми зв'яжемося з вами найближчим часом."
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
@@ -1511,11 +998,11 @@ msgstr ""
 "Ви можете знайти відповіді на поширені запитання в <a href=\"/help/"
 "\">довідковому центрі Zulip</a>."
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 msgid "Get started"
 msgstr "Почати"
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
@@ -1525,51 +1012,50 @@ msgstr ""
 "href=\"https://zulip.com/policies/terms\">Умови надання послуг Zulip</a>, "
 "щоб продовжити."
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr "Або, за вибором, скористайтеся одним з ваших резервних телефонів:"
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr ""
 "В останньому випадку ви можете використовувати значком резервної копії:"
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr "Використовуйте значок резервування"
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr "Прийняти Умови надання послуг"
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr "Ласкаво просимо до Zulip"
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "Електронна пошта"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr ""
 "Підпишіть мене на розсилку Zulip з низьким трафіком (кілька листів на рік)."
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr "Продовжити"
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr "Підтвердьте свою адресу електронної пошти"
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1580,7 +1066,7 @@ msgstr ""
 "class=\"user_email semi-bold\">%(email)s</span>) на наявність електронного "
 "листа з підтвердженням від Zulip."
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
@@ -1589,25 +1075,25 @@ msgstr ""
 "\"Спам\", ми можемо <a href=\"#\" id=\"resend_email_link\">надіслати його "
 "повторно</a>."
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr "Публічний перегляд {org_name} | Чат команди Zulip"
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr "Переглядайте загальнодоступні канали в {org_name} без входу в систему."
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 "Оскільки ви використовуєте непідтримуваний або дуже старий браузер, Zulip "
 "може не завантажуватися."
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
@@ -1617,7 +1103,7 @@ msgstr ""
 "може не завантажуватися. <a href=\"https://zulip.com/apps/\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">Завантажте останню версію.</a>"
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
@@ -1625,39 +1111,38 @@ msgstr ""
 "Якщо це повідомлення не зникає, спробуйте <a class=\"reload-"
 "lnk\">перезавантажити</a> сторінку."
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 "Помилка завантаження Zulip. Спробуйте <a class=\"reload-"
 "lnk\">перезавантажити</a> сторінку."
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr "Немає бесід, що відповідають вашим фільтрам."
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr "Це представлення досі завантажує повідомлення."
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr "Завантажити більше"
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr "Відеодзвінок завершено"
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr "Тепер ви можете закрити це вікно."
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr "Помилка налаштування"
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
@@ -1666,7 +1151,7 @@ msgstr ""
 "Будь ласка, скористайтеся EmailAuthBackend, щоб створити свою організацію, а "
 "потім спробуйте ще раз."
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1677,33 +1162,32 @@ msgstr ""
 "налаштування push-сповіщень дивіться в <a href=\"%(doc_url)s\">документації</"
 "a>."
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr "Обліковий запис не знайдено"
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr "Обліковий запис Zulip не знайдено."
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, python-format
 msgid "No account found for %(email)s."
 msgstr "Не знайдено облікового запису для %(email)s."
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr "Увійдіть, використовуючи інший обліковий запис"
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr "Продовжити реєстрацію"
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 msgid "Try Zulip in a demo organization"
 msgstr "Спробуйте Zulip у демо-організації"
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
@@ -1712,19 +1196,19 @@ msgstr ""
 "Електронна пошта не потрібна. Або <a class=\"registration-lead-subtitle-"
 "link\" href=\"%(root_domain_url)s/new/\">створіть постійну організацію</a>."
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 msgid "Try Zulip"
 msgstr "Спробуйте Zulip"
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "Створити нову організацію"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr "Створіть нову організацію Zulip"
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
@@ -1734,16 +1218,15 @@ msgstr ""
 "new/demo/\">створіть демонстраційну організацію</a> — електронна пошта не "
 "потрібна!"
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr "Введіть адресу вашої електронної пошти"
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr "Ваша електронна адреса"
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
@@ -1753,11 +1236,11 @@ msgstr ""
 "help/import-from-mattermost\">Mattermost</a> чи <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr "Як ви вперше почули про Zulip?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
@@ -1765,42 +1248,41 @@ msgstr ""
 "Це значення використовується лише якщо ви оформлюєте план, і в такому разі "
 "його буде надіслано команді Zulip."
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr "Виберіть опцію"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr "Будь ласка, опишіть"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr "Де ви бачили рекламу?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr "Яка організація?"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr "Який саме?"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr "Виберіть один"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr "Тип організації"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr "Мова організації"
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
@@ -1810,72 +1292,68 @@ msgstr ""
 "mattermost\">Mattermost</a> або <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid "Import chat history?"
 msgstr "Імпортувати історію чату?"
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr "Назва організації"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "URL-адреса організації"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr "Використовуйте %(external_host)s"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "АБО"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "Зареєструватися"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "Зареєструйтесь в Zulip"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr "Вам потрібно запрошення для приєднання до цієї організації."
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr "Зареєструватися з допомогою %(identity_provider)s"
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr "Вже маєте обліковий запис?"
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "Увійти"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr "Налаштування конфіденційності адреси електронної пошти"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
@@ -1883,7 +1361,7 @@ msgstr ""
 "Zulip дозволяє вам контролювати, які ролі в організації можуть переглядати "
 "вашу адресу електронної пошти."
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
@@ -1891,11 +1369,11 @@ msgstr ""
 "Ви хочете змінити налаштування конфіденційності для вашої електронної пошти "
 "порівняно з конфігурацією за замовчуванням для цієї організації?"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr "Хто може отримати доступ до вашої адреси електронної пошти"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1906,7 +1384,7 @@ msgstr ""
 "configure-email-visibility\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">після реєстрації</a>."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
@@ -1914,7 +1392,7 @@ msgstr ""
 "Адміністратори цієї організації Zulip зможуть бачити цю адресу електронної "
 "пошти."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
@@ -1922,13 +1400,13 @@ msgstr ""
 "Адміністратори та модератори цієї організації Zulip зможуть бачити цю адресу "
 "електронної пошти."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 "Ніхто в цій організації Zulip не зможе побачити цю адресу електронної пошти."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
@@ -1936,80 +1414,79 @@ msgstr ""
 "Інші користувачі цієї організації Zulip зможуть бачити цю адресу електронної "
 "пошти."
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "Змінити"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr "Реєстрація"
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr "Створити свою організацію"
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr "Створити свій обліковий запис"
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr "<p>Введіть дані свого облікового запису, щоб завершити реєстрацію.</p>"
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr "Ваша організація"
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr "Ваш обліковий запис"
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr "Не імпортувати налаштування"
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr "Імпортувати налаштування з існуючого облікового запису Zulip"
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr "Ваше повне ім'я"
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "Ім'я"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr "Ось так відображається ваш обліковий запис у Zulip."
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "Пароль"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr "Введіть Ваш LDAP/Active Directory пароль."
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr ""
 "Це використовується для мобільних додатків та інших інструментів, для яких "
 "потрібен пароль."
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr "Надійність паролю"
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr "Що вас цікавить?"
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
@@ -2018,15 +1495,15 @@ msgstr ""
 "Я погоджуюся з <a href=\"%(root_domain_url)s/policies/terms\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">Умовами надання послуг</a>."
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr "Деактивована організація"
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr "Організацію переміщено"
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
@@ -2035,7 +1512,7 @@ msgstr ""
 "Ця організація переїхала до <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -2046,13 +1523,13 @@ msgstr ""
 "id=\"deactivated-org-auto-redirect\">нову URL-адресу</a> через <span "
 "id=\"deactivated-org-auto-redirect-countdown\">5</span> секунд."
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 msgid ""
 "This organization has been deactivated, and all organization data has been "
 "deleted."
 msgstr "Цю організацію деактивовано, а всі дані організації видалено."
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
@@ -2062,7 +1539,7 @@ msgstr ""
 "підтримки Zulip</a>, щоб дізнатися про повторне використання цієї URL-адреси "
 "для нової організації."
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
@@ -2072,11 +1549,11 @@ msgstr ""
 "цього сервера Zulip</a>, щоб дізнатися про повторне використання цієї URL-"
 "адреси для нової організації."
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 msgid "This organization has been deactivated."
 msgstr "Цю організацію деактивовано."
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -2086,7 +1563,7 @@ msgstr ""
 "%(support_email)s\">звернутися до служби підтримки Zulip</a>, щоб повторно "
 "активувати її."
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
@@ -2095,7 +1572,7 @@ msgstr ""
 "Якщо ви є членом організації та хочете отримати інформацію про причини її "
 "деактивації, зверніться безпосередньо до адміністраторів організації."
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -2106,15 +1583,15 @@ msgstr ""
 "%(support_email)s\">зв'язатися з адміністраторами цього сервера Zulip</a>, "
 "щоб повторно активувати його."
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr "Завершити вхід у програму для комп'ютера"
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr "Завершити вхід на комп'ютері"
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
@@ -2122,109 +1599,108 @@ msgstr ""
 "Використайте веббраузер, щоб закінчити вхід, а потім поверніться сюди, щоб "
 "вставити свій токен входу."
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr "Вставте токен тут"
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr "Готово"
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr "Некоректний токен."
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr "Токен прийнятий. Вхід до системи…"
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr "Увійти в десктопний додаток"
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 "Скопіюйте цей токен входу та поверніться у додаток Zulip, щоб завершити вхід:"
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "Копіювати"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr "Потім ви можете закрити це вікно."
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr "Або продовжте у своєму браузері."
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr "Анонімний користувач"
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr "Власники"
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "Адміністратори"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr "Модератори"
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr "Гостьові користувачі"
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "Звичайні користувачі"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr "Пересилання електронних листів на обліковий запис електронної пошти"
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "Закрити"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "Оновити"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr "Zulip"
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr "Дайджест"
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
 "<b>%(realm_name)s</b>."
 msgstr "Вітаємо, ви створили нову організацію Zulip: <b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr "Ласкаво просимо до Zulip!"
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr "Ви приєдналися до організації Zulip <b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
@@ -2233,36 +1709,36 @@ msgstr ""
 "Ви використовуватимете таку інформацію для входу у веб-, <a "
 "href=\"%(apps_page_link)s\">мобільний та настільний</a> додатки Zulip:"
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr "URL-адреса організації: %(organization_url)s"
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr "Ваше ім'я користувача: %(ldap_username)s"
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr "Використовуйте свій обліковий запис LDAP для входу"
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr "Електронна адреса вашого облікового запису: %(email)s"
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr "Перейти до організації"
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
@@ -2271,7 +1747,7 @@ msgstr ""
 "Якщо ви новачок у Zulip, ознайомтеся з нашим <a "
 "href=\"%(getting_user_started_link)s\">посібником з початку роботи</a>!"
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2282,7 +1758,7 @@ msgstr ""
 "href=\"%(getting_organization_started_link)s\">переведення вашої організації "
 "до Zulip</a>."
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
@@ -2291,28 +1767,28 @@ msgstr ""
 "Є питання? <a href=\"mailto:%(support_email)s\">Зв'яжіться з нами</a> — ми "
 "будемо раді допомогти!"
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr "%(realm_name)s на Zulip: Деталі Вашої нової організації"
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr "%(realm_name)s на Zulip: Деталі Вашого нового облікового запису"
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr "Вітаємо, ви створили нову організацію Zulip: %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr "Ви приєднались до Zulip організації %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
@@ -2321,7 +1797,7 @@ msgstr ""
 "Ви використовуватимете таку інформацію для входу у веб-, мобільний та "
 "настільний додатки Zulip (%(apps_page_link)s):"
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
@@ -2330,7 +1806,7 @@ msgstr ""
 "Якщо ви новачок у Zulip, ознайомтеся з нашим посібником з початку роботи "
 "(%(getting_user_started_link)s)!"
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
@@ -2339,19 +1815,19 @@ msgstr ""
 "У нас також є посібник з перенесення вашої організації до Zulip "
 "(%(getting_organization_started_link)s)."
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 "Є питання? Зв’яжіться з нами за адресою %(support_email)s — ми будемо раді "
 "допомогти!"
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2360,17 +1836,17 @@ msgstr ""
 "Якщо у вас є якісь питання, зверніться до адміністраторів цього сервера "
 "Zulip за адресою %(support_email)s."
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr "Привіт,"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2382,12 +1858,12 @@ msgstr ""
 "Щоб підтвердити це оновлення та встановити пароль для цього облікового "
 "запису, натисніть нижче:"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr "Підтвердити та встановити пароль"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2396,14 +1872,14 @@ msgstr ""
 "Якщо ви не запитували цю зміну, будь ласка, негайно зв’яжіться з нами за "
 "адресою %(support_email)s."
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 msgid "Verify your email address for your Zulip demo organization"
 msgstr ""
 "Підтвердьте свою адресу електронної пошти для вашої демонстраційної "
 "організації Zulip"
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2412,8 +1888,8 @@ msgstr ""
 "Якщо Ви не робили запит на цю зміну, будь ласка зв'яжіться з нами негайно за "
 "адресою <%(support_email)s>."
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2424,34 +1900,34 @@ msgstr ""
 "Zulip на %(realm_url)s з %(old_email)s на %(new_email)s. Щоб підтвердити цю "
 "зміну, натисніть нижче:"
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr "Підтвердити зміну електронної пошти"
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr ""
 "Підтвердьте свою нову адресу електронної пошти для %(organization_host)s"
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr "Ви запросили нову організацію Zulip:"
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr "Тип організації: %(organization_type)s"
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr "Ви нещодавно зареєструвались в Zulip. Чудово!"
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
@@ -2459,33 +1935,33 @@ msgstr ""
 "Натисніть кнопку нижче, щоб створити організацію та зареєструвати свій "
 "обліковий запис. Ви зможете оновити інформацію вище, якщо забажаєте."
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr "Клацніть на кнопці нижче щоб закінчити реєстрацію."
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr "Завершити реєстрацію"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr "Створіть свою організацію в Zulip"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr "Активувати свій обліковий запис Zulip"
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr "Клацніть на посилання нижче щоб закінчити реєстрацію."
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
@@ -2494,20 +1970,20 @@ msgstr ""
 "У вас є запитання чи відгуки? Зв’яжіться з нами за адресою %(support_email)s "
 "— ми будемо раді допомогти!"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr "Налаштування сповіщень електронною поштою"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr "Скасувати підписку на маркетингові листи"
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
@@ -2516,17 +1992,17 @@ msgstr ""
 "Ваш обліковий запис Zulip на <a href=\"%(realm_url)s\">%(realm_url)s</a> "
 "деактивовано, і ви більше не зможете увійти."
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr "Адміністратори надали наступний коментар:"
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr "Сповіщення про деактивацію облікового запису %(realm_name)s"
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
@@ -2535,11 +2011,11 @@ msgstr ""
 "Ваш обліковий запис Zulip на %(realm_url)s деактивовано, і ви більше не "
 "зможете увійти."
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr "Нові канали"
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2550,7 +2026,7 @@ msgstr ""
 "%(new_streams_count)s нових каналів у <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
@@ -2559,7 +2035,7 @@ msgstr ""
 "У вас є %(new_messages_count)s нових повідомлень у <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
@@ -2568,8 +2044,8 @@ msgstr ""
 "У <a href=\"%(realm_url)s\">%(realm_name)s</a> з’явилася така кількість "
 "нових каналів: %(new_streams_count)s."
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because your organization <a "
@@ -2581,8 +2057,8 @@ msgstr ""
 "href=\"%(help_url)s\">приховує вміст повідомлень</a> у сповіщеннях "
 "електронною поштою."
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to <a "
@@ -2593,21 +2069,21 @@ msgstr ""
 "class=\"content_disabled_help_link\" href=\"%(help_url)s\">приховати вміст "
 "повідомлення</a> у сповіщеннях електронною поштою."
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr "<a href=\"%(realm_url)s\">Увійдіть</a> до Zulip, щоб бути в курсі."
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr "Скасувати підписку на дайджест листи"
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr "Дайджест Zulip для %(realm_name)s"
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2616,18 +2092,18 @@ msgstr ""
 "У вас є %(new_messages_count)s нових повідомлень, а також "
 "%(new_streams_count)s нових каналів у %(realm_name)s."
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr "У вас є %(new_messages_count)s нових повідомлень у %(realm_name)s."
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr "У %(realm_name)s з’явилося %(new_streams_count)s нових каналів."
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because your organization hides "
@@ -2638,8 +2114,8 @@ msgstr ""
 "організація приховує вміст повідомлень у сповіщеннях електронною поштою. "
 "Докладніше див. %(hide_content_url)s."
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to hide "
@@ -2649,32 +2125,30 @@ msgstr ""
 "приховати вміст повідомлення в сповіщеннях електронною поштою. Див. "
 "%(help_url)s для отримання додаткової інформації."
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr "Увійдіть у Zulip, щоб не збитися з пандемії: %(organization_url)s."
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr "Налаштування повідомлень електронною поштою:"
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr "Скасувати підписку на дайджест листи:"
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr "Плаваюча рибка"
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr "Дякуємо за ваш запит!"
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
@@ -2683,8 +2157,7 @@ msgstr ""
 "Ваша адреса електронної пошти %(email)s має облікові записи в таких "
 "організаціях Zulip Cloud:"
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
@@ -2693,7 +2166,7 @@ msgstr ""
 "Ваша адреса електронної пошти %(email)s має облікові записи в таких "
 "організаціях Zulip, що розміщені на %(external_host)s:"
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
@@ -2702,21 +2175,17 @@ msgstr ""
 "Якщо у вас виникли проблеми зі входом, ви можете <a "
 "href=\"%(help_reset_password_link)s\">скинути свій пароль</a>."
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 "Ви запросили список облікових записів Zulip для цієї адреси електронної "
 "пошти."
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr "На жаль, облікових записів Zulip Cloud не знайдено."
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
@@ -2725,7 +2194,7 @@ msgstr ""
 "На жаль, в організаціях Zulip, що розміщені на %(external_host)s, не "
 "знайдено жодних облікових записів."
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2737,28 +2206,25 @@ msgstr ""
 "=\"%(help_logging_in_link)s\">спробувати інший спосіб</a> знайти свій "
 "обліковий запис."
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 "Якщо ви не впізнаєте цей запит, можете сміливо проігнорувати цей електронний "
 "лист."
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr "Ваші облікові записи Zulip"
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr "Облікових записів Zulip не знайдено"
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr "Якщо у вас виникли проблеми зі входом, ви можете скинути свій пароль."
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
@@ -2768,12 +2234,12 @@ msgstr ""
 "електронної адреси (%(find_accounts_link)s) або спробувати інший спосіб "
 "знайти свій обліковий запис (%(help_logging_in_link)s)."
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr "Привіт,"
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
@@ -2783,18 +2249,18 @@ msgstr ""
 "комунікаційному інструменті для команд, призначеному для збільшення "
 "продуктивності."
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr "Щоб розпочати, клацніть на кнопку нижче."
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr ""
 "%(referrer_full_name)s запросив вас приєднатися %(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
@@ -2804,17 +2270,17 @@ msgstr ""
 "на Zulip — комунікаційному інструменті для команд, призначеному для "
 "збільшення продуктивності."
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr "Щоб розпочати, клацніть на посилання нижче."
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr "Привіт ще раз,"
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
@@ -2823,13 +2289,13 @@ msgstr ""
 "Це дружнє нагадування що %(referrer_name)s бажає, щоб ви приєдналися до них "
 "у Zulip &mdash; платформі для високопродуктивної комунікації в командах."
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr "Це останнє нагадування яке Ви отримаєте для цього запрошення."
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
@@ -2839,13 +2305,13 @@ msgstr ""
 "запрошення закінчиться, вам потрібно буде попросити у%(referrer_name)s ще "
 "одне."
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr ""
 "Нагадування: Приєднайтесь до %(referrer_name)s на %(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2856,7 +2322,7 @@ msgstr ""
 "приєдналися до них у Zulip -- платформа для високопродуктивної комунікації у "
 "командах."
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2865,7 +2331,7 @@ msgstr ""
 "Якщо у вас є будь-які запитання, зверніться до адміністраторів цього сервера "
 "Zulip за адресою <a href=\"mailto:%(email)s\">%(email)s</a>."
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
@@ -2874,13 +2340,13 @@ msgstr ""
 "У вас є запитання чи відгуки? <a href=\"mailto:%(email)s\">Зв'яжіться з "
 "нами</a> — ми будемо раді допомогти!"
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr "Ви отримуєте це, тому що вас особисто згадали."
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
@@ -2888,10 +2354,8 @@ msgstr ""
 "Ви отримуєте це повідомлення, оскільки було згадано "
 "@%(mentioned_user_group_name)s."
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
@@ -2900,8 +2364,8 @@ msgstr ""
 "Ви отримуєте це повідомлення, оскільки всіх учасників теми було згадано в "
 "#%(channel_name)s > %(topic_name)s."
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
@@ -2909,16 +2373,16 @@ msgstr ""
 "Ви отримуєте це повідомлення, оскільки у вас увімкнено сповіщення про згадки "
 "з підстановочними символами для тем, на які ви підписані."
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 "Ви отримуєте це повідомлення, оскільки всіх згадали в #%(channel_name)s."
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
@@ -2926,8 +2390,8 @@ msgstr ""
 "Ви отримуєте це, оскільки у вас увімкнено сповіщення електронною поштою для "
 "тем, на які ви підписані."
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
@@ -2936,7 +2400,7 @@ msgstr ""
 "Ви отримуєте це повідомлення, оскільки у вас увімкнено сповіщення "
 "електронною поштою для #%(channel_name)s."
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2947,7 +2411,7 @@ msgstr ""
 "href=\"%(narrow_url)s\">переглянути його в %(realm_name)s Zulip</a> або <a "
 "href=\"%(notif_url)s\">керувати налаштуваннями електронної пошти</a>."
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
@@ -2957,7 +2421,7 @@ msgstr ""
 "Zulip</a> або <a href=\"%(notif_url)s\">керувати налаштуваннями електронної "
 "пошти</a>."
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
@@ -2966,7 +2430,7 @@ msgstr ""
 "<a href=\"%(narrow_url)s\">Відповісти у %(realm_name)s Zulip</a> або <a "
 "href=\"%(notif_url)s\">керувати налаштуваннями електронної пошти</a>."
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
@@ -2975,43 +2439,43 @@ msgstr ""
 "Не відповідайте на цей електронний лист. Цей сервер Zulip не налаштований на "
 "прийняття вхідних листів (<a href=\"%(url)s\">допомога</a>)."
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr "Групові особисті повідомлення з %(direct_message_group_display_name)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr "Повідомлення з %(sender_str)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr "[вирішено] #%(channel_name)s > %(topic_name)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr "Нові повідомлення"
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 "Відповісти на цей лист безпосередньо або переглянути його в %(realm_name)s "
 "Zulip:"
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr "Переглянути або відповісти в %(realm_name)s Zulip:"
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr "Відповідь у %(realm_name)s Зуліп:"
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
@@ -3019,7 +2483,7 @@ msgstr ""
 "Не відповідайте на цей електронний лист. Цей сервер Zulip не налаштований на "
 "прийняття вхідних листів. Допомога:"
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -3030,22 +2494,22 @@ msgstr ""
 "змінена на %(new_email)s. Якщо ви не виконували цю зміну, негайно зв’яжіться "
 "з нами за адресою%(support_email)s."
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr "Всього найкращого,"
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr "Команда Zulip"
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr "Електронну пошту Zulip змінено на %(realm_name)s"
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -3056,7 +2520,7 @@ msgstr ""
 "змінена на %(new_email)s. Якщо Ви не робили цієї зміни зв'яжіться з нами "
 "негайно за адресою <%(support_email)s>."
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
@@ -3064,46 +2528,46 @@ msgstr ""
 "Організація: %(organization_url)s Час: %(login_time)s Електронна пошта: "
 "%(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr "Ми помітили нещодавній вхід в обліковий запис Zulip."
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr "Організація: %(organization_link)s"
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr "Електронна пошта: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr "Час: %(login_time)s"
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr "Пристрій: %(device_browser)s на %(device_os)s."
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr "IP адреса: %(device_ip)s"
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr "Якщо це були ви — супер! Тоді нічого не треба робити."
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3114,31 +2578,31 @@ msgstr ""
 "скомпрометований <a href=\"%(reset_link)s\">змінить свій пароль</a>, або "
 "зв'яжіться з нами за адресою %(support_email)s."
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr "Дякуємо,"
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr "Безпека Zulip"
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr "Відписатись від повідомлень про вхід в обліковий запис"
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr "Новий вхід з %(device_browser)s на %(device_os)s"
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr "Організація: %(organization_url)s"
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -3149,7 +2613,7 @@ msgstr ""
 "скомпрометовано, будь ласка, змініть свій пароль %(reset_link)s, або "
 "зв'яжіться з нами за адресою %(support_email)s."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -3161,7 +2625,7 @@ msgstr ""
 "href=\"%(get_organization_started)s\">посібником з переходу на Zulip</a>, "
 "щоб розпочати."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
@@ -3169,7 +2633,7 @@ msgstr ""
 "В іншому випадку, ось кілька порад, які ми часто чуємо від клієнтів щодо "
 "оцінювання <i>будь-який</i> продукт командного чату:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
@@ -3178,12 +2642,12 @@ msgstr ""
 "<a href=\"%(invite_users)s\"><b>Запросіть своїх товаришів по команді</b></a> "
 "дослідити разом з вами та поділитися своїми унікальними поглядами."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr "Використовуйте сам додаток, щоб поспілкуватися про свої враження."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -3195,7 +2659,7 @@ msgstr ""
 "єдиний спосіб по-справжньому відчути, як новий додаток для чату допоможе "
 "вашій команді спілкуватися."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -3206,21 +2670,21 @@ msgstr ""
 "комунікації</a>, і ми сподіваємося, що ці поради допоможуть вашій команді "
 "випробувати це на практиці."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr "Скасувати підписку на вітальні електронні листи для %(realm_name)s"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr "Вибір чат-додатку для вашої команди"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
@@ -3229,7 +2693,7 @@ msgstr ""
 "просимо! Ви можете скористатися нашим посібником з переходу на Zulip, щоб "
 "розпочати."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
@@ -3237,7 +2701,7 @@ msgstr ""
 "В іншому випадку, ось кілька порад, які ми часто чуємо від клієнтів щодо "
 "оцінки будь-якого продукту для командного чату:"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
@@ -3245,7 +2709,7 @@ msgstr ""
 "Запросіть своїх товаришів по команді дослідити разом з вами та поділитися "
 "своїми унікальними поглядами."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
@@ -3255,7 +2719,7 @@ msgstr ""
 "інших інструментів для чату. Це єдиний спосіб по-справжньому відчути, як "
 "новий додаток для чату допоможе вашій команді спілкуватися."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
@@ -3263,8 +2727,8 @@ msgstr ""
 "Zulip розроблено для забезпечення ефективної комунікації, і ми сподіваємося, "
 "що ці поради допоможуть вашій команді випробувати його на практиці."
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
@@ -3274,77 +2738,77 @@ msgstr ""
 "дізнатися, як він може найкраще підійти для ваших потреб. Перегляньте цей "
 "посібник із ключових функцій Zulip для таких організацій, як ваша!"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr "Перегляньте посібник Zulip для бізнесу"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr "Перегляньте посібник Zulip для проектів з відкритим кодом"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr "Переглянути посібник Zulip для освіти"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr "Перегляньте посібник Zulip для дослідження"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr "Перегляньте посібник Zulip для подій та конференцій"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr "Перегляньте посібник Zulip для некомерційних організацій"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr "Переглянути посібник Zulip для спільнот"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr "Посібник Zulip для бізнесу"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr "Посібник Zulip для проектів з відкритим кодом"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr "Посібник Zulip для освіти"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr "Посібник Zulip для досліджень"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr "Посібник Zulip для заходів та конференцій"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr "Посібник Zulip для некомерційних організацій"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr "Посібник Zulip для громад"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
 msgstr "Ось кілька порад щодо організації ваших розмов у Zulip за темами."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
@@ -3352,8 +2816,8 @@ msgstr ""
 "У Zulip <b>канали</b> визначають, хто отримає повідомлення. <b>Теми</b> "
 "розповідають, про що йдеться в повідомленні."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
@@ -3362,12 +2826,12 @@ msgstr ""
 "бачитимете кожне повідомлення в контексті, незалежно від того, скільки "
 "різних обговорень триває."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr "Канали та теми в додатку Zulip"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3379,11 +2843,11 @@ msgstr ""
 "теми була гарною, подумайте про те, щоб завершити речення так: «Привіт, чи "
 "можемо ми поговорити про…?»"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr "Приклади коротких тем"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3397,17 +2861,17 @@ msgstr ""
 "або навіть <a href=\"%(move_channels_link)s\">перемістити тему до іншого "
 "каналу</a>."
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr "Перейти до Zulip"
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr "Організуйте свої розмови за темами"
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
@@ -3415,7 +2879,7 @@ msgstr ""
 "У Zulip канали визначають, хто отримає повідомлення. Теми розповідають, про "
 "що йдеться в повідомленні."
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3428,8 +2892,8 @@ msgstr ""
 "(%(move_messages_link)s), перейменувати теми (%(rename_topics_link)s) або "
 "навіть перемістити тему в інший канал (%(move_channels_link)s)."
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
@@ -3438,15 +2902,15 @@ msgstr ""
 "Хтось (можливо, ви) запросив новий пароль для облікового запису Zulip "
 "%(email)s на %(realm_url)s."
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr "Клацніть на кнопку нижче щоб поміняти Ваш пароль."
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr "Скинути пароль"
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3457,41 +2921,41 @@ msgstr ""
 "деактивовано. Ви можете зв’язатися з адміністратором організації, щоб <a "
 "href=\"%(help_link)s\">повторно активувати свій обліковий запис</a>."
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr "У Вас нема облікового запису у той Zulip організації."
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr "У Вас нема активних облікових записів у наступних організаціях."
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
 msgstr ""
 "Ви можете спробувати увійти або змінити Ваш пароль у організаціях вище."
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 "Якщо ви не впізнаєте цієї активності, можете спокійно проігнорувати цей лист."
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr "Запит на зміну паролю для %(realm_name)s"
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr "Клацніть на посилання нижче щоб змінити Ваш пароль."
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
@@ -3501,7 +2965,7 @@ msgstr ""
 "деактивовано. Ви можете звернутися до адміністратора організації, щоб "
 "повторно активувати свій обліковий запис."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3512,7 +2976,7 @@ msgstr ""
 "безкоштовний план Zulip Cloud через неоплачені рахунки. Неоплачені рахунки "
 "анульовано."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
@@ -3521,7 +2985,7 @@ msgstr ""
 "Щоб продовжити користуватися стандартним планом Zulip Cloud, будь ласка, "
 "оновіть його ще раз, перейшовши за посиланням %(upgrade_url)s."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
@@ -3530,8 +2994,8 @@ msgstr ""
 "Якщо ви вважаєте, що це була помилка, або вам потрібна додаткова інформація, "
 "зв’яжіться з нами за адресою %(support_email)s."
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip demo organization, %(realm_name)s, on "
@@ -3540,8 +3004,8 @@ msgstr ""
 "Ви деактивували свою демо-організацію Zulip, %(realm_name)s, "
 "%(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
@@ -3550,8 +3014,8 @@ msgstr ""
 "Ваша демо-організація Zulip, %(realm_name)s, була деактивована користувачем "
 "%(deactivating_owner)s %(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
@@ -3560,8 +3024,8 @@ msgstr ""
 "Вашу демо-організацію Zulip, %(realm_name)s, було деактивовано "
 "%(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
@@ -3569,8 +3033,8 @@ msgid ""
 msgstr ""
 "Ви деактивували свою організацію Zulip, %(realm_name)s, %(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
@@ -3579,8 +3043,8 @@ msgstr ""
 "Вашу організацію Zulip, %(realm_name)s, було деактивовано користувачем "
 "%(deactivating_owner)s %(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
@@ -3588,14 +3052,14 @@ msgid ""
 msgstr ""
 "Вашу організацію Zulip, %(realm_name)s, було деактивовано %(localized_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr "Усі дані, пов’язані з цією організацією, було видалено назавжди."
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
@@ -3604,8 +3068,8 @@ msgstr ""
 "Усі дані, пов’язані з цією організацією, будуть остаточно видалені "
 "%(deletion_date)s."
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
@@ -3613,19 +3077,19 @@ msgstr ""
 "Якщо у вас є будь-які запитання чи зауваження, будь ласка, дайте відповідь "
 "на цей електронний лист якомога швидше."
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr "Вашу організацію Zulip %(realm_name)s деактивовано"
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr "Шановні колишні адміністратори %(realm_name)s,"
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
@@ -3635,8 +3099,8 @@ msgstr ""
 "деактивованої демонстраційної організації Zulip, розміщеної за адресою "
 "%(realm_url)s."
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
@@ -3645,16 +3109,16 @@ msgstr ""
 "Один з ваших адміністраторів надіслав запит на повторну активацію раніше "
 "деактивованої організації Zulip, розміщеної за адресою %(realm_url)s."
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr "Клацніть на кнопку нижче щоб відновити Вашу організацію."
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr "Повторно активувати організацію"
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
@@ -3662,19 +3126,19 @@ msgstr ""
 "Якщо запит був зроблений помилково, Ви можете нічого не робити і посилання "
 "автоматично деактивується за 24 години."
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip demo organization"
 msgstr "Повторно активуйте свою демо-організацію Zulip"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr "Повторно активуйте вашу організацію Zulip"
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr "Клацніть на посилання нижче щоб відновити Вашу організацію."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3683,19 +3147,19 @@ msgstr ""
 "Ви або хтось від вашого імені запросив посилання для входу в систему, щоб "
 "керувати планом Zulip для <b>%(remote_server_hostname)s</b>."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 msgid "Click the button below to log in."
 msgstr "Натисніть кнопку нижче, щоб увійти."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr ""
 "Термін дії цього посилання закінчиться через %(validity_in_hours)s годин."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
@@ -3704,11 +3168,11 @@ msgstr ""
 "Є питання? <a href=\"%(billing_help_link)s\">Дізнайтеся більше</a> або "
 "зв’яжіться з %(billing_contact_email)s."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr "Увійдіть до системи керування планами Zulip"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3717,12 +3181,12 @@ msgstr ""
 "Ви або хтось від вашого імені запросив посилання для входу в систему, щоб "
 "керувати планом Zulip для %(remote_server_hostname)s."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr "Натисніть на посилання нижче, щоб увійти."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
@@ -3731,7 +3195,7 @@ msgstr ""
 "Є питання? Дізнайтеся більше на %(billing_help_link)s або зв’яжіться з "
 "%(billing_contact_email)s."
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
@@ -3740,16 +3204,16 @@ msgstr ""
 "Натисніть кнопку нижче, щоб підтвердити свою електронну адресу та увійти до "
 "керування планом Zulip для <b>%(remote_realm_host)s</b>."
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr "Підтвердити та увійти"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr "Підтвердьте електронну адресу для керування планом Zulip"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
@@ -3758,7 +3222,7 @@ msgstr ""
 "Натисніть посилання нижче, щоб підтвердити свою електронну адресу та увійти "
 "до керування планом Zulip для %(remote_realm_host)s."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
@@ -3767,7 +3231,7 @@ msgstr ""
 "Ваш запит на спонсорство Zulip схвалено! Вашу організацію оновлено до <a "
 "href=\"%(plans_link)s\">плану Zulip Community</a>."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
@@ -3776,12 +3240,12 @@ msgstr ""
 "Якщо ви можете <a href=\"%(link_to_zulip)s\">вказати Zulip як спонсора на "
 "своєму вебсайті</a>, ми були б дуже вдячні!"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr "Схвалено спонсорство плану громади для %(billing_entity)s!"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
@@ -3789,7 +3253,7 @@ msgstr ""
 "Ваш запит на спонсорство Zulip схвалено! Вашу організацію оновлено до плану "
 "Zulip Community."
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
@@ -3797,21 +3261,21 @@ msgstr ""
 "Якщо ви можете вказати Zulip як спонсора на своєму вебсайті, ми були б дуже "
 "вдячні!"
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr "Знайдіть свої облікові записи"
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr "Знайдіть свої облікові записи Zulip"
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 "Листи надіслано! Адреси, введені на попередній сторінці, перелічені нижче:"
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
@@ -3821,7 +3285,7 @@ msgstr ""
 "href=\"%(current_url)s\">знайти облікові записи для іншої адреси електронної "
 "пошти</a>."
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
@@ -3830,7 +3294,7 @@ msgstr ""
 "адресами всіх організацій Zulip Cloud, у яких у вас є активні облікові "
 "записи."
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
@@ -3839,7 +3303,7 @@ msgstr ""
 "адресами всіх організацій Zulip на цьому сервері, в яких у вас є активні "
 "облікові записи."
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
@@ -3847,214 +3311,214 @@ msgstr ""
 "Якщо ви також забули свій пароль, ви можете <a href=\"/help/change-your-"
 "password\">скинути його</a>."
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr "Електронна адреса"
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "Знайти облікові записи"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr "Продукт"
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr "Чому Zulip"
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr "Особливості"
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr "Тарифні плани та ціни"
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 msgid "Zulip Cloud"
 msgstr "Хмара Zulip"
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr "Самостійне розміщення"
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr "Безпека"
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "Інтеграції"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr "Настільні та мобільні додатки"
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr "Нова організація"
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr "Рішення"
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr "Бізнес"
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr "Навчання"
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr "Дослідження"
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr "Заходи та конференції"
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr "Проєкти з відкритим кодом"
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr "Спільноти"
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr "Інженери"
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr "Історії клієнтів"
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr "Відкриті спільноти"
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr "Ресурси"
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr "Початок роботи"
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr "Центр довідки"
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr "Чат спільноти"
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr "Партнери"
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr "Стан хмари Zulip"
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr "Переїзд до Zulip"
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr "Встановлення сервера Zulip"
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr "Оновлення сервера Zulip"
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr "Внесок"
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr "Посібник зі створення контенту"
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr "Спільнота розробників"
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr "Переклад"
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr "GitHub"
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr "Про нас"
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr "Команда"
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "Історія"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr "Значенні"
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr "Робота"
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr "Блог"
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr "Підтримати Zulip"
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr "Mastodon'"
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr "LinkedIn'"
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Bluesky handle"
 msgid "Bluesky"
 msgstr "Ручка Bluesky"
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr "Працює за підтримки <a href=\"https://zulip.com\">Zulip</a>"
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr "Умови обслуговування"
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr "Політика конфіденційності"
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr "Атрибуції веб-сайту"
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr "Більше %(integrations_count_display)s нативних інтеграцій."
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 msgid ""
 "And hundreds more through <a href=\"/integrations/zapier\">Zapier</a> and <a "
 "href=\"/integrations/ifttt\">IFTTT</a>."
@@ -4062,52 +3526,48 @@ msgstr ""
 "І сотні інших через <a href=\"/integrations/zapier\">Zapier</a> та <a "
 "href=\"/integrations/ifttt\">IFTTT</a>."
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr "Пошук інтеграцій"
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr "Власні інтеграції"
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr "Вхідні вебхуки"
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr "Інтерактивні боти"
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr "REST API"
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr "Неправильна адреса електронної пошти"
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr "Електронна пошта заборонена"
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr ""
 "Адреса електронної пошти, з якою ви намагаєтеся зареєструватися, недійсна."
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4118,7 +3578,7 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>, не дозволяє реєстрацію з "
 "використанням електронних адрес з вашим доменом електронної пошти."
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4129,7 +3589,7 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>, не дозволяє реєстрацію з "
 "використанням одноразових адрес електронної пошти."
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -4140,27 +3600,27 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>, не дозволяє реєстрацію з "
 "використанням електронних адрес, що містять символ \"+\"."
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr ""
 "Будь ласка, зареєструйтесь, використовуючи дійсну адресу електронної пошти."
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr ""
 "Будь ласка, зареєструйтесь, використовуючи дозволену адресу електронної "
 "пошти."
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr "Організацію не знайдено"
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr "За адресою <b>%(current_url)s</b> немає організації Zulip."
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -4172,7 +3632,7 @@ msgstr ""
 "або <a href=\"mailto:%(support_email)s\">зверніться до служби підтримки "
 "Zulip</a>."
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -4184,7 +3644,7 @@ msgstr ""
 "сервері або <a href=\"mailto:%(support_email)s\">зв'яжіться з "
 "адміністраторами цього сервера Zulip</a>."
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
@@ -4193,61 +3653,61 @@ msgstr ""
 "<a href=\"%(current_url)s/serverlogin/\">Натисніть тут</a>, щоб отримати "
 "доступ до керування планом для вашого сервера Zulip."
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr "Недійсний або закінчений сеанс входу"
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr "Сеанс входу недійсний, або закінчився."
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr "Увійти в Zulip"
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 "Ви вже зареєструвалися за цією адресою електронної пошти. Будь ласка, "
 "увійдіть в систему нижче."
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr "Електронна пошта або ім'я користувача"
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "Ім'я користувача"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr "Забули пароль?"
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr "Увійти через %(identity_provider)s"
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr "Перегляд без облікового запису"
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 "У вас ще немає облікового запису? Для приєднання до цієї організації "
 "потрібно щоб вас запросили."
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr "Немає доступних ліцензій"
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr "Організація зараз не може приймати нових членів"
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
@@ -4257,7 +3717,7 @@ msgstr ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>, оскільки всі ліцензії Zulip Cloud "
 "використовуються."
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
@@ -4265,19 +3725,19 @@ msgstr ""
 "Будь ласка, зв’яжіться з особою, яка вас запросила, і попросіть її збільшити "
 "кількість ліцензій, а потім спробуйте ще раз."
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr "Перейти до основного вмісту"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr "Помилка автентифікації піддомену"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr "Субдомен автентифікації"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -4291,16 +3751,15 @@ msgstr ""
 "застрягли тут під час спроби входу, це, найімовірніше, помилка сервера або "
 "неправильна конфігурація."
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 msgid "Demo organizations disabled"
 msgstr "Демо-організації вимкнено"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr "Необхідне оновлення"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
@@ -4308,7 +3767,7 @@ msgstr ""
 "Ви використовуєте стару версію десктопної програми Zulip, яка більше не "
 "підтримується."
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
@@ -4316,21 +3775,20 @@ msgstr ""
 "Функція автоматичного оновлення у цій старій версії настільного додатка "
 "Zulip більше не працює."
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr "Завантажте останню версію."
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr "Ви перевищили ліміт частоти виконання цієї дії користувачем."
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr "Потрібне посилання для створення організації"
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -4343,12 +3801,11 @@ msgstr ""
 "html\">документацію</a> щодо створення нової організації для отримання "
 "додаткової інформації."
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr "Посилання для створення організації термін дії минув або недійсне"
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
@@ -4356,11 +3813,11 @@ msgstr ""
 "На жаль, це недійсне посилання для створення організації. Будь ласка, <a "
 "href=\"/new/\">отримайте нове посилання</a> та спробуйте ще раз."
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr "Неочікувана реєстрація сервера Zulip"
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -4372,17 +3829,16 @@ msgstr ""
 "до служби підтримки Zulip</a> для отримання допомоги у вирішенні цієї "
 "проблеми."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr "Непідтримуваний браузер"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr "%(browser_name)s не підтримується Zulip."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
@@ -4391,7 +3847,7 @@ msgstr ""
 "Zulip підтримує <a href=\"%(supported_browsers_page_link)s\">сучасні "
 "браузери</a>, такі як Firefox, Chrome та Edge."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
@@ -4399,21 +3855,20 @@ msgstr ""
 "Ви також можете скористатися <a href=\"%(apps_page_link)s\">додатком Zulip "
 "для настільних комп’ютерів</a>."
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr "Обліковий запис деактивовано"
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 msgid "Finalize organization import"
 msgstr "Завершити імпорт організації"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 msgid "Organization import completed!"
 msgstr "Імпорт організації завершено!"
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -4425,54 +3880,53 @@ msgstr ""
 "strong>). Виберіть обліковий запис, з яким потрібно пов’язати свою адресу "
 "електронної пошти."
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 msgid "Select your account"
 msgstr "Виберіть свій обліковий запис"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 msgid "Create new account"
 msgstr "Створити новий обліковий запис"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr "Організацію успішно повторно активовано"
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr "Ваша організація успішно повторно активована."
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr "Посилання для повторної активації організації закінчилося або недійсне"
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr ""
 "Термін посилання на повторну активацію організації минув, або посилання не "
 "дійсне."
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr "Увійти до своєї організації"
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr "ваша-організація"
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr "Не знаєте URL своєї організації?"
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr "Знайти свою організацію."
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr "Далі"
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4483,11 +3937,11 @@ msgstr ""
 "href=\"%(org_creation_link)s\">Створіть нову організацію</a>, якщо у вас її "
 "ще немає."
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 msgid "Self-hosting Zulip?"
 msgstr "Самостійний хостинг Zulip?"
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4497,11 +3951,11 @@ msgstr ""
 "href=\"%(self_hosted_login_help)s\">увійти, щоб керувати планами та "
 "виставленням рахунків.</a>"
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr "Скинути пароль"
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
@@ -4509,63 +3963,63 @@ msgstr ""
 "Забули пароль? Не проблема, ми надішлемо посилання для скидання пароля на "
 "електронну адресу, яку ви використовували для реєстрації."
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr "Надіслати посилання на скидання"
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr "Встановити новий пароль"
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "Підтвердити пароль"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr "На жаль, вказане вами посилання недійсне, або вже використане."
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr "Новий пароль успішно встановлено"
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr "Ви встановили новий пароль!"
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr ""
 "Будь ласка <a href=\"%(login_url)s\">увійдіть</a>, використовуючи свій новий "
 "пароль."
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr "Надіслано електронний лист для скидання пароля"
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr "Скидання пароля відправлено!"
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr ""
 "Перевірте свою електронну пошту через кілька хвилин, щоб завершити процес."
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr "Імпорт із Slack"
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr "Хід імпорту"
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr "Перевірка статусу імпорту…"
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4573,7 +4027,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4586,15 +4040,15 @@ msgstr ""
 "rel=\"noopener noreferrer\" target=\"_blank\">цих інструкцій</a>, щоб "
 "отримати <strong>токен OAuth користувача бота</strong>."
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr "Токен OAuth користувача Slack-бота"
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr "Завантажте свій файл експорту Slack"
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
@@ -4604,20 +4058,20 @@ msgstr ""
 "slack-data\" target=\"_blank\" rel=\"noopener noreferrer\">цих інструкцій</"
 "a>, щоб отримати експорт історії повідомлень Slack."
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr "Розпочати завантаження"
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr "Завантажений файл експорту"
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr ""
 "Кому буде дозволено бачити адреси електронної пошти інших користувачів?"
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
@@ -4627,11 +4081,11 @@ msgstr ""
 "visibility\" target=\"_blank\">змінити</a> конфігурацію видимості "
 "електронної пошти під час входу в систему."
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr "Розпочати імпорт"
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
@@ -4639,7 +4093,7 @@ msgstr ""
 "Не соромтеся йти далі. Ви завжди можете повернутися на цю сторінку, <br /> "
 "натиснувши кнопку <b>Завершити реєстрацію</b> у вашому електронному листі."
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
@@ -4647,7 +4101,7 @@ msgstr ""
 "Або <span id=\"cancel-slack-import\" tabindex=\"0\">створіть організацію</"
 "span> без імпорту даних."
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4659,7 +4113,7 @@ msgstr ""
 "rel=\"noopener noreferrer\" target=\"_blank\">процесу</a> для імпорту через "
 "службу підтримки."
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4671,22 +4125,22 @@ msgstr ""
 "rel=\"noopener noreferrer\" target=\"_blank\">процесу</a> для самостійно "
 "розміщеного імпорту."
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr "Виберіть обліковий запис для автентифікації"
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr "<h1 class=\"get-started\">Вибрати обліковий запис</h1>"
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 "У вашому обліковому записі GitHub також є неперевірені адреси електронної "
 "пошти."
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
@@ -4695,15 +4149,15 @@ msgstr ""
 "href=\"https://github.com/settings/emails\">підтвердити їх за допомогою "
 "GitHub.</a>"
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr "Помилка скасування підписки на електронну пошту"
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr "Невідомий запит на скасування підписки на електронну пошту"
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
@@ -4711,7 +4165,7 @@ msgstr ""
 "Вітаю! Схоже, ви намагалися відписатися від чогось, але ми не розпізнаємо "
 "URL-адресу."
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4722,12 +4176,11 @@ msgstr ""
 "раз, або <a href=\"mailto:%(support_email)s\">напишіть нам електронного "
 "листа</a>, і ми вирішимо це питання!"
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr "Налаштування електронної пошти оновлено"
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
@@ -4736,7 +4189,7 @@ msgstr ""
 "Ви успішно скасували підписку на електронні листи Zulip "
 "%(subscription_type)s для <a href=\"%(realm_url)s\">%(realm_name)s</a>."
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
@@ -4745,51 +4198,50 @@ msgstr ""
 "Ви можете скасувати цю зміну або переглянути свої налаштування в <a "
 "href=\"%(realm_url)s/#settings/notifications\">налаштуваннях сповіщень</a>."
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr "Недійсне відображення порядку."
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr "Запитання та обговорення щодо використання Zulip."
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr "Поекспериментуйте з Zulip тут. :test_tube:"
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr "Для розмов у команді"
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr "реєстрації"
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr "{user} приєднався до цієї організації."
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr "{user} прийняв ваше запрошення приєднатися до Zulip!"
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 "Не вдається активувати обліковий запис-заповнювач; попросіть користувача "
 "зареєструватися."
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 #, fuzzy
 #| msgid "Cannot deactivate user group in use."
 msgid "Cannot reactivate a deleted user"
 msgstr "Неможливо деактивувати групу користувачів, яка використовується."
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
@@ -4797,26 +4249,25 @@ msgstr ""
 "Ви не маєте права змінювати це поле. Зверніться до адміністратора, щоб "
 "оновити його."
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr "Ідентифікатор поля {id} не знайдено."
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr "Недійсна назва групи каналів за замовчуванням '{group_name}'"
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 "Назва групи каналів за замовчуванням занадто довга (ліміт: {max_length} "
 "символів)"
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
@@ -4824,12 +4275,12 @@ msgstr ""
 "Назва групи каналів за замовчуванням '{group_name}' містить символи NULL "
 "(0x00)."
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr "Недійсна група каналів за замовчуванням {group_name}"
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
@@ -4837,12 +4288,12 @@ msgstr ""
 "«{channel_name}» – це канал за замовчуванням, і його не можна додати до "
 "«{group_name}»"
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr "Група каналів за замовчуванням '{group_name}' вже існує"
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
@@ -4851,7 +4302,7 @@ msgstr ""
 "Канал «{channel_name}» вже присутній у групі каналів за замовчуванням "
 "«{group_name}»"
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
@@ -4860,12 +4311,12 @@ msgstr ""
 "Канал «{channel_name}» відсутній у групі каналів за замовчуванням "
 "«{group_name}»"
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr "Ця група каналів за замовчуванням вже має назву '{group_name}'"
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
@@ -4874,7 +4325,7 @@ msgstr ""
 "надіслати протягом одного дня. Оскільки ви досягли ліміту, жодних запрошень "
 "не було надіслано."
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
@@ -4883,79 +4334,79 @@ msgstr ""
 "організації. Попросіть адміністратора організації або досвідченого "
 "користувача."
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 "Деякі електронні листи не підтверджені, тому ми не надсилали жодних "
 "запрошень."
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr "Ми не змогли запросити когось."
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr "Нема що змінювати"
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr "Прямі повідомлення не можна переміщувати до каналів."
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr "У прямих повідомленнях не може бути тем."
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr "Помилковий propagate_mode без редагування теми"
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr "Загальний чат не можна позначити як вирішений"
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr "Неможливо змінити вміст повідомлення під час зміни каналу"
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr "Віджети не можна редагувати."
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr "Ваша організація вимкнула редагування повідомлень"
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr "Ви не маєте права редагувати це повідомлення"
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr "Термін для редагування цього повідомлення минув"
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr "{user} позначив цю тему як вирішену."
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr "{user} позначив цю тему як невирішену."
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr "Цю тему було переміщено до {new_location} користувачем {user}."
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr ""
 "Повідомлення було переміщено з цієї теми до {new_location} користувачем "
 "{user}."
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
@@ -4964,12 +4415,12 @@ msgstr ""
 "Користувач {user} перемістив повідомлення з цієї теми до {new_location}: "
 "{changed_messages_count}."
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr "Цю тему було перенесено сюди з {old_location} користувачем {user}."
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
@@ -4977,7 +4428,7 @@ msgstr ""
 "[Повідомлення]({message_link}) було переміщено сюди з {old_location} "
 "користувачем {user}."
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
@@ -4986,67 +4437,64 @@ msgstr ""
 "{user} перемістив сюди повідомлення з {old_location}: "
 "{changed_messages_count}."
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to resolve topics in this channel."
 msgstr "У вас немає дозволу вирішувати теми в цьому каналі."
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr "Час для редагування теми цього повідомлення минув."
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr "Ви не маєте дозволу на переміщення цього повідомлення"
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr "Часовий ліміт для редагування каналу цього повідомлення минув"
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr "Недійсний прапорець: '{flag}'"
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr "Прапорець не можна редагувати: '{flag}'"
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr "Недійсна операція з прапорцем повідомлення: '{operation}'"
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr "Недійсне(і) повідомлення"
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr "Неможливо відобразити повідомлення"
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr "Очікується рівно один канал"
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr "Недійсний тип даних для каналу"
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr "Недійсний тип даних для одержувачів"
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr ""
 "Списки одержувачів можуть містити електронні адреси або ID користувачів, але "
 "не обидва разом."
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
@@ -5055,7 +4503,7 @@ msgstr ""
 "Ваш бот {bot_identity} спробував надіслати повідомлення на канал з "
 "ідентифікатором {channel_id}, але каналу з таким ідентифікатором не існує."
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -5066,7 +4514,7 @@ msgstr ""
 "{channel_name}, але цей канал не існує. Натисніть [тут]({new_channel_link}), "
 "щоб створити його."
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
@@ -5075,29 +4523,29 @@ msgstr ""
 "Ваш бот {bot_identity} спробував надіслати повідомлення на канал "
 "{channel_name}. Канал існує, але на нього немає підписників."
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr "У вас немає дозволу на доступ до деяких одержувачів."
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr "Віджети: API розробник надіслав JSON з помилковим вмістом"
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr "Віджети: {error_msg}"
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr "До вашого облікового запису внесено такі зміни."
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr "Користувач {user} вніс такі зміни до вашого облікового запису."
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5108,27 +4556,25 @@ msgstr ""
 "- **Старе {field_name}:** {old_value}\n"
 "- **Нове {field_name}:** {new_value}\n"
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr "Користувацька емодзі з таким іменем вже існує."
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr "Недійсний формат зображення"
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr "Упорядкований список не повинен містити дублікованих лінкіфікаторів"
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 "Упорядкований список повинен перераховувати всі існуючі лінкіфікатори рівно "
 "один раз"
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
@@ -5137,39 +4583,39 @@ msgstr ""
 "Щоб використовувати цей метод автентифікації, вам потрібно оновити тарифний "
 "план до {required_upgrade_plan_name}."
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr "Недійсний метод автентифікації: {name}. Дійсні методи: {methods}"
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr "Метод автентифікації {name} недоступний у вашому поточному плані."
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr "Канал запиту на модерацію має бути приватним."
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr "Збережений фрагмент не існує."
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr "Заплановане повідомлення вже надіслано"
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 #, fuzzy
 #| msgid "Reminder does not exist"
 msgid "Reminder could not be sent."
 msgstr "Нагадування не існує"
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr "Повідомлення не вдалося надіслати у запланований час."
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
@@ -5178,38 +4624,38 @@ msgstr ""
 "Повідомлення, заплановане на {delivery_datetime}, не було надіслано через "
 "таку помилку:"
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr "[Переглянути заплановані повідомлення](#scheduled)"
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr "Канал вже деактивовано"
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr "Канал № **{channel_name}** архівовано."
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr "Канал наразі не деактивовано"
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr "Канал під назвою {channel_name} вже існує"
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr "Канал приватний і не має підписників"
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr "Канал № **{channel_name}** розархівовано."
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
@@ -5218,7 +4664,7 @@ msgstr ""
 "{user} змінив [дозволи доступу]({help_link}) для цього каналу з "
 "**{old_policy}** на **{new_policy}**."
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -5231,41 +4677,39 @@ msgstr ""
 "* **Старий**: {old_setting_description}\n"
 "* **Новий**: {new_setting_description}\n"
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 "{user_name} перейменував канал {old_channel_name} на {new_channel_name}."
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr "Без опису."
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr "{user} змінив опис цього каналу."
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr "Старий опис"
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr "Новий опис"
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr "Назавжди"
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr "{number_of_days} днів"
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
@@ -5274,11 +4718,11 @@ msgstr ""
 "Повідомлення в цьому каналі тепер автоматично видалятимуться через "
 "{number_of_days} днів після їх надсилання."
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr "Повідомлення в цьому каналі тепер зберігатимуться назавжди."
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -5295,26 +4739,26 @@ msgstr ""
 "\n"
 "{summary_line}"
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr "Автоматичний"
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr "*{empty_topic_display_name}* тема дозволена"
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr "Немає теми *{empty_topic_display_name}*"
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr "Дозволено лише тему *{empty_topic_display_name}*"
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
@@ -5323,73 +4767,63 @@ msgstr ""
 "{user_name} змінив налаштування «Дозволити публікації в темі *загального "
 "чату*?» з {old_topics_policy} на {new_topics_policy}."
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr "Ви не можете додати відповідь до цього повідомлення."
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr "Недійсний ідентифікатор користувача {user_id}"
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr "Група користувачів '{group_name}' вже існує."
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr "Недостатній дозвіл"
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr "Цей API недоступний для вхідних вебхук ботів."
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr "Обліковий запис не пов'язаний з цим піддоменом"
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr "Ця точка прийому не приймає запити від ботів."
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr "Має бути адміністратором сервера"
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr "Ця кінцева точка вимагає базової автентифікації HTTP."
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr "Невірний заголовок авторизації для базової аутентифікації"
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr "Відсутня заголовок авторизації для базової аутентифікації"
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr "Вебхук боти мають доступ тільки до вебхуків"
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr "Неправильна електронна адреса або пароль."
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
@@ -5398,54 +4832,53 @@ msgstr ""
 "Ваш обліковий запис {username} деактивовано. Зверніться до адміністратора "
 "вашої організації, щоб повторно активувати його."
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr "Пароль занадто слабкий."
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr "Піддомен повинен мати 3 символа, або більше."
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr "Піддомен не може починатись або закінчуватися символом '-'."
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr "Піддомен може містити лише малі літери, цифри та '-'."
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr "Субдомен вже використовується. Будь ласка, виберіть інший."
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr "Субдомен зарезервовано. Будь ласка, виберіть інший."
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr "Будь ласка, використовуйте свою справжню електронну адресу."
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr ""
 "Організація, яку ви намагаєтеся приєднати, використовуючи {email}, не існує."
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr "Будь ласка, запросіть інвайт для {email} у адміністратора організації."
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 "Не вдається приєднатися до організації: автентифікація за паролем не "
 "ввімкнена."
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
@@ -5454,11 +4887,11 @@ msgstr ""
 "Ваша електронна адреса, {email}, не знаходиться в одному з доменів, яким "
 "дозволено зареєструватися для облікових записів у цій організації."
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr "Електронні адреси що містять +, не дозволяються в цій організації."
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
@@ -5469,32 +4902,31 @@ msgstr ""
 "запросила, і попросіть її збільшити кількість ліцензій, а потім спробуйте ще "
 "раз."
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr "Підтверджено, що ви користувач-людина!"
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr "Підтверджуємо, що ви не бот…"
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 msgid "Challenges are not enabled."
 msgstr "Випробування не ввімкнено."
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr "Не вдалося перевірити, спробуйте ще раз."
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "Новий пароль"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr "Підтвердження нового пароля"
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "You're making too many attempts to sign in. Try again in {seconds} "
@@ -5506,7 +4938,7 @@ msgstr ""
 "Ви робите забагато спроб увійти. Спробуйте ще раз через {seconds} секунд або "
 "зверніться за допомогою до адміністратора вашої організації."
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
@@ -5514,87 +4946,85 @@ msgstr ""
 "Ваш пароль вимкнено, оскільки він занадто слабкий. Скиньте пароль, щоб "
 "створити новий."
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr "Токен"
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 "Порада: Ви можете ввести кілька адрес електронної пошти, розділяючи їх "
 "комами."
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr "Будь ласка, введіть не більше 10 електронних адрес."
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr "Ми не змогли знайти цю організацію Zulip."
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr "Недійсна електронна адреса '{email}'"
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr "Відсутня тема"
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr "Неможливо надсилати на кілька каналів"
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr "Відсутній канал"
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr "Повідомлення має містити одержувачів"
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr "Недійсний тип повідомлення"
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr "Неправильне вкладення"
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr ""
 "Під час видалення вкладення сталася помилка. Будь-ласка спробуйте пізніше."
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr "Повідомлення повинно мати отримувачів!"
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name can't be empty."
 msgstr "Поле для назви папки каналу не може бути порожнім."
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr "Недійсний символ у назві папки каналу в позиції {position}."
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr "Назва папки каналу вже використовується"
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 msgid "Invalid channel folder ID"
 msgstr "Недійсний ідентифікатор папки каналу"
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 msgid "Configure owner account email address."
 msgstr "Налаштуйте адресу електронної пошти облікового запису власника."
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "\n"
@@ -5616,72 +5046,72 @@ msgstr ""
 "[перетворено на\n"
 "постійну організацію]({convert_demo_organization_help_url}).\n"
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a date"
 msgid "{var_name} is not Base64 encoded"
 msgstr "{var_name} не є датою"
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 #, fuzzy
 #| msgid "Invalid emoji code."
 msgid "Invalid `device_id`"
 msgstr "Недійсний код емодзі."
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr "{service_name} дайджест"
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr "Домен не може бути порожнім."
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr "Домен повинен мати принаймні одну крапку (.)"
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr "Домен занадто довгий"
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr "Домен не може починатись чи закінчуватись точкою (.)"
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr "Послідовні '.' заборонені."
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr "Піддомени не можуть починатись чи закінчуватись на '-'."
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr "Домен може мати лише літери, цифри, '.' та '-'."
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr "Часова мітка не може бути від'ємною."
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr "Тема не повинна містити нульових байтів"
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr "Потрібно вказати рівно 1 ідентифікатор каналу для повідомлень каналу"
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr "Користувач вимкнув синхронізацію чернеток."
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr "Чернетки не існує"
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5692,86 +5122,86 @@ msgstr ""
 "електронною поштою:\n"
 "{error_message}"
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr "Електронний лист без теми"
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr "Відкрийте Zulip, щоб побачити прихований вміст"
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr "{service_name} сповіщення"
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr "Недійсна адреса."
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr "За межами вашого домену."
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr "Електронні адреси, що містять +, не дозволені."
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr "Зарезервовано для системних ботів."
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr "{email} вже має обліковий запис"
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr "Вже є обліковий запис."
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr "Обліковий запис був деактивований."
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr "Емодзі «{emoji_name}» не існує"
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr "Недійсний користувацький емодзі."
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr "Недійсне ім'я користувацького емодзі."
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr "Ця нестандартна емодзі була деактивована."
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr "Недійсний код емодзі."
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr "Недійсне ім'я емодзі."
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr "Недійсний тип емодзі."
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr "Необхідно бути адміністратором організації або автором емодзі"
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr "Назви емодзі повинні закінчуватися або літерою, або цифрою."
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
@@ -5779,62 +5209,62 @@ msgstr ""
 "Назви емодзі повинні містити лише малі англійські літери, цифри, пробіли, "
 "тире та символи підкреслення."
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr "Відсутня назва емодзі"
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr "Не вдалося виділити чергу подій"
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr "Відсутній вхід: потрібні API автентифікації або сесія користувача"
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr "Канал «{channel_name}» вже існує"
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr "Канал '{stream}' не існує"
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr "Канал з ідентифікатором '{stream_id}' не існує"
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr "Непідтримувана комбінація параметрів: {parameters}"
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr "власник організації"
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr "користувач"
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr "Неможливо деактивувати єдину {entity}."
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr "Markdown містить недійсний вираз: {include_statement}"
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
@@ -5842,58 +5272,57 @@ msgstr ""
 "Використання API перевищило ліміт швидкості; див. https://zulip.com/api/http-"
 "headers#rate-limiting-response-headers"
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr "Помилковий JSON"
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr "Має бути адміністратором організації"
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr "Має бути власником організації"
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Must be an organization owner"
 msgid "Must be a bot user"
 msgstr "Має бути власником організації"
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr "Ваше ім'я користувача або пароль неправильні"
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr "Ця організація була деактивована"
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr ""
 "Реєстрацію служби мобільних push-сповіщень для вашого сервера деактивовано"
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr "Автентифікація за паролем вимкнена в цій організації"
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr "Ваш пароль вимкнено та потребує скидання"
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr "Неправильний ключ API"
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr "Неправильний ключ API"
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
@@ -5902,26 +5331,25 @@ msgstr ""
 "Подія '{event_type}' наразі не підтримується вебхуком {webhook_name}; "
 "ігнорується"
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr ""
 "Не вдалося проаналізувати запит: Чи {webhook_name} згенерував цю подію?"
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr "Користувач не автентифіковано"
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr "Недійсний піддомен"
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr "У вас немає дозволу розпочинати прямі повідомлення."
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
@@ -5930,12 +5358,12 @@ msgstr ""
 "Надсилання повідомлень на адресу {empty_topic_display_name} заборонено в "
 "цьому каналі."
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr "У цьому каналі дозволено лише тему {empty_topic_display_name}."
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
@@ -5945,19 +5373,19 @@ msgstr ""
 "темі {empty_topic_display_name}. Спробуйте перейменувати або видалити інші "
 "теми."
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr "Особисті повідомлення в цій організації вимкнені."
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr "У цій розмові немає користувачів, які можуть її авторизувати."
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr "Доступ заборонено"
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
@@ -5966,15 +5394,15 @@ msgstr ""
 "Ви маєте дозвіл переміщувати лише {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} найновіших повідомлень у цій темі."
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr "Реакція вже існує."
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr "Реакції не існує."
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
@@ -5982,243 +5410,243 @@ msgstr ""
 "Ваша організація зареєстрована на іншому сервері Zulip. Зверніться до служби "
 "підтримки Zulip, щоб отримати допомогу у вирішенні цієї проблеми."
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr "Організація не зареєстрована"
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 "У вас немає дозволу використовувати згадки каналу з підстановочними "
 "символами в цьому каналі."
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 "У вас немає дозволу використовувати згадки тем із підстановочними символами "
 "в цій темі."
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr "Значення '{field_name}' не відповідає очікуваному значенню."
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr "«{setting_name}» має бути системною групою користувачів."
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr "Неможливо деактивувати групу користувачів, яка використовується."
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr "У вас немає дозволу на адміністрування цього каналу."
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr "У вас немає дозволу змінювати канали за замовчуванням."
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr "Електронна пошта вже використовується."
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr "Запланований час доставки має бути в майбутньому."
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr "Недійсний bouncer_public_key"
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr "Термін дії запиту минув"
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr "Недійсна encrypted_push_registration"
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr "Сервер не налаштовано для використання служби push-сповіщень."
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Already has an account."
 msgid "Atlassian account ID"
 msgstr "Вже є обліковий запис."
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 msgid "Behance username"
 msgstr "Ім'я користувача Behance"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 msgid "Bitbucket username"
 msgstr "Ім'я користувача Bitbucket"
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr "Ручка Bluesky"
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 msgid "Codeberg username"
 msgstr "Ім'я користувача Codeberg"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr "Тег Discord"
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 msgid "Dribbble username"
 msgstr "Ім'я користувача Dribbble"
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 msgid "Facebook username"
 msgstr "Ім'я користувача у Facebook"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr "Ім'я користувача Github"
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 msgid "GitLab username"
 msgstr "Ім'я користувача GitLab"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 msgid "Instagram username"
 msgstr "Ім'я користувача в Instagram"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr "Ім'я профілю LinkedIn"
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 msgid "Mastodon profile"
 msgstr "Профіль Mastodon"
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 msgid "Medium username"
 msgstr "Ім'я користувача Medium"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 msgid "Pinterest username"
 msgstr "Ім'я користувача Pinterest"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 msgid "Reddit username"
 msgstr "Ім'я користувача Reddit"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 msgid "Snapchat username"
 msgstr "Ім'я користувача Snapchat"
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 msgid "Threads username"
 msgstr "Ім'я користувача в Threads"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 msgid "TikTok username"
 msgstr "Ім'я користувача TikTok"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 msgid "Twitch username"
 msgstr "Ім'я користувача Twitch"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 msgid "X username"
 msgstr "Ім'я користувача X"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr "Ідентифікатор YouTube"
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr "Недійсний тип зовнішнього облікового запису"
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr "Інтеграційні фреймворки"
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 msgid "Video calling"
 msgstr "Відеодзвінки"
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr "Безперервна інтеграція"
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr "Підтримка клієнтів"
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr "Розгортання"
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr "Розваги"
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr "Зв'язок"
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr "Фінанси"
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr "Людські ресурси"
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr "Маркетинг"
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr "Різне"
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr "Моніторинг"
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr "Управління проектами"
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr "Продуктивність"
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr "Контроль версій"
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr "Повідомлення не може бути порожнім"
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr "Повідомлення не повинно містити нульових байтів"
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr "Вам не дозволено згадувати групу користувачів '{user_group_name}'."
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
@@ -6227,7 +5655,7 @@ msgstr ""
 "{reporting_user_mention} повідомив про повідомлення, надіслане користувачем "
 "{reported_user_mention} о {reported_message_date_sent}."
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "{reporting_user_mention} reported a direct message sent by "
@@ -6241,7 +5669,7 @@ msgstr ""
 "користувачем {reported_user_mention} користувачу {recipient_user} о "
 "{reported_message_date_sent}."
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "{reporting_user_mention} reported a direct message sent by "
@@ -6255,71 +5683,71 @@ msgstr ""
 "користувачем {reported_user_mention} користувачу {recipient_user} о "
 "{reported_message_date_sent}."
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr "Оригінальне повідомлення о {channel_message_link}"
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr "[Оригінальне повідомлення]({direct_message_link})"
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "{fullname} moderation"
 msgstr "Модерація {fullname}"
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr "Помилковий оператор пошуку: {desc}"
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr "Недійсна комбінація вузьких операторів: {desc}"
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr "Дублікати операторів «with»."
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr "Недійсний оператор «with»"
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr "Відсутній 'anchor' аргумент."
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor_date' argument."
 msgstr "Відсутній аргумент «anchor_date»."
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr "Помилковий гачок"
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr "Оператор {operator} не підтримується."
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr "Операнд {operand} не підтримується."
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 msgid "Navigation view does not exist."
 msgstr "Режим навігації не існує."
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr "Записка від {admin_group_syntax}:"
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6330,7 +5758,7 @@ msgstr ""
 "Щоб дізнатися більше, перегляньте наш [посібник з використання Zulip для "
 "занять]({getting_started_url})!\n"
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6341,7 +5769,7 @@ msgstr ""
 "Щоб дізнатися більше, перегляньте наш [посібник із початку роботи]"
 "({getting_started_url})!\n"
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6352,7 +5780,7 @@ msgstr ""
 "Також у нас є посібник з [налаштування Zulip для класу]"
 "({organization_setup_url}).\n"
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6363,7 +5791,7 @@ msgstr ""
 "Також у нас є посібник з [перенесення вашої організації до Zulip]"
 "({organization_setup_url}).\n"
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "\n"
@@ -6386,7 +5814,7 @@ msgstr ""
 "[перетворено на\n"
 "постійну організацію]({convert_demo_organization_help_url}).\n"
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
@@ -6396,7 +5824,7 @@ msgstr ""
 "Я розпочав кілька розмов, щоб допомогти вам розпочати. Ви можете знайти\n"
 "їх у вашій папці [Вхідні](/#inbox).\n"
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6407,7 +5835,7 @@ msgstr ""
 "Ви завжди можете повернутися до [відео «Ласкаво просимо до Zulip»]"
 "({navigation_tour_video_url}) для короткого огляду програми.\n"
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6431,7 +5859,7 @@ msgstr ""
 "{demo_organization_text}\n"
 "\n"
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
@@ -6441,7 +5869,7 @@ msgstr ""
 "Ви можете [завантажити](/apps/) [мобільні та настільні додатки](/apps/).\n"
 "Zulip також чудово працює у браузері.\n"
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -6453,7 +5881,7 @@ msgstr ""
 "[зображення профілю](/help/change-your-profile-picture)\n"
 "та відредагувати [інформацію профілю](/help/edit-your-profile).\n"
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -6472,7 +5900,7 @@ msgstr ""
 "користування Zulip\n"
 "у [Налаштуваннях](#settings/preferences).\n"
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6489,7 +5917,7 @@ msgstr ""
 "\n"
 "[Переглядайте канали та підписуйтесь на них]({settings_link}).\n"
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -6519,7 +5947,7 @@ msgstr ""
 "Перегляньте [Останні розмови](#recent) для списку тем,\n"
 "які обговорюються.\n"
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -6533,7 +5961,7 @@ msgstr ""
 "\n"
 "Натискайте `?` будь-коли, щоб побачити [шпаргалку](#keyboard-shortcuts).\n"
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -6553,7 +5981,7 @@ msgstr ""
 "глобальний\n"
 "час тощо.\n"
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6569,7 +5997,7 @@ msgstr ""
 "zulip),\n"
 "або перегляньте [центр довідки](/help/), щоб дізнатися більше!\n"
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6581,7 +6009,7 @@ msgstr ""
 "Щоб отримати допомогу, спробуйте одне з наступних повідомлень: "
 "{bot_commands}\n"
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6600,7 +6028,7 @@ msgstr ""
 "або навіть перемістити тему [в інший канал]"
 "({move_content_another_channel_help_url}).\n"
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
@@ -6608,7 +6036,7 @@ msgstr ""
 "\n"
 ":point_right: Спробуйте перенести це повідомлення в іншу тему і назад.\n"
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6630,12 +6058,11 @@ msgstr ""
 "панелі\n"
 "і вище.\n"
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr "ласкаво просимо до Zulip!"
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -6647,7 +6074,7 @@ msgstr ""
 "повідомлення в контексті,\n"
 "незалежно від того, скільки інших розмов триває.\n"
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
@@ -6658,7 +6085,7 @@ msgstr ""
 "наявність інших розмов із\n"
 "непрочитаними повідомленнями.\n"
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -6670,7 +6097,7 @@ msgstr ""
 "натисніть кнопку `+`\n"
 "поруч із його назвою.\n"
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -6681,7 +6108,7 @@ msgstr ""
 "Позначте свою розмову темою. Подумайте про те, щоб закінчити речення:\n"
 "«Привіт, можемо поговорити про…?»\n"
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
@@ -6689,7 +6116,7 @@ msgstr ""
 "\n"
 ":point_right: Спробуйте розпочати нову розмову в цьому каналі.\n"
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6700,7 +6127,7 @@ msgstr ""
 ":point_right: Скористайтеся цією темою, щоб спробувати [функції обміну "
 "повідомленнями Zulip]({format_message_help_url}).\n"
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6735,7 +6162,7 @@ msgstr ""
 "\n"
 "```\n"
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
@@ -6745,7 +6172,7 @@ msgstr ""
 "Ця тема **привітання** – чудовий спосіб привітатися :wave: зі своїми "
 "товаришами по команді.\n"
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
@@ -6755,102 +6182,102 @@ msgstr ""
 ":point_right: Натисніть на це повідомлення, щоб розпочати нове повідомлення "
 "в тій самій розмові.\n"
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr "переміщення повідомлень"
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr "експерименти"
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr "почати розмову"
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr "привітання"
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr "Неправильний JSON у відповіді"
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr "Неправильний формат відповіді"
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr "Пустий чи недійсний токен довжини"
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr "Недійсний токен APNS"
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr "Недійсний параметр GCM для відмовника: пріоритет {priority!r}"
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr "Недійсні параметри GCM для відмовника: {options}"
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr "Токен не існує"
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr "{full_name} згаданий @{user_group_name}:"
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr "{full_name} згадав вас:"
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr "{full_name} згадав усіх:"
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "Нове повідомлення"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr "Перевірити сповіщення"
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr "Це тестове сповіщення від {realm_name} ({realm_url})."
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr "Пристрій не розпізнано"
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr "Пристрій не розпізнано штовхачем-вибивачем"
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr "Немає активного зареєстрованого пристрою для натискання"
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr "Помилка мережі під час підключення до служби push-сповіщень Zulip."
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 "Внутрішня помилка сервера в службі push-сповіщень Zulip, спробуйте пізніше."
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
@@ -6858,11 +6285,11 @@ msgstr ""
 "Проблема з конфігурацією push-сповіщень на сервері. Зверніться до "
 "адміністратора сервера або повторіть спробу пізніше."
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 msgid "Invalid `push_key`"
 msgstr "Недійсний `push_key`"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
@@ -6871,32 +6298,30 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr "Недійсний тип даних для ідентифікатора каналу"
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr "Користувач не авторизований для цього запиту"
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr "'{email}' більше не використовує Zulip."
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr "Ви не можете надсилати прямі повідомлення за межі своєї організації."
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr "Максимальна довжина нагадування: {max_length} символів"
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "You requested a reminder for the following direct message. Note:\n"
@@ -6908,13 +6333,13 @@ msgstr ""
 "Ви запросили нагадування для наступного прямого повідомлення. Примітка:\n"
 " > {note}"
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 #, fuzzy
 #| msgid "You requested a reminder for the following direct message."
 msgid "You requested a reminder for the following message."
 msgstr "Ви запросили нагадування для наступного прямого повідомлення."
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
@@ -6923,11 +6348,11 @@ msgstr ""
 "Ви запросили нагадування для наступного прямого повідомлення. Примітка:\n"
 " > {note}"
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr "Ви запросили нагадування для наступного прямого повідомлення."
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{user_silent_mention} [sent]({conversation_url}) a todo list."
 msgid ""
@@ -6935,14 +6360,14 @@ msgid ""
 "{topic_pretty_link}."
 msgstr "{user_silent_mention} [надіслано]({conversation_url}) список справ."
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{user_silent_mention} [said]({conversation_url}):"
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr "{user_silent_mention} [сказав]({conversation_url}):"
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{user_silent_mention} [sent]({conversation_url}) a todo list."
 msgid ""
@@ -6950,7 +6375,7 @@ msgid ""
 "{list_of_recipient_mentions}."
 msgstr "{user_silent_mention} [надіслано]({conversation_url}) список справ."
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{user_silent_mention} [said]({conversation_url}):"
 msgid ""
@@ -6958,556 +6383,540 @@ msgid ""
 "{list_of_recipient_mentions}:"
 msgstr "{user_silent_mention} [сказав]({conversation_url}):"
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{user_silent_mention} [sent]({conversation_url}) a todo list."
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr "{user_silent_mention} [надіслано]({conversation_url}) список справ."
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{user_silent_mention} [sent]({conversation_url}) a todo list."
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr "{user_silent_mention} [надіслано]({conversation_url}) список справ."
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 msgid "Reminder does not exist"
 msgstr "Нагадування не існує"
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr "Помилка відмов від push-сповіщень: {error}"
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr "Неможливо визначитись між '{var_name1}' та '{var_name2}' аргументами"
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr "Відсутній аргумент '{var_name}'"
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr "Погане значення для '{var_name}': {bad_value}"
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr "Заплановане повідомлення не існує"
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr "{service_name} безпека облікового запису"
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr "Канал за замовчуванням не може бути приватним."
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr "Публічні веб-канали не ввімкнено."
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr "У вас немає дозволу публікувати дописи в цьому каналі."
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr "Не дозволено надсилати до каналу '{channel_name}'"
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 msgid "You do not have permission to create new topics in this channel."
 msgstr "У вас немає дозволу створювати нові теми в цьому каналі."
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr "Недійсний ідентифікатор каналу"
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr "Недійсна назва каналу '{channel_name}'"
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr "Канал(и) ({channel_names}) не існує(ють)"
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 "Група каналів за замовчуванням з ідентифікатором '{group_id}' не існує."
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr "Поле назви каналу не може бути порожнім."
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr "Назва каналу занадто довга (ліміт: {max_length} символів)."
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr "Недійсний символ у назві каналу, у позиції {position}."
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr "Недійсний символ у темі, на позиції {position}!"
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr "Дані про підписників недоступні для цього каналу"
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr "Не вдалося отримати підписників для приватного каналу"
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr "Неможливо декодувати малюнок; ви завантажили файл малюнку?"
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr "Розмір малюнку перевищує встановлений ліміт."
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr "Зображення пошкоджене або обрізане"
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr "{var_name} не є логічним типом «bool»"
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} does not have the expected format"
 msgstr "{var_name} не має очікуваного формату"
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr "{var_name} не є датою"
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr "{var_name} не є словником «dict»"
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr "Недійсний {var_name}"
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr "Аргумент \"{argument}\" у {var_name} є неочікуваним"
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr "{var_name} не є дійсним «float» числом"
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr "{var_name} занадто малий"
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr "{var_name} не є цілим числом"
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr "{var_name} недійсний JSON"
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr "{var_name} занадто великий"
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr "{var_name} не є списком «list»"
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr "{var_name} занадто довге (обмеження: {max_length} символів)"
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr "{var_name} занадто коротке."
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr "{var_name} не є рядком"
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr "{var_name} має недійсний формат"
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr "{var_name} не має довжини {length}"
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr "{var_name} занадто довге (обмеження: {max_length} символів)"
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr "{var_name} занадто довге (обмеження: {max_length} символів)"
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr "{var_name} не може бути порожнім"
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr "Недійсне значення {var_name}: {msg}"
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr "Відсутнє поле {var_name}: {msg}"
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr "Неправильно сформоване корисне навантаження"
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr "Немає у списку можливих значень"
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr "Не URL-адреса"
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr "Не розпізнаний часовий пояс"
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr "{var_name} не є коректним шістнадцятковим «hex» кодом кольору"
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr "Недійсний {setting_name}"
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr "Завантаження перевищить квоту завантаження вашої організації."
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr "Розмір зображення перевищує ліміт"
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr "Групу користувачів деактивовано."
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr "Недійсна група користувачів"
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {user_group_id}"
 msgstr "Недійсний ідентифікатор групи користувачів: {user_group_id}"
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr "Недійсна назва системної групи."
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr "Недійсний ідентифікатор групи користувачів: {group_id}"
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 "Налаштування '{setting_name}' не може бути встановлено на групу 'role:"
 "internet'."
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 "Налаштування '{setting_name}' не може бути встановлено на групу 'role:"
 "nobody'."
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 "Налаштування «{setting_name}» не можна встановити на групу «роль: всі»."
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 "Налаштування '{setting_name}' не можна встановити для групи '{group_name}'."
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr "Назва групи користувачів не може бути порожньою!"
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr "Назва групи користувачів не може перевищувати {max_length} символів."
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr "Назва групи користувачів не може починатися з '{prefix}'."
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr "Клієнт не передав ніякі нові значення."
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 "Клієнт повинен передати emoji_name, якщо він передає emoji_code або "
 "reaction_type."
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr "Ім'я занадто довге!"
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 msgid "Name must not be empty!"
 msgstr "Ім'я не повинно бути порожнім!"
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr "Недійсні символи в імені!"
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr "Недійсний формат!"
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr "У цій організації потрібні унікальні імена."
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr "Назва вже використовується."
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr "Хибне ім'я або ім'я користувача"
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr "Недійсна інтеграція '{integration_name}'."
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr "Відсутні параметри конфігурації: {keys}"
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr "Недійсне значення {key} {value} ({error})"
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr "Недійсні дані конфігурації!"
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr "Невірний тип бота"
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr "Недійсний тип інтерфейсу"
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr "Недійсний ідентифікатор користувача: {user_id}"
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr "Немає такого бота"
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr "Немає такого користувача"
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr "Користувача деактивовано"
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr "{item} не може бути порожнім."
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr "{var_name} має неправильну довжину {length}; має бути {target_length}"
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr "{var_name} не є рядком дати й часу ISO 8601"
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr "{container} повинен мати точно {length} елементів"
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr "{key_name} ключ відсутній у {var_name}"
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr "Неочікувані аргументи: {keys}"
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr "{var_name} не є дозволеним типом allowed_type"
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr "{variable} != {expected_value} ({value} невірне)"
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr "{var_name} не є URL"
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr "Шаблон URL-адреси має містити '%(username)s'."
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr "'{item}' не може бути порожнім."
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr "Поле не повинно мати дублікатів варіантів."
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr "'{value}' не є правильним вибором для '{field_name}'."
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr "{var_name} не є рядком або списком цілих чисел"
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr "{var_name} не є рядком або цілим числом"
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr "{var_name} не має довжини"
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr "{var_name} відсутня"
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr "Невідомо 'PresetUrlOption': {config}"
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr "Відсутній заголовок HTTP-події '{header}'"
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr "Алгоритм '{algorithm}' не підтримується."
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
@@ -7515,153 +6924,153 @@ msgstr ""
 "Секрет вебхука відсутній. Будь ласка, встановіть webhook_secret під час "
 "створення URL-адреси."
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr "Не вдалося перевірити підпис вебхука."
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr "Повинен бути присутній слеш у zcommand."
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr "Немає такої команди: {command}"
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr "`zulip_update_announcements_stream` несподівано деактивовано."
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr "Помилка CSRF: {reason}"
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr "Неправильна конфігурація зворотного проксі-сервера: {proxy_reason}"
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr "Недійсні ідентифікатори користувачів: {invalid_ids}"
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr "Користувач з ідентифікатором {user_id} деактивовано"
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr "Користувач з ідентифікатором {user_id} є ботом"
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr "Випадаючий список"
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr "Короткий текст"
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr "Абзац"
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr "Дата"
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr "Зовнішній обліковий запис"
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr "Займенники"
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr "Ніхто"
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr "Повноправні члени"
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "Члени"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr "Кожен в інтернеті"
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Invalid characters in emoji name"
 msgid "Invalid auto-conversion field: empty field name."
 msgstr "Недійсні символи в назві емодзі"
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr "Група %(name)r у шаблоні URL-адреси відсутня у шаблоні посилання."
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr "Недійсний регулярний вираз: {regex}"
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr "Невідома помилка регулярного виразу"
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr "Недійсний шаблон URL-адреси."
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid "Example input does not match the linkifier pattern."
 msgstr "Група %(name)r у шаблоні URL-адреси відсутня у шаблоні посилання."
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr "Група %(name)r у шаблоні URL-адреси відсутня у шаблоні посилання."
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr "Група %(name)r у шаблоні посилання відсутня в шаблоні URL-адреси."
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid ""
@@ -7669,7 +7078,7 @@ msgid ""
 "pattern."
 msgstr "Група %(name)r у шаблоні URL-адреси відсутня у шаблоні посилання."
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgid ""
@@ -7677,332 +7086,329 @@ msgid ""
 "template."
 msgstr "Група %(name)r у шаблоні посилання відсутня в шаблоні URL-адреси."
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr "Юнікод емодзі"
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "Власні емодзі"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr "Додаткова Zulip емодзі"
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr "Недійсні символи в назві емодзі"
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr "Недійсні символи в мові pygments"
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr "У шаблоні URL-адреси відсутня обов'язкова змінна \"code\""
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr "\"code\" має бути єдиною змінною, присутньою в шаблоні URL-адреси"
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr "пісочниця"
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr "загальний"
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr "події каналу"
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr "Спам"
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr "Домагання"
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr "Неприйнятний контент"
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr "Порушує громадські норми"
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr "Інша причина"
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr "Оновлення Zulip"
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr ""
 "Доступно на Zulip Cloud Standard. Оновіть підписку, щоб отримати доступ."
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr "Доступно в Zulip Cloud Plus. Оновіть підписку, щоб отримати доступ."
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr "Дозволити GIF-файли з рейтингом G (для загальної аудиторії)"
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr "Дозволити GIF-файли з рейтингом PG (батьківський нагляд)"
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 "Дозволити GIF-файли з рейтингом PG-13 (під наглядом батьків – до 13 років)"
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr "Дозволити GIF-файли з рейтингом R (обмежено)"
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr "Відкрито в мережі"
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "Відкритий"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr "Приватна, спільна історія"
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr "Приватна, захищена історія"
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr "Адміністратори, модератори, учасники та гості"
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr "Адміністратори, модератори та учасники"
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr "Адміністратори та модератори"
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr "Лише адміністратори"
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr "Невідомий користувач"
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr "Власник організації"
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr "Адміністратор організації"
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr "Модератор"
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "Учасник"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "Гість"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr "Невідома IP-адреса"
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr "невідома операційна система"
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr "Невідомий браузер"
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr "Відсутній аргумент 'queue_id'"
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr "Відсутній аргумент 'last_event_id'"
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr "Подія, новіша за {event_id} уже була очищена!"
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr "Подія {event_id} була не в цій черзі"
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr "Недійсний ідентифікатор черги подій: {queue_id}"
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 msgid "Failed to generate challenge"
 msgstr "Не вдалося створити завдання"
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr "Автентифікація JWT не ввімкнена для цієї організації"
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr "Жодних JSON веб-токенів не передано у запиті"
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr "Хибний JSON веб-токен"
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr "У заявках веб-токена JSON не вказано електронну адресу"
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr "Необхідний піддомен"
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr "Пароль неправильний."
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr "Вам потрібно видалити всі канали з цієї папки, щоб архівувати її."
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr "Заголовок користувача-агента відсутній у запиті"
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr "Позначка не може бути порожньою."
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr "Поле повинне мати хоча б один вибір."
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr "Тип поля не підтримується для відображення у зведенні профілю."
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for use for user matching."
 msgstr "Тип поля не підтримується для зіставлення користувачів."
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr "Недійсний тип поля."
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 "У зведенні профілю можна відображати лише 2 поля користувацького профілю."
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr "Поле з цією позначкою вже існує."
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr "Користувацьке поле за замовчуванням не можна оновити."
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr "Кінцева точка не доступна у продакшині."
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr "DevAuthBackend не активовано."
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr "Недійсний параметр '{key}' для анонімного запиту"
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr "База даних порожня"
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr "Не вдається зробити запит до postgresql"
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr "Не вдається підключитися до rabbitmq"
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr "Не вдається зробити запит до rabbitmk"
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr "Не вдається зробити запит на Redis"
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr "Неможливо записати в memcached"
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr "Не вдається зробити запит до memcached"
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr "Немає такого запрошення"
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 #, fuzzy
 #| msgid "Invitation has already been revoked"
 msgid "Invitation already used or deactivated."
 msgstr "Запрошення вже відкликано"
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr "Запрошення вже відкликано"
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr "Недійсний ідентифікатор каналу {channel_id}. Запрошення не надіслано."
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr "Ви не маєте дозволу підписувати інших користувачів на канали."
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr "Ви повинні вказати щонайменше одну адресу електронної пошти."
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
@@ -8010,100 +7416,98 @@ msgstr ""
 "Деякі з цих адрес вже використовують Zulip, тому ми не надіслали їм "
 "запрошення. Ми надіслали запрошення всім іншим!"
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr "Історію редагування повідомлень у цій організації вимкнено"
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr "У вас немає дозволу для видалення цього повідомлення"
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr "Термін для видалення цього повідомлення минув"
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr "Повідомлення вже видалене"
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr "Забагато запитів на повідомлення (максимум {max_messages})."
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr "Якір можна виключити лише в кінці діапазону"
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr "Немає такої теми '{topic}'"
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr "Потрібне пояснення."
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 msgid "Message reporting is not enabled in this organization."
 msgstr "Звітування про повідомлення не ввімкнено в цій організації."
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr "Відсутній відправник"
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr "Віддзеркалення недозволене робити для ID отримувачів"
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr "Помилкове віддзеркалене повідомлення"
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr "Функції штучного інтелекту не ввімкнені на цьому сервері."
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr "Досягнуто місячного ліміту для кредитів ШІ."
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr "Немає повідомлень у розмові для підсумовування"
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr "Неможливо заглушити себе"
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr "Користувача вже заглушено"
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr "Користувача не заглушено"
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr "Вбудовані подання не можуть мати власну назву."
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr "Користувацькі подання повинні мати дійсну назву."
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 msgid "Navigation view already exists."
 msgstr "Режим навігації вже існує."
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr "Невідомий крок адаптації: {onboarding_step}"
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -8114,58 +7518,58 @@ msgstr ""
 "Ви просили переглянути [відео «Ласкаво просимо до Zulip»]"
 "({navigation_tour_video_url}) пізніше. Зараз зручний час?\n"
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr "Місцезнаходження не підтримується для користувачів-ботів."
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr "Немає даних про присутність для {user_id_or_email}"
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr "Недійсний статус: {status}"
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 #, fuzzy
 #| msgid "You do not have permission to change default channels."
 msgid "You do not have permission to manage plans and billing."
 msgstr "У вас немає дозволу змінювати канали за замовчуванням."
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr "Сервер не використовує службу push-сповіщень"
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr "Помилка, повернута відсканованою службою: {result}"
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr "Секретний код підтвердження не підготовлено"
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
@@ -8173,49 +7577,49 @@ msgstr ""
 "Принаймні один з наступних аргументів повинен бути присутнім: emoji_name, "
 "emoji_code"
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr "Сповіщення про прочитання вимкнено в цій організації."
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr "Недійсна мова '{language}'"
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr "Необхідно ввімкнути принаймні один метод автентифікації."
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr "Недійсний параметр video_chat_provider {video_chat_provider}"
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr "Недійсна політика оцінювання gif_ocjene_policy {gif_rating_policy}"
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr "Має бути демонстраційна організація."
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr "Недійсний час видалення даних для демонстраційної організації."
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
@@ -8223,7 +7627,7 @@ msgstr ""
 "Час видалення даних має бути не більше ніж {max_allowed_days} днів у "
 "майбутньому."
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
@@ -8231,46 +7635,46 @@ msgstr ""
 "Час видалення даних має бути щонайменше {min_allowed_days} днів у "
 "майбутньому."
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr "Недійсний домен: {error}"
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr "Домен {domain} уже є частиною вашої організації."
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr "Не знайдено жодного запису для домену {domain}."
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr "Ви повинні завантажити рівно один файл."
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr "Тільки адміністратори можуть змінювати емодзі за замовчуванням."
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr "Завантажений файл перевищує дозволений ліміт {max_size} МіБ"
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr ""
 "Експорт усіх публічних та приватних даних не ввімкнено для цієї організації."
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr "Перевищив ліміт."
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
@@ -8279,59 +7683,59 @@ msgstr ""
 "Запитаний вами експорт занадто великий для автоматичної обробки. Будь ласка, "
 "надішліть запит на експорт вручну, звернувшись до {email}."
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr "Недійсний ID експорту даних"
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr "Експорт уже видалено"
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr "Експорт не вдався, нічого видалити"
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr "Експорт все ще триває"
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr "Ви повинні завантажити тільки одну іконку."
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr "Лінкіфікатор не знайдений."
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr "Ви повинні завантажити тільки один логотип."
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid characters in pygments language"
 msgid "Invalid character in language: {character}"
 msgstr "Недійсні символи в мові pygments"
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid language '{language}'"
 msgid "Language '{language}' is not allowed."
 msgstr "Недійсна мова '{language}'"
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr "Помилковий майданчик"
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr "Неможливо скасувати імпорт після його початку."
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr "Неавтентифіковано"
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
@@ -8340,123 +7744,122 @@ msgstr ""
 "вкладку, ви зможете повернутися сюди за посиланням «Завершити реєстрацію» у "
 "вашому електронному листі."
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 msgid "Importing messages…"
 msgstr "Особисті повідомлення…"
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr "Імпортування вкладених даних…"
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr "Імпорт конвертованих даних Slack…"
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr "Завершення імпорту…"
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr "Готово!"
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr "Немає користувачів, які відповідають наданій електронній пошті."
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 msgid "Your name"
 msgstr "Ваше ім'я"
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr ""
 "Одержувач обов'язковий під час оновлення типу запланованого повідомлення."
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 "Тема обов'язкова під час оновлення типу запланованого повідомлення до каналу."
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr "Недійсний формат запиту"
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr "Недійсний DSN"
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr "Приватні канали не можна зробити каналами за замовчуванням."
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr "Ви повинні передати \"new_description\" або \"new_group_name\"."
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr "Помилкове значення для \"op\". Вкажіть один з \"add\" або \"remove\"."
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr "Недійсний параметр"
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr "Потрібен доступ до контенту каналу."
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr "Канал вже має таку назву."
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr "Нема чого робити. Вкажіть хоча б один \"add\" або \"delete\"."
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr "{user_full_name} підписався на ваш канал {channel_name}."
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr "{user_full_name} підписався на такі канали:"
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr "Не вдається отримати доступ до каналу ({channel_name})."
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr "Користувач {user_name} створив такі канали: {new_channels}."
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr "{user_name} створив новий канал {new_channels}."
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr "нові канали"
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 "**Загальнодоступний веб-канал**, створений користувачем {user_name}. **Опис:"
 "**"
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr "**Публічний** канал, створений користувачем {user_name}. **Опис:**"
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
@@ -8464,7 +7867,7 @@ msgstr ""
 "**Приватний канал спільної історії**, створений користувачем {user_name}. "
 "**Опис:**"
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
@@ -8473,26 +7876,26 @@ msgstr ""
 "**Приватний, захищений канал історії**, створений користувачем {user_name}. "
 "**Опис:**"
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr "{property} не є логічним значенням"
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr "Невідома властивість підписки: {property}"
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr "Не підписаний на канал з ідентифікатором {channel_id}"
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr "Помилковий json для частини повідомлення"
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
@@ -8501,7 +7904,7 @@ msgstr ""
 "Розмір файлу перевищує максимальний розмір завантаження ({max_size} MiB), "
 "дозволений планом вашої організації."
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
@@ -8510,7 +7913,7 @@ msgstr ""
 "Файл більший за максимальний розмір завантаження, налаштований цим сервером "
 "({max_size} MiB)."
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
@@ -8519,54 +7922,53 @@ msgstr ""
 "Розмір завантаженого файлу перевищує максимальний розмір для імпорту "
 "({max_file_size} MiB)."
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 "Користувач вимкнув сповіщення про введення тексту для повідомлень каналу"
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr "Відсутній аргумент «до»"
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr "Пустий 'кому' список"
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr ""
 "Користувач вимкнув сповіщення про введення тексту в прямих повідомленнях"
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr "<p>Цей файл не існує або був видалений.</p>"
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr "<p>Ви не маєте права переглядати цей файл.</p>"
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr "Недійсний токен"
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr "Недійсне ім'я файлу"
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr "Ви повинні вказати файл для завантаження"
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr "Ви можете завантажувати лише один файл за раз"
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr "Немає нових даних"
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
@@ -8574,32 +7976,32 @@ msgstr ""
 "Нічого не потрібно робити. Вкажіть принаймні одне з: \"додати\", "
 "\"видалити\", \"додати_підгрупи\" або \"видалити_підгрупи\"."
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr "{user_full_name} додав вас до групи {group_name}."
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr "{user_full_name} видалив вас із групи {group_name}."
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr "Користувач {user_id} вже є учасником цієї групи"
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr "У цій групі користувачів немає учасника '{user_id}'"
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr "Група користувачів {group_id} вже є підгрупою цієї групи."
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
@@ -8608,103 +8010,103 @@ msgstr ""
 "Група користувачів {user_group_id} вже є підгрупою однієї з переданих "
 "підгруп."
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr "Група користувачів {group_id} не є підгрупою цієї групи."
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr "Зміни аватару відключені для цієї організації."
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr "Зміна електронної адреси в цій організації вимкнена."
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr "Неправильний default_language"
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr "Недійсний звук сповіщення '{notification_sound}'"
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr "Недійсний період пакетної обробки електронної пошти: {seconds} секунд"
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr "Потрібно вказати або user_ids, або group_ids."
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr "Не можна змінити цей параметр для інших користувачів."
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr "Ваш пароль Zulip керується в LDAP"
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr "Неправильний пароль!"
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, fuzzy, python-brace-format
 #| msgid "You're making too many attempts! Try again in {seconds} seconds."
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr "Ви робите забагато спроб! Спробуйте ще раз через {seconds} секунд."
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr "Новий пароль надто слабкий!"
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr "Ви повинні завантажити рівно один аватар."
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr "Тема не заглушена"
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr "Неможливо вимкнути єдиного власника організації"
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 #, fuzzy
 #| msgid "Who will be allowed to see other users' email addresses?"
 msgid "User is not allowed to delete other user's messages."
 msgstr ""
 "Кому буде дозволено бачити адреси електронної пошти інших користувачів?"
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr "Користувач не має права змінювати електронні адреси користувачів"
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr "Права власника неможливо вилучити в єдиного власника організації."
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr "Неправильна нова адреса електронної пошти."
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr "Помилка нового значення електронної пошти: {message}"
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 msgid ""
 "Can't change bot email until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
@@ -8713,23 +8115,23 @@ msgstr ""
 "налаштовано правильно.\n"
 "Зверніться до адміністратора сервера."
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 msgid "Email address already in use"
 msgstr "Адреса електронної пошти вже використовується"
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr "Не вдалося змінити власника, немає такого користувача"
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr "Не вдалося змінити власника, користувач деактивований"
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr "Не вдалося змінити власника, боти не можуть володіти іншими ботами"
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
@@ -8738,137 +8140,137 @@ msgstr ""
 "FAKE_EMAIL_DOMAIN.\n"
 "Зверніться до адміністратора сервера."
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr "Вбудовані боти не активовані."
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr "Невірне ім'я вбудованого бота."
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr "Користувач не має права створювати користувачів"
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr "Електронна пошта '{email}' заборонена в цій організації"
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr ""
 "У цій організації не дозволяється використовувати одноразові електронні "
 "адреси"
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} access token"
 msgstr "Недійсний токен доступу {provider_name}"
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} call"
 msgstr "Не вдалося створити виклик {provider_name}"
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} credentials have not been configured"
 msgstr "Облікові дані {provider_name} не налаштовано"
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} credentials"
 msgstr "Недійсні облікові дані {provider_name}"
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error connecting to the BigBlueButton server."
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr "Помилка підключення до сервера BigBlueButton."
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error authenticating to the BigBlueButton server."
 msgid "Error authenticating to the {provider_name} server"
 msgstr "Помилка автентифікації на сервері BigBlueButton."
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "BigBlueButton server returned an unexpected error."
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr "Сервер BigBlueButton повернув неочікувану помилку."
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} session identifier"
 msgstr "Недійсний ідентифікатор сеансу {provider_name}"
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr "Невідома електронна адреса користувача Zoom"
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create {provider_name} call"
 msgid "Failed to create {provider_name} public room."
 msgstr "Не вдалося створити виклик {provider_name}"
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr "Недійсний підпис."
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{full_name}'s Zulip room"
 msgstr "{full_name} згадав вас:"
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 "Проєкти, що використовують цього постачальника системи контролю версій, не "
 "підтримуються"
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr "Помилковий вміст"
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr "Невідомий вебхук запит"
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr "Тема не може бути порожньою"
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr "Вміст не може бути порожнім"
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr "Не вдається обробити корисне навантаження Jotform"
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr "Помилково форматований вхідний JSON"
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr "Ключ подій відсутній у корисному наданні"
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr "Помилка: параметр channels_map_to_topics відрізняються від 0 чи 1"
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr "Невідома дія вебхука WordPress: {hook}"
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
@@ -8877,77 +8279,77 @@ msgstr ""
 "Експорт даних завершено. [Переглянути та завантажити експортовані файли]"
 "({export_settings_link})."
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr "Термін дії секретного ключа перевірки закінчився"
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr "Секрет підтвердження недійсний"
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr "Секретний код підтвердження має неправильний формат"
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr "Секрет перевірки призначений для іншого імені хоста"
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr "Недійсний піддомен для виклику push-сповіщень"
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr "Повинен перевірити з правильним ключем API для Zulip сервера"
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr "Недійсний UUID"
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr "Недійсний тип токену"
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 "{hostname} містить недійсні компоненти (наприклад, шлях, запит, фрагмент)."
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr "{hostname} не є дійсним ім'ям хоста"
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr "{hostname} ще не зареєстровано"
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 "Недійсна адреса електронної пошти адміністратора сервера: {email_reason}"
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr "example.com не є дійсним доменом електронної пошти."
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr "Домен {domain} недійсний, оскільки він не має записів MX"
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr "Домен {domain} не існує"
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
@@ -8956,29 +8358,29 @@ msgstr ""
 "Досягнуто глобальних лімітів на нещодавнє використання цієї кінцевої точки. "
 "Будь ласка, спробуйте пізніше або зверніться за допомогою до {support_email}."
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr "Реєстрацію для цього імені хоста не знайдено"
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr "Ведучий повідомив, що не має секретного коду перевірки."
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, fuzzy, python-brace-format
 #| msgid "Error response received from the host: {status_code}"
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr "Від хоста отримано відповідь про помилку: {status_code}"
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr "Відсутній ios_app_id"
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr "Відсутній user_id або user_uuid"
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
@@ -8987,48 +8389,48 @@ msgstr ""
 "Ваш тарифний план не дозволяє надсилання push-сповіщень. Причина, надана "
 "сервером: {reason}"
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr "Ваш тарифний план не дозволяє надсилати push-сповіщення."
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr "Недійсна властивість {property}"
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr "Недійсний тип події."
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr "Дані невпорядковані."
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr "Виявлено дублікат реєстрації."
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr "Неправильно сформовані дані журналу аудиту"
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr "Вам потрібно змінити Ваш пароль."
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr "Відсутній параметр id_token"
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 msgid "Missing idp param"
 msgstr "Відсутній параметр ідентифікатора"
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr "Недійсний OTP"
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr "Неможливо використовувати mobile_flow_otp та desktop_flow_otp разом."
 

--- a/locale/vi/LC_MESSAGES/django.po
+++ b/locale/vi/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-03-31 19:01+0000\n"
 "Last-Translator: Alex Vandiver <alexmv@zulip.com>\n"
 "Language-Team: Vietnamese <https://hosted.weblate.org/projects/zulip/django/"
@@ -23,53 +23,53 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr ""
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "Nhóm đã ngừng hoạt động"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr ""
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr ""
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr ""
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr ""
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr ""
 "Thời gian bắt đầu muộn hơn thời gian kết thúc. Start: {start}, End: {end}"
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr ""
 "Không có sẵn dữ liệu phân tích. Vui lòng liên hệ với quản trị viên máy chủ "
 "của bạn."
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -78,7 +78,7 @@ msgid ""
 "users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -86,7 +86,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than one user to join."
 msgstr ""
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -94,7 +94,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than two users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -102,7 +102,7 @@ msgid ""
 "({deactivate_user_help_page_link}) to allow more than three users to join."
 msgstr ""
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -111,148 +111,147 @@ msgid ""
 "({billing_page_link}) is greater than the current number of users."
 msgstr ""
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr ""
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr ""
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr ""
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
 "(minimum {min_licenses})."
 msgstr ""
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
 "page. To complete the upgrade, please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr ""
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr ""
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr ""
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr "Đã xảy ra lỗi. Vui lòng liên hệ {email}."
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "Thao tác gửi lại bị lỗi. Xin tải lại trang và thử lần nữa."
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr "Đã xảy ra lỗi. Vui lòng đợi vài giây và thử lại."
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr ""
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr ""
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr ""
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr ""
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
 msgstr ""
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
 msgstr ""
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
 "licenses."
 msgstr ""
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
 "billing period."
 msgstr ""
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr ""
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr ""
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr ""
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr ""
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -262,100 +261,97 @@ msgid ""
 "we would really appreciate it!"
 msgstr ""
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
 "{support_email}"
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr ""
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr ""
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "Lỗi"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr ""
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
 "%(support_email)s\">contact support</a>."
 msgstr ""
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr ""
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
 msgstr ""
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr ""
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
 msgstr ""
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr ""
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr "Lỗi server nội bộ"
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
 msgstr ""
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -363,170 +359,168 @@ msgid ""
 "a> with any questions."
 msgstr ""
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr ""
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
 "a> for support."
 msgstr ""
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
 "href=\"%(troubleshooting_url)s\">Zulip server troubleshooting guide</a>."
 msgstr ""
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr ""
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr ""
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr ""
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr ""
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr ""
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr ""
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr ""
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr ""
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr ""
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr ""
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "Người dùng trực tuyến"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr ""
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr ""
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr "Tổng số người dùng"
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "Người dùng"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr ""
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "Tôi"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "Tất cả mọi người"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "Tuần trước"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "Tháng trước"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "Năm ngoái"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr ""
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr "Tin nhắn được gửi theo thời gian"
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "Hàng ngày"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "Hàng tuần"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr ""
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "Con người"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr ""
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr ""
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr ""
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr ""
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr ""
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
@@ -535,119 +529,102 @@ msgstr ""
 "This confirms that the email address for your Zulip account has changed from "
 "%(old_email_html_tag)s to %(new_email_html_tag)s"
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr ""
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr ""
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr ""
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr ""
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
 msgstr ""
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr ""
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "Hủy"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr "xác nhận"
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr ""
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr ""
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -658,19 +635,19 @@ msgid ""
 "server."
 msgstr ""
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -678,748 +655,258 @@ msgid ""
 "%(support_email)s'>contact support</a> with any questions."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr "Rate limit exceeded."
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr ""
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, fuzzy, python-format
 #| msgid "You can try again in %(retry_after)s seconds."
 msgid "You can try again in %(retry_after_string)s."
 msgstr "You can try again in %(retry_after)s seconds."
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr ""
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr ""
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr ""
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr "Filter by category"
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "Tất cả"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr "Categories"
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr ""
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr ""
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr ""
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr ""
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr ""
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr ""
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "Tạo nhóm"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr ""
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr "Self-host Zulip"
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr "Request sponsorship"
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr "Education pricing"
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr "View pricing"
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr "Zulip for business"
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Zulip for business"
 msgid "Zulip for open source"
 msgstr "Zulip for business"
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Create your Zulip organization"
 msgid "Screenshot of Zulip conversation"
 msgstr "Create your Zulip organization"
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Messages sent over time"
 msgid "Message with code"
 msgstr "Tin nhắn được gửi theo thời gian"
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr "Link"
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr "Liên hệ hỗ trợ"
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr "Cơ quan"
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr ""
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
 msgstr ""
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 #, fuzzy
 #| msgid "Getting started"
 msgid "Get started"
 msgstr "Getting started"
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
@@ -1429,49 +916,48 @@ msgstr ""
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
 "continue."
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr ""
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr ""
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "Email"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1479,78 +965,77 @@ msgid ""
 "from Zulip."
 msgstr ""
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
 msgstr ""
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr ""
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr ""
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr ""
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr ""
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr ""
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr ""
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr ""
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr ""
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
 msgstr ""
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1558,215 +1043,208 @@ msgid ""
 "href=\"%(doc_url)s\">documentation</a>."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, fuzzy, python-format
 #| msgid "No entry found for domain {domain}."
 msgid "No account found for %(email)s."
 msgstr "No entry found for domain {domain}."
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr ""
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Must be a demo organization."
 msgid "Try Zulip in a demo organization"
 msgstr "Must be a demo organization."
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Why Zulip"
 msgid "Try Zulip"
 msgstr "Why Zulip"
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "Tạo nhóm mới"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr ""
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr "Organization type"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 #, fuzzy
 #| msgid "Private, shared history"
 msgid "Import chat history?"
 msgstr "Private, shared history"
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr "Tên nhóm"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "Organization URL"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr "Use %(external_host)s"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "OR"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "Đăng ký"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "Đăng kí sử dụng Zulip"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr "Bạn cần lời mời để tham gia tổ chức này."
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr "Đăng ký sử dụng với %(identity_provider)s"
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr ""
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "Đăng nhập"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr ""
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1774,125 +1252,124 @@ msgid ""
 "noreferrer\">after you join</a>."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr ""
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "Thay đổi"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr "Create your organization"
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr "Create your account"
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 #, fuzzy
 #| msgid "Click the button below to complete registration."
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr "Click the button below to complete registration."
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr "Your account"
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr "Don&rsquo;t import settings"
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr "Import settings from existing Zulip account"
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr ""
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "Tên"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr ""
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "Mật khẩu"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr "Enter your LDAP/Active Directory password."
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr "Dùng cho ứng dụng điện thoại hoặc mọi công cụ yêu cầu mật khẩu."
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr "Độ mạnh của mật khẩu"
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr "What are you interested in?"
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">Terms of Service</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr "Nhóm đã ngừng hoạt động"
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr ""
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>."
 msgstr ""
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -1900,7 +1377,7 @@ msgid ""
 "a> in <span id=\"deactivated-org-auto-redirect-countdown\">5</span> seconds."
 msgstr ""
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid ""
@@ -1908,41 +1385,41 @@ msgid ""
 "deleted."
 msgstr "This organization has been deactivated"
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
 "inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
 "administrators</a> to inquire about reusing this URL for a new organization."
 msgstr ""
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid "This organization has been deactivated."
 msgstr "This organization has been deactivated"
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
 "%(support_email)s\">contact Zulip support</a> to reactivate it."
 msgstr ""
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -1950,105 +1427,104 @@ msgid ""
 "reactivate it."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr ""
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr ""
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "Sao chép"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr ""
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr ""
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "Admin"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr "Kiểm duyệt viên"
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr "Người qua đường"
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "Người dùng thường"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr ""
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "Tắt"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr ""
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr "Zulip"
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, fuzzy, python-format
 #| msgid "You've joined the Zulip organization %(realm_name)s."
 msgid ""
@@ -2056,61 +1532,61 @@ msgid ""
 "<b>%(realm_name)s</b>."
 msgstr "You've joined the Zulip organization %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr "Welcome to Zulip!"
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, fuzzy, python-format
 #| msgid "You've joined the Zulip organization %(realm_name)s."
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr "You've joined the Zulip organization %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
 "href=\"%(apps_page_link)s\">mobile and desktop</a> apps:"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr "Organization URL: %(organization_url)s"
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr "Use your LDAP account to log in"
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
 "href=\"%(getting_user_started_link)s\">getting started guide</a>!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2118,83 +1594,83 @@ msgid ""
 "Zulip</a>."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
 "to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr "%(realm_name)s on Zulip: Your new organization details"
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr "%(realm_name)s on Zulip: Your new account details"
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr "You've joined the Zulip organization %(realm_name)s."
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
 "desktop apps (%(apps_page_link)s):"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
 "(%(getting_user_started_link)s)!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
 "(%(getting_organization_started_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at %(support_email)s."
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2202,12 +1678,12 @@ msgid ""
 "password for this account, please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr ""
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2216,14 +1692,14 @@ msgstr ""
 "If you did not request this change, please contact us immediately at "
 "%(support_email)s."
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 #, fuzzy
 #| msgid "Create your Zulip organization"
 msgid "Verify your email address for your Zulip demo organization"
 msgstr "Create your Zulip organization"
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
@@ -2232,8 +1708,8 @@ msgstr ""
 "If you did not request this change, please contact us immediately at "
 "<%(support_email)s>."
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2241,113 +1717,113 @@ msgid ""
 "please click below:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr "Confirm email change"
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr "You recently signed up for Zulip. Awesome!"
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr "Click the button below to complete registration."
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr "Complete registration"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr "Create your Zulip organization"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr "Activate your Zulip account"
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr ""
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
 "— we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr "Manage email preferences"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr "Unsubscribe from marketing emails"
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
 "deactivated, and you will no longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr ""
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2355,22 +1831,22 @@ msgid ""
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
 "href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because your organization has "
@@ -2386,8 +1862,8 @@ msgstr ""
 "disabled <a class=\"content_disabled_help_link\" "
 "href=\"%(help_url)s\">message content appearing in email notifications</a>."
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, fuzzy, python-format
 #| msgid ""
 #| "This email does not include message content because you have disabled <a "
@@ -2402,40 +1878,40 @@ msgstr ""
 "class=\"content_disabled_help_link\" href=\"%(alert_notif_url)s\">message "
 "content appearing in email notifications</a>."
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, fuzzy, python-format
 #| msgid "Click here to log in to Zulip and catch up."
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr "Click here to log in to Zulip and catch up."
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr "Unsubscribe from digest emails"
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr "Zulip digest for %(realm_name)s"
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
 "%(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr ""
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2452,8 +1928,8 @@ msgstr ""
 "disabled message content appearing in email notifications.\n"
 "See %(hide_content_url)s for more details.\n"
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -2469,41 +1945,38 @@ msgstr ""
 "message content appearing in email notifications.\n"
 "See %(alert_notif_url)s for more details.\n"
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, fuzzy, python-format
 #| msgid "Log in to your organization"
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr "Log in to your organization"
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr "Manage email preferences:"
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr "Unsubscribe from digest emails:"
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr "Swimming fish"
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr "Thanks for your request!"
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
 "organizations:"
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
@@ -2512,33 +1985,29 @@ msgstr ""
 "Your email address %(email)s has accounts with the following Zulip "
 "organizations hosted by %(external_host)s:"
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
 "href=\"%(help_reset_password_link)s\">reset your password</a>."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
 "%(external_host)s."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2546,38 +2015,35 @@ msgid ""
 "to find your account."
 msgstr ""
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr ""
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr "Your Zulip accounts"
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr ""
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
 "try another way to find your account (%(help_logging_in_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr "Hi there,"
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
@@ -2586,17 +2052,17 @@ msgstr ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
 "communication tool designed for productivity."
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr "To get started, click the button below."
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
@@ -2605,17 +2071,17 @@ msgstr ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
 "-- the team communication tool designed for productivity."
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr "To get started, click the link below."
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr "Hi again,"
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
@@ -2624,13 +2090,13 @@ msgstr ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
 "Zulip &mdash; the team communication tool designed for productivity."
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr "This is the last reminder you'll receive for this invitation."
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
@@ -2639,12 +2105,12 @@ msgstr ""
 "This invitation expires in two days. If the invitation expires, you'll need "
 "to ask %(referrer_name)s for another one."
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2655,72 +2121,70 @@ msgstr ""
 "wants you to join them on Zulip -- the team communication tool designed for "
 "productivity."
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
 "at <a href=\"mailto:%(email)s\">%(email)s</a>."
 msgstr ""
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
 "%(email)s\">Contact us</a> — we'd love to help!"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
 "#%(channel_name)s > %(topic_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2728,21 +2192,21 @@ msgid ""
 "preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
 "href=\"%(notif_url)s\">manage email preferences</a>."
 msgstr ""
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
@@ -2751,41 +2215,41 @@ msgstr ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails (<a href=\"%(url)s\">help</a>)."
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr "New messages"
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr ""
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
@@ -2793,7 +2257,7 @@ msgstr ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2804,22 +2268,22 @@ msgstr ""
 "%(new_email)s. If you did not request this change, please contact us "
 "immediately at %(support_email)s."
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr "Best,"
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr "Team Zulip"
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr "Zulip email changed for %(realm_name)s"
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2830,53 +2294,53 @@ msgstr ""
 "%(new_email)s. If you did not request this change, please contact us "
 "immediately at <%(support_email)s>."
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 msgstr ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr "We noticed a recent login for the following Zulip account."
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr "Organization: %(organization_link)s"
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr "Email: %(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr "Time: %(login_time)s"
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr "Device: %(device_browser)s on %(device_os)s."
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr "IP address: %(device_ip)s"
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr "If this was you, great! There's nothing else you need to do."
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2887,31 +2351,31 @@ msgstr ""
 "compromised, please <a href=\"%(reset_link)s\">reset your password</a> or "
 "contact us immediately at %(support_email)s."
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr "Thanks,"
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr "Zulip Security"
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr "Unsubscribe from login notifications"
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr "New login from %(device_browser)s on %(device_os)s"
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr "Organization: %(organization_url)s"
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2922,7 +2386,7 @@ msgstr ""
 "compromised, please reset your password at %(reset_link)s or contact us "
 "immediately at %(support_email)s."
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -2930,25 +2394,25 @@ msgid ""
 "Zulip</a> to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
 "with you and share their unique perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -2956,7 +2420,7 @@ msgid ""
 "experience how a new chat app will help your team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -2964,148 +2428,148 @@ msgid ""
 "action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
 "team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
 "organizations like yours!"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3113,11 +2577,11 @@ msgid ""
 "about…?”"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr "Examples of short topics"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3126,23 +2590,23 @@ msgid ""
 "href=\"%(move_channels_link)s\">move a topic to a different channel</a>."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr "Tới Zulip"
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3151,23 +2615,23 @@ msgid ""
 "(%(move_channels_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
 "%(email)s on %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr "Click the button below to reset your password."
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr "Reset password"
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3178,18 +2642,18 @@ msgstr ""
 "deactivated. You can contact an organization administrator to <a "
 "href=\"%(help_link)s\">reactivate your account</a>."
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr "You do not have an account in that Zulip organization."
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr "You do have active accounts in the following organization(s)."
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
@@ -3197,30 +2661,30 @@ msgstr ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr ""
 "If you do not recognize this activity, you can safely ignore this email."
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr "Password reset request for %(realm_name)s"
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr "Click the link below to reset your password."
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
 "You can contact an organization administrator to reactivate your account."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3231,7 +2695,7 @@ msgstr ""
 "the Zulip Cloud Free plan because of unpaid invoices. The unpaid invoices "
 "have been voided."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
@@ -3240,7 +2704,7 @@ msgstr ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
 "to %(upgrade_url)s."
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
@@ -3249,8 +2713,8 @@ msgstr ""
 "If you think this was a mistake or need more details, please reach out to us "
 "at %(support_email)s."
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, fuzzy, python-format
 #| msgid "You've joined the Zulip organization %(realm_name)s."
 msgid ""
@@ -3258,104 +2722,104 @@ msgid ""
 "%(localized_date)s."
 msgstr "You've joined the Zulip organization %(realm_name)s."
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr "Dear former administrators of %(realm_name)s,"
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip demo organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr "Click the button below to reactivate your organization."
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr "Reactivate organization"
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
@@ -3363,370 +2827,370 @@ msgstr ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Reactivate your Zulip organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "Reactivate your Zulip organization"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr "Reactivate your Zulip organization"
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr "Click the link below to reactivate your organization."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for <b>%(remote_server_hostname)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, fuzzy
 #| msgid "Click the button below to complete registration."
 msgid "Click the button below to log in."
 msgstr "Click the button below to complete registration."
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for %(remote_server_hostname)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
 "management for <b>%(remote_realm_host)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
 "management for %(remote_realm_host)s."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the <a href=\"%(plans_link)s\">Zulip Community plan</a>."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
 "website</a>, we would really appreciate it!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
 msgstr ""
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
 msgstr ""
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr ""
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr "Find your Zulip accounts"
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr ""
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
 "accounts for another email address</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
 msgstr ""
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
 msgstr ""
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr ""
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "Find accounts"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr "Product"
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr "Why Zulip"
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr "Features"
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr ""
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Zulip"
 msgid "Zulip Cloud"
 msgstr "Zulip"
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr "Self-hosting"
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr "Security"
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "Hợp nhất"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr "Ứng dụng máy tính & điện thoại"
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr "New organization"
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr "Solutions"
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr "Business"
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr "Giáo dục"
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr "Research"
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr ""
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr "Open source projects"
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr "Communities"
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr "Customer stories"
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr ""
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr ""
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr "Getting started"
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr "Trung tâm hỗ trợ"
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr "Nhóm chat chung"
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr ""
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr ""
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr ""
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr "Installing a Zulip server"
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr "Upgrading a Zulip server"
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr ""
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr ""
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr "Development community"
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr "Translation"
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr "GitHub"
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr "About us"
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr "Hội nhóm"
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "History"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr ""
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr "Jobs"
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr "Blog"
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr "Hỗ trợ Zulip"
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr ""
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr ""
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 msgid "Bluesky"
 msgstr ""
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr ""
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr "Terms of Service"
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr "Chính sách bảo mật"
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr ""
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr "Over %(integrations_count_display)s native integrations."
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 #, fuzzy
 #| msgid ""
 #| "And hundreds more through <a href=\"/integrations/doc/zapier\">Zapier</a> "
@@ -3738,51 +3202,47 @@ msgstr ""
 "And hundreds more through <a href=\"/integrations/doc/zapier\">Zapier</a> "
 "and <a href=\"/integrations/doc/ifttt\">IFTTT</a>."
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr "Search integrations"
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr "Custom integrations"
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr "Incoming webhooks"
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr "Interactive bots"
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr "REST API"
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr "Invalid email"
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3790,7 +3250,7 @@ msgid ""
 "emails with your email domain."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3798,7 +3258,7 @@ msgid ""
 "disposable email addresses."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3806,24 +3266,24 @@ msgid ""
 "emails that contain \"+\"."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr ""
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3831,7 +3291,7 @@ msgid ""
 "%(support_email)s\">contact Zulip support</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3839,91 +3299,91 @@ msgid ""
 "%(support_email)s\">contact this Zulip server's administrators</a>."
 msgstr ""
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
 "management for your Zulip server."
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr ""
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr "Invalid or expired login session."
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr "Log in to Zulip"
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr ""
 "You've already registered with this email address. Please log in below."
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr "Email or username"
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "Tên tài khoản"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr "Forgot your password?"
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr "Log in with %(identity_provider)s"
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr ""
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr ""
 "Don't have an account yet? You need to be invited to join this organization."
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
 "a> because all Zulip Cloud licenses are in use."
 msgstr ""
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr ""
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -3932,44 +3392,42 @@ msgid ""
 "or misconfiguration."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 #, fuzzy
 #| msgid "New organization"
 msgid "Demo organizations disabled"
 msgstr "New organization"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr "Update required"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr "Download the latest release."
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -3977,22 +3435,21 @@ msgid ""
 "organization for more information."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr ""
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -4000,49 +3457,47 @@ msgid ""
 "Zulip support</a> for assistance in resolving this issue."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr "Unsupported browser"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, fuzzy, python-format
 #| msgid "Presence is not supported for bot users."
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr "Presence is not supported for bot users."
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
 "a> like Firefox, Chrome, and Edge."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr ""
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr "Account is deactivated"
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Invalid organization"
 msgid "Finalize organization import"
 msgstr "Nhóm đã ngừng hoạt động"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Organization type"
 msgid "Organization import completed!"
 msgstr "Organization type"
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -4050,56 +3505,55 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Select your account"
 msgstr "Create your account"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Create new account"
 msgstr "Create your account"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr ""
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr "Your organization has been successfully reactivated."
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr ""
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr "The organization reactivation link has expired or is not valid."
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr "Log in to your organization"
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr "Don't know your organization URL?"
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr "Find your organization."
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr "Next"
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4107,84 +3561,84 @@ msgid ""
 "have one yet."
 msgstr ""
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 #, fuzzy
 #| msgid "Self-host Zulip"
 msgid "Self-hosting Zulip?"
 msgstr "Self-host Zulip"
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">log in to manage plans and billing.</a>"
 msgstr ""
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr "Reset your password"
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
 msgstr ""
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr "Send reset link"
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr ""
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "Xác nhận mật khẩu"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr ""
 "Xin lỗi nha, đường link bạn cung cấp không hợp lệ hoặc đã được sử dụng."
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr ""
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr ""
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr ""
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr "Password reset sent!"
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr "Check your email in a few minutes to finish the process."
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr ""
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4192,7 +3646,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4201,57 +3655,57 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr ""
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4259,7 +3713,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4267,21 +3721,21 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr "<h1 class=\"get-started\">Select account</h1>"
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr ""
 "Your GitHub account also has unverified email addresses associated with it."
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
@@ -4289,21 +3743,21 @@ msgstr ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr "Unknown email unsubscribe request"
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
 msgstr ""
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4311,132 +3765,129 @@ msgid ""
 "away!"
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr "Đã cập nhật cài đặt email"
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
 "href=\"%(realm_url)s/#settings/notifications\">notification settings</a>."
 msgstr ""
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr "Invalid order mapping."
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr ""
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr ""
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr ""
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr "signups"
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr ""
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr "{user} accepted your invitation to join Zulip!"
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr ""
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 #, fuzzy
 #| msgid "Cannot deactivate the only {entity}."
 msgid "Cannot reactivate a deleted user"
 msgstr "Cannot deactivate the only {entity}."
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr ""
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr "Field id {id} not found."
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr ""
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr ""
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr ""
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
@@ -4444,7 +3895,7 @@ msgstr ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
@@ -4452,76 +3903,76 @@ msgstr ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr ""
 "Một số tài khoản email chưa xác nhận nên chúng tôi không thể gửi lời mời."
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr "Chúng tôi không thể mời ai."
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr "Không có gì để thay đổi"
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr ""
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr ""
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr "Invalid propagate_mode without topic edit"
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr ""
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr ""
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr "Widgets cannot be edited."
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr "Your organization has turned off message editing"
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr "Bạn không được cho phép chỉnh sửa tinh nhắn này"
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr "The time limit for editing this message has passed"
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr "{user} has marked this topic as resolved."
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr "{user} has marked this topic as unresolved."
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr "This topic was moved to {new_location} by {user}."
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr "A message was moved from this topic to {new_location} by {user}."
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
@@ -4530,18 +3981,18 @@ msgstr ""
 "{changed_messages_count} messages were moved from this topic to "
 "{new_location} by {user}."
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr "This topic was moved here from {old_location} by {user}."
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
@@ -4550,74 +4001,71 @@ msgstr ""
 "{changed_messages_count} messages were moved here from {old_location} by "
 "{user}."
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 #, fuzzy
 #| msgid "You don't have permission to delete this message"
 msgid "You don't have permission to resolve topics in this channel."
 msgstr "You don't have permission to delete this message"
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr "You don't have permission to move this message"
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr ""
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr "Tin nhắn không hợp lệ"
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr "Không thể chuẩn bị tin nhắn"
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr "Invalid data type for recipients"
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr "Recipient lists may contain emails or user IDs, but not both."
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
 "but there is no channel with that ID."
 msgstr ""
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4625,36 +4073,36 @@ msgid ""
 "it."
 msgstr ""
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
 "The channel exists but does not have any subscribers."
 msgstr ""
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr ""
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr "Widgets: API programmer sent invalid JSON content"
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr "Widgets: {error_msg}"
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4662,109 +4110,107 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr "A custom emoji with this name already exists."
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr ""
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
 "authentication method."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr ""
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr ""
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder could not be sent."
 msgstr "Token không tồn tại"
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
 "the following error:"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr ""
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr ""
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr ""
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr ""
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr ""
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr ""
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
 "**{old_policy}** to **{new_policy}**."
 msgstr ""
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -4773,51 +4219,49 @@ msgid ""
 "* **New**: {new_setting_description}\n"
 msgstr ""
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr "No description."
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr ""
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr "Old description"
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr "New description"
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr "Forever"
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr ""
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 msgstr ""
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr ""
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -4828,99 +4272,89 @@ msgid ""
 "{summary_line}"
 msgstr ""
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr "You cannot attach a submessage to this message."
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr ""
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr ""
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr "Thiếu sự cho phép"
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr "This API is not available to incoming webhook bots."
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr "Tài khoản không liên kết với miền con"
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr "This endpoint does not accept bot requests."
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr "Must be an server administrator"
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr "This endpoint requires HTTP basic authentication."
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr "Invalid authorization header for basic auth"
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr "Missing authorization header for basic auth"
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr "Webhook bots chỉ có thể truy cập webhook"
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr ""
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
@@ -4929,52 +4363,51 @@ msgstr ""
 "Your account {username} has been deactivated. Please contact your "
 "organization administrator to reactivate it."
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr "The password is too weak."
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr "Subdomain needs to have length 3 or greater."
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr "Subdomain cannot start or end with a '-'."
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr "Subdomain can only have lowercase letters, numbers, and '-'s."
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr ""
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr "Xin hãy sử dụng địa chỉ email thật."
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr "The organization you are trying to join using {email} does not exist."
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr ""
 "Please request an invite for {email} from the organization administrator."
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
@@ -4983,11 +4416,11 @@ msgstr ""
 "Your email address, {email}, is not in one of the domains that are allowed "
 "to register for accounts in this organization."
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr "Email addresses containing + are not allowed in this organization."
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
@@ -4997,41 +4430,40 @@ msgstr ""
 "use. Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 #, fuzzy
 #| msgid "Embedded bots are not enabled."
 msgid "Challenges are not enabled."
 msgstr "Embedded bots are not enabled."
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "New password"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr "New password confirmation"
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "You're making too many attempts to sign in. Try again in "
 "{retry_after_string} or contact your organization administrator for help."
 msgstr ""
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
@@ -5039,91 +4471,89 @@ msgstr ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr "Token"
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr ""
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr "Please enter at most 10 emails."
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr "We couldn't find that Zulip organization."
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr ""
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr "Chủ đề bị thiếu"
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr ""
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr ""
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr "Tin nhắn phải có người nhận"
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr "Kiểu tin nhắn không hợp lệ"
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr "Invalid attachment"
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr ""
 "An error occurred while deleting the attachment. Please try again later."
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr "Message must have recipients!"
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Content can't be empty"
 msgid "Channel folder name can't be empty."
 msgstr "Nội dung không thể để trống"
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr ""
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Invalid data export ID"
 msgid "Invalid channel folder ID"
 msgstr "Invalid data export ID"
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 #, fuzzy
 #| msgid "Please use your real email address."
 msgid "Configure owner account email address."
 msgstr "Xin hãy sử dụng địa chỉ email thật."
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5132,72 +4562,72 @@ msgid ""
 "organization]({convert_demo}).\n"
 msgstr ""
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a date"
 msgid "{var_name} is not Base64 encoded"
 msgstr "{var_name} is not a date"
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 #, fuzzy
 #| msgid "Invalid emoji code."
 msgid "Invalid `device_id`"
 msgstr "Invalid emoji code."
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr ""
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr "Domain can't be empty."
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr "Domain must have at least one dot (.)"
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr "Domain is too long"
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr "Domain cannot start or end with a dot (.)"
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr "Consecutive '.' are not allowed."
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr "Subdomains cannot start or end with a '-'."
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr "Domain can only have letters, numbers, '.' and '-'s."
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr "Timestamp must not be negative."
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr "Topic must not contain null bytes"
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr ""
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr "User has disabled synchronizing drafts."
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr "Draft does not exist"
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5205,181 +4635,180 @@ msgid ""
 "{error_message}"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr ""
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr "Open Zulip to see the spoiler content"
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr ""
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr "Địa chỉ không hợp lệ."
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr "Ngoài miền của bạn."
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr "Email addresses containing + are not allowed."
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr "Reserved for system bots."
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr "{email} already has an account"
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr "Đã có tài khoản."
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr "Account has been deactivated."
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr ""
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr "Invalid custom emoji."
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr "Invalid custom emoji name."
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr "This custom emoji has been deactivated."
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr "Invalid emoji code."
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr "Invalid emoji name."
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr "Kiểu emoji không hợp lệ."
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr "Must be an organization administrator or emoji author"
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr ""
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
 msgstr ""
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr "Emoji name is missing"
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr "Could not allocate event queue"
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr "Not logged in: API authentication or user session required"
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr ""
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr "organization owner"
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr "user"
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr "Cannot deactivate the only {entity}."
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr "Invalid Markdown include statement: {include_statement}"
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr "Malformed JSON"
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr "Must be an organization administrator"
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr "Must be an organization owner"
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Must be an organization owner"
 msgid "Must be a bot user"
 msgstr "Must be an organization owner"
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr "Your username or password is incorrect"
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr "This organization has been deactivated"
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
@@ -5387,448 +4816,447 @@ msgstr ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr "Password authentication is disabled in this organization"
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr "Your password has been disabled and needs to be reset"
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr "Mã API không hợp lệ"
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr "Malformed API key"
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
 "webhook; ignoring"
 msgstr ""
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr "Unable to parse request: Did {webhook_name} generate this event?"
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr "Invalid subdomain"
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr ""
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr ""
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr ""
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr "Từ chối truy cập"
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} most recent messages in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr "Reaction already exists."
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr "Reaction doesn't exist."
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
 msgstr ""
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr ""
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr ""
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr ""
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr ""
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr ""
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Already has an account."
 msgid "Atlassian account ID"
 msgstr "Đã có tài khoản."
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Behance username"
 msgstr "Tên hoặc tên tài khoản không ổn"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 msgid "Bitbucket username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Codeberg username"
 msgstr "Tên hoặc tên tài khoản không ổn"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Dribbble username"
 msgstr "Email or username"
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Facebook username"
 msgstr "Tên hoặc tên tài khoản không ổn"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "GitLab username"
 msgstr "Email or username"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Instagram username"
 msgstr "Tên hoặc tên tài khoản không ổn"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 msgid "Mastodon profile"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Medium username"
 msgstr "Tên hoặc tên tài khoản không ổn"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Pinterest username"
 msgstr "Tên hoặc tên tài khoản không ổn"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Reddit username"
 msgstr "Email or username"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 msgid "Snapchat username"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Threads username"
 msgstr "Tên hoặc tên tài khoản không ổn"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "TikTok username"
 msgstr "Email or username"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Email or username"
 msgid "Twitch username"
 msgstr "Email or username"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "Tên tài khoản"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr "Invalid external account type"
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr "Integration frameworks"
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 msgid "Video calling"
 msgstr ""
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr "Continuous integration"
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr "Customer support"
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr "Deployment"
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr "Entertainment"
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr "Communication"
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr "Financial"
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr ""
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr "Marketing"
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr "Miscellaneous"
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr ""
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr "Project management"
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr "Productivity"
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr "Version control"
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr "Tin nhắn không được để trống"
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr "Message must not contain null bytes"
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{fullname} moderation"
 msgstr "{full_name} mentioned you:"
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr "Invalid narrow operator: {desc}"
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr ""
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr ""
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr "Missing 'anchor' argument."
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 #, fuzzy
 #| msgid "Missing 'anchor' argument."
 msgid "Missing 'anchor_date' argument."
 msgstr "Missing 'anchor' argument."
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr "Invalid anchor"
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr ""
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 #, fuzzy
 #| msgid "Reaction doesn't exist."
 msgid "Navigation view does not exist."
 msgstr "Reaction doesn't exist."
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5836,7 +5264,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5844,7 +5272,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5852,7 +5280,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5860,7 +5288,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5870,14 +5298,14 @@ msgid ""
 "a permanent organization]({convert_demo_organization_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
 "them in your [Inbox](/#inbox).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5885,7 +5313,7 @@ msgid ""
 "({navigation_tour_video_url}) for a quick app overview.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5900,14 +5328,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -5915,7 +5343,7 @@ msgid ""
 "and edit your [profile information](/help/edit-your-profile).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -5926,7 +5354,7 @@ msgid ""
 "experience in your [Preferences](#settings/preferences).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5937,7 +5365,7 @@ msgid ""
 "[Browse and subscribe to channels]({settings_link}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -5954,7 +5382,7 @@ msgid ""
 "discussed.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -5963,7 +5391,7 @@ msgid ""
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -5975,7 +5403,7 @@ msgid ""
 "times, and more.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5985,7 +5413,7 @@ msgid ""
 "or browse the [help center](/help/) to learn more!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5993,7 +5421,7 @@ msgid ""
 "get help, try one of the following messages: {bot_commands}\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6005,13 +5433,13 @@ msgid ""
 "({move_content_another_channel_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6025,12 +5453,11 @@ msgid ""
 "and above.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr ""
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -6038,14 +5465,14 @@ msgid ""
 "no matter how many other conversations are going on.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
 "conversations with unread messages.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -6053,7 +5480,7 @@ msgid ""
 "the `+` button next to its name.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -6061,13 +5488,13 @@ msgid ""
 "can we chat about…?”\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6075,7 +5502,7 @@ msgid ""
 "({format_message_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6095,1245 +5522,1224 @@ msgid ""
 "```\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
 "teammates.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
 "conversation.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr ""
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr ""
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr ""
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr "Invalid JSON in response"
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr "Invalid response format"
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr "Token trống hoặc có độ dài không hợp lệ"
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr "Invalid APNS token"
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr ""
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr "Token không tồn tại"
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr "{full_name} mentioned @{user_group_name}:"
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr "{full_name} mentioned you:"
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr "{full_name} mentioned everyone:"
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "Tin nhắn mới"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 #, fuzzy
 #| msgid "Invalid API key"
 msgid "Invalid `push_key`"
 msgstr "Mã API không hợp lệ"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
 msgstr[0] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr "User not authorized for this query"
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr "'{email}' is no longer using Zulip."
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr ""
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr "{var_name} is too long (limit: {max_length} characters)"
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder does not exist"
 msgstr "Token không tồn tại"
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr ""
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr "Missing '{var_name}' argument"
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr "Bad value for '{var_name}': {bad_value}"
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr ""
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr ""
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr ""
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr ""
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr ""
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 #, fuzzy
 #| msgid "You don't have permission to delete this message"
 msgid "You do not have permission to create new topics in this channel."
 msgstr "You don't have permission to delete this message"
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr ""
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr ""
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr ""
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr ""
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr ""
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr ""
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr "Could not decode image; did you upload an image file?"
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr "Image size exceeds limit."
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr "{var_name} is not a boolean"
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} does not have a length"
 msgid "{var_name} does not have the expected format"
 msgstr "{var_name} does not have a length"
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr "{var_name} is not a date"
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr "{var_name} is not a dict"
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr "Invalid {var_name}"
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr "{var_name} is not a float"
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr "{var_name} is too small"
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr "{var_name} is not an integer"
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr "{var_name} is too large"
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr "{var_name} is not a list"
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr "{var_name} is too long (limit: {max_length} characters)"
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr "{var_name} is not a string"
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr "{var_name} is too long (limit: {max_length} characters)"
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr "{var_name} is too long (limit: {max_length} characters)"
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr "Malformed payload"
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr "{var_name} is not a valid hex color code"
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr "Invalid {setting_name}"
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr "Upload would exceed your organization's upload quota."
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr ""
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr ""
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr "Invalid user group"
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid user group"
 msgid "Invalid user group ID: {user_group_id}"
 msgstr "Invalid user group"
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr ""
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr ""
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr ""
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr "Client did not pass any new values."
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr "Tên quá dài!"
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 #, fuzzy
 #| msgid "Message must not be empty"
 msgid "Name must not be empty!"
 msgstr "Tin nhắn không được để trống"
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr "Invalid characters in name!"
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr "Invalid format!"
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr ""
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr ""
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr "Tên hoặc tên tài khoản không ổn"
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr ""
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr ""
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr ""
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr "Invalid configuration data!"
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr "Invalid bot type"
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr "Invalid interface type"
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr ""
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr "Không tìm thấy bot"
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr "Không tìm thấy người dùng"
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr "User is deactivated"
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr "{item} cannot be blank."
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr "{var_name} has incorrect length {length}; should be {target_length}"
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a string"
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr "{var_name} is not a string"
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr "{container} should have exactly {length} items"
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr "{key_name} key is missing from {var_name}"
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr ""
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr "{var_name} is not an allowed_type"
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr "{variable} != {expected_value} ({value} is wrong)"
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr "{var_name} is not a URL"
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr ""
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr "'{item}' cannot be blank."
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr ""
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr "'{value}' is not a valid choice for '{field_name}'."
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr "{var_name} is not a string or an integer list"
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr "{var_name} is not a string or integer"
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr "{var_name} does not have a length"
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr "{var_name} is missing"
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr "Missing the HTTP event header '{header}'"
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr "There should be a leading slash in the zcommand."
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr ""
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr "CSRF error: {reason}"
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr "External account"
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr ""
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr "Không ai"
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr ""
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "Thành viên"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr ""
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Invalid characters in emoji name"
 msgid "Invalid auto-conversion field: empty field name."
 msgstr "Invalid characters in emoji name"
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr ""
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr "Unknown regular expression error"
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 msgid "Example input does not match the linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in alternative URL template is not present in linkifier "
 "pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in linkifier pattern is not present in alternative URL "
 "template."
 msgstr ""
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr "Unicode emoji"
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "Custom emoji"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr "Zulip extra emoji"
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr "Invalid characters in emoji name"
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr "Invalid characters in pygments language"
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr ""
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr ""
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr ""
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr ""
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr ""
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr "Available on Zulip Cloud Standard. Upgrade to access."
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr ""
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr ""
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr ""
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr ""
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr ""
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr "Web-public"
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "Công cộng"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr "Private, shared history"
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr "Private, protected history"
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr ""
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr ""
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr ""
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr "Dành riêng cho Admin"
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr ""
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr "Organization owner"
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr "Organization administrator"
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr "Moderator"
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "Member"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "Guest"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr "Unknown IP address"
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr "an unknown operating system"
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr "An unknown browser"
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr "Missing 'queue_id' argument"
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr "Missing 'last_event_id' argument"
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr "An event newer than {event_id} has already been pruned!"
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr "Event {event_id} was not in this queue"
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr ""
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 #, fuzzy
 #| msgid "Failed to create Zoom call"
 msgid "Failed to generate challenge"
 msgstr "Failed to create Zoom call"
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr ""
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr "No JSON web token passed in request"
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr "Bad JSON web token"
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr ""
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr "Subdomain required"
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr "Password is incorrect."
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr "User-Agent header missing from request"
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr "Label cannot be blank."
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr "Field must have at least one choice."
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 #, fuzzy
 #| msgid "Presence is not supported for bot users."
 msgid "Field type not supported for use for user matching."
 msgstr "Presence is not supported for bot users."
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr "Invalid field type."
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr ""
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr "A field with that label already exists."
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr "Default custom field cannot be updated."
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr "Endpoint not available in production."
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr "DevAuthBackend not enabled."
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr ""
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr ""
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr ""
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr ""
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr ""
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr ""
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr "Không có lời mời như vậy"
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 #, fuzzy
 #| msgid "This organization has been deactivated"
 msgid "Invitation already used or deactivated."
 msgstr "This organization has been deactivated"
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr ""
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr ""
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr "Bạn phải chọn ít nhất một địa chỉ email."
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
@@ -7341,104 +6747,102 @@ msgstr ""
 "Một số địa chỉ đã lập tài khoản Zulip nên chúng tôi không gửi lời mời. Chúng "
 "tôi đã gửi lời mời tới tất cả những người khác!"
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr "Message edit history is disabled in this organization"
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr "You don't have permission to delete this message"
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr "The time limit for deleting this message has passed"
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr "Message already deleted"
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr ""
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr ""
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr ""
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr ""
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Zephyr mirroring is not allowed in this organization"
 msgid "Message reporting is not enabled in this organization."
 msgstr "Zephyr mirroring is not allowed in this organization"
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr "Thiếu người gửi"
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr "Mirroring not allowed with recipient user IDs"
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr "Invalid mirrored message"
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr ""
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr ""
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr ""
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr "Cannot mute self"
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr "User already muted"
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr "User is not muted"
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 #, fuzzy
 #| msgid "Reaction already exists."
 msgid "Navigation view already exists."
 msgstr "Reaction already exists."
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7446,58 +6850,58 @@ msgid ""
 "later. Is this a good time?\n"
 msgstr ""
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr "Presence is not supported for bot users."
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr "No presence data for {user_id_or_email}"
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 #, fuzzy
 #| msgid "You don't have permission to delete this message"
 msgid "You do not have permission to manage plans and billing."
 msgstr "You don't have permission to delete this message"
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr ""
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr ""
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
@@ -7505,508 +6909,506 @@ msgstr ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr ""
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr ""
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr "At least one authentication method must be enabled."
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr ""
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr ""
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr "Must be a demo organization."
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr ""
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr "The domain {domain} is already a part of your organization."
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr "No entry found for domain {domain}."
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr "You must upload exactly one file."
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr ""
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr ""
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 #, fuzzy
 #| msgid "Disposable email addresses are not allowed in this organization"
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr "Disposable email addresses are not allowed in this organization"
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr "Exceeded rate limit."
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr "Invalid data export ID"
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr "Export already deleted"
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr ""
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr ""
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr "You must upload exactly one icon."
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr "Linkifier not found."
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr "You must upload exactly one logo."
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid characters in pygments language"
 msgid "Invalid character in language: {character}"
 msgstr "Invalid characters in pygments language"
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not an allowed_type"
 msgid "Language '{language}' is not allowed."
 msgstr "{var_name} is not an allowed_type"
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr "Invalid playground"
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr ""
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 msgid "Importing messages…"
 msgstr ""
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 msgid "Your name"
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr ""
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr ""
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr ""
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr ""
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr ""
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr "You must pass \"new_description\" or \"new_group_name\"."
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr "Giá trị \"op\" không hợp lệ. Chọn \"thêm\" hoặc\"xóa\"."
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr ""
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr ""
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr ""
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr "Không có gì để thực hiện. Chọn \"Thêm\" hoặc \"Xóa\"."
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr ""
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr ""
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr ""
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr ""
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
 "**"
 msgstr ""
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr ""
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr ""
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr ""
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr "Invalid json for submessage"
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr ""
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr ""
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr ""
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr "Empty 'to' list"
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr ""
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr "<p>You are not authorized to view this file.</p>"
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr "Invalid token"
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr "Invalid filename"
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr "Bạn phải chọn file để gửi lên"
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr "Bạn chỉ có thể gửi lên từng file một"
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr "Không bổ sung thông tin mới"
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 msgstr ""
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr "User {user_id} is already a member of this group"
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr ""
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
 "subgroups."
 msgstr ""
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr ""
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr "Avatar changes are disabled in this organization."
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr "Email address changes are disabled in this organization."
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr "Invalid default_language"
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr ""
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr ""
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr "Your Zulip password is managed in LDAP"
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr "Sai mật khẩu!"
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, fuzzy, python-brace-format
 #| msgid "You can try again in %(retry_after)s seconds."
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr "You can try again in %(retry_after)s seconds."
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr "New password is too weak!"
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr "Bạn phải tải lên duy nhất một ảnh avatar."
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr "Topic is not muted"
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr "Cannot deactivate the only organization owner"
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 msgid "User is not allowed to delete other user's messages."
 msgstr ""
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr ""
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr ""
 "The owner permission cannot be removed from the only organization owner."
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr ""
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr ""
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
@@ -8018,23 +7420,23 @@ msgstr ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 msgid "Email address already in use"
 msgstr ""
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr "Failed to change owner, no such user"
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr "Failed to change owner, user is deactivated"
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr "Failed to change owner, bots can't own other bots"
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
@@ -8042,291 +7444,291 @@ msgstr ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr "Embedded bots are not enabled."
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr "Invalid embedded bot name."
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr ""
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr "Email '{email}' not allowed in this organization"
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr "Disposable email addresses are not allowed in this organization"
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom access token"
 msgid "Invalid {provider_name} access token"
 msgstr "Invalid Zoom access token"
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} call"
 msgstr "Failed to create Zoom call"
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Zoom credentials have not been configured"
 msgid "{provider_name} credentials have not been configured"
 msgstr "Zoom credentials have not been configured"
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom credentials"
 msgid "Invalid {provider_name} credentials"
 msgstr "Invalid Zoom credentials"
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error connecting to the BigBlueButton server."
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr "Error connecting to the BigBlueButton server."
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error authenticating to the BigBlueButton server."
 msgid "Error authenticating to the {provider_name} server"
 msgstr "Error authenticating to the BigBlueButton server."
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "BigBlueButton server returned an unexpected error."
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr "BigBlueButton server returned an unexpected error."
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid Zoom session identifier"
 msgid "Invalid {provider_name} session identifier"
 msgstr "Invalid Zoom session identifier"
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr ""
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create Zoom call"
 msgid "Failed to create {provider_name} public room."
 msgstr "Failed to create Zoom call"
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr "Invalid signature."
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{full_name}'s Zulip room"
 msgstr "{full_name} mentioned you:"
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr ""
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr "Invalid payload"
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr "Unknown webhook request"
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr "Chủ đề không được để trống"
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr "Nội dung không thể để trống"
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr ""
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr "Malformed JSON input"
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr ""
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr "Error: channels_map_to_topics parameter other than 0 or 1"
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr ""
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
 "({export_settings_link})."
 msgstr ""
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr ""
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr ""
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr ""
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr ""
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr "Invalid subdomain for push notifications bouncer"
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr "Must validate with valid Zulip server API key"
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr "Invalid UUID"
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr "Invalid token type"
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr ""
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr ""
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr ""
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr ""
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
 "try again later or reach out to {support_email} for assistance."
 msgstr ""
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr ""
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr ""
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr ""
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr "Missing user_id or user_uuid"
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
 "server: {reason}"
 msgstr ""
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr ""
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr ""
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr ""
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr "Data is out of order."
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr ""
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr ""
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr "You need to reset your password."
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr "Missing id_token parameter"
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 #, fuzzy
 #| msgid "Missing id_token parameter"
 msgid "Missing idp param"
 msgstr "Missing id_token parameter"
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr "Invalid OTP"
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr "Can't use both mobile_flow_otp and desktop_flow_otp together."
 

--- a/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/locale/zh_Hans/LC_MESSAGES/django.po
@@ -23,7 +23,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-04-26 05:26+0000\n"
 "Last-Translator: Yidan Wang <wangyidan@westlake.edu.cn>\n"
 "Language-Team: Chinese (Simplified Han script) <https://hosted.weblate.org/"
@@ -35,50 +35,50 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.17.1-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "禁止访客用户"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "无效的组织"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr "公共频道"
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr "私人频道"
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr "私信"
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr "群组私信消息"
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr "缺少聊天频道:{chart_name}"
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr "未知的图表名称：{chart_name}"
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr "开始时间晚于结束时间。 开始: {start}, 结束: {end}"
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr "没有分析数据可用。 请联系您的服务器管理员。"
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -90,7 +90,7 @@ msgstr ""
 "({billing_page_link}) 或[停用非活动用户]({deactivate_user_help_page_link}) 以"
 "允许新用户加入。"
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -101,7 +101,7 @@ msgstr ""
 "({billing_page_link}) 或 [停用非活动用户]({deactivate_user_help_page_link}) "
 "以允许多个用户加入。"
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -112,7 +112,7 @@ msgstr ""
 "({billing_page_link}) 或 [停用非活动用户]({deactivate_user_help_page_link}) "
 "以允许两个以上的用户加入。"
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -123,7 +123,7 @@ msgstr ""
 "({billing_page_link}) 或 [停用非活动用户]({deactivate_user_help_page_link}) "
 "以允许三个以上的用户加入。"
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -135,35 +135,34 @@ msgstr ""
 "加入，请确保[当前和下一个账单期的许可证数量]({billing_page_link})大于当前用户"
 "数。"
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr "您的组织没有足够的 Zulip 许可证，邀请函未发送。"
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
 msgstr "您的组织没有足够的 Zulip 许可证来更改来宾用户的角色。"
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr "注册被禁用"
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr "无效的远程服务器。"
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
 "(minimum {min_licenses})."
 msgstr "您必须为组织中的所有活动用户购买许可证（最低{min_licenses}）。"
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
@@ -171,113 +170,113 @@ msgid ""
 msgstr ""
 "此页面无法处理许可证数量超过{max_licenses}的发票。要完成升级，请联系{email}。"
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr "档案中没有付款方式。"
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr "{brand} 以 {last4} 结尾"
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr "未知的付款方式。请联系{email}。"
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr "发生了一些错误。请联系 {email}。"
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "出错啦。请刷新页面。"
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr "出错啦！请过几秒再试."
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr "请在开始免费试用之前添加信用卡。"
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr "请添加信用卡以安排升级。"
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
 msgstr "无法更新计划。该计划已过期并被新计划取代。"
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr "无法更新计划。计划已经结束。"
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr "无法在当前计费期内更新免费试用计划的许可证。"
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
 msgstr "无法手动更新许可证。您的计划是自动许可证管理。"
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr "在当前计费周期内，您的计划已使用 {licenses} 许可。"
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr "您不能减少当前计费周期内的许可证。"
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
 msgstr "无法更改正在降级的计划的下一个计费周期的许可证。"
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
 "licenses."
 msgstr "您的计划已安排续订 {licenses_at_next_renewal} 许可证。"
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
 "billing period."
 msgstr "您已经为下一计费期购买了{licenses_at_next_renewal}许可证。"
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr "没什么可改变的。"
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr "该组织没有客户！"
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr "找不到会话"
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr "未找到付款意图"
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr "传递 stripe_session_id 或者 stripe_invoice_id"
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -291,58 +290,56 @@ msgstr ""
 "如果您可以{begin_link} 将Zulip在您网站上列为赞助商 {end_link}，我们将非常感"
 "谢！"
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr "参数“confirmed”是必需的"
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr "计费访问令牌已过期。"
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr "计费访问令牌无效。"
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
 "{support_email}"
 msgstr "无法核对服务器和订阅式托管服务之间的计费数据。请联系 {support_email}"
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr "用户账号尚不存在。"
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr "您必须接受服务条款才能继续。"
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr "此 zulip_org_id 未在 zulip 的计费管理系统中注册。"
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr "此 zulip_org_id 的 zulp_org_key 无效。"
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr "您的服务器注册已停用。"
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "错误"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr "页面未找到 (404)"
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
@@ -351,37 +348,36 @@ msgstr ""
 "如果此错误是意外的，您可以<a href=\"mailto:%(support_email)s\">联系支持人员</"
 "a>。"
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr "禁止访问（403）"
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
 msgstr "您的请求无法完成， 因为浏览器没有发送您访问所需的凭证 去解决这个问题："
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr "确保您的浏览器允许此网站使用Cookie。"
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
 msgstr ""
 "检查是否有任何浏览器隐私设置或扩展阻止Referer标头，并禁用它们这个网站。"
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr "方法不被允许 (405)"
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr "服务器内部错误"
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
@@ -389,7 +385,7 @@ msgstr ""
 "发生了一些问题，对此很抱歉！我们已知晓并正在努力解决此问题。Zulip 将在问题解"
 "决后自动重新加载。"
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -399,13 +395,13 @@ msgstr ""
 "请检查 <a href=\"%(status_url)s\">Zulip Cloud 状态</a>以了解更多信息，如有任"
 "何问题请<a href=\"mailto:%(support_email)s\">联系 Zulip 客服</a>。"
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr "发生了一些问题，对此很抱歉！Zulip 将会在问题解决后自动重新加载。"
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
@@ -413,7 +409,7 @@ msgid ""
 msgstr ""
 "<a href=\"mailto:%(support_email)s\">联系此服务器的管理员</a>寻求帮助。"
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
@@ -422,151 +418,149 @@ msgstr ""
 "如果您管理此服务器，您可能需要查看<a href=\"%(troubleshooting_url)s\">Zulip服"
 "务器故障排除指南</a>。"
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr "%(target_name)s 的分析 | Zulip"
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr "组织创建24小时后方可查阅完整分析数据。"
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr "Zulip分析之%(target_name)s"
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr "组织概要"
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr "用户数量"
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr "过去 15 天内活跃的用户"
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr "访客数量"
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr "消息总数"
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr "过去 30 天内消息数量"
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr "正在使用的文件存储"
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "活动用户"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr "日活跃数"
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr "15日活跃数"
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr "总用户数"
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "用户"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr "由收件人类型发送的消息"
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "我"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "每个人"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "上周"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "上月"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "上一年"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "所有时间"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr "信息发送时间"
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "每天"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "每周"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr "积累"
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "人类"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "机器人"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr "读取消息超时"
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr "客户端发送的消息"
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr "最近更新"
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
 msgstr ""
 "所有图表的完整更新每天发生一次。 “随时间发送的消息”图表每小时更新一次。"
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr "电子邮件已更改"
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr "电子邮件已修改！"
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
@@ -575,48 +569,48 @@ msgstr ""
 "确认一下嗷，Zulip账号邮箱已经更改咯 从%(old_email_html_tag)s 更改"
 "为%(new_email_html_tag)s"
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr "确认您的电子邮件地址"
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr "确认链接不存在"
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr "糟糕，我们在系统找不到您的确认链接。"
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
 "resolved shortly."
 msgstr "不管任何麻烦，请联系 %(support_email_html_tag)s，我们将尽快给您解决。"
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr "确认链接已过期或已停用"
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr "确认链接已过期或已停用。"
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr "请联系您的组织管理员以获取新链接。"
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr "确认链接错误"
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr "糟糕，这个确认链接格式错误。"
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
@@ -624,72 +618,55 @@ msgstr ""
 "确保将链接正确复制到浏览器中。如果您仍然遇到此页面，这可能是我们的错。我们很"
 "抱歉。"
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr "账单"
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr "关闭模式"
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr "无关紧要"
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr "降级"
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "取消"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr "确认"
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr "取消升级"
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr "账单状态"
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr "停用服务器注册吗？"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr "计划管理不可用"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -704,7 +681,7 @@ msgstr ""
 "href=\"https://zulip.com/help/self-hosted-billing#log-in-to-billing-"
 "management\">登录说明</a>，以管理您 Zulip 服务器方案。"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
@@ -712,7 +689,7 @@ msgstr ""
 "要将计划从服务器移到此组织 或其他问题 <a href=\"mailto:{{ support_email }}\">"
 "联系支持</a>."
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
@@ -720,7 +697,7 @@ msgstr ""
 "该服务器的计划管理不可用，因为至少一个组织 托管在该服务器上已经有一个活动计"
 "划。"
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -731,747 +708,257 @@ msgstr ""
 "</a>以管理您的组织方案， 如有任何问题请<a href='mailto:%(support_email)s'>联"
 "系技术支持</a>。"
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr "超出速率限制"
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr "超过速率限制。"
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr "您的服务器已超过此操作的 次数限制。"
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, python-format
 msgid "You can try again in %(retry_after_string)s."
 msgstr "您可以在 %(retry_after_string)s 秒后重试。"
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr "升级"
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr "发送发票并开始免费试用"
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr "发送收据"
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr "打开社区目录"
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr "按照类型筛选"
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "全部"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr "分类"
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr "10,000 条消息"
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr "无限制"
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr "文件最大支持 10 MB"
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr "文件最大支持 1 GB"
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr "已支持"
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr "自托管"
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr "适用于10人以上的组织"
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr "最少25个用户"
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr "不可用"
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr "Zulip 开发社区"
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr "以用户身份加入"
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr "以自助托管人身份加入"
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr "作为贡献者加入"
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "创建组织"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr "获取演示示例"
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr "自托管 Zulip"
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr "请求赞助"
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr "教育定价"
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr "查看定价"
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr "商务用Zulip"
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Zulip guide for open-source projects"
 msgid "Zulip for open source"
 msgstr "开源项目的Zulip指南"
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Create your Zulip organization"
 msgid "Screenshot of Zulip conversation"
 msgstr "创建您的 Zulip 组织"
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 #, fuzzy
 #| msgid "Messages sent over time"
 msgid "Message with code"
 msgstr "信息发送时间"
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr ""
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr "链接"
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr ""
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr "客户支持"
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr "从"
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr "组织"
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr "主题"
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr "信息"
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr "提交"
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr "感谢您联系我们"
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr "感谢您联系我们！"
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr "我们会尽快与您联系。"
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
 msgstr "您可以在常见问题中找到答案。 <a href=\"/help/\">Zulip帮助中心</a>."
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 #, fuzzy
 #| msgid "Getting started"
 msgid "Get started"
 msgstr "入门"
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
@@ -1480,49 +967,48 @@ msgstr ""
 "这个团队聊天现在托管在 Zulip Cloud 上。请接受<a href=\"https://zulip.com/"
 "policies/terms\">Zulip 服务条款</a>以继续。"
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr "或者，使用您的备用手机："
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr "最后一招，您可以使用一个备份令牌："
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr "使用备份令牌"
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr "接受服务条款"
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr "欢迎来到 Zulip"
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "邮箱"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr "订阅我 Zulip 的低频量通讯（每年几封电子邮件）。"
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr "继续"
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr "确认电子邮箱地址"
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1532,7 +1018,7 @@ msgstr ""
 "要完成注册，请查看您的电子邮箱账号（<span class=\"user_email semi-"
 "bold\">%(email)s</span>），查看来自 Zulip 的确认电子邮件。"
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
@@ -1540,66 +1026,65 @@ msgstr ""
 "如果您在收件箱或垃圾邮件文件夹中没有看到确认电子邮件，我们可以 <a href=\"#\" "
 "id=\"resend_email_link\">重新发送</a>。"
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr "公开查看 {org_name} | Zulip 团队聊天"
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr "无需登录即可浏览 {org_name} 中可公开访问的频道。"
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr ""
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
 "noreferrer\">Download the latest version.</a>"
 msgstr ""
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
 msgstr "如果该消息没有消失，请尝试<a class=\"reload-lnk\">重新加载</a>该页面。"
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr "加载 Zulip 时出错。尝试<a class=\"reload-lnk\">重新加载</a>该页面。"
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr "没有匹配的对话。"
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr "该视图仍在加载消息。"
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr "加载更多"
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr "视频通话已结束"
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr "您现在可以关闭此窗口。"
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr "配置错误"
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
@@ -1607,7 +1092,7 @@ msgstr ""
 "您正在尝试使用LDAP登录但尚未创建组织。请先使用EmailAuthBackend建立您的组织，"
 "然后再次尝试。"
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1617,70 +1102,68 @@ msgstr ""
 "此服务器未设定使用推送通知。关于如何设置推送通知的说明， 请参阅<a "
 "href=\"%(doc_url)s\">文档</a>。"
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr "账号未找到"
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr "未找到Zulip账号。"
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, python-format
 msgid "No account found for %(email)s."
 msgstr "找不到账号 %(email)s 。"
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr "更换账号登录"
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr "继续完成注册"
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 msgid "Try Zulip in a demo organization"
 msgstr "必须是演示组织"
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">create a permanent organization</a>."
 msgstr ""
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 #, fuzzy
 #| msgid "Try Zulip now"
 msgid "Try Zulip"
 msgstr "现在尝试 Zulip"
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "创建新的组织"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr "创建一个新的Zulip组织"
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">create a demo organization</a> — no email required!"
 msgstr ""
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr "请输入您的邮箱地址"
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr "您的电子邮箱"
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
@@ -1690,52 +1173,51 @@ msgstr ""
 "from-mattermost\">Mattermost</a> 或 <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a> 导入。"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr "您是如何初次听闻Zulip？"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 msgstr "该值仅在您注册计划时使用，在这种情况下，该值将发送给 Zulip 团队。"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr "选择一个选项"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr "请描述"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr "你在哪里看到的广告？"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr "哪个组织？"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr "哪个？"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr "选择一项"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr "组织类型"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr "组织语言偏好"
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
@@ -1744,88 +1226,84 @@ msgstr ""
 "了解如何从 <a href=\"/help/import-from-mattermost\">Mattermost</a> 或 <a "
 "href=\"/help/import-from-rocketchat\">Rocket.Chat</a> 导入。"
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid "Import chat history?"
 msgstr "导入历史消息？"
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr "组织名称"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "组织网址"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr "使用%(external_host)s"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "或"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "注册"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "注册Zulip"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr "您需要邀请才能加入本组织。"
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr "使用%(identity_provider)s登录"
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr "已有账号？"
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "登录"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr "配置电子邮箱地址隐私"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
 msgstr "Zulip 可让您控制组织中哪些角色可以查看您的电子邮件地址。"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
 msgstr "您是否要更改电子邮箱地址的隐私设置，使其与本组织的默认配置不同？"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr "谁可以查看你的电子邮箱地址"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1835,101 +1313,100 @@ msgstr ""
 "您也可以在<a href=\"%(root_domain_url)s/help/configure-email-visibility\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">加入后</a>变更设置。"
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr "该 Zulip 组织的管理员可以看到此电子邮件地址。"
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
 msgstr "该 Zulip 组织的管理员和版主可以看到此电子邮件地址。"
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr "Zulip 组织中的任何人都无法看到此电子邮箱地址。"
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr "该 Zulip 组织中的所有用户都可以看到此电子邮箱地址。"
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "修改"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr "注册"
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr "创建您的组织"
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr "创建您的账号"
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr "<p>输入您的账号详细资料来完成注册。</p>"
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr "您的组织"
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr "您的账号"
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr "Don&rsquo;t导入设置"
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr "从已有Zulip账号导入设置"
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr "您的全名"
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "名称"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr "这是在 Zulip 中您账号的显示方式。"
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "密码"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr "输入LDAP/Active Directory 密码。"
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr "这用于移动设备和以及其他需要密码的工具。"
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr "密码强度"
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr "您对什么感兴趣？"
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
@@ -1938,15 +1415,15 @@ msgstr ""
 "我同意 <a href=\"%(root_domain_url)s/policies/terms\" target=\"_blank\" "
 "rel=\"noopener noreferrer\">服务条款</a>。."
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr "关闭的组织"
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr "组织已迁移"
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
@@ -1955,7 +1432,7 @@ msgstr ""
 "此组织已迁移至 <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>。"
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -1966,13 +1443,13 @@ msgstr ""
 "redirect\">新网站</a> 在 <span id=\"deactivated-org-auto-redirect-"
 "countdown\"> 5 </span> 秒后。"
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 msgid ""
 "This organization has been deactivated, and all organization data has been "
 "deleted."
 msgstr "此组织已被禁用，所有的组织数据已被删除。"
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
@@ -1981,7 +1458,7 @@ msgstr ""
 "您可以<a href=\"mailto:%(support_email)s\">联系 Zulip 客服</a>洽谈重新使用此"
 "网址建立新组织的相关事宜。"
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
@@ -1990,11 +1467,11 @@ msgstr ""
 "您可以<a href=\"mailto:%(support_email)s\">联系此 Zulip 服务器的管理员</a>洽"
 "谈重新使用此网址建立新组织的相关事宜。"
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 msgid "This organization has been deactivated."
 msgstr "此组织已被停用。"
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -2003,14 +1480,14 @@ msgstr ""
 "如果您是此组织的所有者，您可以<a href=\"mailto:%(support_email)s\">联系 "
 "Zulip 支持团队</a>以重新启用。"
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
 "directly."
 msgstr ""
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -2020,122 +1497,121 @@ msgstr ""
 "如果您是此组织的所有者，您可以<a href=\"mailto:%(support_email)s\">联系此 "
 "Zulip 服务器的管理员</a>以重新启用。"
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr "完成桌面应用登陆"
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr "完成桌面版登录"
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
 msgstr "使用您的网络浏览器完成登录，然后返回此处粘贴您的登录令牌。"
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr "在此处粘贴令牌"
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr "结束"
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr "不正确的令牌。"
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr "令牌接受。正在登录…"
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr "登录至桌面应用"
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr "复制此登录令牌并返回您的 Zulip 应用程序以完成登录："
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "复制"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr "然后您可以关闭此窗口。"
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr "或者，在浏览器中继续。"
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr "匿名用户"
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr "拥有者"
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "管理员"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr "版主"
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr "访客用户"
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "普通用户"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr "转发电子邮件至另一个电子邮箱账号"
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "关闭"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "更新"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr "Zulip"
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr "摘要"
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
 "<b>%(realm_name)s</b>."
 msgstr "恭喜，您创建了一个新的 Zulip 组织：<b>%(realm_name)s</b>。"
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr "欢迎访问Zulip！"
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr "您已加入Zulip 组织 <b>%(realm_name)s</b>."
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
@@ -2144,36 +1620,36 @@ msgstr ""
 "您将使用以下信息登录 Zulip 网页、<a href=\"%(apps_page_link)s\">桌面和移动应"
 "用程序</a>："
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr "组织网址：%(organization_url)s"
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr "您的用户名：%(ldap_username)s"
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr "使用您的 LDAP 账号登录"
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr "您的电子邮箱账号：%(email)s"
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr "访问组织"
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
@@ -2182,7 +1658,7 @@ msgstr ""
 "如果您是 Zulip 的新用户，请查看我们的 <a "
 "href=\"%(getting_user_started_link)s\">入门指南</a>！"
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2192,7 +1668,7 @@ msgstr ""
 "我们还有一份<a href=\"%(getting_organization_started_link)s\">将您的组织转移"
 "到 Zulip</a>的指南。"
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
@@ -2201,28 +1677,28 @@ msgstr ""
 "有问题？<a href=\"mailto:%(support_email)s\">联系我们</a>—我们很乐意提供帮"
 "助！"
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr "Zulip组织%(realm_name)s：您的新组织详情"
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr "Zulip组织%(realm_name)s：您的新账号详情"
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr "恭喜，您创建了一个新的 Zulip 组织：%(realm_name)s。"
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr "您加入了Zulip组织%(realm_name)s。"
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
@@ -2231,7 +1707,7 @@ msgstr ""
 "您将使用以下信息登录 Zulip 网页版、移动终端和桌面应用程序 "
 "(%(apps_page_link)s)："
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
@@ -2239,7 +1715,7 @@ msgid ""
 msgstr ""
 "如果您是 Zulip 新手，请查看我们的入门指南 (%(getting_user_started_link)s)！"
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
@@ -2248,17 +1724,17 @@ msgstr ""
 "我们也有一份将您的组织迁移到 Zulip 的指南 "
 "(%(getting_organization_started_link)s)。"
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr "遇到问题？请通过 %(support_email)s 联系我们—我们很乐意提供帮助！"
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2267,17 +1743,17 @@ msgstr ""
 "如果您有任何问题，请通过以下方式联系 Zulip 服务器的管理员："
 "%(support_email)s。"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr "您好，"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2287,34 +1763,34 @@ msgstr ""
 "我们收到了一个将电子邮箱地址 %(new_email)s 加入您在 %(realm_url)s 的 Zulip 使"
 "用的组织账号的请求。要确认此更新并为此账号设定密码，请点击下方："
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr "确认密码"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "%(support_email)s."
 msgstr "如果您未请求此更改，请立即通过 %(support_email)s 与我们联系。"
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 #, fuzzy
 #| msgid "Verify your new email address for your demo Zulip organization"
 msgid "Verify your email address for your Zulip demo organization"
 msgstr "为演示 Zulip 组织验证您的新电子邮箱地址"
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "<%(support_email)s>."
 msgstr "如果不是你请求的变更，请立即联系我们<%(support_email)s>。"
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2324,65 +1800,65 @@ msgstr ""
 "我们收到了一个将 %(realm_url)s 上 Zulip 账号的电子邮箱地址从 %(old_email)s 更"
 "改为 %(new_email)s 的请求。要确认此变更，请点击下方："
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr "确认电子邮件更改"
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr "验证您在 %(organization_host)s 的新电子邮箱地址"
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr "您已请求了一个新的 Zulip 组织："
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr "组织类型：%(organization_type)s"
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr "您刚刚注册了Zulip，太棒了！"
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
 msgstr "点击下面的按钮创建组织并注册账号。如果您愿意，您可以更新上面的信息。"
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr "请点击以下按钮以完成注册。"
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr "完成注册"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr "创建您的 Zulip 组织"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr "激活您的Zulip账号"
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr "请点击下面的链接以完成注册。"
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
@@ -2391,20 +1867,20 @@ msgstr ""
 "您有问题或建议要分享吗？请通过 %(support_email)s 联系我们 — 我们很乐意提供帮"
 "助！"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr "管理电子邮件首选项"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr "退订营销电子邮件"
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
@@ -2413,28 +1889,28 @@ msgstr ""
 "您在 <a href=\"%(realm_url)s\">%(realm_url)s</a> 的 Zulip 账号已被停用，您将"
 "无法再次登录。"
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr "管理员提供了以下信息："
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr "%(realm_name)s账号停用通知"
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 msgstr "您在 %(realm_url)s 的 Zulip 账号已被停用，您将无法再次登录。"
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr "新频道"
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2444,7 +1920,7 @@ msgstr ""
 "您在 <a href=\"%(realm_url)s\">%(realm_name)s</a> 有 %(new_messages_count)s "
 "条新消息，以及 %(new_streams_count)s 个新频道。"
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
@@ -2453,7 +1929,7 @@ msgstr ""
 "您在 <a href=\"%(realm_url)s\">%(realm_name)s</a> 有 %(new_messages_count)s "
 "条新消息。"
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
@@ -2462,8 +1938,8 @@ msgstr ""
 "<a href=\"%(realm_url)s\">%(realm_name)s</a> 有 %(new_streams_count)s 个新频"
 "道。"
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because your organization <a "
@@ -2473,8 +1949,8 @@ msgstr ""
 "此电子邮件不包含消息內容，因为您的组织在电子邮件通知中<a "
 "class=\"content_disabled_help_link\" href=\"%(help_url)s\">隐藏消息内容</a>。"
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to <a "
@@ -2484,21 +1960,21 @@ msgstr ""
 "此电子邮件不包含消息内容，因为您在选择电子邮件通知中选择<a "
 "class=\"content_disabled_help_link\" href=\"%(help_url)s\">隐藏消息内容</a>。"
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr "<a href=\"%(realm_url)s\">登录</a> Zulip 查看最新动态。"
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr "退订摘要电子邮件"
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr "%(realm_name)s 的 Zulip 消息摘要"
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2507,18 +1983,18 @@ msgstr ""
 "您在 %(realm_name)s 有 %(new_messages_count)s 条新消息，以及 "
 "%(new_streams_count)s 个新频道。"
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr "您在 %(realm_name)s 有 %(new_messages_count)s 条新消息。"
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr "%(realm_name)s 有 %(new_streams_count)s 个新频道。"
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because your organization hides "
@@ -2528,8 +2004,8 @@ msgstr ""
 "此电子邮件不包含消息内容，因为您的组织已禁用出现在电子邮件通知中的消息内容。"
 "更多有关信息，请参阅 %(hide_content_url)s。"
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to hide "
@@ -2538,40 +2014,37 @@ msgstr ""
 "此电子邮件不包含消息内容，因为您已禁用出现在电子邮件通知中的消息内容。有关详"
 "细信息，请参阅 %(help_url)s。"
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr "登录 Zulip 查看最新动态：%(organization_url)s。"
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr "管理电子邮件首选项："
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr "退订摘要电子邮件："
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr "游动的鱼"
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr "感谢您提交的需求！"
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
 "organizations:"
 msgstr "您的电子邮箱地址%(email)s 在以下 Zulip Cloud 组织中拥有账户："
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
@@ -2580,7 +2053,7 @@ msgstr ""
 "您的电子邮件地址 %(email)s 拥有以下由 %(external_host)s 托管的 Zulip 组织的账"
 "号："
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
@@ -2589,26 +2062,22 @@ msgstr ""
 "如果登录遇到问题，可以尝试<a href=\"%(help_reset_password_link)s\">重置密码</"
 "a>。"
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr "您要求查看此电子邮箱地址的 Zulip 账户列表。"
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr "抱歉，找不到 Zulip Cloud 账号。"
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
 "%(external_host)s."
 msgstr "遗憾的是，在 Zulip 组织中未发现由%(external_host)s 托管的账户。"
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2618,26 +2087,23 @@ msgstr ""
 "您可以用另一个电子邮箱地址<a href = \"%(find_accounts_link)s\" >检查账户</"
 "a>，或 <a href =\"%(help_logging_in_link)s\">尝试其他方法</a> 查找您的账号。"
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr "如果您不知道这一请求，您可以放心地忽略这封电子邮件。"
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr "您的 Zulip 账号"
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr "找不到 Zulip 账号"
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr "如果登录遇到问题，可以尝试重置密码。"
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
@@ -2646,12 +2112,12 @@ msgstr ""
 "您可以使用其他电子邮件查询账号 (%(find_accounts_link)s)，或尝试其它方式寻找您"
 "的账号 (%(help_logging_in_link)s)。"
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr "您好，"
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
@@ -2660,17 +2126,17 @@ msgstr ""
 "%(referrer_name)s 希望您加入他们的 Zulip — 专为提高生产力而设计的团队沟通工"
 "具。"
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr "点击下面的按钮开始吧。"
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr "%(referrer_full_name)s 邀请您加入 %(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
@@ -2679,17 +2145,17 @@ msgstr ""
 "%(referrer_full_name)s(%(referrer_email)s)邀请您加入他们，在 Zulip -- 一个专"
 "为提高工作效率的团队交流工具。"
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr "点击下面的按钮开始吧。"
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr "又见面了"
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
@@ -2698,13 +2164,13 @@ msgstr ""
 "这是一个友好的提醒，%(referrer_name)s 希望您加入他们的 Zulip - 专为提高生产力"
 "而设计的团队沟通工具。"
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr "这是你收到此邀请的最后一次提醒。"
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
@@ -2713,12 +2179,12 @@ msgstr ""
 "此邀请将在两天后到期。如果邀请过期，您需要向 %(referrer_name)s 请求另一个邀"
 "请。"
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr "提示：%(referrer_name)s加入了%(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2728,7 +2194,7 @@ msgstr ""
 "友情提示：%(referrer_name)s（%(referrer_email)s）邀请您加入他们的Zulip —一个"
 "能大大提高工作效率的团队交流工具。"
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2737,7 +2203,7 @@ msgstr ""
 "如果您有任何问题，请通过<a href=\"mailto:%(email)s\">%(email)s</a>联系 Zulip "
 "服务器的管理员。"
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
@@ -2746,22 +2212,20 @@ msgstr ""
 "您有问题或反馈意见要分享吗？<a href=\"mailto:%(email)s\">联系我们</a> — 我们"
 "很乐意提供帮助！"
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr "您收到此邮件是因为您被用户「@-提及」。"
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr "您收到此邮件是因为被%(mentioned_user_group_name)s @-提及。"
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
@@ -2770,36 +2234,36 @@ msgstr ""
 "您收到此电子邮件是因为在 #%(channel_name)s > %(topic_name)s 中「@-提及」了所"
 "有话题参与者。"
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
 msgstr "您收到此消息的原因是您为所关注的话题启用了通配符提及通知。"
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr "您收到此电子邮件是因为在 #%(channel_name)s 中「@-提及」了所有人。"
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
 msgstr "您之所以能收到此消息，是因为您已为所关注的话题启用了电子邮件通知功能。"
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 msgstr "您收到此电子邮件是因为您已启用 #%(channel_name)s 的电子邮件通知。"
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2809,7 +2273,7 @@ msgstr ""
 "直接回复此邮件，<a href=\"%(narrow_url)s\">在 %(realm_name)s Zulip 中查看</"
 "a>，或<a href=\"%(notif_url)s\">管理电子邮件偏好</a>。"
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
@@ -2818,7 +2282,7 @@ msgstr ""
 "<a href=\"%(narrow_url)s\">在 %(realm_name)s Zulip 中查看或回复</a>，或<a "
 "href=\"%(notif_url)s\">管理电子邮件偏好</a>。"
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
@@ -2827,54 +2291,54 @@ msgstr ""
 "<a href=\"%(narrow_url)s\">在 %(realm_name)s Zulip 中回复</a>，或<a "
 "href=\"%(notif_url)s\">管理电子邮件偏好</a>。"
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails (<a href=\"%(url)s\">help</a>)."
 msgstr "请勿回复此电子邮件。 (<a href=\"%(url)s\">help</a>)."
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr "与%(direct_message_group_display_name)s的群组私信"
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr "与%(sender_str)s的私信"
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr "[已解決] #%(channel_name)s > %(topic_name)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr "新消息"
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr "直接回复此邮件，或在 %(realm_name)sZulip 中查看："
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr "在 %(realm_name)s Zulip 中查看或回复："
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr "在 %(realm_name)sZulip 中回复："
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
 msgstr "请勿回复次邮件. Help:"
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2884,22 +2348,22 @@ msgstr ""
 "与您的 Zulip 账号关联的电子邮箱最近更改为 %(new_email)s。如果您未请求此更改，"
 "请立即通过 %(support_email)s 与我们联系。"
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr "祝好，"
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr "Zulip团队"
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr "Zulip电子邮件更改为%(realm_name)s"
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2909,52 +2373,52 @@ msgstr ""
 "您Zulip账号关联的电子邮件变更为%(new_email)s。如果不是你请求的变更请立即联系"
 "我们<%(support_email)s>。"
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 msgstr "组织：%(organization_url)s时间：%(login_time)s电子邮件：%(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr "我们注意到最近登录了以下Zulip账号。"
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr "组织：%(organization_link)s"
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr "电子邮件：%(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr "时间：%(login_time)s"
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr "设备：%(device_browser)s于%(device_os)s。"
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr "IP地址：%(device_ip)s"
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr "如果这是你，太好了!你没有别的事要做。"
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2965,31 +2429,31 @@ msgstr ""
 "href=\"%(reset_link)s\">重置您的密码</a>或立即通过 %(support_email)s 联系我"
 "们。"
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr "感谢,"
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr "Zulip安全"
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr "取消订阅登录通知"
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr "新的登录来自%(device_os)s上的%(device_browser)s"
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr "组织：%(organization_url)s"
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2999,7 +2463,7 @@ msgstr ""
 "如果您不认识此登录名，或认为您的账号可能已被盗用，请在 %(reset_link)s 重置您"
 "的密码或立即通过 %(support_email)s 联系我们。"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -3009,13 +2473,13 @@ msgstr ""
 "如果您已经决定在您的组织中使用 Zulip，欢迎您！您可以从我们的 <a "
 "href=\"%(get_organization_started)s\"> 迁移至Zulip</a>开始。"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
 msgstr "此外，以下是我们在评估<i>许多</i>团队聊天产品时经常听到的客户建议："
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
@@ -3024,12 +2488,12 @@ msgstr ""
 "<a href=\"%(invite_users)s\"><b>邀请您的团队成员</b></a>与您一起探索并分享他"
 "们独特的观点。"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr "使用应用程序本身来聊天，谈谈你的印象。"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -3037,7 +2501,7 @@ msgid ""
 "experience how a new chat app will help your team communicate."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -3045,21 +2509,21 @@ msgid ""
 "action."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr "从%(realm_name)s取消订阅欢迎邮件"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr "为团队选择聊天应用程序"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
@@ -3067,20 +2531,20 @@ msgstr ""
 "如果您已经决定在您的组织中使用 Zulip，欢迎您！您可以使用我们的 Zulip 迁移指南"
 "来开始。"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
 msgstr ""
 "此外，以下是我们经常从客户那里听到的一些建议，用于评估任何团队聊天产品："
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
 msgstr "邀请你的队友与你一起探索，分享他们的独特观点。"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
@@ -3089,7 +2553,7 @@ msgstr ""
 "在不使用任何其他聊天工具的情况下，与您的团队一起进行为期一周的试用。这是真正"
 "体验新聊天应用程序如何帮助团队沟通的唯一方法。"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
@@ -3097,8 +2561,8 @@ msgstr ""
 "Zulip 旨在实现高效沟通，我们希望这些技巧可以帮助您的团队在实际使用中更好的使"
 "用。"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
@@ -3107,85 +2571,85 @@ msgstr ""
 "当您开始使用 Zulip 时，我们很乐意帮助您了解它如何最能满足您的需求。请查看本指"
 "南，了解适合您这样的组织的 Zulip 主要功能！"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr "查看Zulip 商用指南"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr "查看开源项目的Zulip指南"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr "查看Zulip教育指南"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr "查看Zulip 科研团队指南"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr "查看 Zulip 活动和会议指南"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr "查看 Zulip 非营利组织指南"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr "查看 Zulip 社区指南"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr "Zulip 商用指南"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr "开源项目的Zulip指南"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr "Zulip 教育指南"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr "Zulip 科研团队指南"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr "Zulip 活动和会议指南"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr "非营利组织Zulip指南"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr "Zulip 社区指南"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
 msgstr "以下是一些让您的 Zulip 会话按话题有条理地进行的提示。"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
 msgstr ""
 "在 Zulip 中，<b>频道</b>决定谁能收到消息。<b>话题</b>则告诉你消息的内容。"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
@@ -3193,12 +2657,12 @@ msgstr ""
 "使用话题，您可以在 Zulip 中一次阅读所有的对话。无论正在进行多少不同的讨论，您"
 "都会在上下文中看到每条消息。"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr "Zulip 应用程序中的频道和话题"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3209,11 +2673,11 @@ msgstr ""
 "中断正在进行的讨论。对于一个好的话题名称，可以考虑下面的对话：“嘿，我们可以聊"
 "聊关于……吗？”"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr "简短话题的例子"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3222,23 +2686,23 @@ msgid ""
 "href=\"%(move_channels_link)s\">move a topic to a different channel</a>."
 msgstr ""
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr "前往 Zulip"
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr "使用话题来保持对话更有条理"
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
 msgstr "在 Zulip 中，频道决定谁能收到消息。话题则告诉你消息的内容。"
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3247,8 +2711,8 @@ msgid ""
 "(%(move_channels_link)s)."
 msgstr ""
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
@@ -3256,15 +2720,15 @@ msgid ""
 msgstr ""
 "有人 (可能是您) 为 %(realm_url)s 上的 Zulip 账号 %(email)s 请求新密码。"
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr "点击下面的链接以重置您的密码。"
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr "重置密码"
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3274,46 +2738,46 @@ msgstr ""
 "您之前在 %(organization_url)s 上拥有一个账号，但它已被停用。您可以联系组织管"
 "理员<a href=\"%(help_link)s\">重新激活您的账号</a>。"
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr "您在此 Zulip 组织中还没有账号。"
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr "您在这个(些)组织中有活跃账号。"
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
 msgstr "您可以尝试在上面这个(些)组织中登录或重置密码。"
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr "如果您不知道这些活动，您可以安全的忽略这封电子邮件。"
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr "%(realm_name)s密码重置请求"
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr "点击下面的链接以重置您的密码。"
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
 "You can contact an organization administrator to reactivate your account."
 msgstr ""
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3323,14 +2787,14 @@ msgstr ""
 "您的组织%(organization_name_with_link)s由于没有支付账单已被降级为Zulip Cloud "
 "Free 计划。 未付账单已作废。"
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
 "to %(upgrade_url)s."
 msgstr "要继续使用 Zulip Cloud 标准计划，请转到 %(upgrade_url)s 再次升级。"
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
@@ -3339,180 +2803,180 @@ msgstr ""
 "如果您认为这是一个错误或需要更多详细信息，请通过 %(support_email)s 与我们联"
 "系。"
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip demo organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr "您于 %(localized_date)s 停用了您的 Zulip Demo 组织：%(realm_name)s。"
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
 "%(deactivating_owner)s on %(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr "与该组织相关的所有数据已被永久删除。"
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr "如果您有任何问题或疑虑，请尽快回复此电子邮件。"
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr "尊敬的%(realm_name)s前管理员"
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip demo organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
 "deactivated Zulip organization hosted at %(realm_url)s."
 msgstr ""
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr "点击下面的按钮重新启用您的组织。"
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr "重新激活组织"
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
 msgstr "如果请求是错误的，您可以不采取任何行动，这个链接将在24小时内过期。"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 #, fuzzy
 #| msgid "Reactivate your Zulip organization"
 msgid "Reactivate your Zulip demo organization"
 msgstr "重新激活您的Zulip组织"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr "重新激活您的Zulip组织"
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr "点击下面的链接重新激活您的组织。"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for <b>%(remote_server_hostname)s</b>."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 msgid "Click the button below to log in."
 msgstr "请点击下面的按钮以登录。"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr "这个链接将会在%(validity_in_hours)s小时后过期。"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr "登录 Zulip 计划管理"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
 "the Zulip plan for %(remote_server_hostname)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr "请点击下面的链接以登录。"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
 "%(billing_contact_email)s."
 msgstr ""
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
@@ -3521,16 +2985,16 @@ msgstr ""
 "点击下方按钮以确认您的电子邮件并登录来管理 <b>%(remote_realm_host)s</b> 的 "
 "Zulip 方案。"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr "确认并登录"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr "确认 Zulip 计划管理电子邮件"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
@@ -3539,7 +3003,7 @@ msgstr ""
 "点击下方链接以确认您的电子邮件并登录来管理 %(remote_realm_host)s 的 Zulip 方"
 "案。"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
@@ -3548,7 +3012,7 @@ msgstr ""
 "您的 Zulip 赞助申请已获得批准！您的组织已升级至<a "
 "href=\"%(plans_link)s\">Zulip 社群方案</a>。"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
@@ -3557,37 +3021,37 @@ msgstr ""
 "如果您能在您的网站上<a href=\"%(link_to_zulip)s\">将 Zulip 列为赞助商</a>，我"
 "们将非常感谢！"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr "%(billing_entity)s 的社群方案赞助已获得批准！"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
 msgstr "您的 Zulip 赞助申请已获批准！您的组织已升级至 Zulip 社区计划。"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
 msgstr "如果贵网站能将 Zulip 列为赞助商，我们将不胜感激！"
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr "查找您的账号"
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr "查找您的Zulip账号"
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr "电子邮件已发送！在前一页输入的地址列在下方："
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
@@ -3596,7 +3060,7 @@ msgstr ""
 "如果您没有收到电子邮件，您可以 <a href=\"%(current_url)s\">寻找另一个电子邮箱"
 "地址的账户</a>。"
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
@@ -3604,7 +3068,7 @@ msgstr ""
 "输入您的电子邮箱地址以接收一封包含您拥有活跃账号的 Zulip Cloud 组织的 URL的电"
 "子邮件。"
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
@@ -3612,223 +3076,223 @@ msgstr ""
 "输入您的电子邮箱地址以接收一封包含用来登录此服务器的Zulip 组织的 URL的电子邮"
 "件。"
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
 msgstr ""
 "如果您也忘记了密码，可以<a href=\"/help/change-your-password\">重新设置</a>。"
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr "电子邮件地址"
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "查找账号"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr "产品"
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr "为什么选择Zulip"
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr "功能"
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr "计划和定价"
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Zulip Cloud status"
 msgid "Zulip Cloud"
 msgstr "Zulip Cloud 状态"
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr "自托管"
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr "安全"
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "应用整合"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr "桌面&移动应用"
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr "新组织"
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr "解决方案"
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr "商业"
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr "教育"
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr "研究"
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr "活动和会议"
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr "开源项目"
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr "社区"
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr ""
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr "客户故事"
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr "开放社区"
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr "资源"
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr "入门"
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr "帮助中心"
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr "社区聊天"
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr "合作伙伴"
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr "Zulip Cloud 状态"
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr "迁移至 Zulip"
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr "安装 Zulip 服务器"
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr "升级 Zulip 服务器"
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr "贡献"
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr "贡献指南"
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr "开发社区"
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr "翻译"
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr "GitHub"
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr "关于我们"
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr "团队"
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "历史消息"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr "价值观"
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr "工作"
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr "博客"
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr "支持 Zulip"
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr "Mastodon"
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Values"
 msgid "Bluesky"
 msgstr "价值观"
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr "服务条款"
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr "隐私策略"
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr "网站归因"
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr "超过%(integrations_count_display)s个原生集成。"
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 #, fuzzy
 #| msgid ""
 #| "And hundreds more through <a href=\"/integrations/doc/zapier\">Zapier</a> "
@@ -3840,51 +3304,47 @@ msgstr ""
 "还有数百个通过<a href=\"/integrations/doc/zapier\">Zapier</a>和<a href=\"/"
 "integrations/doc/ifttt\">IFTTT</a> 。"
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr "搜索模块"
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr "自定义集成"
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr "传入的网络钩子"
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr "交互机器人"
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr "REST API"
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr "无效的电子邮件"
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr "此邮箱不被允许使用"
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr "您试图注册的电子邮箱地址无效。"
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3894,7 +3354,7 @@ msgstr ""
 "您尝试加入的组织 <a href=\"%(realm_url)s\">%(realm_name)s</a> 不允许使用您的"
 "电子邮箱域名进行注册。"
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3904,7 +3364,7 @@ msgstr ""
 "您尝试加入的组织 <a href=\"%(realm_url)s\">%(realm_name)s</a> 不允许使用临时"
 "电子邮箱地址进行注册。"
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3914,24 +3374,24 @@ msgstr ""
 "您尝试加入的组织 <a href=\"%(realm_url)s\">%(realm_name)s</a> 不允许使用含有"
 "\"+\"号的电子邮箱进行注册。"
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr "请使用有效的电子邮箱地址注册。"
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr "请使用被允许的电子邮箱地址注册。"
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr "找不到组织"
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr "在 <b>%(current_url)s</b> 中没有 Zulip 组织。"
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3942,7 +3402,7 @@ msgstr ""
 "Zulip Cloud 账号列表</a>，或<a href=\"mailto:%(support_email)s\">联系 Zulip "
 "支援</a>。"
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3953,7 +3413,7 @@ msgstr ""
 "务器上的账户列表</a>，或 <a href=\"mailto:%(support_email)s\">联系此 Zulip 服"
 "务器的管理员</a>。"
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
@@ -3962,57 +3422,57 @@ msgstr ""
 "单击<a href=\"%(current_url)s/serverlogin/\">此处</a>访问 Zulip 服务器的计划"
 "管理。"
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr "登录会话无效或过期"
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr "无效或过期的登录会话。"
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr "登录Zulip"
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr "您已用此电子邮箱注册，请直接在下面登录。"
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr "邮箱或用户名"
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "用户名"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr "忘记密码？"
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr "使用%(identity_provider)s登录"
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr "无账号查看"
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr "还没有账号？您需要被邀请加入这个组织。"
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr "没有可用的许可证"
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr "本组织现在不能接受新成员"
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
@@ -4021,25 +3481,25 @@ msgstr ""
 "新成员目前无法加入 <a href=\"%(realm_url)s\">%(realm_name)s</a>，因为所有的 "
 "Zulip Cloud 授权都在使用中。"
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr "请联系邀请您的人并要求他们增加许可证数量，然后重试。"
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr "跳至主要内容"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr "验证子域错误"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr "验证子域"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -4051,44 +3511,42 @@ msgstr ""
 "问。如果您是直接來到这里，您可能输入了错误的网址。如果您在尝试登录时卡在这"
 "里，很可能是因为服务器错误或者设置出现问题。"
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 #, fuzzy
 #| msgid "No organization found"
 msgid "Demo organizations disabled"
 msgstr "找不到组织"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr "更新需求"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr "您正在使用已不再支持的旧版 Zulip 桌面应用程序。"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr "此旧版 Zulip 桌面应用程序的自动更新功能已无法使用。"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr "下载最新版本。"
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr "您已超过用户执行此操作的频率限制。"
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr "需要组织创建链接"
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -4099,12 +3557,11 @@ msgstr ""
 "zulip.readthedocs.io/en/stable/production/multiple-organizations.html\">文件"
 "</a> 了解建立新组织的更多信息。"
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr "组织创建链接已过期或无效"
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
@@ -4112,11 +3569,11 @@ msgstr ""
 "非常抱歉，此链接无法用于建立组织。请 <a href=\"/new/\">取得新的链接</a> 后再"
 "试一次。"
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr "意外的 Zulip 服务器注册"
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -4126,17 +3583,16 @@ msgstr ""
 "您的 Zulip 组织已注册并关联至不同的 Zulip 服务器环境。 请 <a href=\"mailto:"
 "%(support_email)s\">联系 Zulip 支持团队</a> 协助解决此问题。"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr "不支持的浏览器"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr "Zulip 不支持 %(browser_name)s。"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
@@ -4145,27 +3601,26 @@ msgstr ""
 "Zulip 支持 <a href=\"%(supported_browsers_page_link)s\">现代浏览器</a>， 如 "
 "Firefox、Chrome 和 Edge。"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr "你也可以使用 <a href=\"%(apps_page_link)s\">Zulip 桌面应用程序</a>。"
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr "账号被禁用"
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 msgid "Finalize organization import"
 msgstr "完成组织导入"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 msgid "Organization import completed!"
 msgstr "组织导入完成！"
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -4173,56 +3628,55 @@ msgid ""
 "associate your email address with."
 msgstr ""
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Select your account"
 msgstr "创建您的账号"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 #, fuzzy
 #| msgid "Create your account"
 msgid "Create new account"
 msgstr "创建您的账号"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr "组织已成功重新激活"
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr "您的组织已经成功地重新激活。"
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr "组织重新激活链接已过期或无效"
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr "组织重新激活链接已过期或无效。"
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr "登录您的组织"
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr "您的组织"
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr "不知道您组织的地址？"
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr "寻找组织。"
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr "下一步"
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4232,11 +3686,11 @@ msgstr ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(org_creation_link)s\">创建一个新的组织</a> 如果你还没有的话。"
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 msgid "Self-hosting Zulip?"
 msgstr "自托管 Zulip？"
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4245,71 +3699,71 @@ msgstr ""
 "您可以 <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">登录以管理计划和账单</a>"
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr "重置密码"
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
 msgstr ""
 "忘记密码了吗？没问题，我们会将重置密码的链接发送到您注册时使用的电子邮箱。"
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr "发送重置链接"
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr "设置一个新密码"
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "确认密码"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr "对不起，您提供的链接不正确，或已被使用。"
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr "新密码已设置成功"
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr "您的密码已重设！"
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr "请<a href=\"%(login_url)s\">登录</a>并使用你的新密码。"
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr "已发送密码重置邮件"
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr "密码重置已发送！"
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr "几分钟内查看你的邮箱来完成操作。"
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr ""
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr ""
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr ""
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4317,7 +3771,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4326,57 +3780,57 @@ msgid ""
 "obtain a <strong>Bot User OAuth Token</strong>."
 msgstr ""
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr ""
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
 "to obtain your Slack message history export."
 msgstr ""
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr ""
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr ""
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr "谁被允许查看其他用户的电子邮件地址？"
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
 "log in."
 msgstr ""
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr ""
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
 msgstr ""
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4384,7 +3838,7 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for imports via support."
 msgstr ""
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4392,20 +3846,20 @@ msgid ""
 "noreferrer\" target=\"_blank\">process</a> for self-hosted imports."
 msgstr ""
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr "选择账号进行身份验证"
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr "<h1 class=\"get-started\">选择账号</h1>"
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr "您的 GitHub 账号也有与之关联的未经验证的电子邮件地址。"
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
@@ -4413,21 +3867,21 @@ msgstr ""
 "要使用其中之一登录 Zulip，您必须先<a href=\"https://github.com/settings/"
 "emails\">使用 GitHub 进行验证。</a>"
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr "取消订阅电子邮件出错"
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr "未知的邮件退订请求"
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
 msgstr "您好！您似乎在尝试取消订阅某些消息，但我们没能识别该网址。"
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4437,132 +3891,129 @@ msgstr ""
 "请仔细检查您是否有完整的网址，然后再试一次，或者给我们<a href=\"mailto:"
 "%(support_email)s\">发邮件</a>，我们会解决这个问题！"
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr "邮件设置已更新"
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
 "<a href=\"%(realm_url)s\">%(realm_name)s</a>."
 msgstr ""
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
 "href=\"%(realm_url)s/#settings/notifications\">notification settings</a>."
 msgstr ""
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr "无效的命令映射"
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr "有关使用 Zulip 的问题和讨论。"
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr ""
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr "用于团队范围的对话"
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr "注册"
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr "{user} 已加入组织。"
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr "{user} 接受了您加入 Zulip 的邀请！"
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr "无法激活占位账号，请用户进行注册。"
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 #, fuzzy
 #| msgid "Cannot deactivate the only {entity}."
 msgid "Cannot reactivate a deleted user"
 msgstr "不能禁用唯一的 {entity}"
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr "您不被允许更改此区域，请联系管理员更新。"
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr "找不到字段id {id}。"
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr "默认频道组名称“{group_name}”无效"
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr ""
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr ""
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr ""
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr ""
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr ""
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr ""
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
@@ -4570,174 +4021,171 @@ msgstr ""
 "为了保护用户，Zulip 限制了您一天内可以发送的邀请数量。由于您已达到限制，因此"
 "未发送任何邀请。"
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
 msgstr ""
 "你的账号太新了，不能为这个组织发送邀请。询问组织管理人员或更有经验的用户。"
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr "一些邮箱没有通过验证，因此我们没有发送邀请"
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr "没有邀请任何人"
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr "无需修改（Nothing to change）"
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr "私信不能被移动到频道中。"
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr "私信不能有话题。"
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr "没有话题编辑的无效传播模式"
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr "一般聊天无法标记为已解决"
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr "更换频道时无法更改消息内容"
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr "无法编辑小部件。"
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr "您的组织已关闭邮件编辑"
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr "您没有权限编辑该消息"
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr "编辑消息超时"
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr "{user} 已将此话题标记为已解决。"
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr "{user} 已将此话题标记为未解决。"
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr "此话题已由 {user} 移至 {new_location}。"
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr "{user} 将一条消息从该话题移至 {new_location}。"
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
 "{new_location} by {user}."
 msgstr "{changed_messages_count} 消息已由 {user} 从此话题移至 {new_location}。"
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr "此话题由 {user} 从 {old_location} 移至此处。"
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 msgstr ""
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
 "{user}."
 msgstr "{changed_messages_count} 消息由 {user} 从 {old_location} 移至此处。"
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 #, fuzzy
 #| msgid "You do not have permission to post in this channel."
 msgid "You don't have permission to resolve topics in this channel."
 msgstr "您无权在此频道发帖。"
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr "编辑此消息话题的时限已过。"
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr "您无权移动此邮件"
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr "编辑该消息频道的时限已过"
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr ""
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr "无效信息标志操作：'{operation}'"
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr "消息不正确"
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr "无法显示消息"
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr ""
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr "频道数据类型无效"
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr "收件人数据类型无效"
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr "收件人列表可能包含电子邮件或用户 ID，但不能同时包含两者。"
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
 "but there is no channel with that ID."
 msgstr ""
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4745,7 +4193,7 @@ msgid ""
 "it."
 msgstr ""
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
@@ -4754,29 +4202,29 @@ msgstr ""
 "您的机器人 {bot_identity} 尝试向频道 {channel_name} 发送信息。该频道存在，但"
 "没有任何订阅者。"
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr "您没有权限访问某些收件人。"
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr "组件:API程序发送了无效的JSON内容"
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr "小部件：{error_msg}"
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr ""
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4784,111 +4232,109 @@ msgid ""
 "- **New {field_name}:** {new_value}\n"
 msgstr ""
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr "自定义表情名称已经存在"
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr "图像格式无效"
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr "有序列表不得包含重复的链接器"
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr "有序列表必须将所有现有链接器枚举一次"
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
 "authentication method."
 msgstr "您需要升级到 {required_upgrade_plan_name} 计划才能使用此身份验证方法。"
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr ""
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr "您当前的计划中没有 {name} 身份验证方法。"
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr "审核申请频道必须为私人频道。"
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr "定时消息已被发送"
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder could not be sent."
 msgstr "Token不存在"
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr "无法在预定时间发送消息。"
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
 "the following error:"
 msgstr ""
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr "[查看定时消息](#scheduled)"
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr "频道已停用"
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, fuzzy, python-brace-format
 #| msgid "Channel {channel_name} has been archived."
 msgid "Channel #**{channel_name}** has been archived."
 msgstr "频道 {channel_name} 已被归档。"
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr "频道当前未停用"
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr "频道名{channel_name}已存在"
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr "频道为私人频道，没有订阅者"
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, fuzzy, python-brace-format
 #| msgid "Channel {channel_name} has been archived."
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr "频道 {channel_name} 已被归档。"
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
 "**{old_policy}** to **{new_policy}**."
 msgstr ""
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -4897,51 +4343,49 @@ msgid ""
 "* **New**: {new_setting_description}\n"
 msgstr ""
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr ""
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr "没有描述信息。"
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr "{user} 更改了此频道的描述。"
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr "旧描述"
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr "新描述"
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr "永远"
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr "{number_of_days} 天"
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 msgstr ""
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr "现在，该频道中的消息将被永久保留。"
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -4952,161 +4396,150 @@ msgid ""
 "{summary_line}"
 msgstr ""
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr ""
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr ""
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr ""
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
 "setting from {old_topics_policy} to {new_topics_policy}."
 msgstr ""
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr "您不能在此邮件中附加子邮件。"
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr "用户 ID {user_id} 无效"
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr ""
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr "权限不足"
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr "这个API不适用于传入的webhook机器人"
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr "账号未与任何子域关联"
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr "该端点不接受bot请求"
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr "必须是服务器管理员"
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr "此端点需要HTTP基本身份验证。"
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr "基本认证的授权头不正确"
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr "缺少基本认证的授权头信息"
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr "WebHook机器人只能访问Webhook内容"
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr "电子邮箱或密码不正确。"
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
 "organization administrator to reactivate it."
 msgstr "您的账号 {username} 已停用。请联系您的组织管理员以重新激活它。"
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr "密码太弱。"
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr "子域名需要长度至少3个字符以上"
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr "子域名不能以“-”开头或结尾"
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr "子域只能有小写字母，数字和'-'。"
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr "子域名已被使用。请选择其他子域。"
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr "已保留子域。请选择其他子域。"
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr "请使用真实的邮件地址注册"
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr "您尝试使用{email}加入的组织不存在。"
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr "请查询来自组织管理员{email}的邀请"
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr ""
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
 "to register for accounts in this organization."
 msgstr "您的电子邮箱地址 {email} 不在允许在该组织中注册账号的域之一。"
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr "在这个组织中电子邮件地址不能包含+"
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
@@ -5115,34 +4548,33 @@ msgstr ""
 "新成员无法加入此组织，因为所有 Zulip 许可证都在使用中。请联系邀请您的人并要求"
 "他们增加许可证数量，然后重试。"
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr ""
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr ""
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 #, fuzzy
 #| msgid "Embedded bots are not enabled."
 msgid "Challenges are not enabled."
 msgstr "内置机器人被禁用"
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr ""
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "新密码"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr "确认新密码"
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "You're making too many attempts to sign in. Try again in "
@@ -5151,96 +4583,94 @@ msgstr ""
 "您尝试登录的次数过多，请在{retry_after_string}秒后重试，或联系您的组织管理员"
 "寻求帮助。"
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
 msgstr "您的密码已被禁用，因为它太弱了。重置您的密码以创建一个新密码。"
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr "令牌"
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr "提示：您可以输入多个电子邮箱地址，中间用逗号隔开。"
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr "请输入最多10个电子邮件地址"
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr "我们找不到那个Zulip组织"
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr ""
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr "话题不存在"
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr ""
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr "缺少频道"
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr "消息必须指定接收人"
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr "消息类型不正确"
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr "无效的附件文件"
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr "删除附件时发生错误。请稍后再试。"
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr "消息必须指定接收人！"
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name can't be empty."
 msgstr "频道文件夹名称不能为空。"
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr ""
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Channel named {channel_name} already exists"
 msgid "Channel folder name already in use"
 msgstr "频道名{channel_name}已存在"
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 #, fuzzy
 #| msgid "Invalid channel ID"
 msgid "Invalid channel folder ID"
 msgstr "无效的频道ID"
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 #, fuzzy
 #| msgid "Confirm your email address"
 msgid "Configure owner account email address."
 msgstr "确认电子邮箱地址"
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5252,72 +4682,72 @@ msgstr ""
 "请注意，这个 [示例组织]({demo_help}) 将会被自动删除于 {deletion_time}, 除非它"
 "被 [转为永久性组织]({convert_demo}).\n"
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a date"
 msgid "{var_name} is not Base64 encoded"
 msgstr "{var_name} 不是日期"
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 #, fuzzy
 #| msgid "Invalid emoji code."
 msgid "Invalid `device_id`"
 msgstr "无效的表情代码"
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr ""
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr "域名不能为空。"
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr "域名必须至少包含一个点(.)"
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr "域名太长"
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr "域名不能以点(.)为开始或结束"
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr "不允许连续的\".\"（dot）"
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr "子域名不能以“-”开头或结尾"
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr "域名允许包含字母或数字，以及'-'"
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr "时间戳不能为负数。"
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr "话题不得包含空字节"
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr "必须准确指定 1 个频道消息的频道ID"
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr "用户已禁用同步草稿。"
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr "草稿不存在"
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5325,275 +4755,273 @@ msgid ""
 "{error_message}"
 msgstr ""
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr "没有主题的电子邮件"
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr "打开Zulip看代码框内容"
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr "{service_name} 通知"
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr "地址不正确"
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr "不属于该社区"
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr "电子邮件不允许包含+"
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr "为系统机器人保留。"
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr "{email} 已经有一个账号"
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr "账号已经存在"
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr "账号已被禁用"
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr ""
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr "无效自定义表情"
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr "无效自定义表情名称"
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr "自定义表情被禁用"
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr "无效的表情代码"
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr "无效的表情名称"
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr "无效的表情类型"
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr "必须是组织管理员或表情作者"
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr "表情符号名称必须以字母或数字结尾。"
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
 msgstr "Emoji 名称必须只包含小写英文字母、数字、空格、破折号和下划线。"
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr "缺少表情名称"
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr "无法分配事件队列"
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr "未登录：提供用户会话或者API认证"
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, fuzzy, python-brace-format
 #| msgid "Channel named {channel_name} already exists"
 msgid "Channel '{channel_name}' already exists"
 msgstr "频道名{channel_name}已存在"
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr ""
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr ""
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr "组织所有者"
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr "用户"
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr "不能禁用唯一的 {entity}"
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr "无效的 Markdown 包含语句：{include_statement}"
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 msgstr ""
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr "JSON格式不正确"
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr "必须是组织管理员"
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr "必须是组织所有者"
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Must be an organization owner"
 msgid "Must be a bot user"
 msgstr "必须是组织所有者"
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr "您的用户名或密码不正确"
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr "这个组织已被禁用"
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr "您的服务器的移动推送通知服务注册已停用"
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr "此组织中已禁用密码身份验证"
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr "您的密码已被禁用，需要重新设置"
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr "错误的 API key"
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr "API key 格式错误"
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
 "webhook; ignoring"
 msgstr ""
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr "无法解析请求：{webhook_name} 是否生成了此事件？"
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr ""
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr "无效的子域名"
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr "您无权发起私信对话。"
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr ""
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
 "{empty_topic_display_name} topic. Consider renaming or deleting other topics."
 msgstr ""
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr "私信功能已被组织停用。"
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr "该对话不包括任何可以授权的用户。"
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr "访问被拒绝"
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} most recent messages in this topic."
 msgstr ""
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr "反应已经存在"
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr "反应不存在"
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
@@ -5601,363 +5029,363 @@ msgstr ""
 "您的组织已注册到不同的 Zulip 服务器。请联系 Zulip 支持以获得解决此问题的帮"
 "助。"
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr "组织尚未注册"
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr "您没有在此频道中使用频道通配符提及的权限。"
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr "您无权在此话题中使用话题通配符提及。"
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr ""
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr ""
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr ""
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr "您没有管理此频道的权限。"
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr "您没有权限更改默认频道。"
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr "电子邮箱已被使用。"
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr "计划送达时间必须在未来"
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr ""
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr ""
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr ""
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr ""
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Already has an account."
 msgid "Atlassian account ID"
 msgstr "账号已经存在"
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Behance username"
 msgstr "名字或者用户名错误"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Bitbucket username"
 msgstr "GitHub 用户名"
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Codeberg username"
 msgstr "Twitter 用户名"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Dribbble username"
 msgstr "GitHub 用户名"
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Bad name or username"
 msgid "Facebook username"
 msgstr "名字或者用户名错误"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr "GitHub 用户名"
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "GitLab username"
 msgstr "GitHub 用户名"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Instagram username"
 msgstr "Twitter 用户名"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Mastodon"
 msgid "Mastodon profile"
 msgstr "Mastodon"
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Medium username"
 msgstr "GitHub 用户名"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Pinterest username"
 msgstr "Twitter 用户名"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Reddit username"
 msgstr "GitHub 用户名"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "GitHub username"
 msgid "Snapchat username"
 msgstr "GitHub 用户名"
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Threads username"
 msgstr "Twitter 用户名"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "TikTok username"
 msgstr "Twitter 用户名"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Twitter username"
 msgid "Twitch username"
 msgstr "Twitter 用户名"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Username"
 msgid "X username"
 msgstr "用户名"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr ""
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr "无效的外部账号类型"
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr "集成框架"
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 #, fuzzy
 #| msgid "Video call ended"
 msgid "Video calling"
 msgstr "视频通话已结束"
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr "持续集成"
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr "客户支持"
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr "部署"
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr "娱乐"
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr "通信"
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr "财务"
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr "人力资源"
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr "销售"
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr "杂项"
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr ""
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr "工程管理"
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr "效率"
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr "版本控制"
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr "消息不能为空"
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr "消息不能包含空字节"
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr ""
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {recipient_user} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
 "to {list_of_direct_message_recipients} at {reported_message_date_sent}."
 msgstr ""
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr ""
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr ""
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid "{fullname}'s moderation requests"
 msgid "{fullname} moderation"
 msgstr "{fullname} 提到了您："
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr "无效的窄运算符：{desc}"
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr ""
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr ""
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr ""
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr "缺少“锚”参数。"
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 #, fuzzy
 #| msgid "Missing 'anchor' argument."
 msgid "Missing 'anchor_date' argument."
 msgstr "缺少“锚”参数。"
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr "无效的锚点"
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr ""
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr ""
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 #, fuzzy
 #| msgid "Confirmation link does not exist"
 msgid "Navigation view does not exist."
 msgstr "确认链接不存在"
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr ""
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5965,7 +5393,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5973,7 +5401,7 @@ msgid ""
 "({getting_started_url})!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5981,7 +5409,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -5989,7 +5417,7 @@ msgid ""
 "({organization_setup_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6003,14 +5431,14 @@ msgstr ""
 "除非[转换为永久组织]({convert_demo_organization_help_url})，\n"
 "否则会在 {deletion_global_time}天后自动删除。\n"
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
 "them in your [Inbox](/#inbox).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6018,7 +5446,7 @@ msgid ""
 "({navigation_tour_video_url}) for a quick app overview.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6033,14 +5461,14 @@ msgid ""
 "\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
 "Zulip also works great in a browser.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -6048,7 +5476,7 @@ msgid ""
 "and edit your [profile information](/help/edit-your-profile).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -6066,7 +5494,7 @@ msgstr ""
 "[更改您的语言设定](/help/change-your-language)，\n"
 "并自定义您的 Zulip 体验。\n"
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6077,7 +5505,7 @@ msgid ""
 "[Browse and subscribe to channels]({settings_link}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -6094,7 +5522,7 @@ msgid ""
 "discussed.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -6103,7 +5531,7 @@ msgid ""
 "Press `?` any time to see a [cheat sheet](#keyboard-shortcuts).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -6115,7 +5543,7 @@ msgid ""
 "times, and more.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6125,7 +5553,7 @@ msgid ""
 "or browse the [help center](/help/) to learn more!\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6133,7 +5561,7 @@ msgid ""
 "get help, try one of the following messages: {bot_commands}\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6145,13 +5573,13 @@ msgid ""
 "({move_content_another_channel_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6165,12 +5593,11 @@ msgid ""
 "and above.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr "欢迎来到Zulip！"
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -6181,14 +5608,14 @@ msgstr ""
 "您可以一次只阅读 Zulip 上的一个对话并根据上下文查看每条消息。\n"
 "无论有多少其他对话正在进行。\n"
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
 "conversations with unread messages.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -6196,7 +5623,7 @@ msgid ""
 "the `+` button next to its name.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -6204,13 +5631,13 @@ msgid ""
 "can we chat about…?”\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6218,7 +5645,7 @@ msgid ""
 "({format_message_help_url}).\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6238,1345 +5665,1322 @@ msgid ""
 "```\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
 "teammates.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
 "conversation.\n"
 msgstr ""
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr ""
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr ""
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr ""
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr ""
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr "响应中的 JSON 无效"
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr "无效的响应格式"
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr "Token为空或者长度不正确"
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr "无效的 APNS token"
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr ""
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr "Token不存在"
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr "{full_name} 提到 @{user_group_name} ："
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr "{full_name} 提到了您："
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr "{full_name} 提到了大家："
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "新的消息"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr "测试通知"
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr ""
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr ""
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 msgid "Invalid `push_key`"
 msgstr "无效的 `push_key`"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
 msgstr[0] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr ""
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr "用户没有授权本次查询"
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr "“{email}”不再使用 Zulip。"
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr "您无法向组织外发送私信。"
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "Channel name too long (limit: {max_length} characters)."
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr "频道名称太长（限制：{max_length} 字符）。"
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following message."
 msgstr ""
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
 " > {note}"
 msgstr ""
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr ""
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} in "
 "{topic_pretty_link}."
 msgstr ""
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [sent]({conversation_url}) a {widget} to "
 "{list_of_recipient_mentions}."
 msgstr ""
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) to "
 "{list_of_recipient_mentions}:"
 msgstr ""
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr ""
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr ""
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 #, fuzzy
 #| msgid "Token does not exist"
 msgid "Reminder does not exist"
 msgstr "Token不存在"
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr ""
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr "不能在“{var_name1}”和“{var_name2}”参数之间进行选择"
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr "缺少参数： '{var_name}'"
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr "错误值：'{var_name}': {bad_value}"
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr "定时消息不存在"
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr "{service_name} 账号安全"
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr "默认频道不能是私人频道。"
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr ""
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr "您无权在此频道发帖。"
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 #, fuzzy
 #| msgid "You do not have permission to post in this channel."
 msgid "You do not have permission to create new topics in this channel."
 msgstr "您无权在此频道发帖。"
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr "无效的频道ID"
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr ""
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr ""
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr ""
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr ""
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr "频道名称太长（限制：{max_length} 字符）。"
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr ""
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr ""
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr "该频道没有用户数据"
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr "无法检索私人频道的订阅者"
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr "不能解码图片；您上传的是图片文件吗？"
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr "图像大小超过了限制"
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr "{var_name} 不是布尔值"
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} does not have a length"
 msgid "{var_name} does not have the expected format"
 msgstr "{var_name} 没有长度"
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr "{var_name} 不是日期"
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr "{var_name} 不是字典"
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr "{var_name} 无效"
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr "{var_name} 不是浮点数"
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr "{var_name} 太小"
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr "{var_name} 不是整数"
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr "{var_name} 太大"
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr "{var_name} 不是列表"
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr "{var_name} 过长 (不超过: {max_length}个字符)"
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr "{var_name} 不是字符串"
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr "{var_name} 过长 (不超过: {max_length}个字符)"
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr "{var_name} 太短 (至少 {min_length}个字符)"
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr ""
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr "格式错误的有效载荷"
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr ""
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr "不是有效网址"
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr "无法识别时区"
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr "{var_name} 不是有效的十六进制颜色代码"
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr "{setting_name} 无效"
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr "上传超出了您组织的允许范围"
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr "图片尺寸超过限制"
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr "用户组已停用。"
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr "无效的用户组"
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {user_group_id}"
 msgstr "无效的用户ID：{user_group_id}"
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr "系统组名称无效。"
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr ""
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr ""
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr "用户组名称不能为空！"
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr ""
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr "客户端没有传递任何新值。"
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr "如果客户端传递 emoji_code 或反应类型，则客户端必须传递 emoji_name。"
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr "名称过长！"
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 msgid "Name must not be empty!"
 msgstr "名字不能为空！"
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr "名称中有无效字符！"
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr "无效的格式！"
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr "该组织需要唯一名称。"
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr "名称已被使用。"
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr "名字或者用户名错误"
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr ""
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr ""
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr ""
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr "无效的配置数据！"
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr "无效的机器人类型"
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr "无效的接口类型"
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr ""
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr "机器人不存在"
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr "不存在该用户"
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr "用户被禁用"
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr "{item}不能为空格"
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr "{var_name} 长度不正确 {length}; 应该为 {target_length}"
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a string"
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr "{var_name} 不是字符串"
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr "{container} 应该正好有 {length} 项"
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr "{var_name} 中缺少 {key_name} 键"
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr ""
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr "{var_name} 不是 allowed_type"
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr "{variable} != {expected_value}（{value} 错误）"
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr "{var_name} 不是网址"
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr "URL 模式必须包含'%(username)s'。"
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr "'{item}' 不能为空格"
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr "字段不能有重复的选择。"
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr "'{value}' 不是 '{field_name}'字段的合法选项"
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr "{var_name} 不是字符串或整数列表"
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr "{var_name} 不是字符串或整数"
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr "{var_name} 没有长度"
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr "{var_name} 丢失"
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr "HTTP事件头 '{header}'丢失"
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr ""
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr ""
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr "zcommand前面必须有/"
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr ""
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr ""
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr "CSRF 错误：{reason}"
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr ""
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr "外部账号"
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr "称谓"
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr "没人"
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr "全部成员"
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "成员"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr "互联网中的每一个人"
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Invalid characters in emoji name"
 msgid "Invalid auto-conversion field: empty field name."
 msgstr "表情符号名称中无效的字符"
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr ""
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr "未知的正则表达式错误"
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr "无效的 URL 模版。"
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 msgid "Example input does not match the linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in alternative URL template is not present in linkifier "
 "pattern."
 msgstr ""
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, python-format
 msgid ""
 "Group %(name)r in linkifier pattern is not present in alternative URL "
 "template."
 msgstr ""
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr "Unicode 表情符号"
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "自定义表情"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr "Zulip额外表情"
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr "表情符号名称中无效的字符"
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr "pygments 语言中的无效字符"
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr ""
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr "“code\"应该是 URL 模板中唯一变量"
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr "沙箱"
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr ""
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr ""
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr ""
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr ""
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr ""
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr ""
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr ""
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr ""
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr "在 Zulip Cloud Standard 上可用。升级访问。"
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr "可在 Zulip Cloud Plus 上使用。升级即可访问。"
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr "允许使用 G评级 GIF（普通观众）"
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr "允许使用 PG 级 GIF（家长指导）"
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr "允许使用 PG-13 级的 GIF（13 岁以下儿童）"
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr "允许使用 R 级 GIF（受限）"
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr "网络公开"
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "公开"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr "私人的、共享的历史消息"
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr "私人的、受保护的历史消息"
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr "管理员、版主、成员和访客"
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr "管理员、版主和成员"
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr "管理者和拥有调节权限的成员"
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr "只允许管理员"
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr "未知用户"
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr "组织所有者"
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr "组织管理员"
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr "版主"
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "成员"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "访客"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr "未知IP地址"
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr "未知的操作系统"
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr "未知的浏览器"
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr "缺少参数'queue_id'"
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr "缺少参数'last_event_id'"
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr "比 {event_id} 更新的事件已被修剪！"
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr "事件 {event_id} 不在此队列中"
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr ""
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 #, fuzzy
 #| msgid "Failed to create Zoom call"
 msgid "Failed to generate challenge"
 msgstr "未能创建 Zoom 通话"
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr ""
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr "请求中未传递JSON web token"
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr "JSON web token错误"
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr ""
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr "需要子域名"
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr "密码不正确。"
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr ""
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr "请求中缺少用户代理标头"
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr "标签不能为空。"
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr "字段必须至少有一个选项"
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr "不支持在配置文件摘要中显示字段类型。"
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 #, fuzzy
 #| msgid "Field type not supported for display in profile summary."
 msgid "Field type not supported for use for user matching."
 msgstr "不支持在配置文件摘要中显示字段类型。"
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr "无效字段类型。"
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr "个人资料摘要中只能显示 2 个自定义用户资料字段。"
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr "具有该标签的字段已存在。"
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr "无法更新默认自定义字段。"
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr "端点在生产中不可用。"
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr "未启用 DevAuthBackend。"
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr ""
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr ""
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr ""
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr ""
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr ""
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr ""
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr ""
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr "没有这个邀请"
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 #, fuzzy
 #| msgid "Invitation has already been revoked"
 msgid "Invitation already used or deactivated."
 msgstr "邀请已被撤销"
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr "邀请已被撤销"
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr ""
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr "您没有权限订阅其他用户的频道。"
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr "必须指定至少一个邮箱地址"
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
 msgstr "有部分地址已经在使用Zulip，因此没有向他们发送邀请；其余地址已经发送！"
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr "组织内禁止更改消息历史记录"
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr "无删除此消息权限"
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr "删除此消息超时"
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr "信息已经被删除"
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr ""
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr ""
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr ""
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Organization creation link required"
 msgid "An explanation is required."
 msgstr "需要组织创建链接"
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 #, fuzzy
 #| msgid "Zephyr mirroring is not allowed in this organization"
 msgid "Message reporting is not enabled in this organization."
 msgstr "这个组织禁止Zephyr镜像"
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr "缺少发送人"
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr "不允许对收件人用户ID进行镜像"
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr "镜像消息不正确（Invalid mirrored message）"
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr "该服务器未启用人工智能功能。"
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr ""
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr ""
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr "无法使自己静音"
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr "用户已静音"
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr "用户未静音"
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr ""
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 #, fuzzy
 #| msgid "{hostname} is not a valid hostname"
 msgid "Custom views must have a valid name."
 msgstr "{hostname} 不是有效的主机名"
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 #, fuzzy
 #| msgid "Reaction already exists."
 msgid "Navigation view already exists."
 msgstr "反应已经存在"
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr ""
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7584,567 +6988,565 @@ msgid ""
 "later. Is this a good time?\n"
 msgstr ""
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr "不支持机器人的用户不存在。"
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr "{user_id_or_email} 没有存在数据"
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 #, fuzzy
 #| msgid "You do not have permission to change default channels."
 msgid "You do not have permission to manage plans and billing."
 msgstr "您没有权限更改默认频道。"
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr ""
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr ""
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr ""
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr "至少提供一个下面的参数:表情名称，表情代码"
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr "本组织已禁用已读回执功能。"
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr "无效的语言'{language}'"
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr "必须至少启用一种身份验证方法。"
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr ""
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr ""
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr "必须是演示组织。"
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr ""
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr "数据删除时间必须是在最多 {max_allowed_days} 天之后。"
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr ""
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr "无效的域名：{error}"
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr "域 {domain} 已经是您组织的一部分。"
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr "找不到域 {domain} 的条目。"
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr "你只能上传一个文件。"
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr "只有管理员才能覆盖默认表情。"
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr "上传的文件大于允许的 {max_size} MiB限制"
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 #, fuzzy
 #| msgid "Disposable email addresses are not allowed in this organization"
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr "本组织不允许使用一次性电子邮件地址"
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr "超出速率限制。"
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr ""
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr "数据导出 ID 无效"
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr "导出已删除"
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr ""
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr ""
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr "你必须上传一个图标"
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr "未找到链接器。"
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr "您必须上传一个Logo"
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, python-brace-format
 msgid "Invalid character in language: {character}"
 msgstr "无效的字符：{character}"
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid language '{language}'"
 msgid "Language '{language}' is not allowed."
 msgstr "无效的语言'{language}'"
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr "无效的代码游乐场"
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr ""
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr ""
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
 msgstr ""
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 msgid "Importing messages…"
 msgstr "正在导入消息…"
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr ""
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr ""
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr ""
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr ""
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr ""
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 #, fuzzy
 #| msgid "Your full name"
 msgid "Your name"
 msgstr "您的全名"
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr "定时消息需要指定接收对象"
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr "将定时消息发送至频道需要指定话题。"
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr "无效的请求格式"
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr "无效的 DSN"
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr "私人频道不能设为默认频道。"
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr "您必须传递“new_description”或“new_group_name”。"
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr "“op”的无效值。使用“添加”或“删除”。"
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr "无效参数"
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr ""
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr ""
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr "没有动作，至少指定\"add\"或者\"delete\""
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr ""
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr ""
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr ""
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr ""
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr "新频道"
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr ""
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
 "**"
 msgstr ""
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr ""
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr ""
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr ""
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr "子消息的json无效"
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr ""
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr "文件大于此服务器配置的最大上传大小 ({max_size} MiB)。"
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr "上传的文件大于允许的 {max_file_size} MiB限制。"
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr ""
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr ""
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr "空的“到”列表"
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr "用户停用私信的输入状态"
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr ""
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr "<p>没有权限查看这个文件！</p>"
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr "令牌无效"
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr "无效的文件名"
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr "必须指定要上传的文件"
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr "一次只可以上传一个文件"
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr "没有提供新的数据"
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
 msgstr ""
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr ""
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr "用户 {user_id} 已经是该组的成员"
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr "该用户组中没有用户名为'{user_id}'的成员"
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr "用户组 {group_id} 已经是该组的子组。"
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
 "subgroups."
 msgstr ""
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr "用户组 {group_id} 不是该组的子组。"
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr "此组织已禁用头像更改。"
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr "本组织禁止更改电子邮件地址。"
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr "无效的默认语言"
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr ""
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr ""
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr ""
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr ""
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr "您的Zulip密码由LDAP管理"
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr "密码错误！"
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr "您尝试的次数太多了！请在{retry_after_string}秒后再次尝试。"
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr "新密码太弱！"
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr "必须上传恰好一个头像文件"
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr "话题未设置免打扰"
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr "无法停用唯一的组织所有者"
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Nobody in this Zulip organization will be able to see this email address."
 msgid "User is not allowed to delete other user's messages."
 msgstr "Zulip 组织中的任何人都无法看到此电子邮箱地址。"
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr "用户无权更改用户电子邮件"
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr "无法从唯一的组织所有者中删除所有者权限。"
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr "新电子邮箱地址无效。"
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr ""
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 #, fuzzy
 #| msgid ""
 #| "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
@@ -8156,25 +7558,25 @@ msgstr ""
 "在正确配置 FAKE_EMAIL_DOMAIN 之前无法创建机器人。\n"
 "请联系您的服务器管理员。"
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 #, fuzzy
 #| msgid "Email is already in use."
 msgid "Email address already in use"
 msgstr "电子邮箱已被使用。"
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr "用户不存在，未能更改所有者"
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr "更换拥有者失败，用户被禁用"
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr "更换拥有者失败，机器人不能拥有其他机器人"
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
@@ -8182,204 +7584,204 @@ msgstr ""
 "在正确配置 FAKE_EMAIL_DOMAIN 之前无法创建机器人。\n"
 "请联系您的服务器管理员。"
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr "内置机器人被禁用"
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr "无效的内置机器人名称"
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr "当前用户无权创建用户"
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr "电子邮箱 '{email}' 不允许在此组织使用"
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr "本组织不允许使用一次性电子邮件地址"
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} access token"
 msgstr "无效的 {provider_name} 访问令牌"
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} call"
 msgstr "未能创建 {provider_name} 通话"
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} credentials have not been configured"
 msgstr "{provider_name} 凭据尚未配置"
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} credentials"
 msgstr "无效的 {provider_name} 凭证"
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr "连接到 {provider_name} 服务器时出错：{reason}"
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Error authenticating to the {provider_name} server"
 msgstr "对 {provider_name} 服务器进行身份验证时出错"
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr "{provider_name} 服务器返回意外错误：{status}"
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} session identifier"
 msgstr "无效的 {provider_name} 会话标识符"
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr ""
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} public room."
 msgstr "未能创建 {provider_name} 公开房间"
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr "无效的签名。"
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{full_name}'s Zulip room"
 msgstr "{full_name} 提到了您："
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr "不支持使用该版本控制系统提供商的项目"
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr "无效的负载"
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr "未知的Webhook请求"
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr "话题不能为空"
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr "内容不能为空"
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr ""
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr "JSON输入格式不正确"
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr "Payload 中缺少 events 键"
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr "错误：channels_map_to_topics 参数必须是 0 或 1"
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr ""
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
 "({export_settings_link})."
 msgstr ""
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr ""
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr ""
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr ""
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr ""
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr "推送通知到无效子域"
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr "必须验证有效的Zulip服务器 API Key"
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr "无效的 UUID"
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr "无效的Token类型"
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr ""
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr "{hostname} 不是有效的主机名"
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr ""
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr ""
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr ""
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr "{domain}无效，因为它没有任何 MX 记录"
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr ""
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
@@ -8388,78 +7790,78 @@ msgstr ""
 "已达到该终端最近使用量的全局限制。请稍后再试，或联系 {support_email} 寻求帮"
 "助。"
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr ""
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr ""
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, python-brace-format
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr ""
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr "缺少 ios_app_id"
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr "缺少 user_id 或 user_uuid"
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
 "server: {reason}"
 msgstr ""
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr "您当前计划不允许发送推送通知。"
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr ""
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr ""
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr "数据超出要求"
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr ""
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr ""
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr "您需要重设密码。"
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr "缺少 id_token 参数"
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 #, fuzzy
 #| msgid "Missing id_token parameter"
 msgid "Missing idp param"
 msgstr "缺少 id_token 参数"
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr "无效的OTP"
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr "不能同时使用 mobile_flow_otp 和 desktop_flow_otp。"
 

--- a/locale/zh_TW/LC_MESSAGES/django.po
+++ b/locale/zh_TW/LC_MESSAGES/django.po
@@ -18,7 +18,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zulip\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 16:31+0000\n"
+"POT-Creation-Date: 2026-04-27 18:51+0000\n"
 "PO-Revision-Date: 2026-04-10 08:32+0000\n"
 "Last-Translator: UDP <udp@users.noreply.hosted.weblate.org>\n"
 "Language-Team: Chinese (Traditional Han script) <https://hosted.weblate.org/"
@@ -30,50 +30,50 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.17-dev\n"
 
-#: analytics/views/stats.py:109 zerver/decorator.py:682 zerver/decorator.py:700
+#: analytics/views/stats.py zerver/decorator.py
 msgid "Not allowed for guest users"
 msgstr "訪客使用者不允許此操作"
 
-#: analytics/views/stats.py:160
+#: analytics/views/stats.py
 msgid "Invalid organization"
 msgstr "無效的組織"
 
-#: analytics/views/stats.py:391
+#: analytics/views/stats.py
 msgid "Public channels"
 msgstr "公開頻道"
 
-#: analytics/views/stats.py:392
+#: analytics/views/stats.py
 msgid "Private channels"
 msgstr "私人頻道"
 
-#: analytics/views/stats.py:393
+#: analytics/views/stats.py
 msgid "Direct messages"
 msgstr "私人訊息"
 
-#: analytics/views/stats.py:394
+#: analytics/views/stats.py
 msgid "Group direct messages"
 msgstr "群組私人訊息"
 
-#: analytics/views/stats.py:417
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Missing channel for chart: {chart_name}"
 msgstr "圖表缺少對應頻道：{chart_name}"
 
-#: analytics/views/stats.py:425
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Unknown chart name: {chart_name}"
 msgstr "未知的圖表名稱：{chart_name}"
 
-#: analytics/views/stats.py:435
+#: analytics/views/stats.py
 #, python-brace-format
 msgid "Start time is later than end time. Start: {start}, End: {end}"
 msgstr "開始時間晚於結束時間。開始時間：{start}，結束時間：{end}"
 
-#: analytics/views/stats.py:454 analytics/views/stats.py:489
+#: analytics/views/stats.py
 msgid "No analytics data available. Please contact your server administrator."
 msgstr "沒有可用的分析資料。請聯繫您的伺服器管理員。"
 
-#: corporate/lib/registration.py:35
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has no Zulip licenses remaining and can no longer accept "
@@ -85,7 +85,7 @@ msgstr ""
 "({billing_page_link})或[停用不活躍使用者]({deactivate_user_help_page_link})，"
 "以允許新使用者加入。"
 
-#: corporate/lib/registration.py:42
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only one Zulip license remaining. You can [increase "
@@ -95,7 +95,7 @@ msgstr ""
 "您的組織只剩下一個 Zulip 授權。您可以[增加授權數量]({billing_page_link}) 或"
 "[停用閒置使用者]({deactivate_user_help_page_link}) 以允許多個使用者加入。"
 
-#: corporate/lib/registration.py:47
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only two Zulip licenses remaining. You can [increase "
@@ -105,7 +105,7 @@ msgstr ""
 "您的組織只剩下兩個 Zulip 授權。您可以[增加授權數量]({billing_page_link}) 或"
 "[停用閒置使用者]({deactivate_user_help_page_link}) 以允許超過兩個使用者加入。"
 
-#: corporate/lib/registration.py:52
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "Your organization has only three Zulip licenses remaining. You can [increase "
@@ -115,7 +115,7 @@ msgstr ""
 "您的組織只剩下三個 Zulip 授權。您可以[增加授權數量]({billing_page_link}) 或"
 "[停用閒置使用者]({deactivate_user_help_page_link}) 以允許超過三個使用者加入。"
 
-#: corporate/lib/registration.py:63
+#: corporate/lib/registration.py
 #, python-brace-format
 msgid ""
 "A new user ({email}) was unable to join because your organization does not "
@@ -127,35 +127,34 @@ msgstr ""
 "用者加入，請確保[當前和下一計費週期的授權數量]({billing_page_link}) 大於目前"
 "的使用者數量。"
 
-#: corporate/lib/registration.py:119
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses. Invitations were not "
 "sent."
 msgstr "您的組織沒有足夠的 Zulip 授權。邀請未能送出。"
 
-#: corporate/lib/registration.py:133
+#: corporate/lib/registration.py
 msgid ""
 "Your organization does not have enough Zulip licenses to change a guest "
 "user's role."
 msgstr "您的組織沒有足夠的 Zulip 授權來變更訪客使用者的角色。"
 
-#: corporate/lib/remote_billing_util.py:144
-#: corporate/lib/remote_billing_util.py:180
+#: corporate/lib/remote_billing_util.py
 msgid "Registration is deactivated"
 msgstr "註冊功能已停用"
 
-#: corporate/lib/remote_billing_util.py:177
+#: corporate/lib/remote_billing_util.py
 msgid "Invalid remote server."
 msgstr "遠端伺服器失效。"
 
-#: corporate/lib/stripe.py:220
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You must purchase licenses for all active users in your organization "
 "(minimum {min_licenses})."
 msgstr "您必須為組織中所有啟用的使用者購買授權（最少 {min_licenses} 個）。"
 
-#: corporate/lib/stripe.py:226
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Invoices with more than {max_licenses} licenses can't be processed from this "
@@ -164,113 +163,113 @@ msgstr ""
 "此頁面無法處理超過 {max_licenses} 個授權的發票。若要完成升級，請聯繫 "
 "{email}。"
 
-#: corporate/lib/stripe.py:363
+#: corporate/lib/stripe.py
 msgid "No payment method on file."
 msgstr "沒有任何付款方式。"
 
-#: corporate/lib/stripe.py:371
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "{brand} ending in {last4}"
 msgstr "{brand} 卡號末四碼 {last4}"
 
-#: corporate/lib/stripe.py:379
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Unknown payment method. Please contact {email}."
 msgstr "未知的付款方式。請聯繫 {email}。"
 
-#: corporate/lib/stripe.py:418
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid "Something went wrong. Please contact {email}."
 msgstr "發生錯誤。請聯絡 {email}。"
 
-#: corporate/lib/stripe.py:419
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please reload the page."
 msgstr "發生錯誤。請重新載入頁面。"
 
-#: corporate/lib/stripe.py:515
+#: corporate/lib/stripe.py
 msgid "Something went wrong. Please wait a few seconds and try again."
 msgstr "發生錯誤。請稍候幾秒鐘後再試一次。"
 
-#: corporate/lib/stripe.py:1942
+#: corporate/lib/stripe.py
 msgid "Please add a credit card before starting your free trial."
 msgstr "請增加信用卡付款方式以獲取免費試用。"
 
-#: corporate/lib/stripe.py:1964
+#: corporate/lib/stripe.py
 msgid "Please add a credit card to schedule upgrade."
 msgstr "請增加信用卡付款方式以排定升級。"
 
-#: corporate/lib/stripe.py:3040
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update the plan. The plan has been expired and replaced with a new "
 "plan."
 msgstr "無法更新方案。該方案已過期並已被新方案取代。"
 
-#: corporate/lib/stripe.py:3045
+#: corporate/lib/stripe.py
 msgid "Unable to update the plan. The plan has ended."
 msgstr "無法更新方案。該方案已結束。"
 
-#: corporate/lib/stripe.py:3113
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot update licenses in the current billing period for free trial plan."
 msgstr "無法在目前計費週期內更新免費試用計畫的授權。"
 
-#: corporate/lib/stripe.py:3118 corporate/lib/stripe.py:3146
+#: corporate/lib/stripe.py
 msgid ""
 "Unable to update licenses manually. Your plan is on automatic license "
 "management."
 msgstr "無法手動更新授權。您的方案為自動授權管理。"
 
-#: corporate/lib/stripe.py:3124
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already on {licenses} licenses in the current billing period."
 msgstr "您的方案在目前計費週期已有 {licenses} 個授權。"
 
-#: corporate/lib/stripe.py:3129
+#: corporate/lib/stripe.py
 msgid "You cannot decrease the licenses in the current billing period."
 msgstr "您無法在目前計費週期減少授權數量。"
 
-#: corporate/lib/stripe.py:3155
+#: corporate/lib/stripe.py
 msgid ""
 "Cannot change the licenses for next billing cycle for a plan that is being "
 "downgraded."
 msgstr "無法更改正在降級方案的下一個計費週期授權數量。"
 
-#: corporate/lib/stripe.py:3161
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your plan is already scheduled to renew with {licenses_at_next_renewal} "
 "licenses."
 msgstr "您的方案已安排以 {licenses_at_next_renewal} 個授權進行續約。"
 
-#: corporate/lib/stripe.py:3185
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "You’ve already purchased {licenses_at_next_renewal} licenses for the next "
 "billing period."
 msgstr "您已經購買了下一個計費週期的 {licenses_at_next_renewal} 個授權。"
 
-#: corporate/lib/stripe.py:3207
+#: corporate/lib/stripe.py
 msgid "Nothing to change."
 msgstr "沒有需要變更的項目。"
 
-#: corporate/lib/stripe.py:3590
+#: corporate/lib/stripe.py
 msgid "No customer for this organization!"
 msgstr "此組織沒有對應的客戶記錄！"
 
-#: corporate/lib/stripe.py:3599
+#: corporate/lib/stripe.py
 msgid "Session not found"
 msgstr "找不到工作階段"
 
-#: corporate/lib/stripe.py:3613
+#: corporate/lib/stripe.py
 msgid "Payment intent not found"
 msgstr "找不到付款意圖"
 
-#: corporate/lib/stripe.py:3616
+#: corporate/lib/stripe.py
 msgid "Pass stripe_session_id or stripe_invoice_id"
 msgstr "請提供 stripe_session_id 或 stripe_invoice_id"
 
-#: corporate/lib/stripe.py:4409
+#: corporate/lib/stripe.py
 #, python-brace-format
 msgid ""
 "Your organization's request for sponsored hosting has been approved! You "
@@ -283,58 +282,56 @@ msgstr ""
 "\n"
 "如果您能夠{begin_link}在網站上列出 Zulip 為贊助商{end_link}，我們將非常感謝！"
 
-#: corporate/views/billing_page.py:349
+#: corporate/views/billing_page.py
 msgid "Parameter 'confirmed' is required"
 msgstr "必須提供參數 'confirmed'"
 
-#: corporate/views/remote_billing_page.py:134
+#: corporate/views/remote_billing_page.py
 msgid "Billing access token expired."
 msgstr "計費存取權杖已過期。"
 
-#: corporate/views/remote_billing_page.py:136
+#: corporate/views/remote_billing_page.py
 msgid "Invalid billing access token."
 msgstr "無效的計費存取權杖。"
 
-#: corporate/views/remote_billing_page.py:230 zilencer/views.py:1523
-#: zilencer/views.py:1548
+#: corporate/views/remote_billing_page.py zilencer/views.py
 #, python-brace-format
 msgid ""
 "Couldn't reconcile billing data between server and realm. Please contact "
 "{support_email}"
 msgstr "無法協調伺服器與組織間的計費資料。請聯繫 {support_email}"
 
-#: corporate/views/remote_billing_page.py:311
+#: corporate/views/remote_billing_page.py
 msgid "User account doesn't exist yet."
 msgstr "使用者帳戶尚未存在。"
 
-#: corporate/views/remote_billing_page.py:316
-#: corporate/views/remote_billing_page.py:751
+#: corporate/views/remote_billing_page.py
 msgid "You must accept the Terms of Service to proceed."
 msgstr "您必須接受服務條款才能繼續。"
 
-#: corporate/views/remote_billing_page.py:553
+#: corporate/views/remote_billing_page.py
 msgid ""
 "This zulip_org_id is not registered with Zulip's billing management system."
 msgstr "此 zulip_org_id 未在 Zulip 的計費管理系統中註冊。"
 
-#: corporate/views/remote_billing_page.py:560
+#: corporate/views/remote_billing_page.py
 msgid "Invalid zulip_org_key for this zulip_org_id."
 msgstr "此 zulip_org_id 的 zulip_org_key 無效。"
 
-#: corporate/views/remote_billing_page.py:564
+#: corporate/views/remote_billing_page.py
 msgid "Your server registration has been deactivated."
 msgstr "您的伺服器註冊已被停用。"
 
-#: templates/404.html:4 templates/4xx.html:4
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:4
+#: templates/404.html templates/4xx.html
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Error"
 msgstr "錯誤"
 
-#: templates/404.html:11
+#: templates/404.html
 msgid "Page not found (404)"
 msgstr "找不到頁面 (404)"
 
-#: templates/404.html:13 templates/4xx.html:37
+#: templates/404.html templates/4xx.html
 #, python-format
 msgid ""
 "If this error is unexpected, you can <a href=\"mailto:"
@@ -343,11 +340,11 @@ msgstr ""
 "如果這個錯誤是非預期的，您可以 <a href=\"mailto:%(support_email)s\">聯繫技術"
 "支援</a>。"
 
-#: templates/4xx.html:11
+#: templates/4xx.html
 msgid "Access forbidden (403)"
 msgstr "禁止存取 (403)"
 
-#: templates/4xx.html:13
+#: templates/4xx.html
 msgid ""
 "Your request could not be completed because your browser did not send the "
 "credentials required to authenticate your access. To resolve this issue:"
@@ -355,11 +352,11 @@ msgstr ""
 "您的請求無法完成， 因為您的瀏覽器未發送驗證存取權限所需的憑證。 若要解決此問"
 "題："
 
-#: templates/4xx.html:22
+#: templates/4xx.html
 msgid "Make sure that your browser allows cookies for this site."
 msgstr "確保您的瀏覽器允許此網站使用 Cookie。"
 
-#: templates/4xx.html:27
+#: templates/4xx.html
 msgid ""
 "Check for any browser privacy settings or extensions that block Referer "
 "headers, and disable them for this site."
@@ -367,16 +364,15 @@ msgstr ""
 "請檢查瀏覽器的隱私設定或擴充功能 是否封鎖了 Referer 標頭， 並為此網站停用這些"
 "設定。"
 
-#: templates/4xx.html:35
+#: templates/4xx.html
 msgid "Method not allowed (405)"
 msgstr "不允許的方法 (405)"
 
-#: templates/500.html:4 templates/500.html:16
-#: zerver/actions/scheduled_messages.py:467 zerver/middleware.py:415
+#: templates/500.html zerver/actions/scheduled_messages.py zerver/middleware.py
 msgid "Internal server error"
 msgstr "伺服器內部錯誤"
 
-#: templates/500.html:20
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! We're aware of the problem and are "
 "working to fix it. Zulip will load automatically once it is working again."
@@ -384,7 +380,7 @@ msgstr ""
 "發生了一些問題，很抱歉造成困擾！我們已經知道此問題並正在努力修復中。Zulip 將"
 "會在問題解決後自動重新載入。"
 
-#: templates/500.html:27
+#: templates/500.html
 #, python-format
 msgid ""
 "Please check <a href=\"%(status_url)s\">Zulip Cloud status</a> for more "
@@ -394,13 +390,13 @@ msgstr ""
 "請查看 <a href=\"%(status_url)s\">Zulip Cloud 狀態</a>了解更多資訊，如有任何"
 "問題請<a href=\"mailto:%(support_email)s\">聯繫 Zulip 客服</a>。"
 
-#: templates/500.html:36
+#: templates/500.html
 msgid ""
 "Something went wrong. Sorry about that! Zulip will load automatically once "
 "it is working again."
 msgstr "發生了一些問題，很抱歉造成困擾！Zulip 將會在問題解決後自動重新載入。"
 
-#: templates/500.html:42
+#: templates/500.html
 #, python-format
 msgid ""
 "<a href=\"mailto:%(support_email)s\">Contact this server's administrators</"
@@ -408,7 +404,7 @@ msgid ""
 msgstr ""
 "<a href=\"mailto:%(support_email)s\">聯繫此伺服器的管理員</a>尋求協助。"
 
-#: templates/500.html:47
+#: templates/500.html
 #, python-format
 msgid ""
 "If you administer this server, you may want to check out the <a "
@@ -417,151 +413,149 @@ msgstr ""
 "如果您是此伺服器的管理員，建議您查看 <a "
 "href=\"%(troubleshooting_url)s\">Zulip 伺服器疑難排解指南</a>。"
 
-#: templates/analytics/stats.html:6
+#: templates/analytics/stats.html
 #, python-format
 msgid "Analytics for %(target_name)s | Zulip"
 msgstr "%(target_name)s 的分析 | Zulip"
 
-#: templates/analytics/stats.html:18
+#: templates/analytics/stats.html
 msgid "Analytics are fully available 24 hours after organization creation."
 msgstr "分析功能將在組織建立後 24 小時完全可用。"
 
-#: templates/analytics/stats.html:23
+#: templates/analytics/stats.html
 #, python-format
 msgid "Zulip analytics for %(target_name)s"
 msgstr "%(target_name)s 的 Zulip 分析"
 
-#: templates/analytics/stats.html:25
+#: templates/analytics/stats.html
 msgid "Organization summary"
 msgstr "組織摘要"
 
-#: templates/analytics/stats.html:27
+#: templates/analytics/stats.html
 msgid "Number of users"
 msgstr "使用者數量"
 
-#: templates/analytics/stats.html:28
+#: templates/analytics/stats.html
 msgid "Users active during the last 15 days"
 msgstr "過去 15 天內的活躍使用者"
 
-#: templates/analytics/stats.html:29
+#: templates/analytics/stats.html
 msgid "Number of guests"
 msgstr "訪客數量"
 
-#: templates/analytics/stats.html:30
+#: templates/analytics/stats.html
 msgid "Total number of messages"
 msgstr "訊息總數"
 
-#: templates/analytics/stats.html:31
+#: templates/analytics/stats.html
 msgid "Number of messages in the last 30 days"
 msgstr "過去 30 天的訊息數量"
 
-#: templates/analytics/stats.html:32
+#: templates/analytics/stats.html
 msgid "File storage in use"
 msgstr "已使用的檔案儲存空間"
 
-#: templates/analytics/stats.html:37
+#: templates/analytics/stats.html
 msgid "Active users"
 msgstr "活躍使用者"
 
-#: templates/analytics/stats.html:40
+#: templates/analytics/stats.html
 msgid "Daily actives"
 msgstr "日活躍使用者"
 
-#: templates/analytics/stats.html:41
+#: templates/analytics/stats.html
 msgid "15 day actives"
 msgstr "15 天活躍使用者"
 
-#: templates/analytics/stats.html:42
+#: templates/analytics/stats.html
 msgid "Total users"
 msgstr "使用者總數"
 
-#: templates/analytics/stats.html:50 zerver/models/custom_profile_fields.py:108
+#: templates/analytics/stats.html zerver/models/custom_profile_fields.py
 msgid "Users"
 msgstr "使用者"
 
-#: templates/analytics/stats.html:58
+#: templates/analytics/stats.html
 msgid "Messages sent by recipient type"
 msgstr "依接收者類型分類的已發送訊息"
 
-#: templates/analytics/stats.html:61 templates/analytics/stats.html:91
-#: templates/analytics/stats.html:113 templates/analytics/stats.html:124
+#: templates/analytics/stats.html
 msgid "Me"
 msgstr "我"
 
-#: templates/analytics/stats.html:62 templates/analytics/stats.html:115
-#: templates/analytics/stats.html:125 zerver/models/groups.py:28
-#: zerver/views/registration.py:412
+#: templates/analytics/stats.html zerver/models/groups.py
+#: zerver/views/registration.py
 msgid "Everyone"
 msgstr "所有人"
 
-#: templates/analytics/stats.html:70 templates/analytics/stats.html:132
+#: templates/analytics/stats.html
 msgid "Last week"
 msgstr "上週"
 
-#: templates/analytics/stats.html:71 templates/analytics/stats.html:133
+#: templates/analytics/stats.html
 msgid "Last month"
 msgstr "上個月"
 
-#: templates/analytics/stats.html:72 templates/analytics/stats.html:134
+#: templates/analytics/stats.html
 msgid "Last year"
 msgstr "去年"
 
-#: templates/analytics/stats.html:73 templates/analytics/stats.html:135
+#: templates/analytics/stats.html
 msgid "All time"
 msgstr "全部時間"
 
-#: templates/analytics/stats.html:78
+#: templates/analytics/stats.html
 msgid "Messages sent over time"
 msgstr "訊息發送時間趨勢"
 
-#: templates/analytics/stats.html:81 templates/analytics/stats.html:103
+#: templates/analytics/stats.html
 msgid "Daily"
 msgstr "每日"
 
-#: templates/analytics/stats.html:82 templates/analytics/stats.html:104
+#: templates/analytics/stats.html
 msgid "Weekly"
 msgstr "每週"
 
-#: templates/analytics/stats.html:83 templates/analytics/stats.html:105
+#: templates/analytics/stats.html
 msgid "Cumulative"
 msgstr "累計"
 
-#: templates/analytics/stats.html:93
+#: templates/analytics/stats.html
 msgid "Humans"
 msgstr "真人使用者"
 
-#: templates/analytics/stats.html:95
+#: templates/analytics/stats.html
 msgid "Bots"
 msgstr "機器人"
 
-#: templates/analytics/stats.html:100
+#: templates/analytics/stats.html
 msgid "Messages read over time"
 msgstr "訊息閱讀時間趨勢"
 
-#: templates/analytics/stats.html:121
+#: templates/analytics/stats.html
 msgid "Messages sent by client"
 msgstr "依客戶端分類的已發送訊息"
 
-#: templates/analytics/stats.html:143
+#: templates/analytics/stats.html
 msgid "Last update"
 msgstr "最後更新"
 
-#: templates/analytics/stats.html:144
+#: templates/analytics/stats.html
 msgid ""
 "A full update of all the graphs happens once a day. The “messages sent over "
 "time” graph is updated once an hour."
 msgstr ""
 "所有圖表每天完整更新一次。“「按時間先後的已讀訊息」”圖表每小時更新一次。"
 
-#: templates/confirmation/confirm_email_change.html:4
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed"
 msgstr "電子郵件已變更"
 
-#: templates/confirmation/confirm_email_change.html:12
+#: templates/confirmation/confirm_email_change.html
 msgid "Email changed!"
 msgstr "電子郵件已變更！"
 
-#: templates/confirmation/confirm_email_change.html:16
+#: templates/confirmation/confirm_email_change.html
 #, python-format
 msgid ""
 "This confirms that the email address for your Zulip account has changed from "
@@ -570,21 +564,21 @@ msgstr ""
 "此訊息確認您的 Zulip 帳戶電子郵件地址已從 %(old_email_html_tag)s 變更為 "
 "%(new_email_html_tag)s"
 
-#: templates/confirmation/confirm_preregistrationuser.html:5
-#: templates/confirmation/redirect_to_post.html:5
+#: templates/confirmation/confirm_preregistrationuser.html
+#: templates/confirmation/redirect_to_post.html
 msgid "Confirming your email address"
 msgstr "確認您的電子郵件地址"
 
-#: templates/confirmation/link_does_not_exist.html:4
+#: templates/confirmation/link_does_not_exist.html
 msgid "Confirmation link does not exist"
 msgstr "認證連結不存在"
 
-#: templates/confirmation/link_does_not_exist.html:11
+#: templates/confirmation/link_does_not_exist.html
 msgid "Whoops. We couldn't find your confirmation link in the system."
 msgstr "糟糕，我們在系統中找不到您的確認連結。"
 
-#: templates/confirmation/link_does_not_exist.html:13
-#: templates/confirmation/link_malformed.html:14
+#: templates/confirmation/link_does_not_exist.html
+#: templates/confirmation/link_malformed.html
 #, python-format
 msgid ""
 "Anyway, shoot us a line at %(support_email_html_tag)s and we'll get this "
@@ -592,27 +586,27 @@ msgid ""
 msgstr ""
 "請透過 %(support_email_html_tag)s 與我們聯絡，我們會盡快為您解決此問題。"
 
-#: templates/confirmation/link_expired.html:4
+#: templates/confirmation/link_expired.html
 msgid "Confirmation link expired or deactivated"
 msgstr "認證連結已過期或被停用"
 
-#: templates/confirmation/link_expired.html:11
+#: templates/confirmation/link_expired.html
 msgid "Whoops. The confirmation link has expired or been deactivated."
 msgstr "糟糕，這個確認連結已經過期或被停用。"
 
-#: templates/confirmation/link_expired.html:12
+#: templates/confirmation/link_expired.html
 msgid "Please contact your organization administrator for a new link."
 msgstr "請聯繫您的組織管理員以取得新的連結。"
 
-#: templates/confirmation/link_malformed.html:4
+#: templates/confirmation/link_malformed.html
 msgid "Confirmation link malformed"
 msgstr "認證連結格式錯誤"
 
-#: templates/confirmation/link_malformed.html:11
+#: templates/confirmation/link_malformed.html
 msgid "Whoops. The confirmation link is malformed."
 msgstr "糟糕，這個確認連結格式錯誤。"
 
-#: templates/confirmation/link_malformed.html:12
+#: templates/confirmation/link_malformed.html
 msgid ""
 "Make sure you copied the link correctly in to your browser. If you're still "
 "encountering this page, it's probably our fault. We're sorry."
@@ -620,72 +614,55 @@ msgstr ""
 "請確認您已正確地將連結複製到瀏覽器中。如果您仍然看到此頁面，可能是我們的問"
 "題，很抱歉。"
 
-#: templates/corporate/billing/billing.html:5
+#: templates/corporate/billing/billing.html
 msgid "Billing"
 msgstr "帳單"
 
-#: templates/corporate/billing/billing.html:421
-#: templates/corporate/billing/billing.html:460
-#: templates/corporate/billing/billing.html:497
-#: templates/corporate/billing/billing.html:530
-#: templates/corporate/billing/billing.html:560
-#: templates/corporate/billing/billing.html:592
-#: templates/corporate/billing/billing.html:641
-#: templates/corporate/billing/upgrade.html:330
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:10
-#: templates/zerver/development/email_log.html:35
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/development/email_log.html
 msgid "Close modal"
 msgstr "關閉對話框"
 
-#: templates/corporate/billing/billing.html:443
-#: templates/corporate/billing/billing.html:543
-#: templates/corporate/billing/billing.html:575
-#: templates/corporate/billing/billing.html:607
-#: templates/corporate/billing/billing.html:646
+#: templates/corporate/billing/billing.html
 msgid "Never mind"
 msgstr "取消"
 
-#: templates/corporate/billing/billing.html:445
-#: templates/corporate/billing/billing.html:545
-#: templates/corporate/billing/billing.html:577
+#: templates/corporate/billing/billing.html
 msgid "Downgrade"
 msgstr "降級"
 
-#: templates/corporate/billing/billing.html:480
-#: templates/corporate/billing/billing.html:513
-#: templates/corporate/billing/upgrade.html:350
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:30
+#: templates/corporate/billing/billing.html
+#: templates/corporate/billing/upgrade.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Cancel"
 msgstr "取消"
 
-#: templates/corporate/billing/billing.html:482
-#: templates/corporate/billing/billing.html:515
-#: templates/corporate/billing/billing.html:648
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:32
-#: templates/zerver/realm_import_post_process.html:45
+#: templates/corporate/billing/billing.html
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
+#: templates/zerver/realm_import_post_process.html
 msgid "Confirm"
 msgstr "確認"
 
-#: templates/corporate/billing/billing.html:609
+#: templates/corporate/billing/billing.html
 msgid "Cancel upgrade"
 msgstr "取消升級"
 
-#: templates/corporate/billing/event_status.html:5
+#: templates/corporate/billing/event_status.html
 msgid "Billing status"
 msgstr "帳單狀態"
 
-#: templates/corporate/billing/remote_billing_server_deactivate.html:5
+#: templates/corporate/billing/remote_billing_server_deactivate.html
 msgid "Deactivate server registration?"
 msgstr "停用伺服器註冊？"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:4
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:11
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:4
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:11
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid "Plan management not available"
 msgstr "方案管理不可用"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:13
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 #, python-format
 msgid ""
 "Plan management is not available for this organization, because your Zulip "
@@ -700,7 +677,7 @@ msgstr ""
 "href=\"https://zulip.com/help/self-hosted-billing#log-in-to-billing-"
 "management\">登入說明</a>，以管理您 Zulip 伺服器的方案。"
 
-#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html:23
+#: templates/corporate/billing/remote_realm_login_error_for_server_on_active_plan.html
 msgid ""
 "To move the plan from the server to this organization, or for other "
 "questions, <a href=\"mailto:{{ support_email }}\">contact support</a>."
@@ -708,14 +685,14 @@ msgstr ""
 "若要將方案從伺服器轉移到此組織， 或有其他問題，請<a href=\"mailto:"
 "{{ support_email }}\">聯繫技術支援</a>。"
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:13
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 msgid ""
 "Plan management for this server is not available because at least one "
 "organization hosted on this server already has an active plan."
 msgstr ""
 "此伺服器無法使用方案管理，因為此伺服器上至少有一個組織 已有啟用的方案。"
 
-#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html:19
+#: templates/corporate/billing/remote_server_login_error_for_any_realm_on_active_plan.html
 #, python-format
 msgid ""
 "<a href=\"https://zulip.com/help/self-hosted-billing#manage-billing\">Log "
@@ -726,740 +703,250 @@ msgstr ""
 "登入</a>您組織的方案管理， 或有任何問題請<a href='mailto:%(support_email)s'>"
 "聯繫技術支援</a>。"
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:4
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:4
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded"
 msgstr "超過速率限制"
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:11
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:11
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid "Rate limit exceeded."
 msgstr "超過速率限制。"
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:13
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
 msgid ""
 "Your server has exceeded the limit for how often this action can be "
 "performed."
 msgstr "您的伺服器已超過此操作的 執行頻率限制。"
 
-#: templates/corporate/billing/remote_server_rate_limit_exceeded.html:15
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:15
+#: templates/corporate/billing/remote_server_rate_limit_exceeded.html
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 #, fuzzy, python-format
 #| msgid "You can try again in %(retry_after)s seconds."
 msgid "You can try again in %(retry_after_string)s."
 msgstr "您可以在 %(retry_after)s 秒後重試。"
 
-#: templates/corporate/billing/upgrade.html:5
+#: templates/corporate/billing/upgrade.html
 msgid "Upgrade"
 msgstr "昇級"
 
-#: templates/corporate/billing/upgrade.html:354
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice and start free trial"
 msgstr "發送發票並開始免費試用"
 
-#: templates/corporate/billing/upgrade.html:356
+#: templates/corporate/billing/upgrade.html
 msgid "Send invoice"
 msgstr "寄送發票"
 
-#: templates/corporate/communities.html:24
+#: templates/corporate/communities.html
 msgid "Open communities directory"
 msgstr "開放社群目錄"
 
-#: templates/corporate/communities.html:35
-#: templates/zerver/integrations/catalog.html:44
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Filter by category"
 msgstr "依類別篩選"
 
-#: templates/corporate/communities.html:40
-#: templates/corporate/communities.html:54
-#: templates/zerver/integrations/catalog.html:55
-#: templates/zerver/integrations/catalog.html:79
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "All"
 msgstr "全部"
 
-#: templates/corporate/communities.html:52
-#: templates/zerver/integrations/catalog.html:77
+#: templates/corporate/communities.html
+#: templates/zerver/integrations/catalog.html
 msgid "Categories"
 msgstr "類別"
 
-#: templates/corporate/comparison_table_integrated.html:103
+#: templates/corporate/comparison_table_integrated.html
 msgid "10,000 messages"
 msgstr "10,000 則訊息"
 
-#: templates/corporate/comparison_table_integrated.html:107
-#: templates/corporate/comparison_table_integrated.html:108
-#: templates/corporate/comparison_table_integrated.html:109
-#: templates/corporate/comparison_table_integrated.html:110
-#: templates/corporate/comparison_table_integrated.html:118
-#: templates/corporate/comparison_table_integrated.html:119
-#: templates/corporate/comparison_table_integrated.html:120
-#: templates/corporate/comparison_table_integrated.html:121
-#: templates/corporate/comparison_table_integrated.html:131
-#: templates/corporate/comparison_table_integrated.html:132
-#: templates/corporate/comparison_table_integrated.html:133
-#: templates/corporate/comparison_table_integrated.html:134
-#: templates/corporate/comparison_table_integrated.html:144
-#: templates/corporate/comparison_table_integrated.html:145
-#: templates/corporate/comparison_table_integrated.html:146
-#: templates/corporate/comparison_table_integrated.html:147
-#: templates/corporate/comparison_table_integrated.html:157
-#: templates/corporate/comparison_table_integrated.html:158
-#: templates/corporate/comparison_table_integrated.html:159
-#: templates/corporate/comparison_table_integrated.html:160
-#: templates/corporate/comparison_table_integrated.html:171
-#: templates/corporate/comparison_table_integrated.html:172
-#: templates/corporate/comparison_table_integrated.html:173
-#: templates/corporate/comparison_table_integrated.html:174
-#: templates/corporate/comparison_table_integrated.html:185
-#: templates/corporate/comparison_table_integrated.html:186
-#: templates/corporate/comparison_table_integrated.html:187
-#: templates/corporate/comparison_table_integrated.html:188
-#: templates/corporate/comparison_table_integrated.html:198
-#: templates/corporate/comparison_table_integrated.html:199
-#: templates/corporate/comparison_table_integrated.html:200
-#: templates/corporate/comparison_table_integrated.html:201
-#: templates/corporate/comparison_table_integrated.html:283
-#: templates/corporate/comparison_table_integrated.html:284
-#: templates/corporate/comparison_table_integrated.html:285
+#: templates/corporate/comparison_table_integrated.html
 msgid "Unlimited"
 msgstr "無限制"
 
-#: templates/corporate/comparison_table_integrated.html:153
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 10 MB"
 msgstr "檔案大小上限 10 MB"
 
-#: templates/corporate/comparison_table_integrated.html:154
-#: templates/corporate/comparison_table_integrated.html:155
+#: templates/corporate/comparison_table_integrated.html
 msgid "Files up to 1 GB"
 msgstr "檔案大小上限 1 GB"
 
-#: templates/corporate/comparison_table_integrated.html:211
-#: templates/corporate/comparison_table_integrated.html:212
-#: templates/corporate/comparison_table_integrated.html:213
-#: templates/corporate/comparison_table_integrated.html:214
-#: templates/corporate/comparison_table_integrated.html:231
-#: templates/corporate/comparison_table_integrated.html:232
-#: templates/corporate/comparison_table_integrated.html:233
-#: templates/corporate/comparison_table_integrated.html:245
-#: templates/corporate/comparison_table_integrated.html:246
-#: templates/corporate/comparison_table_integrated.html:247
-#: templates/corporate/comparison_table_integrated.html:259
-#: templates/corporate/comparison_table_integrated.html:260
-#: templates/corporate/comparison_table_integrated.html:261
-#: templates/corporate/comparison_table_integrated.html:272
-#: templates/corporate/comparison_table_integrated.html:301
-#: templates/corporate/comparison_table_integrated.html:302
-#: templates/corporate/comparison_table_integrated.html:303
-#: templates/corporate/comparison_table_integrated.html:304
-#: templates/corporate/comparison_table_integrated.html:315
-#: templates/corporate/comparison_table_integrated.html:316
-#: templates/corporate/comparison_table_integrated.html:317
-#: templates/corporate/comparison_table_integrated.html:318
-#: templates/corporate/comparison_table_integrated.html:328
-#: templates/corporate/comparison_table_integrated.html:329
-#: templates/corporate/comparison_table_integrated.html:330
-#: templates/corporate/comparison_table_integrated.html:331
-#: templates/corporate/comparison_table_integrated.html:343
-#: templates/corporate/comparison_table_integrated.html:344
-#: templates/corporate/comparison_table_integrated.html:345
-#: templates/corporate/comparison_table_integrated.html:346
-#: templates/corporate/comparison_table_integrated.html:357
-#: templates/corporate/comparison_table_integrated.html:358
-#: templates/corporate/comparison_table_integrated.html:359
-#: templates/corporate/comparison_table_integrated.html:360
-#: templates/corporate/comparison_table_integrated.html:370
-#: templates/corporate/comparison_table_integrated.html:371
-#: templates/corporate/comparison_table_integrated.html:372
-#: templates/corporate/comparison_table_integrated.html:373
-#: templates/corporate/comparison_table_integrated.html:383
-#: templates/corporate/comparison_table_integrated.html:384
-#: templates/corporate/comparison_table_integrated.html:385
-#: templates/corporate/comparison_table_integrated.html:386
-#: templates/corporate/comparison_table_integrated.html:394
-#: templates/corporate/comparison_table_integrated.html:395
-#: templates/corporate/comparison_table_integrated.html:396
-#: templates/corporate/comparison_table_integrated.html:397
-#: templates/corporate/comparison_table_integrated.html:407
-#: templates/corporate/comparison_table_integrated.html:408
-#: templates/corporate/comparison_table_integrated.html:409
-#: templates/corporate/comparison_table_integrated.html:410
-#: templates/corporate/comparison_table_integrated.html:420
-#: templates/corporate/comparison_table_integrated.html:421
-#: templates/corporate/comparison_table_integrated.html:422
-#: templates/corporate/comparison_table_integrated.html:423
-#: templates/corporate/comparison_table_integrated.html:433
-#: templates/corporate/comparison_table_integrated.html:434
-#: templates/corporate/comparison_table_integrated.html:435
-#: templates/corporate/comparison_table_integrated.html:436
-#: templates/corporate/comparison_table_integrated.html:447
-#: templates/corporate/comparison_table_integrated.html:448
-#: templates/corporate/comparison_table_integrated.html:449
-#: templates/corporate/comparison_table_integrated.html:450
-#: templates/corporate/comparison_table_integrated.html:460
-#: templates/corporate/comparison_table_integrated.html:461
-#: templates/corporate/comparison_table_integrated.html:462
-#: templates/corporate/comparison_table_integrated.html:463
-#: templates/corporate/comparison_table_integrated.html:475
-#: templates/corporate/comparison_table_integrated.html:476
-#: templates/corporate/comparison_table_integrated.html:477
-#: templates/corporate/comparison_table_integrated.html:478
-#: templates/corporate/comparison_table_integrated.html:489
-#: templates/corporate/comparison_table_integrated.html:490
-#: templates/corporate/comparison_table_integrated.html:491
-#: templates/corporate/comparison_table_integrated.html:502
-#: templates/corporate/comparison_table_integrated.html:503
-#: templates/corporate/comparison_table_integrated.html:504
-#: templates/corporate/comparison_table_integrated.html:516
-#: templates/corporate/comparison_table_integrated.html:517
-#: templates/corporate/comparison_table_integrated.html:518
-#: templates/corporate/comparison_table_integrated.html:537
-#: templates/corporate/comparison_table_integrated.html:538
-#: templates/corporate/comparison_table_integrated.html:539
-#: templates/corporate/comparison_table_integrated.html:550
-#: templates/corporate/comparison_table_integrated.html:551
-#: templates/corporate/comparison_table_integrated.html:552
-#: templates/corporate/comparison_table_integrated.html:563
-#: templates/corporate/comparison_table_integrated.html:564
-#: templates/corporate/comparison_table_integrated.html:565
-#: templates/corporate/comparison_table_integrated.html:577
-#: templates/corporate/comparison_table_integrated.html:578
-#: templates/corporate/comparison_table_integrated.html:579
-#: templates/corporate/comparison_table_integrated.html:592
-#: templates/corporate/comparison_table_integrated.html:593
-#: templates/corporate/comparison_table_integrated.html:594
-#: templates/corporate/comparison_table_integrated.html:608
-#: templates/corporate/comparison_table_integrated.html:609
-#: templates/corporate/comparison_table_integrated.html:623
-#: templates/corporate/comparison_table_integrated.html:624
-#: templates/corporate/comparison_table_integrated.html:639
-#: templates/corporate/comparison_table_integrated.html:640
-#: templates/corporate/comparison_table_integrated.html:652
-#: templates/corporate/comparison_table_integrated.html:653
-#: templates/corporate/comparison_table_integrated.html:664
-#: templates/corporate/comparison_table_integrated.html:679
-#: templates/corporate/comparison_table_integrated.html:680
-#: templates/corporate/comparison_table_integrated.html:681
-#: templates/corporate/comparison_table_integrated.html:682
-#: templates/corporate/comparison_table_integrated.html:692
-#: templates/corporate/comparison_table_integrated.html:693
-#: templates/corporate/comparison_table_integrated.html:694
-#: templates/corporate/comparison_table_integrated.html:695
-#: templates/corporate/comparison_table_integrated.html:707
-#: templates/corporate/comparison_table_integrated.html:708
-#: templates/corporate/comparison_table_integrated.html:709
-#: templates/corporate/comparison_table_integrated.html:720
-#: templates/corporate/comparison_table_integrated.html:721
-#: templates/corporate/comparison_table_integrated.html:722
-#: templates/corporate/comparison_table_integrated.html:735
-#: templates/corporate/comparison_table_integrated.html:736
-#: templates/corporate/comparison_table_integrated.html:748
-#: templates/corporate/comparison_table_integrated.html:749
-#: templates/corporate/comparison_table_integrated.html:766
-#: templates/corporate/comparison_table_integrated.html:783
-#: templates/corporate/comparison_table_integrated.html:797
-#: templates/corporate/comparison_table_integrated.html:798
-#: templates/corporate/comparison_table_integrated.html:813
-#: templates/corporate/comparison_table_integrated.html:824
-#: templates/corporate/comparison_table_integrated.html:835
-#: templates/corporate/comparison_table_integrated.html:846
-#: templates/corporate/comparison_table_integrated.html:856
-#: templates/corporate/comparison_table_integrated.html:857
-#: templates/corporate/comparison_table_integrated.html:869
-#: templates/corporate/comparison_table_integrated.html:870
-#: templates/corporate/comparison_table_integrated.html:881
-#: templates/corporate/comparison_table_integrated.html:882
-#: templates/corporate/comparison_table_integrated.html:883
-#: templates/corporate/comparison_table_integrated.html:895
-#: templates/corporate/comparison_table_integrated.html:896
-#: templates/corporate/comparison_table_integrated.html:912
-#: templates/corporate/comparison_table_integrated.html:913
-#: templates/corporate/comparison_table_integrated.html:914
-#: templates/corporate/comparison_table_integrated.html:925
-#: templates/corporate/comparison_table_integrated.html:926
-#: templates/corporate/comparison_table_integrated.html:927
-#: templates/corporate/comparison_table_integrated.html:938
-#: templates/corporate/comparison_table_integrated.html:939
-#: templates/corporate/comparison_table_integrated.html:940
-#: templates/corporate/comparison_table_integrated.html:953
-#: templates/corporate/comparison_table_integrated.html:954
-#: templates/corporate/comparison_table_integrated.html:955
-#: templates/corporate/comparison_table_integrated.html:973
-#: templates/corporate/comparison_table_integrated.html:974
-#: templates/corporate/comparison_table_integrated.html:975
-#: templates/corporate/comparison_table_integrated.html:988
-#: templates/corporate/comparison_table_integrated.html:989
-#: templates/corporate/comparison_table_integrated.html:990
-#: templates/corporate/comparison_table_integrated.html:1003
-#: templates/corporate/comparison_table_integrated.html:1004
-#: templates/corporate/comparison_table_integrated.html:1005
-#: templates/corporate/comparison_table_integrated.html:1018
-#: templates/corporate/comparison_table_integrated.html:1019
-#: templates/corporate/comparison_table_integrated.html:1020
-#: templates/corporate/comparison_table_integrated.html:1033
-#: templates/corporate/comparison_table_integrated.html:1034
-#: templates/corporate/comparison_table_integrated.html:1035
-#: templates/corporate/comparison_table_integrated.html:1048
-#: templates/corporate/comparison_table_integrated.html:1049
-#: templates/corporate/comparison_table_integrated.html:1050
-#: templates/corporate/comparison_table_integrated.html:1063
-#: templates/corporate/comparison_table_integrated.html:1064
-#: templates/corporate/comparison_table_integrated.html:1065
-#: templates/corporate/comparison_table_integrated.html:1076
-#: templates/corporate/comparison_table_integrated.html:1077
-#: templates/corporate/comparison_table_integrated.html:1078
-#: templates/corporate/comparison_table_integrated.html:1089
-#: templates/corporate/comparison_table_integrated.html:1090
-#: templates/corporate/comparison_table_integrated.html:1091
-#: templates/corporate/comparison_table_integrated.html:1102
-#: templates/corporate/comparison_table_integrated.html:1103
-#: templates/corporate/comparison_table_integrated.html:1104
-#: templates/corporate/comparison_table_integrated.html:1116
-#: templates/corporate/comparison_table_integrated.html:1117
-#: templates/corporate/comparison_table_integrated.html:1127
-#: templates/corporate/comparison_table_integrated.html:1128
-#: templates/corporate/comparison_table_integrated.html:1129
-#: templates/corporate/comparison_table_integrated.html:1130
-#: templates/corporate/comparison_table_integrated.html:1145
-#: templates/corporate/comparison_table_integrated.html:1146
-#: templates/corporate/comparison_table_integrated.html:1147
-#: templates/corporate/comparison_table_integrated.html:1148
-#: templates/corporate/comparison_table_integrated.html:1160
-#: templates/corporate/comparison_table_integrated.html:1161
-#: templates/corporate/comparison_table_integrated.html:1162
-#: templates/corporate/comparison_table_integrated.html:1163
-#: templates/corporate/comparison_table_integrated.html:1175
-#: templates/corporate/comparison_table_integrated.html:1176
-#: templates/corporate/comparison_table_integrated.html:1177
-#: templates/corporate/comparison_table_integrated.html:1178
-#: templates/corporate/comparison_table_integrated.html:1190
-#: templates/corporate/comparison_table_integrated.html:1191
-#: templates/corporate/comparison_table_integrated.html:1192
-#: templates/corporate/comparison_table_integrated.html:1193
-#: templates/corporate/comparison_table_integrated.html:1205
-#: templates/corporate/comparison_table_integrated.html:1206
-#: templates/corporate/comparison_table_integrated.html:1220
-#: templates/corporate/comparison_table_integrated.html:1221
-#: templates/corporate/comparison_table_integrated.html:1234
-#: templates/corporate/comparison_table_integrated.html:1235
-#: templates/corporate/comparison_table_integrated.html:1236
-#: templates/corporate/comparison_table_integrated.html:1247
-#: templates/corporate/comparison_table_integrated.html:1257
-#: templates/corporate/comparison_table_integrated.html:1258
-#: templates/corporate/comparison_table_integrated.html:1272
-#: templates/corporate/comparison_table_integrated.html:1273
-#: templates/corporate/comparison_table_integrated.html:1287
-#: templates/corporate/comparison_table_integrated.html:1288
-#: templates/corporate/comparison_table_integrated.html:1302
-#: templates/corporate/comparison_table_integrated.html:1303
-#: templates/corporate/comparison_table_integrated.html:1321
-#: templates/corporate/comparison_table_integrated.html:1322
-#: templates/corporate/comparison_table_integrated.html:1323
-#: templates/corporate/comparison_table_integrated.html:1334
-#: templates/corporate/comparison_table_integrated.html:1335
-#: templates/corporate/comparison_table_integrated.html:1336
-#: templates/corporate/comparison_table_integrated.html:1348
-#: templates/corporate/comparison_table_integrated.html:1349
-#: templates/corporate/comparison_table_integrated.html:1359
-#: templates/corporate/comparison_table_integrated.html:1360
-#: templates/corporate/comparison_table_integrated.html:1376
-#: templates/corporate/comparison_table_integrated.html:1377
-#: templates/corporate/comparison_table_integrated.html:1389
-#: templates/corporate/comparison_table_integrated.html:1390
-#: templates/corporate/comparison_table_integrated.html:1401
-#: templates/corporate/comparison_table_integrated.html:1412
-#: templates/corporate/comparison_table_integrated.html:1429
-#: templates/corporate/comparison_table_integrated.html:1430
-#: templates/corporate/comparison_table_integrated.html:1443
-#: templates/corporate/comparison_table_integrated.html:1444
-#: templates/corporate/comparison_table_integrated.html:1456
-#: templates/corporate/comparison_table_integrated.html:1457
-#: templates/corporate/comparison_table_integrated.html:1469
-#: templates/corporate/comparison_table_integrated.html:1470
-#: templates/corporate/comparison_table_integrated.html:1483
-#: templates/corporate/comparison_table_integrated.html:1484
-#: templates/corporate/comparison_table_integrated.html:1496
-#: templates/corporate/comparison_table_integrated.html:1497
-#: templates/corporate/comparison_table_integrated.html:1509
-#: templates/corporate/comparison_table_integrated.html:1510
-#: templates/corporate/comparison_table_integrated.html:1523
-#: templates/corporate/comparison_table_integrated.html:1536
-#: templates/corporate/comparison_table_integrated.html:1549
-#: templates/corporate/comparison_table_integrated.html:1562
-#: templates/corporate/comparison_table_integrated.html:1575
-#: templates/corporate/comparison_table_integrated.html:1588
-#: templates/corporate/comparison_table_integrated.html:1603
-#: templates/corporate/comparison_table_integrated.html:1604
-#: templates/corporate/comparison_table_integrated.html:1605
-#: templates/corporate/comparison_table_integrated.html:1606
-#: templates/corporate/comparison_table_integrated.html:1617
-#: templates/corporate/comparison_table_integrated.html:1618
-#: templates/corporate/comparison_table_integrated.html:1619
-#: templates/corporate/comparison_table_integrated.html:1620
-#: templates/corporate/comparison_table_integrated.html:1629
-#: templates/corporate/comparison_table_integrated.html:1630
-#: templates/corporate/comparison_table_integrated.html:1631
-#: templates/corporate/comparison_table_integrated.html:1643
-#: templates/corporate/comparison_table_integrated.html:1644
-#: templates/corporate/comparison_table_integrated.html:1654
-#: templates/corporate/comparison_table_integrated.html:1655
-#: templates/corporate/comparison_table_integrated.html:1668
-#: templates/corporate/comparison_table_integrated.html:1669
-#: templates/corporate/comparison_table_integrated.html:1670
-#: templates/corporate/comparison_table_integrated.html:1681
-#: templates/corporate/comparison_table_integrated.html:1692
-#: templates/corporate/comparison_table_integrated.html:1703
-#: templates/corporate/comparison_table_integrated.html:1714
-#: templates/corporate/comparison_table_integrated.html:1725
-#: templates/corporate/comparison_table_integrated.html:1736
+#: templates/corporate/comparison_table_integrated.html
 msgid "Supported"
 msgstr "支援"
 
-#: templates/corporate/comparison_table_integrated.html:230
-#: templates/corporate/comparison_table_integrated.html:244
-#: templates/corporate/comparison_table_integrated.html:258
-#: templates/corporate/comparison_table_integrated.html:269
-#: templates/corporate/comparison_table_integrated.html:270
-#: templates/corporate/comparison_table_integrated.html:271
-#: templates/corporate/comparison_table_integrated.html:488
-#: templates/corporate/comparison_table_integrated.html:501
-#: templates/corporate/comparison_table_integrated.html:515
-#: templates/corporate/comparison_table_integrated.html:536
-#: templates/corporate/comparison_table_integrated.html:549
-#: templates/corporate/comparison_table_integrated.html:562
-#: templates/corporate/comparison_table_integrated.html:576
-#: templates/corporate/comparison_table_integrated.html:591
-#: templates/corporate/comparison_table_integrated.html:606
-#: templates/corporate/comparison_table_integrated.html:607
-#: templates/corporate/comparison_table_integrated.html:621
-#: templates/corporate/comparison_table_integrated.html:622
-#: templates/corporate/comparison_table_integrated.html:637
-#: templates/corporate/comparison_table_integrated.html:638
-#: templates/corporate/comparison_table_integrated.html:650
-#: templates/corporate/comparison_table_integrated.html:651
-#: templates/corporate/comparison_table_integrated.html:661
-#: templates/corporate/comparison_table_integrated.html:662
-#: templates/corporate/comparison_table_integrated.html:663
-#: templates/corporate/comparison_table_integrated.html:706
-#: templates/corporate/comparison_table_integrated.html:719
-#: templates/corporate/comparison_table_integrated.html:733
-#: templates/corporate/comparison_table_integrated.html:734
-#: templates/corporate/comparison_table_integrated.html:746
-#: templates/corporate/comparison_table_integrated.html:747
-#: templates/corporate/comparison_table_integrated.html:763
-#: templates/corporate/comparison_table_integrated.html:764
-#: templates/corporate/comparison_table_integrated.html:765
-#: templates/corporate/comparison_table_integrated.html:780
-#: templates/corporate/comparison_table_integrated.html:781
-#: templates/corporate/comparison_table_integrated.html:782
-#: templates/corporate/comparison_table_integrated.html:795
-#: templates/corporate/comparison_table_integrated.html:796
-#: templates/corporate/comparison_table_integrated.html:810
-#: templates/corporate/comparison_table_integrated.html:811
-#: templates/corporate/comparison_table_integrated.html:812
-#: templates/corporate/comparison_table_integrated.html:821
-#: templates/corporate/comparison_table_integrated.html:822
-#: templates/corporate/comparison_table_integrated.html:823
-#: templates/corporate/comparison_table_integrated.html:832
-#: templates/corporate/comparison_table_integrated.html:833
-#: templates/corporate/comparison_table_integrated.html:834
-#: templates/corporate/comparison_table_integrated.html:843
-#: templates/corporate/comparison_table_integrated.html:844
-#: templates/corporate/comparison_table_integrated.html:845
-#: templates/corporate/comparison_table_integrated.html:854
-#: templates/corporate/comparison_table_integrated.html:855
-#: templates/corporate/comparison_table_integrated.html:867
-#: templates/corporate/comparison_table_integrated.html:868
-#: templates/corporate/comparison_table_integrated.html:880
-#: templates/corporate/comparison_table_integrated.html:893
-#: templates/corporate/comparison_table_integrated.html:894
-#: templates/corporate/comparison_table_integrated.html:911
-#: templates/corporate/comparison_table_integrated.html:924
-#: templates/corporate/comparison_table_integrated.html:937
-#: templates/corporate/comparison_table_integrated.html:952
-#: templates/corporate/comparison_table_integrated.html:972
-#: templates/corporate/comparison_table_integrated.html:987
-#: templates/corporate/comparison_table_integrated.html:1002
-#: templates/corporate/comparison_table_integrated.html:1017
-#: templates/corporate/comparison_table_integrated.html:1032
-#: templates/corporate/comparison_table_integrated.html:1047
-#: templates/corporate/comparison_table_integrated.html:1062
-#: templates/corporate/comparison_table_integrated.html:1075
-#: templates/corporate/comparison_table_integrated.html:1088
-#: templates/corporate/comparison_table_integrated.html:1101
-#: templates/corporate/comparison_table_integrated.html:1114
-#: templates/corporate/comparison_table_integrated.html:1115
-#: templates/corporate/comparison_table_integrated.html:1203
-#: templates/corporate/comparison_table_integrated.html:1204
-#: templates/corporate/comparison_table_integrated.html:1218
-#: templates/corporate/comparison_table_integrated.html:1219
-#: templates/corporate/comparison_table_integrated.html:1233
-#: templates/corporate/comparison_table_integrated.html:1244
-#: templates/corporate/comparison_table_integrated.html:1245
-#: templates/corporate/comparison_table_integrated.html:1246
-#: templates/corporate/comparison_table_integrated.html:1255
-#: templates/corporate/comparison_table_integrated.html:1256
-#: templates/corporate/comparison_table_integrated.html:1270
-#: templates/corporate/comparison_table_integrated.html:1271
-#: templates/corporate/comparison_table_integrated.html:1285
-#: templates/corporate/comparison_table_integrated.html:1286
-#: templates/corporate/comparison_table_integrated.html:1300
-#: templates/corporate/comparison_table_integrated.html:1301
-#: templates/corporate/comparison_table_integrated.html:1320
-#: templates/corporate/comparison_table_integrated.html:1333
-#: templates/corporate/comparison_table_integrated.html:1346
-#: templates/corporate/comparison_table_integrated.html:1347
-#: templates/corporate/comparison_table_integrated.html:1357
-#: templates/corporate/comparison_table_integrated.html:1358
-#: templates/corporate/comparison_table_integrated.html:1374
-#: templates/corporate/comparison_table_integrated.html:1375
-#: templates/corporate/comparison_table_integrated.html:1387
-#: templates/corporate/comparison_table_integrated.html:1388
-#: templates/corporate/comparison_table_integrated.html:1398
-#: templates/corporate/comparison_table_integrated.html:1399
-#: templates/corporate/comparison_table_integrated.html:1400
-#: templates/corporate/comparison_table_integrated.html:1427
-#: templates/corporate/comparison_table_integrated.html:1428
-#: templates/corporate/comparison_table_integrated.html:1441
-#: templates/corporate/comparison_table_integrated.html:1442
-#: templates/corporate/comparison_table_integrated.html:1454
-#: templates/corporate/comparison_table_integrated.html:1455
-#: templates/corporate/comparison_table_integrated.html:1467
-#: templates/corporate/comparison_table_integrated.html:1468
-#: templates/corporate/comparison_table_integrated.html:1481
-#: templates/corporate/comparison_table_integrated.html:1482
-#: templates/corporate/comparison_table_integrated.html:1494
-#: templates/corporate/comparison_table_integrated.html:1495
-#: templates/corporate/comparison_table_integrated.html:1507
-#: templates/corporate/comparison_table_integrated.html:1508
-#: templates/corporate/comparison_table_integrated.html:1520
-#: templates/corporate/comparison_table_integrated.html:1521
-#: templates/corporate/comparison_table_integrated.html:1522
-#: templates/corporate/comparison_table_integrated.html:1533
-#: templates/corporate/comparison_table_integrated.html:1534
-#: templates/corporate/comparison_table_integrated.html:1535
-#: templates/corporate/comparison_table_integrated.html:1546
-#: templates/corporate/comparison_table_integrated.html:1547
-#: templates/corporate/comparison_table_integrated.html:1548
-#: templates/corporate/comparison_table_integrated.html:1559
-#: templates/corporate/comparison_table_integrated.html:1560
-#: templates/corporate/comparison_table_integrated.html:1561
-#: templates/corporate/comparison_table_integrated.html:1572
-#: templates/corporate/comparison_table_integrated.html:1573
-#: templates/corporate/comparison_table_integrated.html:1574
-#: templates/corporate/comparison_table_integrated.html:1585
-#: templates/corporate/comparison_table_integrated.html:1586
-#: templates/corporate/comparison_table_integrated.html:1587
-#: templates/corporate/comparison_table_integrated.html:1652
-#: templates/corporate/comparison_table_integrated.html:1653
-#: templates/corporate/comparison_table_integrated.html:1667
-#: templates/corporate/comparison_table_integrated.html:1678
-#: templates/corporate/comparison_table_integrated.html:1679
+#: templates/corporate/comparison_table_integrated.html
 msgid "Self-managed"
 msgstr "自行管理"
 
-#: templates/corporate/comparison_table_integrated.html:282
+#: templates/corporate/comparison_table_integrated.html
 msgid "For organizations with up to 10 users"
 msgstr "適用於最多 10 個使用者的組織"
 
-#: templates/corporate/comparison_table_integrated.html:1125
+#: templates/corporate/comparison_table_integrated.html
 msgid "25 users minimum"
 msgstr "最少 25 個使用者"
 
-#: templates/corporate/comparison_table_integrated.html:1409
-#: templates/corporate/comparison_table_integrated.html:1641
-#: templates/corporate/comparison_table_integrated.html:1642
-#: templates/corporate/comparison_table_integrated.html:1689
-#: templates/corporate/comparison_table_integrated.html:1690
-#: templates/corporate/comparison_table_integrated.html:1700
-#: templates/corporate/comparison_table_integrated.html:1711
-#: templates/corporate/comparison_table_integrated.html:1722
-#: templates/corporate/comparison_table_integrated.html:1723
-#: templates/corporate/comparison_table_integrated.html:1733
-#: templates/corporate/comparison_table_integrated.html:1734
-#: templates/corporate/comparison_table_integrated.html:1735
+#: templates/corporate/comparison_table_integrated.html
 msgid "Not available"
 msgstr "不提供"
 
-#: templates/corporate/development-community.html:16
+#: templates/corporate/development-community.html
 msgid "The Zulip development community"
 msgstr "Zulip 開發社群"
 
-#: templates/corporate/development-community.html:23
-#: templates/corporate/development-community.html:48
+#: templates/corporate/development-community.html
 msgid "Join as a user"
 msgstr "以使用者身份加入"
 
-#: templates/corporate/development-community.html:26
-#: templates/corporate/development-community.html:51
+#: templates/corporate/development-community.html
 msgid "Join as a self-hoster"
 msgstr "以自託管使用者身份加入"
 
-#: templates/corporate/development-community.html:29
-#: templates/corporate/development-community.html:54
+#: templates/corporate/development-community.html
 msgid "Join as a contributor"
 msgstr "以貢獻者身份加入"
 
-#: templates/corporate/for/business.html:18
-#: templates/corporate/for/communities.html:32
-#: templates/corporate/for/communities.html:64
-#: templates/corporate/for/education.html:25
-#: templates/corporate/for/events.html:27
-#: templates/corporate/for/events.html:291
-#: templates/corporate/for/open-source.html:33
-#: templates/corporate/for/open-source.html:743
-#: templates/corporate/for/research.html:29
-#: templates/corporate/for/research.html:464
-#: templates/corporate/for/use-cases.html:17
-#: templates/corporate/role/engineers.html:555
-#: templates/corporate/why-zulip.html:21
-#: templates/zerver/create_realm/create_realm.html:50
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html templates/corporate/why-zulip.html
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create organization"
 msgstr "建立組織"
 
-#: templates/corporate/for/business.html:21
-#: templates/corporate/self-hosting.html:21
-#: templates/corporate/why-zulip.html:24
-#: templates/corporate/zulip-cloud.html:23 templates/zerver/footer.html:47
+#: templates/corporate/for/business.html templates/corporate/self-hosting.html
+#: templates/corporate/why-zulip.html templates/corporate/zulip-cloud.html
+#: templates/zerver/footer.html
 msgid "Get a demo"
 msgstr "取得試用"
 
-#: templates/corporate/for/business.html:24
-#: templates/corporate/for/communities.html:38
-#: templates/corporate/for/communities.html:70
-#: templates/corporate/for/education.html:31
-#: templates/corporate/for/events.html:33
-#: templates/corporate/for/events.html:297
-#: templates/corporate/for/open-source.html:39
-#: templates/corporate/for/open-source.html:749
-#: templates/corporate/for/research.html:35
-#: templates/corporate/for/research.html:470
-#: templates/corporate/for/use-cases.html:23
-#: templates/corporate/role/engineers.html:561
+#: templates/corporate/for/business.html
+#: templates/corporate/for/communities.html
+#: templates/corporate/for/education.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html templates/corporate/for/use-cases.html
+#: templates/corporate/role/engineers.html
 msgid "Self-host Zulip"
 msgstr "自託管 Zulip"
 
-#: templates/corporate/for/communities.html:35
-#: templates/corporate/for/communities.html:67
-#: templates/corporate/for/events.html:30
-#: templates/corporate/for/events.html:294
-#: templates/corporate/for/open-source.html:36
-#: templates/corporate/for/open-source.html:746
-#: templates/corporate/for/research.html:32
-#: templates/corporate/for/research.html:467
+#: templates/corporate/for/communities.html templates/corporate/for/events.html
+#: templates/corporate/for/open-source.html
+#: templates/corporate/for/research.html
 msgid "Request sponsorship"
 msgstr "申請贊助"
 
-#: templates/corporate/for/education.html:28
+#: templates/corporate/for/education.html
 msgid "Education pricing"
 msgstr "教育優惠價格"
 
-#: templates/corporate/for/use-cases.html:20
+#: templates/corporate/for/use-cases.html
 msgid "View pricing"
 msgstr "查看價格"
 
-#: templates/corporate/role/engineers.html:20
-#: templates/corporate/role/engineers.html:558
-#: templates/corporate/self-hosting.html:27
+#: templates/corporate/role/engineers.html
+#: templates/corporate/self-hosting.html
 msgid "Zulip for business"
 msgstr "商務版 Zulip"
 
-#: templates/corporate/role/engineers.html:23
+#: templates/corporate/role/engineers.html
 msgid "Zulip for open source"
 msgstr "開源專案的 Zulip"
 
-#: templates/corporate/role/engineers.html:64
+#: templates/corporate/role/engineers.html
 msgid "Dog in glasses with a laptop"
 msgstr "戴著眼鏡並使用筆電的狗"
 
-#: templates/corporate/role/engineers.html:77
-#: templates/corporate/role/engineers.html:123
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation"
 msgstr "Zulip 對話螢幕截圖"
 
-#: templates/corporate/role/engineers.html:165
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip conversation with sentry bot"
 msgstr "與 sentry bot 對話的 Zulip 畫面截圖"
 
-#: templates/corporate/role/engineers.html:178
-#: templates/corporate/role/engineers.html:215
+#: templates/corporate/role/engineers.html
 msgid "Screenshot of Zulip inbox"
 msgstr "Zulip 收件匣的畫面截圖"
 
-#: templates/corporate/role/engineers.html:262
+#: templates/corporate/role/engineers.html
 msgid "Open laptop with book inside"
 msgstr "打開的筆電，裡面放著一本書"
 
-#: templates/corporate/role/engineers.html:275
-#: templates/corporate/role/engineers.html:333
+#: templates/corporate/role/engineers.html
 msgid "Two hands assembling puzzle"
 msgstr "正在拼拼圖的雙手"
 
-#: templates/corporate/role/engineers.html:364
+#: templates/corporate/role/engineers.html
 msgid "Message with code"
 msgstr "包含程式碼的訊息"
 
-#: templates/corporate/role/engineers.html:403
+#: templates/corporate/role/engineers.html
 msgid "Lightning"
 msgstr "閃電"
 
-#: templates/corporate/role/engineers.html:451
-#: zerver/models/custom_profile_fields.py:123
+#: templates/corporate/role/engineers.html
+#: zerver/models/custom_profile_fields.py
 msgid "Link"
 msgstr "連結"
 
-#: templates/corporate/role/engineers.html:487
+#: templates/corporate/role/engineers.html
 msgid "Ship wheel"
 msgstr "船舵"
 
-#: templates/corporate/support/support_request.html:9
-#: templates/zerver/footer.html:46
+#: templates/corporate/support/support_request.html
+#: templates/zerver/footer.html
 msgid "Contact support"
 msgstr "聯繫技術支援"
 
-#: templates/corporate/support/support_request.html:17
+#: templates/corporate/support/support_request.html
 msgid "From"
 msgstr "寄件者"
 
-#: templates/corporate/support/support_request.html:21
+#: templates/corporate/support/support_request.html
 msgid "Organization"
 msgstr "組織"
 
-#: templates/corporate/support/support_request.html:25
+#: templates/corporate/support/support_request.html
 msgid "Subject"
 msgstr "主旨"
 
-#: templates/corporate/support/support_request.html:29
+#: templates/corporate/support/support_request.html
 msgid "Message"
 msgstr "訊息"
 
-#: templates/corporate/support/support_request.html:35
-#: templates/zerver/slack_import.html:69
+#: templates/corporate/support/support_request.html
+#: templates/zerver/slack_import.html
 msgid "Submit"
 msgstr "送出"
 
-#: templates/corporate/support/support_request_thanks.html:4
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us"
 msgstr "感謝您聯繫我們"
 
-#: templates/corporate/support/support_request_thanks.html:10
+#: templates/corporate/support/support_request_thanks.html
 msgid "Thanks for contacting us!"
 msgstr "感謝您聯繫我們！"
 
-#: templates/corporate/support/support_request_thanks.html:11
+#: templates/corporate/support/support_request_thanks.html
 msgid "We will be in touch with you soon."
 msgstr "我們會盡快與您聯繫。"
 
-#: templates/corporate/support/support_request_thanks.html:13
+#: templates/corporate/support/support_request_thanks.html
 msgid ""
 "You can find answers to frequently asked questions in the <a href=\"/help/"
 "\">Zulip help center</a>."
 msgstr "您可以在 <a href=\"/help/\">Zulip 說明中心</a> 找到常見問題的解答。"
 
-#: templates/corporate/zulip-cloud.html:20
+#: templates/corporate/zulip-cloud.html
 msgid "Get started"
 msgstr "開始使用"
 
-#: templates/corporate/zulipchat_migration_tos.html:3
+#: templates/corporate/zulipchat_migration_tos.html
 msgid ""
 "This team chat is now being hosted on Zulip Cloud. Please accept the <a "
 "href=\"https://zulip.com/policies/terms\">Zulip Terms of Service</a> to "
@@ -1468,49 +955,48 @@ msgstr ""
 "此團隊聊天現在由 Zulip Cloud 託管。請接受 <a href=\"https://zulip.com/"
 "policies/terms\">Zulip 服務條款</a>以繼續使用。"
 
-#: templates/two_factor/_wizard_forms.html:26
+#: templates/two_factor/_wizard_forms.html
 msgid "Or, alternatively, use one of your backup phones:"
 msgstr "或者，您也可以使用其中一支備用手機："
 
-#: templates/two_factor/_wizard_forms.html:37
+#: templates/two_factor/_wizard_forms.html
 msgid "As a last resort, you can use a backup token:"
 msgstr "作為最後手段，您可以使用備用權杖："
 
-#: templates/two_factor/_wizard_forms.html:41
+#: templates/two_factor/_wizard_forms.html
 msgid "Use backup token"
 msgstr "使用備份金鑰"
 
-#: templates/zerver/accounts_accept_terms.html:4
+#: templates/zerver/accounts_accept_terms.html
 msgid "Accept the Terms of Service"
 msgstr "接受服務條款"
 
-#: templates/zerver/accounts_accept_terms.html:18
+#: templates/zerver/accounts_accept_terms.html
 msgid "Welcome to Zulip"
 msgstr "歡迎使用 Zulip"
 
-#: templates/zerver/accounts_accept_terms.html:25
-#: templates/zerver/create_user/accounts_home.html:63
-#: templates/zerver/create_user/register.html:88 templates/zerver/login.html:86
-#: templates/zerver/reset.html:24 templates/zerver/reset_confirm.html:20
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset.html templates/zerver/reset_confirm.html
 msgid "Email"
 msgstr "電子郵件"
 
-#: templates/zerver/accounts_accept_terms.html:48
-#: templates/zerver/create_user/register.html:218
-#: templates/zerver/reset_confirm.html:64
+#: templates/zerver/accounts_accept_terms.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/reset_confirm.html
 msgid "Subscribe me to Zulip's low-traffic newsletter (a few emails a year)."
 msgstr "訂閱 Zulip 的低頻電子報（每年幾封郵件）。"
 
-#: templates/zerver/accounts_accept_terms.html:54
+#: templates/zerver/accounts_accept_terms.html
 msgid "Continue"
 msgstr "繼續"
 
-#: templates/zerver/accounts_send_confirm.html:5
-#: templates/zerver/accounts_send_confirm.html:17
+#: templates/zerver/accounts_send_confirm.html
 msgid "Confirm your email address"
 msgstr "確認您的電子郵件地址"
 
-#: templates/zerver/accounts_send_confirm.html:21
+#: templates/zerver/accounts_send_confirm.html
 #, python-format
 msgid ""
 "To complete your registration, check your email account (<span "
@@ -1520,7 +1006,7 @@ msgstr ""
 "要完成註冊，請檢查您的電子郵件帳號（<span class=\"user_email semi-"
 "bold\">%(email)s</span>）中來自 Zulip 的確認郵件。"
 
-#: templates/zerver/accounts_send_confirm.html:25
+#: templates/zerver/accounts_send_confirm.html
 msgid ""
 "If you don't see a confirmation email in your Inbox or Spam folder, we can "
 "<a href=\"#\" id=\"resend_email_link\">resend it</a>."
@@ -1528,23 +1014,23 @@ msgstr ""
 "如果您在收件夾或垃圾郵件資料夾中沒有看到確認郵件，我們可以<a href=\"#\" "
 "id=\"resend_email_link\">重新發送</a>。"
 
-#: templates/zerver/app/index.html:6
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid "Public view of {org_name} | Zulip team chat"
 msgstr "{org_name} 的公開檢視 | Zulip 團隊聊天"
 
-#: templates/zerver/app/index.html:7
+#: templates/zerver/app/index.html
 #, python-brace-format
 msgid ""
 "Browse the publicly accessible channels in {org_name} without logging in."
 msgstr "無需登入即可瀏覽 {org_name} 中的公開頻道。"
 
-#: templates/zerver/app/index.html:143
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using an unsupported or very old browser, Zulip may not load."
 msgstr "因為您使用的瀏覽器不受支援或版本太舊，Zulip 可能無法載入。"
 
-#: templates/zerver/app/index.html:147
+#: templates/zerver/app/index.html
 msgid ""
 "Because you're using a very old version of the desktop app, Zulip may not "
 "load. <a href=\"https://zulip.com/apps/\" target=\"_blank\" rel=\"noopener "
@@ -1554,44 +1040,43 @@ msgstr ""
 "zulip.com/apps/\" target=\"_blank\" rel=\"noopener noreferrer\">下載最新版"
 "本。</a>"
 
-#: templates/zerver/app/index.html:154
+#: templates/zerver/app/index.html
 msgid ""
 "If this message does not go away, try <a class=\"reload-lnk\">reloading</a> "
 "the page."
 msgstr "如果此訊息沒有消失，請嘗試<a class=\"reload-lnk\">重新載入</a>頁面。"
 
-#: templates/zerver/app/index.html:157
+#: templates/zerver/app/index.html
 msgid ""
 "Error loading Zulip. Try <a class=\"reload-lnk\">reloading</a> the page."
 msgstr ""
 "載入 Zulip 時發生錯誤。請嘗試<a class=\"reload-lnk\">重新載入</a>頁面。"
 
-#: templates/zerver/app/index.html:221
+#: templates/zerver/app/index.html
 msgid "No conversations match your filters."
 msgstr "沒有對話符合您的篩選。"
 
-#: templates/zerver/app/index.html:234
+#: templates/zerver/app/index.html
 msgid "This view is still loading messages."
 msgstr "此檢視仍在載入訊息中。"
 
-#: templates/zerver/app/index.html:237
+#: templates/zerver/app/index.html
 msgid "Load more"
 msgstr "載入更多"
 
-#: templates/zerver/close_window.html:5
+#: templates/zerver/close_window.html
 msgid "Video call ended"
 msgstr "視訊通話已結束"
 
-#: templates/zerver/close_window.html:13
+#: templates/zerver/close_window.html
 msgid "You may now close this window."
 msgstr "您現在可以關閉此視窗。"
 
-#: templates/zerver/config_error/container.html:4
-#: templates/zerver/config_error/container.html:12
+#: templates/zerver/config_error/container.html
 msgid "Configuration error"
 msgstr "設定錯誤"
 
-#: templates/zerver/config_error/ldap.html:4
+#: templates/zerver/config_error/ldap.html
 msgid ""
 "You are trying to log in using LDAP without creating an organization first. "
 "Please use EmailAuthBackend to create your organization and then try again."
@@ -1599,7 +1084,7 @@ msgstr ""
 "您正在嘗試使用 LDAP 登入但尚未建立組織。 請先使用 EmailAuthBackend 建立您的組"
 "織，然後再試一次。"
 
-#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html:4
+#: templates/zerver/config_error/remote_billing_bouncer_not_configured.html
 #, python-format
 msgid ""
 "This server is not configured to use push notifications. For instructions on "
@@ -1609,33 +1094,32 @@ msgstr ""
 "此伺服器未設定為使用推播通知。關於如何設定推播通知的說明， 請參閱<a "
 "href=\"%(doc_url)s\">文件</a>。"
 
-#: templates/zerver/confirm_continue_registration.html:4
+#: templates/zerver/confirm_continue_registration.html
 msgid "Account not found"
 msgstr "找不到帳號"
 
-#: templates/zerver/confirm_continue_registration.html:14
+#: templates/zerver/confirm_continue_registration.html
 msgid "Zulip account not found."
 msgstr "找不到 Zulip 帳號。"
 
-#: templates/zerver/confirm_continue_registration.html:18
+#: templates/zerver/confirm_continue_registration.html
 #, python-format
 msgid "No account found for %(email)s."
 msgstr "找不到帳號 %(email)s 。"
 
-#: templates/zerver/confirm_continue_registration.html:30
+#: templates/zerver/confirm_continue_registration.html
 msgid "Log in with another account"
 msgstr "使用其他帳號登入"
 
-#: templates/zerver/confirm_continue_registration.html:37
+#: templates/zerver/confirm_continue_registration.html
 msgid "Continue to registration"
 msgstr "繼續註冊"
 
-#: templates/zerver/create_realm/create_demo_realm.html:4
-#: templates/zerver/create_realm/create_demo_realm.html:11
+#: templates/zerver/create_realm/create_demo_realm.html
 msgid "Try Zulip in a demo organization"
 msgstr "在 Demo 組織中體驗 Zulip"
 
-#: templates/zerver/create_realm/create_demo_realm.html:13
+#: templates/zerver/create_realm/create_demo_realm.html
 #, python-format
 msgid ""
 "No email required. Or <a class=\"registration-lead-subtitle-link\" "
@@ -1644,19 +1128,19 @@ msgstr ""
 "無需電子郵件。或是 <a class=\"registration-lead-subtitle-link\" "
 "href=\"%(root_domain_url)s/new/\">建立永久組織</a>。"
 
-#: templates/zerver/create_realm/create_demo_realm.html:27
+#: templates/zerver/create_realm/create_demo_realm.html
 msgid "Try Zulip"
 msgstr "試用 Zulip"
 
-#: templates/zerver/create_realm/create_realm.html:5
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new organization"
 msgstr "新增組織"
 
-#: templates/zerver/create_realm/create_realm.html:16
+#: templates/zerver/create_realm/create_realm.html
 msgid "Create a new Zulip organization"
 msgstr "新建一個 Zulip 組織"
 
-#: templates/zerver/create_realm/create_realm.html:19
+#: templates/zerver/create_realm/create_realm.html
 #, python-format
 msgid ""
 "Or <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
@@ -1665,16 +1149,15 @@ msgstr ""
 "或是 <a class=\"registration-lead-subtitle-link\" href=\"%(root_domain_url)s/"
 "new/demo/\">建立示範組織</a> — 無需電子郵件！"
 
-#: templates/zerver/create_realm/create_realm.html:39
-#: templates/zerver/reset.html:27
+#: templates/zerver/create_realm/create_realm.html templates/zerver/reset.html
 msgid "Enter your email address"
 msgstr "輸入您的電子郵件地址"
 
-#: templates/zerver/create_realm/create_realm.html:41
+#: templates/zerver/create_realm/create_realm.html
 msgid "Your email"
 msgstr "您的電子郵件"
 
-#: templates/zerver/create_realm/create_realm.html:64
+#: templates/zerver/create_realm/create_realm.html
 msgid ""
 "Or import from <a href=\"/help/import-from-slack\">Slack</a>, <a href=\"/"
 "help/import-from-mattermost\">Mattermost</a>, or <a href=\"/help/import-from-"
@@ -1684,52 +1167,51 @@ msgstr ""
 "from-mattermost\">Mattermost</a> 或 <a href=\"/help/import-from-"
 "rocketchat\">Rocket.Chat</a> 匯入。"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:3
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "How did you first hear about Zulip?"
 msgstr "您最初是如何得知 Zulip 的？"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:5
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid ""
 "This value is used only if you sign up for a plan, in which case it will be "
 "sent to the Zulip team."
 msgstr "此值僅在您註冊方案時使用，在此情況下將會傳送給 Zulip 團隊。"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:9
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Select an option"
 msgstr "選擇一個選項"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:14
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Please describe"
 msgstr "請描述"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:15
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Where did you see the ad?"
 msgstr "您在哪裡看到廣告？"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:16
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which organization?"
 msgstr "哪個組織？"
 
-#: templates/zerver/create_realm/found_zulip_form_field.html:17
-#: templates/zerver/create_realm/found_zulip_form_field.html:18
+#: templates/zerver/create_realm/found_zulip_form_field.html
 msgid "Which one?"
 msgstr "哪一個？"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:5
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
 msgid "Select one"
 msgstr "請選擇一項"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:14
-#: templates/zerver/create_user/register.html:57
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization type"
 msgstr "組織類型"
 
-#: templates/zerver/create_realm/realm_creation_base_form_fields.html:31
-#: templates/zerver/create_user/register.html:61
+#: templates/zerver/create_realm/realm_creation_base_form_fields.html
+#: templates/zerver/create_user/register.html
 msgid "Organization language"
 msgstr "組織語言"
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:15
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid ""
 "Learn how to import from <a href=\"/help/import-from-"
 "mattermost\">Mattermost</a> or <a href=\"/help/import-from-"
@@ -1738,88 +1220,84 @@ msgstr ""
 "了解如何從 <a href=\"/help/import-from-mattermost\">Mattermost</a> 或 <a "
 "href=\"/help/import-from-rocketchat\">Rocket.Chat</a> 匯入。"
 
-#: templates/zerver/create_realm/realm_creation_import_form_field.html:24
+#: templates/zerver/create_realm/realm_creation_import_form_field.html
 msgid "Import chat history?"
 msgstr "匯入訊息歷史記錄？"
 
-#: templates/zerver/create_realm/realm_creation_name_form_field.html:9
-#: templates/zerver/create_user/register.html:53
+#: templates/zerver/create_realm/realm_creation_name_form_field.html
+#: templates/zerver/create_user/register.html
 msgid "Organization name"
 msgstr "組織名稱"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:4
-#: templates/zerver/create_user/register.html:65
-#: templates/zerver/realm_redirect.html:22
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/register.html
+#: templates/zerver/realm_redirect.html
 msgid "Organization URL"
 msgstr "組織網址"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:11
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
 #, python-format
 msgid "Use %(external_host)s"
 msgstr "使用 %(external_host)s"
 
-#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html:17
-#: templates/zerver/create_user/accounts_home.html:76
-#: templates/zerver/login.html:124 templates/zerver/login.html:145
+#: templates/zerver/create_realm/realm_creation_subdomain_form_field.html
+#: templates/zerver/create_user/accounts_home.html templates/zerver/login.html
 msgid "OR"
 msgstr "或"
 
-#: templates/zerver/create_user/accounts_home.html:5
-#: templates/zerver/create_user/accounts_home.html:72
-#: templates/zerver/create_user/register.html:224
-#: templates/zerver/login.html:163 templates/zerver/portico-header.html:48
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/portico-header.html
 msgid "Sign up"
 msgstr "註冊"
 
-#: templates/zerver/create_user/accounts_home.html:18
+#: templates/zerver/create_user/accounts_home.html
 msgid "Sign up for Zulip"
 msgstr "註冊 Zulip"
 
-#: templates/zerver/create_user/accounts_home.html:37
+#: templates/zerver/create_user/accounts_home.html
 msgid "You need an invitation to join this organization."
 msgstr "您需要邀請才能加入此組織。"
 
-#: templates/zerver/create_user/accounts_home.html:89
+#: templates/zerver/create_user/accounts_home.html
 #, python-format
 msgid "Sign up with %(identity_provider)s"
 msgstr "使用 %(identity_provider)s 註冊"
 
-#: templates/zerver/create_user/accounts_home.html:95
+#: templates/zerver/create_user/accounts_home.html
 msgid "Already have an account?"
 msgstr "已有帳號？"
 
-#: templates/zerver/create_user/accounts_home.html:95
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:21
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:6
-#: templates/zerver/footer.html:18
-#: templates/zerver/log_into_subdomain_token_invalid.html:13
-#: templates/zerver/login.html:5 templates/zerver/login.html:119
-#: templates/zerver/portico-header.html:37
-#: templates/zerver/portico-header.html:44
+#: templates/zerver/create_user/accounts_home.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/footer.html
+#: templates/zerver/log_into_subdomain_token_invalid.html
+#: templates/zerver/login.html templates/zerver/portico-header.html
 msgid "Log in"
 msgstr "登入"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:7
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Configure email address privacy"
 msgstr "設定電子郵件地址隱私"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:16
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Zulip lets you control which roles in the organization can view your email "
 "address."
 msgstr "Zulip 允許您控制組織中哪些角色可以查看您的電子郵件地址。"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:17
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid ""
 "Do you want to change the privacy setting for your email from the default "
 "configuration for this organization?"
 msgstr "您是否要變更電子郵件的隱私設定，不使用此組織的預設設定？"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:19
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 msgid "Who can access your email address"
 msgstr "誰可以存取您的電子郵件地址"
 
-#: templates/zerver/create_user/change_email_address_visibility_modal.html:26
+#: templates/zerver/create_user/change_email_address_visibility_modal.html
 #, python-format
 msgid ""
 "You can also change this setting <a href=\"%(root_domain_url)s/help/"
@@ -1829,101 +1307,100 @@ msgstr ""
 "您也可以在<a href=\"%(root_domain_url)s/help/configure-email-visibility\" "
 "target=\"_blank\" rel=\"noopener noreferrer\">加入後</a>變更此設定。"
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:5
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators of this Zulip organization will be able to see this email "
 "address."
 msgstr "此 Zulip 組織的管理員將能夠看到此電子郵件地址。"
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:8
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Administrators and moderators of this Zulip organization will be able to see "
 "this email address."
 msgstr "此 Zulip 組織的管理員和版主將能夠看到此電子郵件地址。"
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:11
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Nobody in this Zulip organization will be able to see this email address."
 msgstr "此 Zulip 組織中沒有人能夠看到此電子郵件地址。"
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:14
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid ""
 "Other users in this Zulip organization will be able to see this email "
 "address."
 msgstr "此 Zulip 組織中的其他使用者將能夠看到此電子郵件地址。"
 
-#: templates/zerver/create_user/new_user_email_address_visibility.html:18
+#: templates/zerver/create_user/new_user_email_address_visibility.html
 msgid "Change"
 msgstr "變更"
 
-#: templates/zerver/create_user/register.html:5
+#: templates/zerver/create_user/register.html
 msgid "Registration"
 msgstr "註冊"
 
-#: templates/zerver/create_user/register.html:21
+#: templates/zerver/create_user/register.html
 msgid "Create your organization"
 msgstr "建立貴組織"
 
-#: templates/zerver/create_user/register.html:23
+#: templates/zerver/create_user/register.html
 msgid "Create your account"
 msgstr "建立您的帳號"
 
-#: templates/zerver/create_user/register.html:26
+#: templates/zerver/create_user/register.html
 msgid "<p>Enter your account details to complete registration.</p>"
 msgstr "<p>輸入您的帳號詳細資料以完成註冊。</p>"
 
-#: templates/zerver/create_user/register.html:36
+#: templates/zerver/create_user/register.html
 msgid "Your organization"
 msgstr "您的組織"
 
-#: templates/zerver/create_user/register.html:75
+#: templates/zerver/create_user/register.html
 msgid "Your account"
 msgstr "您的帳號"
 
-#: templates/zerver/create_user/register.html:101
+#: templates/zerver/create_user/register.html
 msgid "Don&rsquo;t import settings"
 msgstr "不匯入設定"
 
-#: templates/zerver/create_user/register.html:112
+#: templates/zerver/create_user/register.html
 msgid "Import settings from existing Zulip account"
 msgstr "從現有的 Zulip 帳號匯入設定"
 
-#: templates/zerver/create_user/register.html:124
+#: templates/zerver/create_user/register.html
 msgid "Your full name"
 msgstr "您的全名"
 
-#: templates/zerver/create_user/register.html:125
+#: templates/zerver/create_user/register.html
 msgid "Name"
 msgstr "名稱"
 
-#: templates/zerver/create_user/register.html:132
+#: templates/zerver/create_user/register.html
 msgid "This is how your account is displayed in Zulip."
 msgstr "這是您的帳號在 Zulip 中的顯示方式。"
 
-#: templates/zerver/create_user/register.html:143
-#: templates/zerver/create_user/register.html:156
-#: templates/zerver/login.html:95 templates/zerver/reset_confirm.html:27
+#: templates/zerver/create_user/register.html templates/zerver/login.html
+#: templates/zerver/reset_confirm.html
 msgid "Password"
 msgstr "密碼"
 
-#: templates/zerver/create_user/register.html:146
+#: templates/zerver/create_user/register.html
 msgid "Enter your LDAP/Active Directory password."
 msgstr "輸入您的 LDAP/Active Directory 密碼。"
 
-#: templates/zerver/create_user/register.html:160
+#: templates/zerver/create_user/register.html
 msgid ""
 "This is used for mobile applications and other tools that require a password."
 msgstr "這用於行動應用程式和其他需要密碼的工具。"
 
-#: templates/zerver/create_user/register.html:168
+#: templates/zerver/create_user/register.html
 msgid "Password strength"
 msgstr "密碼強度"
 
-#: templates/zerver/create_user/register.html:177
+#: templates/zerver/create_user/register.html
 msgid "What are you interested in?"
 msgstr "您對什麼感興趣？"
 
-#: templates/zerver/create_user/terms_of_service_form_field.html:14
+#: templates/zerver/create_user/terms_of_service_form_field.html
 #, python-format
 msgid ""
 "I agree to the <a href=\"%(root_domain_url)s/policies/terms\" "
@@ -1932,15 +1409,15 @@ msgstr ""
 "我同意<a href=\"%(root_domain_url)s/policies/terms\" target=\"_blank\" "
 "rel=\"noopener noreferrer\">服務條款</a>。"
 
-#: templates/zerver/deactivated.html:4 templates/zerver/deactivated.html:22
+#: templates/zerver/deactivated.html
 msgid "Deactivated organization"
 msgstr "停用組織"
 
-#: templates/zerver/deactivated.html:20
+#: templates/zerver/deactivated.html
 msgid "Organization moved"
 msgstr "組織已遷移"
 
-#: templates/zerver/deactivated.html:29
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This organization has moved to <a "
@@ -1949,7 +1426,7 @@ msgstr ""
 "此組織已遷移至 <a "
 "href=\"%(deactivated_redirect)s\">%(deactivated_redirect)s</a>。"
 
-#: templates/zerver/deactivated.html:33
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "This page will automatically redirect to the <a "
@@ -1960,13 +1437,13 @@ msgstr ""
 "auto-redirect\">新網址</a> 在 <span id=\"deactivated-org-auto-redirect-"
 "countdown\"> 5 </span> 秒後。"
 
-#: templates/zerver/deactivated.html:38
+#: templates/zerver/deactivated.html
 msgid ""
 "This organization has been deactivated, and all organization data has been "
 "deleted."
 msgstr "此組織已被停用，所有組織資料已被刪除。"
 
-#: templates/zerver/deactivated.html:40
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact Zulip support</a> to "
@@ -1975,7 +1452,7 @@ msgstr ""
 "您可以<a href=\"mailto:%(support_email)s\">聯繫 Zulip 客服</a>洽詢重新使用此"
 "網址建立新組織的相關事宜。"
 
-#: templates/zerver/deactivated.html:44
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "You can <a href=\"mailto:%(support_email)s\">contact this Zulip server's "
@@ -1984,11 +1461,11 @@ msgstr ""
 "您可以<a href=\"mailto:%(support_email)s\">聯繫此 Zulip 伺服器的管理員</a>洽"
 "詢重新使用此網址建立新組織的相關事宜。"
 
-#: templates/zerver/deactivated.html:49
+#: templates/zerver/deactivated.html
 msgid "This organization has been deactivated."
 msgstr "此組織已被停用。"
 
-#: templates/zerver/deactivated.html:51
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -1997,7 +1474,7 @@ msgstr ""
 "如果您是此組織的擁有者，您可以<a href=\"mailto:%(support_email)s\">聯絡 "
 "Zulip 支援</a>以重新啟用。"
 
-#: templates/zerver/deactivated.html:55
+#: templates/zerver/deactivated.html
 msgid ""
 "If you're a member of the organization and want information about why it has "
 "been deactivated, please reach out to the organization's administrators "
@@ -2005,7 +1482,7 @@ msgid ""
 msgstr ""
 "如果您是該組織的成員，並想了解組織被停用的原因，請直接與組織管理員聯繫。"
 
-#: templates/zerver/deactivated.html:59
+#: templates/zerver/deactivated.html
 #, python-format
 msgid ""
 "If you are an owner of this organization, you can <a href=\"mailto:"
@@ -2015,122 +1492,121 @@ msgstr ""
 "如果您是此組織的擁有者，您可以<a href=\"mailto:%(support_email)s\">聯絡此 "
 "Zulip 伺服器的管理員</a>以重新啟用。"
 
-#: templates/zerver/desktop_login.html:5
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop app login"
 msgstr "完成桌面應用程式登入"
 
-#: templates/zerver/desktop_login.html:11
+#: templates/zerver/desktop_login.html
 msgid "Finish desktop login"
 msgstr "完成桌面版登入"
 
-#: templates/zerver/desktop_login.html:14
+#: templates/zerver/desktop_login.html
 msgid ""
 "Use your web browser to finish logging in, then come back here to paste in "
 "your login token."
 msgstr "使用您的瀏覽器完成登入，之後回來這貼上您的登入 token。"
 
-#: templates/zerver/desktop_login.html:18
+#: templates/zerver/desktop_login.html
 msgid "Paste token here"
 msgstr "貼上 token 於此"
 
-#: templates/zerver/desktop_login.html:20
+#: templates/zerver/desktop_login.html
 msgid "Finish"
 msgstr "完成"
 
-#: templates/zerver/desktop_login.html:24
+#: templates/zerver/desktop_login.html
 msgid "Incorrect token."
 msgstr "不正確的 token。"
 
-#: templates/zerver/desktop_login.html:28
+#: templates/zerver/desktop_login.html
 msgid "Token accepted.  Logging you in…"
 msgstr "Token 已接受。您正在登入中…"
 
-#: templates/zerver/desktop_redirect.html:5
+#: templates/zerver/desktop_redirect.html
 msgid "Log in to desktop app"
 msgstr "登入桌面應用程式"
 
-#: templates/zerver/desktop_redirect.html:12
+#: templates/zerver/desktop_redirect.html
 msgid ""
 "Copy this login token and return to your Zulip app to finish logging in:"
 msgstr "複製此登入 token 並回到您的 Zulip 應用程式以完成登入："
 
-#: templates/zerver/desktop_redirect.html:17
+#: templates/zerver/desktop_redirect.html
 msgid "Copy"
 msgstr "複製"
 
-#: templates/zerver/desktop_redirect.html:19
+#: templates/zerver/desktop_redirect.html
 msgid "You may then close this window."
 msgstr "您可以關閉此視窗。"
 
-#: templates/zerver/desktop_redirect.html:20
+#: templates/zerver/desktop_redirect.html
 msgid "Or, continue in your browser."
 msgstr "或在瀏覽器中繼續。"
 
-#: templates/zerver/development/dev_login.html:26
+#: templates/zerver/development/dev_login.html
 msgid "Anonymous user"
 msgstr "匿名使用者"
 
-#: templates/zerver/development/dev_login.html:32 zerver/models/groups.py:23
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Owners"
 msgstr "擁有者"
 
-#: templates/zerver/development/dev_login.html:49 zerver/models/groups.py:24
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Administrators"
 msgstr "組織管理員"
 
-#: templates/zerver/development/dev_login.html:60 zerver/models/groups.py:25
+#: templates/zerver/development/dev_login.html zerver/models/groups.py
 msgid "Moderators"
 msgstr "版主"
 
-#: templates/zerver/development/dev_login.html:71
+#: templates/zerver/development/dev_login.html
 msgid "Guest users"
 msgstr "訪客"
 
-#: templates/zerver/development/dev_login.html:85
+#: templates/zerver/development/dev_login.html
 msgid "Normal users"
 msgstr "普通使用者"
 
-#: templates/zerver/development/email_log.html:32
+#: templates/zerver/development/email_log.html
 msgid "Forward emails to an email account"
 msgstr "轉發電子郵件至電子郵件帳號"
 
-#: templates/zerver/development/email_log.html:68
+#: templates/zerver/development/email_log.html
 msgid "Close"
 msgstr "關閉"
 
-#: templates/zerver/development/email_log.html:70
-#: templates/zerver/slack_import.html:67
+#: templates/zerver/development/email_log.html
+#: templates/zerver/slack_import.html
 msgid "Update"
 msgstr "更新"
 
-#: templates/zerver/development/integrations_dev_panel.html:19
-#: templates/zerver/portico-header.html:8
-#: templates/zerver/portico-header.html:12 zerver/models/realms.py:462
+#: templates/zerver/development/integrations_dev_panel.html
+#: templates/zerver/portico-header.html zerver/models/realms.py
 msgid "Zulip"
 msgstr "Zulip"
 
-#: templates/zerver/digest_base.html:5
+#: templates/zerver/digest_base.html
 msgid "Digest"
 msgstr "摘要"
 
-#: templates/zerver/emails/account_registered.html:10
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: "
 "<b>%(realm_name)s</b>."
 msgstr "恭喜，您已建立了一個新的 Zulip 組織：<b>%(realm_name)s</b>。"
 
-#: templates/zerver/emails/account_registered.html:14
-#: templates/zerver/emails/account_registered.txt:1
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Welcome to Zulip!"
 msgstr "歡迎來到 Zulip！"
 
-#: templates/zerver/emails/account_registered.html:16
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid "You've joined the Zulip organization <b>%(realm_name)s</b>."
 msgstr "您已加入 Zulip 組織 <b>%(realm_name)s</b>。"
 
-#: templates/zerver/emails/account_registered.html:22
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, <a "
@@ -2139,36 +1615,36 @@ msgstr ""
 "您將使用以下資訊登入 Zulip 網頁版、<a href=\"%(apps_page_link)s\">行動裝置和"
 "桌面版</a>應用程式："
 
-#: templates/zerver/emails/account_registered.html:25
-#: templates/zerver/emails/account_registered.txt:12
-#: templates/zerver/emails/confirm_registration.html:13
-#: templates/zerver/emails/confirm_registration.txt:3
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization URL: %(organization_url)s"
 msgstr "組織網址：%(organization_url)s"
 
-#: templates/zerver/emails/account_registered.html:28
-#: templates/zerver/emails/account_registered.txt:16
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your username: %(ldap_username)s"
 msgstr "您的使用者名稱：%(ldap_username)s"
 
-#: templates/zerver/emails/account_registered.html:30
-#: templates/zerver/emails/account_registered.txt:18
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 msgid "Use your LDAP account to log in"
 msgstr "使用您的 LDAP 帳號登入"
 
-#: templates/zerver/emails/account_registered.html:33
-#: templates/zerver/emails/account_registered.txt:21
+#: templates/zerver/emails/account_registered.html
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Your account email: %(email)s"
 msgstr "您的帳號電子郵件：%(email)s"
 
-#: templates/zerver/emails/account_registered.html:37
+#: templates/zerver/emails/account_registered.html
 msgid "Go to organization"
 msgstr "前往組織"
 
-#: templates/zerver/emails/account_registered.html:41
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our <a "
@@ -2177,7 +1653,7 @@ msgstr ""
 "如果您是 Zulip 新手，請查看我們的<a href=\"%(getting_user_started_link)s\">入"
 "門指南</a>！"
 
-#: templates/zerver/emails/account_registered.html:43
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "We also have a guide for <a "
@@ -2187,7 +1663,7 @@ msgstr ""
 "我們也有一份<a href=\"%(getting_organization_started_link)s\">將您的組織遷移"
 "到 Zulip</a> 的指南。"
 
-#: templates/zerver/emails/account_registered.html:49
+#: templates/zerver/emails/account_registered.html
 #, python-format
 msgid ""
 "Questions? <a href=\"mailto:%(support_email)s\">Contact us</a> — we'd love "
@@ -2196,28 +1672,28 @@ msgstr ""
 "有問題嗎？<a href=\"mailto:%(support_email)s\">聯絡我們</a> — 我們很樂意協"
 "助！"
 
-#: templates/zerver/emails/account_registered.subject.txt:2
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new organization details"
 msgstr "Zulip 上的 %(realm_name)s：您的新組織詳細資訊"
 
-#: templates/zerver/emails/account_registered.subject.txt:4
+#: templates/zerver/emails/account_registered.subject.txt
 #, python-format
 msgid "%(realm_name)s on Zulip: Your new account details"
 msgstr "Zulip 上的 %(realm_name)s：您的新帳號詳細資訊"
 
-#: templates/zerver/emails/account_registered.txt:4
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "Congratulations, you have created a new Zulip organization: %(realm_name)s."
 msgstr "恭喜，您已建立了一個新的 Zulip 組織：%(realm_name)s。"
 
-#: templates/zerver/emails/account_registered.txt:6
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "You've joined the Zulip organization %(realm_name)s."
 msgstr "您已加入 Zulip 組織 %(realm_name)s。"
 
-#: templates/zerver/emails/account_registered.txt:10
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "You will use the following info to log into the Zulip web, mobile and "
@@ -2226,7 +1702,7 @@ msgstr ""
 "您將使用以下資訊登入 Zulip 網頁版、行動裝置和桌面版應用程式 "
 "(%(apps_page_link)s)："
 
-#: templates/zerver/emails/account_registered.txt:25
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "If you are new to Zulip, check out our getting started guide "
@@ -2234,7 +1710,7 @@ msgid ""
 msgstr ""
 "如果您是 Zulip 新手，請查看我們的入門指南 (%(getting_user_started_link)s)！"
 
-#: templates/zerver/emails/account_registered.txt:27
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid ""
 "We also have a guide for moving your organization to Zulip "
@@ -2243,17 +1719,17 @@ msgstr ""
 "我們也有一份將您的組織遷移到 Zulip 的指南 "
 "(%(getting_organization_started_link)s)。"
 
-#: templates/zerver/emails/account_registered.txt:32
+#: templates/zerver/emails/account_registered.txt
 #, python-format
 msgid "Questions? Contact us at %(support_email)s — we'd love to help!"
 msgstr "有問題嗎？請透過 %(support_email)s 聯絡我們 — 我們很樂意協助！"
 
-#: templates/zerver/emails/account_registered.txt:34
-#: templates/zerver/emails/confirm_registration.txt:21
-#: templates/zerver/emails/invitation.txt:11
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:23
-#: templates/zerver/emails/realm_reactivation.txt:20
+#: templates/zerver/emails/account_registered.txt
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2261,17 +1737,17 @@ msgid ""
 msgstr ""
 "如果您有任何問題，請透過 %(support_email)s 聯絡此 Zulip 伺服器的管理員。"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:8
-#: templates/zerver/emails/confirm_demo_organization_email.txt:1
-#: templates/zerver/emails/confirm_new_email.html:8
-#: templates/zerver/emails/confirm_new_email.txt:1
-#: templates/zerver/emails/notify_change_in_email.html:8
-#: templates/zerver/emails/notify_change_in_email.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Hi,"
 msgstr "嗨，"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:10
-#: templates/zerver/emails/confirm_demo_organization_email.txt:4
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_demo_organization_email.txt
 #, python-format
 msgid ""
 "We received a request to add the email address %(new_email)s to your Zulip "
@@ -2281,32 +1757,32 @@ msgstr ""
 "我們收到了一個將電子郵件地址 %(new_email)s 加入您在 %(realm_url)s 的 Zulip 試"
 "用組織帳號的請求。要確認此更新並為此帳號設定密碼，請點擊下方："
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:11
+#: templates/zerver/emails/confirm_demo_organization_email.html
 msgid "Confirm and set password"
 msgstr "確認並設定密碼"
 
-#: templates/zerver/emails/confirm_demo_organization_email.html:13
-#: templates/zerver/emails/confirm_new_email.html:13
+#: templates/zerver/emails/confirm_demo_organization_email.html
+#: templates/zerver/emails/confirm_new_email.html
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "%(support_email)s."
 msgstr "如果您沒有請求此變更，請立即透過 %(support_email)s 聯絡我們。"
 
-#: templates/zerver/emails/confirm_demo_organization_email.subject.txt:1
+#: templates/zerver/emails/confirm_demo_organization_email.subject.txt
 msgid "Verify your email address for your Zulip demo organization"
 msgstr "驗證您的 Zulip Demo 組織電子郵件地址"
 
-#: templates/zerver/emails/confirm_demo_organization_email.txt:9
-#: templates/zerver/emails/confirm_new_email.txt:9
+#: templates/zerver/emails/confirm_demo_organization_email.txt
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "If you did not request this change, please contact us immediately at "
 "<%(support_email)s>."
 msgstr "如果您沒有請求此變更，請立即透過 <%(support_email)s> 聯絡我們。"
 
-#: templates/zerver/emails/confirm_new_email.html:10
-#: templates/zerver/emails/confirm_new_email.txt:4
+#: templates/zerver/emails/confirm_new_email.html
+#: templates/zerver/emails/confirm_new_email.txt
 #, python-format
 msgid ""
 "We received a request to change the email address for the Zulip account on "
@@ -2316,65 +1792,65 @@ msgstr ""
 "我們收到了一個將 %(realm_url)s 上 Zulip 帳號的電子郵件地址從 %(old_email)s 變"
 "更為 %(new_email)s 的請求。要確認此變更，請點擊下方："
 
-#: templates/zerver/emails/confirm_new_email.html:11
+#: templates/zerver/emails/confirm_new_email.html
 msgid "Confirm email change"
 msgstr "確認電子郵件變更"
 
-#: templates/zerver/emails/confirm_new_email.subject.txt:1
+#: templates/zerver/emails/confirm_new_email.subject.txt
 #, python-format
 msgid "Verify your new email address for %(organization_host)s"
 msgstr "驗證您在 %(organization_host)s 的新電子郵件地址"
 
-#: templates/zerver/emails/confirm_registration.html:10
-#: templates/zerver/emails/confirm_registration.txt:2
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You have requested a new Zulip organization:"
 msgstr "您已申請一個新的 Zulip 組織："
 
-#: templates/zerver/emails/confirm_registration.html:14
-#: templates/zerver/emails/confirm_registration.txt:5
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 #, python-format
 msgid "Organization type: %(organization_type)s"
 msgstr "組織類型：%(organization_type)s"
 
-#: templates/zerver/emails/confirm_registration.html:18
-#: templates/zerver/emails/confirm_registration.txt:7
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid "You recently signed up for Zulip. Awesome!"
 msgstr "您近期註冊了 Zulip。非常好！"
 
-#: templates/zerver/emails/confirm_registration.html:23
-#: templates/zerver/emails/confirm_registration.txt:12
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/confirm_registration.txt
 msgid ""
 "Click the button below to create the organization and register your account. "
 "You'll be able to update the information above if you like."
 msgstr "點擊下方按鈕建立組織並註冊您的帳號。您可以隨時更新上述資訊。"
 
-#: templates/zerver/emails/confirm_registration.html:25
+#: templates/zerver/emails/confirm_registration.html
 msgid "Click the button below to complete registration."
 msgstr "點擊以下按鈕以完成註冊。"
 
-#: templates/zerver/emails/confirm_registration.html:27
-#: templates/zerver/emails/invitation.html:16
-#: templates/zerver/emails/invitation_reminder.html:14
+#: templates/zerver/emails/confirm_registration.html
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "Complete registration"
 msgstr "完成註冊"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:2
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Create your Zulip organization"
 msgstr "建立您的 Zulip 組織"
 
-#: templates/zerver/emails/confirm_registration.subject.txt:4
+#: templates/zerver/emails/confirm_registration.subject.txt
 msgid "Activate your Zulip account"
 msgstr "啟用您的 Zulip 帳號"
 
-#: templates/zerver/emails/confirm_registration.txt:14
+#: templates/zerver/emails/confirm_registration.txt
 msgid "Click the link below to complete registration."
 msgstr "點擊下方連結以完成註冊。"
 
-#: templates/zerver/emails/confirm_registration.txt:19
-#: templates/zerver/emails/invitation.txt:9
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:21
-#: templates/zerver/emails/realm_reactivation.txt:18
+#: templates/zerver/emails/confirm_registration.txt
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? Contact us at %(support_email)s "
@@ -2382,20 +1858,20 @@ msgid ""
 msgstr ""
 "您有問題或意見要分享嗎？請透過 %(support_email)s 聯絡我們 — 我們很樂意協助！"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:12
-#: templates/zerver/emails/digest.html:55
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/notify_new_login.html
 msgid "Manage email preferences"
 msgstr "管理電子郵件偏好"
 
-#: templates/zerver/emails/custom_email_base.pre.html:23
-#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt:16
+#: templates/zerver/emails/custom_email_base.pre.html
+#: templates/zerver/emails/custom_email_base.pre.manage_preferences_block.txt
 msgid "Unsubscribe from marketing emails"
 msgstr "取消訂閱行銷郵件"
 
-#: templates/zerver/emails/deactivate.html:8
-#: templates/zerver/portico_error_pages/user_deactivated.html:13
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/portico_error_pages/user_deactivated.html
 #, python-format
 msgid ""
 "Your Zulip account on <a href=\"%(realm_url)s\">%(realm_url)s</a> has been "
@@ -2404,28 +1880,28 @@ msgstr ""
 "您在 <a href=\"%(realm_url)s\">%(realm_url)s</a> 的 Zulip 帳號已被停用，您將"
 "無法再登入。"
 
-#: templates/zerver/emails/deactivate.html:15
-#: templates/zerver/emails/deactivate.txt:6
+#: templates/zerver/emails/deactivate.html
+#: templates/zerver/emails/deactivate.txt
 msgid "The administrators provided the following comment:"
 msgstr "管理員提供了以下意見："
 
-#: templates/zerver/emails/deactivate.subject.txt:1
+#: templates/zerver/emails/deactivate.subject.txt
 #, python-format
 msgid "Notification of account deactivation on %(realm_name)s"
 msgstr "%(realm_name)s 帳號停用通知"
 
-#: templates/zerver/emails/deactivate.txt:1
+#: templates/zerver/emails/deactivate.txt
 #, python-format
 msgid ""
 "Your Zulip account on %(realm_url)s has been deactivated, and you will no "
 "longer be able to log in."
 msgstr "您在 %(realm_url)s 的 Zulip 帳號已被停用，您將無法再登入。"
 
-#: templates/zerver/emails/digest.html:28 templates/zerver/emails/digest.txt:9
+#: templates/zerver/emails/digest.html templates/zerver/emails/digest.txt
 msgid "New channels"
 msgstr "新頻道"
 
-#: templates/zerver/emails/digest.html:35
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2435,7 +1911,7 @@ msgstr ""
 "您在 <a href=\"%(realm_url)s\">%(realm_name)s</a> 有 %(new_messages_count)s "
 "則新訊息，以及 %(new_streams_count)s 個新頻道。"
 
-#: templates/zerver/emails/digest.html:37
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages in <a "
@@ -2444,7 +1920,7 @@ msgstr ""
 "您在 <a href=\"%(realm_url)s\">%(realm_name)s</a> 有 %(new_messages_count)s "
 "則新訊息。"
 
-#: templates/zerver/emails/digest.html:39
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid ""
 "There are %(new_streams_count)s new channels in <a "
@@ -2453,8 +1929,8 @@ msgstr ""
 "<a href=\"%(realm_url)s\">%(realm_name)s</a> 有 %(new_streams_count)s 個新頻"
 "道。"
 
-#: templates/zerver/emails/digest.html:44
-#: templates/zerver/emails/missed_message.html:17
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because your organization <a "
@@ -2464,8 +1940,8 @@ msgstr ""
 "此電子郵件不包含訊息內容，因為您的組織在電子郵件通知中<a "
 "class=\"content_disabled_help_link\" href=\"%(help_url)s\">隱藏訊息內容</a>。"
 
-#: templates/zerver/emails/digest.html:46
-#: templates/zerver/emails/missed_message.html:19
+#: templates/zerver/emails/digest.html
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to <a "
@@ -2475,21 +1951,21 @@ msgstr ""
 "此電子郵件不包含訊息內容，因為您選擇在電子郵件通知中<a "
 "class=\"content_disabled_help_link\" href=\"%(help_url)s\">隱藏訊息內容</a>。"
 
-#: templates/zerver/emails/digest.html:50
+#: templates/zerver/emails/digest.html
 #, python-format
 msgid "<a href=\"%(realm_url)s\">Log in</a> to Zulip to catch up."
 msgstr "<a href=\"%(realm_url)s\">登入</a> Zulip 查看最新動態。"
 
-#: templates/zerver/emails/digest.html:56
+#: templates/zerver/emails/digest.html
 msgid "Unsubscribe from digest emails"
 msgstr "取消訂閱摘要郵件"
 
-#: templates/zerver/emails/digest.subject.txt:1
+#: templates/zerver/emails/digest.subject.txt
 #, python-format
 msgid "Zulip digest for %(realm_name)s"
 msgstr "%(realm_name)s 的 Zulip 摘要"
 
-#: templates/zerver/emails/digest.txt:14
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid ""
 "You have %(new_messages_count)s new messages, and there are "
@@ -2498,18 +1974,18 @@ msgstr ""
 "您在 %(realm_name)s 有 %(new_messages_count)s 則新訊息，以及 "
 "%(new_streams_count)s 個新頻道。"
 
-#: templates/zerver/emails/digest.txt:16
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "You have %(new_messages_count)s new messages in %(realm_name)s."
 msgstr "您在 %(realm_name)s 有 %(new_messages_count)s 則新訊息。"
 
-#: templates/zerver/emails/digest.txt:18
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "There are %(new_streams_count)s new channels in %(realm_name)s."
 msgstr "%(realm_name)s 有 %(new_streams_count)s 個新頻道。"
 
-#: templates/zerver/emails/digest.txt:22
-#: templates/zerver/emails/missed_message.txt:11
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because your organization hides "
@@ -2519,8 +1995,8 @@ msgstr ""
 "此電子郵件不包含訊息內容，因為您的組織在電子郵件通知中隱藏訊息內容。詳情請參"
 "見 %(hide_content_url)s。"
 
-#: templates/zerver/emails/digest.txt:26
-#: templates/zerver/emails/missed_message.txt:15
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "This email does not include message content because you have chosen to hide "
@@ -2529,40 +2005,37 @@ msgstr ""
 "此電子郵件不包含訊息內容，因為您選擇在電子郵件通知中隱藏訊息內容。詳情請參見 "
 "%(help_url)s。"
 
-#: templates/zerver/emails/digest.txt:32
+#: templates/zerver/emails/digest.txt
 #, python-format
 msgid "Log in to Zulip to catch up: %(organization_url)s."
 msgstr "登入 Zulip 查看最新動態：%(organization_url)s。"
 
-#: templates/zerver/emails/digest.txt:35
-#: templates/zerver/emails/missed_message.txt:60
+#: templates/zerver/emails/digest.txt
+#: templates/zerver/emails/missed_message.txt
 msgid "Manage email preferences:"
 msgstr "管理電子郵件偏好："
 
-#: templates/zerver/emails/digest.txt:39
+#: templates/zerver/emails/digest.txt
 msgid "Unsubscribe from digest emails:"
 msgstr "取消訂閱摘要郵件："
 
-#: templates/zerver/emails/email_base_default.html:33
-#: templates/zerver/emails/email_base_marketing.html:33
+#: templates/zerver/emails/email_base_default.html
+#: templates/zerver/emails/email_base_marketing.html
 msgid "Swimming fish"
 msgstr "游泳的魚"
 
-#: templates/zerver/emails/find_team.html:9
-#: templates/zerver/emails/find_team.txt:2
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Thanks for your request!"
 msgstr "感謝您的請求！"
 
-#: templates/zerver/emails/find_team.html:12
-#: templates/zerver/emails/find_team.txt:5
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip Cloud "
 "organizations:"
 msgstr "您的電子郵件地址 %(email)s 擁有以下 Zulip Cloud 組織的帳號："
 
-#: templates/zerver/emails/find_team.html:14
-#: templates/zerver/emails/find_team.txt:7
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Your email address %(email)s has accounts with the following Zulip "
@@ -2571,7 +2044,7 @@ msgstr ""
 "您的電子郵件地址 %(email)s 擁有以下由 %(external_host)s 託管的 Zulip 組織帳"
 "號："
 
-#: templates/zerver/emails/find_team.html:24
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "If you have trouble logging in, you can <a "
@@ -2580,26 +2053,22 @@ msgstr ""
 "如果您在登入時遇到困難，您可以<a href=\"%(help_reset_password_link)s\">重設密"
 "碼</a>。"
 
-#: templates/zerver/emails/find_team.html:28
-#: templates/zerver/emails/find_team.txt:21
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "You have requested a list of Zulip accounts for this email address."
 msgstr "您已請求此電子郵件地址的 Zulip 帳號清單。"
 
-#: templates/zerver/emails/find_team.html:30
-#: templates/zerver/emails/find_team.txt:21
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "Unfortunately, no Zulip Cloud accounts were found."
 msgstr "很抱歉，未找到 Zulip Cloud 帳號。"
 
-#: templates/zerver/emails/find_team.html:32
-#: templates/zerver/emails/find_team.txt:28
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "Unfortunately, no accounts were found in Zulip organizations hosted by "
 "%(external_host)s."
 msgstr "很抱歉，在由 %(external_host)s 託管的 Zulip 組織中未找到帳號。"
 
-#: templates/zerver/emails/find_team.html:37
+#: templates/zerver/emails/find_team.html
 #, python-format
 msgid ""
 "You can <a href = \"%(find_accounts_link)s\" >check for accounts</a> with "
@@ -2609,26 +2078,23 @@ msgstr ""
 "您可以<a href = \"%(find_accounts_link)s\" >使用其他電子郵件查詢帳號</a>，或"
 "<a href =\"%(help_logging_in_link)s\">嘗試其他方式</a> 尋找您的帳號。"
 
-#: templates/zerver/emails/find_team.html:38
-#: templates/zerver/emails/find_team.txt:26
-#: templates/zerver/emails/find_team.txt:34
+#: templates/zerver/emails/find_team.html templates/zerver/emails/find_team.txt
 msgid "If you do not recognize this request, you can safely ignore this email."
 msgstr "如果您不認得此請求，可以安全地忽略此郵件。"
 
-#: templates/zerver/emails/find_team.subject.txt:2
+#: templates/zerver/emails/find_team.subject.txt
 msgid "Your Zulip accounts"
 msgstr "您的 Zulip 帳號"
 
-#: templates/zerver/emails/find_team.subject.txt:4
+#: templates/zerver/emails/find_team.subject.txt
 msgid "No Zulip accounts found"
 msgstr "未找到 Zulip 帳號"
 
-#: templates/zerver/emails/find_team.txt:15
+#: templates/zerver/emails/find_team.txt
 msgid "If you have trouble logging in, you can reset your password."
 msgstr "如果您在登入時遇到困難，您可以重設密碼。"
 
-#: templates/zerver/emails/find_team.txt:23
-#: templates/zerver/emails/find_team.txt:31
+#: templates/zerver/emails/find_team.txt
 #, python-format
 msgid ""
 "You can check for accounts with another email (%(find_accounts_link)s), or "
@@ -2637,12 +2103,12 @@ msgstr ""
 "您可以使用其他電子郵件查詢帳號 (%(find_accounts_link)s)，或 嘗試其他方式尋找"
 "您的帳號 (%(help_logging_in_link)s)。"
 
-#: templates/zerver/emails/invitation.html:9
-#: templates/zerver/emails/invitation.txt:1
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation.txt
 msgid "Hi there,"
 msgstr "嗨，"
 
-#: templates/zerver/emails/invitation.html:12
+#: templates/zerver/emails/invitation.html
 #, python-format
 msgid ""
 "%(referrer_name)s wants you to join them on Zulip &mdash; the team "
@@ -2651,17 +2117,17 @@ msgstr ""
 "%(referrer_name)s 希望您在 Zulip 加入他們。 Zulip -- 專為提升生產力設計的團隊"
 "溝通工具。"
 
-#: templates/zerver/emails/invitation.html:15
-#: templates/zerver/emails/invitation_reminder.html:13
+#: templates/zerver/emails/invitation.html
+#: templates/zerver/emails/invitation_reminder.html
 msgid "To get started, click the button below."
 msgstr "點擊下方按鈕開始。"
 
-#: templates/zerver/emails/invitation.subject.txt:1
+#: templates/zerver/emails/invitation.subject.txt
 #, python-format
 msgid "%(referrer_full_name)s has invited you to join %(referrer_realm_name)s"
 msgstr "%(referrer_full_name)s 已邀請您加入 %(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation.txt:3
+#: templates/zerver/emails/invitation.txt
 #, python-format
 msgid ""
 "%(referrer_full_name)s (%(referrer_email)s) wants you to join them on Zulip "
@@ -2670,17 +2136,17 @@ msgstr ""
 "%(referrer_full_name)s (%(referrer_email)s) 希望您加入他們在 Zulip -- 專為提"
 "升生產力設計的團隊溝通工具。"
 
-#: templates/zerver/emails/invitation.txt:5
-#: templates/zerver/emails/invitation_reminder.txt:5
+#: templates/zerver/emails/invitation.txt
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "To get started, click the link below."
 msgstr "點擊下方連結開始。"
 
-#: templates/zerver/emails/invitation_reminder.html:8
-#: templates/zerver/emails/invitation_reminder.txt:1
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "Hi again,"
 msgstr "再次問好，"
 
-#: templates/zerver/emails/invitation_reminder.html:10
+#: templates/zerver/emails/invitation_reminder.html
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s wants you to join them on "
@@ -2689,13 +2155,13 @@ msgstr ""
 "這是一個友善的提醒，%(referrer_name)s 希望您在 Zulip 加入他們。 Zulip -- 專為"
 "提升生產力設計的團隊溝通工具。"
 
-#: templates/zerver/emails/invitation_reminder.html:18
-#: templates/zerver/emails/invitation_reminder.txt:8
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 msgid "This is the last reminder you'll receive for this invitation."
 msgstr "這是您將收到的此邀請的最後一次提醒。"
 
-#: templates/zerver/emails/invitation_reminder.html:22
-#: templates/zerver/emails/invitation_reminder.txt:10
+#: templates/zerver/emails/invitation_reminder.html
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This invitation expires in two days. If the invitation expires, you'll need "
@@ -2703,12 +2169,12 @@ msgid ""
 msgstr ""
 "此邀請將在兩天後過期。如果邀請過期，您需要向 %(referrer_name)s 請求新的邀請。"
 
-#: templates/zerver/emails/invitation_reminder.subject.txt:1
+#: templates/zerver/emails/invitation_reminder.subject.txt
 #, python-format
 msgid "Reminder: Join %(referrer_name)s at %(referrer_realm_name)s"
 msgstr "提醒：加入 %(referrer_name)s 在 %(referrer_realm_name)s"
 
-#: templates/zerver/emails/invitation_reminder.txt:3
+#: templates/zerver/emails/invitation_reminder.txt
 #, python-format
 msgid ""
 "This is a friendly reminder that %(referrer_name)s (%(referrer_email)s) "
@@ -2718,7 +2184,7 @@ msgstr ""
 "這是一個友善的提醒，%(referrer_name)s (%(referrer_email)s) 希望您加入他們在 "
 "Zulip -- 專為提升生產力設計的團隊溝通工具。"
 
-#: templates/zerver/emails/macros.html:14
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "If you have any questions, please contact this Zulip server's administrators "
@@ -2727,7 +2193,7 @@ msgstr ""
 "如果您有任何問題，請透過 <a href=\"mailto:%(email)s\">%(email)s</a> 聯絡此 "
 "Zulip 伺服器的管理員。"
 
-#: templates/zerver/emails/macros.html:18
+#: templates/zerver/emails/macros.html
 #, python-format
 msgid ""
 "Do you have questions or feedback to share? <a href=\"mailto:"
@@ -2736,22 +2202,20 @@ msgstr ""
 "您有問題或意見要分享嗎？<a href=\"mailto:%(email)s\">聯絡我們</a> — 我們很樂"
 "意協助！"
 
-#: templates/zerver/emails/missed_message.html:29
-#: templates/zerver/emails/missed_message.txt:23
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid "You are receiving this because you were personally mentioned."
 msgstr "您收到此郵件是因為您被個人「@-提及」。"
 
-#: templates/zerver/emails/missed_message.html:31
-#: templates/zerver/emails/missed_message.txt:25
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because @%(mentioned_user_group_name)s was mentioned."
 msgstr "您收到此郵件是因為 被%(mentioned_user_group_name)s 「@-提及」。"
 
-#: templates/zerver/emails/missed_message.html:33
-#: templates/zerver/emails/missed_message.html:37
-#: templates/zerver/emails/missed_message.txt:27
-#: templates/zerver/emails/missed_message.txt:31
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because all topic participants were mentioned in "
@@ -2760,36 +2224,36 @@ msgstr ""
 "您收到此郵件是因為在 #%(channel_name)s > %(topic_name)s 中「@-提及」了所有議"
 "題參與者。"
 
-#: templates/zerver/emails/missed_message.html:35
-#: templates/zerver/emails/missed_message.txt:29
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have wildcard mention notifications "
 "enabled for topics you follow."
 msgstr "您收到此郵件是因為您已啟用您追蹤議題的萬用字元「@-提及」通知。"
 
-#: templates/zerver/emails/missed_message.html:39
-#: templates/zerver/emails/missed_message.txt:33
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because everyone was mentioned in #%(channel_name)s."
 msgstr "您收到此郵件是因為在 #%(channel_name)s 中「@-提及」了所有人。"
 
-#: templates/zerver/emails/missed_message.html:41
-#: templates/zerver/emails/missed_message.txt:35
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "topics you follow."
 msgstr "您收到此郵件是因為您已啟用追蹤議題的電子郵件通知。"
 
-#: templates/zerver/emails/missed_message.html:43
-#: templates/zerver/emails/missed_message.txt:37
+#: templates/zerver/emails/missed_message.html
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid ""
 "You are receiving this because you have email notifications enabled for "
 "#%(channel_name)s."
 msgstr "您收到此郵件是因為您已啟用 #%(channel_name)s 的電子郵件通知。"
 
-#: templates/zerver/emails/missed_message.html:46
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Reply to this email directly, <a href=\"%(narrow_url)s\">view it in "
@@ -2799,7 +2263,7 @@ msgstr ""
 "直接回覆此郵件，<a href=\"%(narrow_url)s\">在 %(realm_name)s Zulip 中查看</"
 "a>，或<a href=\"%(notif_url)s\">管理電子郵件 偏好</a>。"
 
-#: templates/zerver/emails/missed_message.html:48
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">View or reply in %(realm_name)s Zulip</a>, or <a "
@@ -2808,7 +2272,7 @@ msgstr ""
 "<a href=\"%(narrow_url)s\">在 %(realm_name)s Zulip 中查看或回覆</a>，或<a "
 "href=\"%(notif_url)s\">管理電子郵件偏好</a>。"
 
-#: templates/zerver/emails/missed_message.html:50
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "<a href=\"%(narrow_url)s\">Reply in %(realm_name)s Zulip</a>, or <a "
@@ -2817,7 +2281,7 @@ msgstr ""
 "<a href=\"%(narrow_url)s\">在 %(realm_name)s Zulip 中回覆</a>，或<a "
 "href=\"%(notif_url)s\">管理電子郵件偏好</a>。"
 
-#: templates/zerver/emails/missed_message.html:52
+#: templates/zerver/emails/missed_message.html
 #, python-format
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
@@ -2826,47 +2290,47 @@ msgstr ""
 "請勿回覆此郵件。此 Zulip 伺服器未設定為接收外來郵件（<a href=\"%(url)s\">說明"
 "</a>）。"
 
-#: templates/zerver/emails/missed_message.subject.txt:2
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "Group DMs with %(direct_message_group_display_name)s"
 msgstr "與 %(direct_message_group_display_name)s 的群組私人訊息"
 
-#: templates/zerver/emails/missed_message.subject.txt:3
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "DMs with %(sender_str)s"
 msgstr "與 %(sender_str)s 的私訊"
 
-#: templates/zerver/emails/missed_message.subject.txt:12
+#: templates/zerver/emails/missed_message.subject.txt
 #, python-format
 msgid "[resolved] #%(channel_name)s > %(topic_name)s"
 msgstr "[解決] #%(channel_name)s > %(topic_name)s"
 
-#: templates/zerver/emails/missed_message.subject.txt:17
+#: templates/zerver/emails/missed_message.subject.txt
 msgid "New messages"
 msgstr "新訊息"
 
-#: templates/zerver/emails/missed_message.txt:41
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply to this email directly, or view it in %(realm_name)s Zulip:"
 msgstr "直接回覆此郵件，或在 %(realm_name)s Zulip 中查看："
 
-#: templates/zerver/emails/missed_message.txt:45
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "View or reply in %(realm_name)s Zulip:"
 msgstr "在 %(realm_name)s Zulip 中查看或回覆："
 
-#: templates/zerver/emails/missed_message.txt:49
+#: templates/zerver/emails/missed_message.txt
 #, python-format
 msgid "Reply in %(realm_name)s Zulip:"
 msgstr "在 %(realm_name)s Zulip 中回覆："
 
-#: templates/zerver/emails/missed_message.txt:53
+#: templates/zerver/emails/missed_message.txt
 msgid ""
 "Do not reply to this email. This Zulip server is not configured to accept "
 "incoming emails. Help:"
 msgstr "請勿回覆此郵件。此 Zulip 伺服器未設定為接收外來郵件。說明："
 
-#: templates/zerver/emails/notify_change_in_email.html:10
+#: templates/zerver/emails/notify_change_in_email.html
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2876,22 +2340,22 @@ msgstr ""
 "您 Zulip 帳號關聯的電子郵件地址最近已變更為 %(new_email)s。如果您沒有請求此變"
 "更，請立即透過 %(support_email)s 聯絡我們。"
 
-#: templates/zerver/emails/notify_change_in_email.html:13
-#: templates/zerver/emails/notify_change_in_email.txt:6
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Best,"
 msgstr "最好的，"
 
-#: templates/zerver/emails/notify_change_in_email.html:14
-#: templates/zerver/emails/notify_change_in_email.txt:7
+#: templates/zerver/emails/notify_change_in_email.html
+#: templates/zerver/emails/notify_change_in_email.txt
 msgid "Team Zulip"
 msgstr "Zulip 團隊"
 
-#: templates/zerver/emails/notify_change_in_email.subject.txt:1
+#: templates/zerver/emails/notify_change_in_email.subject.txt
 #, python-format
 msgid "Zulip email changed for %(realm_name)s"
 msgstr "%(realm_name)s 的 Zulip 電子郵件已變更"
 
-#: templates/zerver/emails/notify_change_in_email.txt:3
+#: templates/zerver/emails/notify_change_in_email.txt
 #, python-format
 msgid ""
 "The email associated with your Zulip account was recently changed to "
@@ -2901,53 +2365,53 @@ msgstr ""
 "您 Zulip 帳號關聯的電子郵件地址最近已變更為 %(new_email)s。如果您沒有請求此變"
 "更，請立即透過 <%(support_email)s> 聯絡我們。"
 
-#: templates/zerver/emails/notify_new_login.html:4
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "Organization: %(organization_url)s Time: %(login_time)s Email: %(user_email)s"
 msgstr ""
 "組織：%(organization_url)s 時間：%(login_time)s 電子郵件：%(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:12
-#: templates/zerver/emails/notify_new_login.txt:1
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "We noticed a recent login for the following Zulip account."
 msgstr "我們注意到以下 Zulip 帳號最近有登入活動。"
 
-#: templates/zerver/emails/notify_new_login.html:15
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid "Organization: %(organization_link)s"
 msgstr "組織：%(organization_link)s"
 
-#: templates/zerver/emails/notify_new_login.html:18
-#: templates/zerver/emails/notify_new_login.txt:5
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Email: %(user_email)s"
 msgstr "電子郵件：%(user_email)s"
 
-#: templates/zerver/emails/notify_new_login.html:21
-#: templates/zerver/emails/notify_new_login.txt:7
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Time: %(login_time)s"
 msgstr "時間：%(login_time)s"
 
-#: templates/zerver/emails/notify_new_login.html:24
-#: templates/zerver/emails/notify_new_login.txt:9
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Device: %(device_browser)s on %(device_os)s."
 msgstr "設備：%(device_browser)s 在 %(device_os)s。"
 
-#: templates/zerver/emails/notify_new_login.html:27
-#: templates/zerver/emails/notify_new_login.txt:11
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "IP address: %(device_ip)s"
 msgstr "IP 地址：%(device_ip)s"
 
-#: templates/zerver/emails/notify_new_login.html:31
-#: templates/zerver/emails/notify_new_login.txt:14
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "If this was you, great! There's nothing else you need to do."
 msgstr "如果這是您本人的操作，太好了！您不需要做任何其他事情。"
 
-#: templates/zerver/emails/notify_new_login.html:34
+#: templates/zerver/emails/notify_new_login.html
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2957,31 +2421,31 @@ msgstr ""
 "如果你對這次登入感到陌生，或認為你的帳號可能已遭入侵，請<a "
 "href=\"%(reset_link)s\">重設你的密碼</a>，或立即聯絡我們：%(support_email)s。"
 
-#: templates/zerver/emails/notify_new_login.html:38
-#: templates/zerver/emails/notify_new_login.txt:20
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Thanks,"
 msgstr "感謝，"
 
-#: templates/zerver/emails/notify_new_login.html:39
-#: templates/zerver/emails/notify_new_login.txt:21
+#: templates/zerver/emails/notify_new_login.html
+#: templates/zerver/emails/notify_new_login.txt
 msgid "Zulip Security"
 msgstr "Zulip 安全性"
 
-#: templates/zerver/emails/notify_new_login.html:44
+#: templates/zerver/emails/notify_new_login.html
 msgid "Unsubscribe from login notifications"
 msgstr "從登入通知取消訂閱"
 
-#: templates/zerver/emails/notify_new_login.subject.txt:1
+#: templates/zerver/emails/notify_new_login.subject.txt
 #, python-format
 msgid "New login from %(device_browser)s on %(device_os)s"
 msgstr "在 %(device_os)s 從 %(device_browser)s 有新登入"
 
-#: templates/zerver/emails/notify_new_login.txt:3
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid "Organization: %(organization_url)s"
 msgstr "組織：%(organization_url)s"
 
-#: templates/zerver/emails/notify_new_login.txt:16
+#: templates/zerver/emails/notify_new_login.txt
 #, python-format
 msgid ""
 "If you do not recognize this login, or think your account may have been "
@@ -2991,7 +2455,7 @@ msgstr ""
 "如果您不認識此次登入，或認為您的帳戶可能已被入侵，請前往 %(reset_link)s 重設"
 "您的密碼，或立即透過 %(support_email)s 聯絡我們。"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:10
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
@@ -3001,14 +2465,14 @@ msgstr ""
 "如果您已經決定為您的組織使用 Zulip，歡迎您！您可以使用我們的<a "
 "href=\"%(get_organization_started)s\">Zulip 遷移指南</a>來開始使用。"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:13
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "<i>any</i> team chat product:"
 msgstr ""
 "否則，以下是我們經常從客戶那裡聽到的關於評估<i>任何</i>團隊聊天產品的建議："
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:16
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(invite_users)s\"><b>Invite your teammates</b></a> to explore "
@@ -3017,12 +2481,12 @@ msgstr ""
 "<a href=\"%(invite_users)s\"><b>邀請您的團隊成員</b></a>與您一起探索並分享他"
 "們獨特的觀點。"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:17
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid "Use the app itself to chat about your impressions."
 msgstr "使用應用程式本身來聊天分享您的印象。"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:19
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "<a href=\"%(trying_out_zulip)s\"><b>Run a week-long trial</b></a> with your "
@@ -3033,7 +2497,7 @@ msgstr ""
 "使用任何其他聊天工具。這是真正體驗新聊天應用程式如何幫助您的團隊溝通的唯一方"
 "式。"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:23
+#: templates/zerver/emails/onboarding_team_to_zulip.html
 #, python-format
 msgid ""
 "Zulip is designed to <a href=\"%(why_zulip)s\">enable efficient "
@@ -3043,21 +2507,21 @@ msgstr ""
 "Zulip 的設計旨在<a href=\"%(why_zulip)s\">實現高效溝通</a>，我們希望這些提示"
 "能幫助您的團隊在實際使用中體驗到這一點。"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.html:38
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:19
-#: templates/zerver/emails/onboarding_zulip_guide.html:40
-#: templates/zerver/emails/onboarding_zulip_guide.txt:27
-#: templates/zerver/emails/onboarding_zulip_topics.html:34
-#: templates/zerver/emails/onboarding_zulip_topics.txt:14
+#: templates/zerver/emails/onboarding_team_to_zulip.html
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid "Unsubscribe from welcome emails for %(realm_name)s"
 msgstr "取消訂閱 %(realm_name)s 的歡迎郵件"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.subject.txt
 msgid "Choosing the chat app for your team"
 msgstr "為您的團隊選擇聊天應用程式"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:1
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "If you've already decided to use Zulip for your organization, welcome! You "
 "can use our guide for moving to Zulip to get started."
@@ -3065,19 +2529,19 @@ msgstr ""
 "如果您已經決定為您的組織使用 Zulip，歡迎您！您可以使用我們的 Zulip 遷移指南來"
 "開始使用。"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:3
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Otherwise, here is some advice we often hear from customers for evaluating "
 "any team chat product:"
 msgstr "否則，以下是我們經常從客戶那裡聽到的關於評估任何團隊聊天產品的建議："
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:6
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Invite your teammates to explore with you and share their unique "
 "perspectives."
 msgstr "邀請您的團隊成員與您一起探索並分享他們獨特的觀點。"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:8
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Run a week-long trial with your team, without using any other chat tools. "
 "This is the only way to truly experience how a new chat app will help your "
@@ -3086,7 +2550,7 @@ msgstr ""
 "與您的團隊進行為期一週的試用，不使用任何其他聊天工具。這是真正體驗新聊天應用"
 "程式如何幫助您的團隊溝通的唯一方式。"
 
-#: templates/zerver/emails/onboarding_team_to_zulip.txt:10
+#: templates/zerver/emails/onboarding_team_to_zulip.txt
 msgid ""
 "Zulip is designed to enable efficient communication, and we hope these tips "
 "help your team experience it in action."
@@ -3094,8 +2558,8 @@ msgstr ""
 "Zulip 的設計旨在實現高效溝通，我們希望這些提示能幫助您的團隊在實際使用中體驗"
 "到這一點。"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:9
-#: templates/zerver/emails/onboarding_zulip_guide.txt:1
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid ""
 "As you are getting started with Zulip, we'd love to help you discover how it "
 "can work best for your needs. Check out this guide to key Zulip features for "
@@ -3104,85 +2568,85 @@ msgstr ""
 "當您開始使用 Zulip 時，我們很樂意幫助您了解如何讓它最好地滿足您的需求。請查看"
 "這份針對像您這樣的組織的 Zulip 核心功能指南！"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:13
-#: templates/zerver/emails/onboarding_zulip_guide.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for businesses"
 msgstr "查看 Zulip 企業指南"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:15
-#: templates/zerver/emails/onboarding_zulip_guide.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for open-source projects"
 msgstr "查看 Zulip 開源專案指南"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:17
-#: templates/zerver/emails/onboarding_zulip_guide.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for education"
 msgstr "查看 Zulip 教育指南"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:19
-#: templates/zerver/emails/onboarding_zulip_guide.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for research"
 msgstr "查看 Zulip 研究指南"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:21
-#: templates/zerver/emails/onboarding_zulip_guide.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for events and conferences"
 msgstr "查看 Zulip 活動與會議指南"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:23
-#: templates/zerver/emails/onboarding_zulip_guide.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for non-profits"
 msgstr "查看 Zulip 非營利組織指南"
 
-#: templates/zerver/emails/onboarding_zulip_guide.html:25
-#: templates/zerver/emails/onboarding_zulip_guide.txt:16
+#: templates/zerver/emails/onboarding_zulip_guide.html
+#: templates/zerver/emails/onboarding_zulip_guide.txt
 msgid "View Zulip guide for communities"
 msgstr "查看 Zulip 社群指南"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:2
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for businesses"
 msgstr "Zulip 企業指南"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:4
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for open-source projects"
 msgstr "Zulip 開源專案指南"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:6
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for education"
 msgstr "Zulip 教育指南"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:8
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for research"
 msgstr "Zulip 研究指南"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:10
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for events and conferences"
 msgstr "Zulip 活動與會議指南"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:12
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for non-profits"
 msgstr "Zulip 非營利組織指南"
 
-#: templates/zerver/emails/onboarding_zulip_guide.subject.txt:14
+#: templates/zerver/emails/onboarding_zulip_guide.subject.txt
 msgid "Zulip guide for communities"
 msgstr "Zulip 社群指南"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:9
-#: templates/zerver/emails/onboarding_zulip_topics.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Here are some tips for keeping your Zulip conversations organized with "
 "topics."
 msgstr "以下是一些使用議題來保持您的 Zulip 對話有條理的提示。"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid ""
 "In Zulip, <b>channels</b> determine who gets a message. <b>Topics</b> tell "
 "you what the message is about."
 msgstr ""
 "在 Zulip 中，<b>頻道</b>決定誰會收到訊息。<b>議題</b>告訴您訊息的內容是什麼。"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:13
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "Using topics, you can read Zulip one conversation at a time. You'll see each "
 "message in context, no matter how many different discussions are going on."
@@ -3190,12 +2654,12 @@ msgstr ""
 "使用議題，您可以一次閱讀一個 Zulip 對話。無論正在進行多少不同的討論，您都能看"
 "到每則訊息的上下文。"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:16
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Channels and topics in the Zulip app"
 msgstr "Zulip 應用程式中的頻道和議題"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:19
-#: templates/zerver/emails/onboarding_zulip_topics.txt:5
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "To kick off a new conversation, just pick a channel and start a new topic. "
 "This way, the new conversation thread won't interrupt ongoing discussions. "
@@ -3206,11 +2670,11 @@ msgstr ""
 "打斷正在進行的討論。要取一個好的議題名稱，請考慮完成這個句子：「嘿，我們可以"
 "聊聊...嗎？」"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:22
+#: templates/zerver/emails/onboarding_zulip_topics.html
 msgid "Examples of short topics"
 msgstr "簡短議題的例子"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:25
+#: templates/zerver/emails/onboarding_zulip_topics.html
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3223,23 +2687,23 @@ msgstr ""
 "href=\"%(rename_topics_link)s\">重新命名議題</a>，甚至<a "
 "href=\"%(move_channels_link)s\">將議題移動到不同頻道</a>。"
 
-#: templates/zerver/emails/onboarding_zulip_topics.html:28
-#: templates/zerver/emails/onboarding_zulip_topics.txt:10
-#: templates/zerver/portico-header-dropdown.html:3
+#: templates/zerver/emails/onboarding_zulip_topics.html
+#: templates/zerver/emails/onboarding_zulip_topics.txt
+#: templates/zerver/portico-header-dropdown.html
 msgid "Go to Zulip"
 msgstr "回到 Zulip"
 
-#: templates/zerver/emails/onboarding_zulip_topics.subject.txt:1
+#: templates/zerver/emails/onboarding_zulip_topics.subject.txt
 msgid "Keep your conversations organized with topics"
 msgstr "使用議題讓您的對話保持有條理"
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:3
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 msgid ""
 "In Zulip, channels determine who gets a message. Topics tell you what the "
 "message is about."
 msgstr "在 Zulip 中，頻道決定誰會收到訊息。議題告訴您訊息的內容是什麼。"
 
-#: templates/zerver/emails/onboarding_zulip_topics.txt:7
+#: templates/zerver/emails/onboarding_zulip_topics.txt
 #, python-format
 msgid ""
 "Don't stress about picking the perfect name for your topic. If anything is "
@@ -3251,8 +2715,8 @@ msgstr ""
 "動訊息 (%(move_messages_link)s)、重新命名議題 (%(rename_topics_link)s)，甚至"
 "將議題移動到不同頻道 (%(move_channels_link)s)。"
 
-#: templates/zerver/emails/password_reset.html:9
-#: templates/zerver/emails/password_reset.txt:1
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "Somebody (possibly you) requested a new password for the Zulip account "
@@ -3260,15 +2724,15 @@ msgid ""
 msgstr ""
 "有人 (可能是您) 為 %(realm_url)s 上的 Zulip 帳戶 %(email)s 請求新密碼。"
 
-#: templates/zerver/emails/password_reset.html:13
+#: templates/zerver/emails/password_reset.html
 msgid "Click the button below to reset your password."
 msgstr "點擊下方按鈕以重置您的密碼。"
 
-#: templates/zerver/emails/password_reset.html:14
+#: templates/zerver/emails/password_reset.html
 msgid "Reset password"
 msgstr "重置密碼"
 
-#: templates/zerver/emails/password_reset.html:19
+#: templates/zerver/emails/password_reset.html
 #, python-format
 msgid ""
 "You previously had an account on %(organization_url)s, but it has been "
@@ -3278,39 +2742,39 @@ msgstr ""
 "您之前在 %(organization_url)s 上有一個帳戶，但它已被停用。您可以聯絡組織管理"
 "員來<a href=\"%(help_link)s\">重新啟用您的帳戶</a>。"
 
-#: templates/zerver/emails/password_reset.html:21
-#: templates/zerver/emails/password_reset.txt:11
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do not have an account in that Zulip organization."
 msgstr "您在該 Zulip 組織中沒有帳戶。"
 
-#: templates/zerver/emails/password_reset.html:26
-#: templates/zerver/emails/password_reset.txt:16
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid "You do have active accounts in the following organization(s)."
 msgstr "您在以下組織中有作用中的帳戶。"
 
-#: templates/zerver/emails/password_reset.html:34
-#: templates/zerver/emails/password_reset.txt:21
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "You can try logging in or resetting your password in the organization(s) "
 "above."
 msgstr "您能嘗試登入或在上方組織(s)內重置您的密碼。"
 
-#: templates/zerver/emails/password_reset.html:40
-#: templates/zerver/emails/password_reset.txt:25
+#: templates/zerver/emails/password_reset.html
+#: templates/zerver/emails/password_reset.txt
 msgid ""
 "If you do not recognize this activity, you can safely ignore this email."
 msgstr "如果您不認識此活動，您可以安全地忽略這封電子郵件。"
 
-#: templates/zerver/emails/password_reset.subject.txt:1
+#: templates/zerver/emails/password_reset.subject.txt
 #, python-format
 msgid "Password reset request for %(realm_name)s"
 msgstr "%(realm_name)s 的密碼重置請求"
 
-#: templates/zerver/emails/password_reset.txt:4
+#: templates/zerver/emails/password_reset.txt
 msgid "Click the link below to reset your password."
 msgstr "請點選以下的連結以重新設定您的密碼。"
 
-#: templates/zerver/emails/password_reset.txt:8
+#: templates/zerver/emails/password_reset.txt
 #, python-format
 msgid ""
 "You previously had an account on %(realm_url)s, but it has been deactivated. "
@@ -3319,7 +2783,7 @@ msgstr ""
 "您之前在 %(realm_url)s 上有一個帳戶，但它已被停用。您可以聯絡組織管理員來重新"
 "啟用您的帳戶。"
 
-#: templates/zerver/emails/realm_auto_downgraded.html:8
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "Your organization, %(organization_name_with_link)s, has been downgraded to "
@@ -3329,14 +2793,14 @@ msgstr ""
 "您的組織 %(organization_name_with_link)s 因為未付發票已被降級至 Zulip Cloud "
 "免費方案。未付發票已被作廢。"
 
-#: templates/zerver/emails/realm_auto_downgraded.html:15
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "To continue on the Zulip Cloud Standard plan, please upgrade again by going "
 "to %(upgrade_url)s."
 msgstr "要繼續使用 Zulip Cloud 標準方案，請前往 %(upgrade_url)s 重新升級。"
 
-#: templates/zerver/emails/realm_auto_downgraded.html:22
+#: templates/zerver/emails/realm_auto_downgraded.html
 #, python-format
 msgid ""
 "If you think this was a mistake or need more details, please reach out to us "
@@ -3344,16 +2808,16 @@ msgid ""
 msgstr ""
 "如果您認為這是個錯誤或需要更多詳細資訊，請透過 %(support_email)s 聯絡我們。"
 
-#: templates/zerver/emails/realm_deactivated.html:15
-#: templates/zerver/emails/realm_deactivated.txt:7
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip demo organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr "您已於 %(localized_date)s 停用了您的 Zulip Demo 組織：%(realm_name)s。"
 
-#: templates/zerver/emails/realm_deactivated.html:17
-#: templates/zerver/emails/realm_deactivated.txt:9
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated by "
@@ -3362,24 +2826,24 @@ msgstr ""
 "您的 Zulip Demo 組織 %(realm_name)s 已由 %(deactivating_owner)s 於 "
 "%(localized_date)s 停用。"
 
-#: templates/zerver/emails/realm_deactivated.html:19
-#: templates/zerver/emails/realm_deactivated.txt:11
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip demo organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr "您的 Zulip Demo 組織 %(realm_name)s 已於 %(localized_date)s 被停用。"
 
-#: templates/zerver/emails/realm_deactivated.html:23
-#: templates/zerver/emails/realm_deactivated.txt:15
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "You have deactivated your Zulip organization, %(realm_name)s, on "
 "%(localized_date)s."
 msgstr "您已於 %(localized_date)s 停用您的 Zulip 組織 %(realm_name)s。"
 
-#: templates/zerver/emails/realm_deactivated.html:25
-#: templates/zerver/emails/realm_deactivated.txt:17
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated by "
@@ -3388,48 +2852,48 @@ msgstr ""
 "您的 Zulip 組織 %(realm_name)s 已於 %(localized_date)s 被 "
 "%(deactivating_owner)s 停用。"
 
-#: templates/zerver/emails/realm_deactivated.html:27
-#: templates/zerver/emails/realm_deactivated.txt:19
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "Your Zulip organization, %(realm_name)s, was deactivated on "
 "%(localized_date)s."
 msgstr "您的 Zulip 組織 %(realm_name)s 已於 %(localized_date)s 被停用。"
 
-#: templates/zerver/emails/realm_deactivated.html:31
-#: templates/zerver/emails/realm_deactivated.txt:23
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "All data associated with this organization has been permanently deleted."
 msgstr "與此組織相關的所有資料已被永久刪除。"
 
-#: templates/zerver/emails/realm_deactivated.html:33
-#: templates/zerver/emails/realm_deactivated.txt:25
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 #, python-format
 msgid ""
 "All data associated with this organization will be permanently deleted on "
 "%(deletion_date)s."
 msgstr "與此組織相關的所有資料將於 %(deletion_date)s 被永久刪除。"
 
-#: templates/zerver/emails/realm_deactivated.html:37
-#: templates/zerver/emails/realm_deactivated.txt:29
+#: templates/zerver/emails/realm_deactivated.html
+#: templates/zerver/emails/realm_deactivated.txt
 msgid ""
 "If you have any questions or concerns, please reply to this email as soon as "
 "possible."
 msgstr "如果您有任何問題或疑慮，請儘快回覆此電子郵件。"
 
-#: templates/zerver/emails/realm_deactivated.subject.txt:1
+#: templates/zerver/emails/realm_deactivated.subject.txt
 #, python-format
 msgid "Your Zulip organization %(realm_name)s has been deactivated"
 msgstr "您的 Zulip 組織 %(realm_name)s 已被停用"
 
-#: templates/zerver/emails/realm_reactivation.html:8
-#: templates/zerver/emails/realm_reactivation.txt:1
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid "Dear former administrators of %(realm_name)s,"
 msgstr "親愛的 %(realm_name)s 前管理員："
 
-#: templates/zerver/emails/realm_reactivation.html:11
-#: templates/zerver/emails/realm_reactivation.txt:5
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
@@ -3438,8 +2902,8 @@ msgstr ""
 "您的其中一位管理員已請求重新啟用先前停用的 Zulip Demo 組織 (位於 "
 "%(realm_url)s)。"
 
-#: templates/zerver/emails/realm_reactivation.html:13
-#: templates/zerver/emails/realm_reactivation.txt:7
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 #, python-format
 msgid ""
 "One of your administrators requested reactivation of the previously "
@@ -3447,34 +2911,34 @@ msgid ""
 msgstr ""
 "您的其中一位管理員要求重新啟用先前在 %(realm_url)s 託管的已停用 Zulip 組織。"
 
-#: templates/zerver/emails/realm_reactivation.html:17
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Click the button below to reactivate your organization."
 msgstr "點擊下方按鈕以重新啟用您的組織。"
 
-#: templates/zerver/emails/realm_reactivation.html:18
+#: templates/zerver/emails/realm_reactivation.html
 msgid "Reactivate organization"
 msgstr "重新啟用組織"
 
-#: templates/zerver/emails/realm_reactivation.html:21
-#: templates/zerver/emails/realm_reactivation.txt:14
+#: templates/zerver/emails/realm_reactivation.html
+#: templates/zerver/emails/realm_reactivation.txt
 msgid ""
 "If the request was in error, you can take no action and this link will "
 "expire in 24 hours."
 msgstr "如果此要求是錯誤的，您可以不採取任何行動，此連結將在 24 小時後過期。"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:2
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip demo organization"
 msgstr "重新啟用您的 Zulip Demo 組織"
 
-#: templates/zerver/emails/realm_reactivation.subject.txt:4
+#: templates/zerver/emails/realm_reactivation.subject.txt
 msgid "Reactivate your Zulip organization"
 msgstr "重新啟用您的 Zulip 組織"
 
-#: templates/zerver/emails/realm_reactivation.txt:11
+#: templates/zerver/emails/realm_reactivation.txt
 msgid "Click the link below to reactivate your organization."
 msgstr "點擊下方連結以重新啟用您的組織。"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:9
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3483,18 +2947,18 @@ msgstr ""
 "您或代表您的某人已要求登入連結以管理 <b>%(remote_server_hostname)s</b> 的 "
 "Zulip 方案。"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:12
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
 msgid "Click the button below to log in."
 msgstr "點擊下方按鈕以登入。"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:16
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid "This link will expire in %(validity_in_hours)s hours."
 msgstr "此連結將在 %(validity_in_hours)s 小時後過期。"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html:24
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:17
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Questions? <a href=\"%(billing_help_link)s\">Learn more</a> or contact "
@@ -3503,11 +2967,11 @@ msgstr ""
 "有問題嗎？<a href=\"%(billing_help_link)s\">了解更多</a>或聯絡 "
 "%(billing_contact_email)s。"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.subject.txt
 msgid "Log in to Zulip plan management"
 msgstr "登入 Zulip 方案管理"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:1
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 #, python-format
 msgid ""
 "Either you, or someone on your behalf, has requested a log in link to manage "
@@ -3516,12 +2980,12 @@ msgstr ""
 "您或代表您的某人已要求登入連結以管理 %(remote_server_hostname)s 的 Zulip 方"
 "案。"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:4
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
 msgid "Click the link below to log in."
 msgstr "點擊下方連結以登入。"
 
-#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt:8
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:6
+#: templates/zerver/emails/remote_billing_legacy_server_confirm_login.txt
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Questions? Learn more at %(billing_help_link)s or contact "
@@ -3529,7 +2993,7 @@ msgid ""
 msgstr ""
 "有問題嗎？在 %(billing_help_link)s 了解更多或聯絡 %(billing_contact_email)s。"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:9
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
 #, python-format
 msgid ""
 "Click the button below to confirm your email and log in to Zulip plan "
@@ -3538,16 +3002,16 @@ msgstr ""
 "點擊下方按鈕以確認您的電子郵件並登入 <b>%(remote_realm_host)s</b> 的 Zulip 方"
 "案管理。"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.html:14
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:4
+#: templates/zerver/emails/remote_realm_billing_confirm_login.html
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 msgid "Confirm and log in"
 msgstr "確認並登入"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.subject.txt
 msgid "Confirm email for Zulip plan management"
 msgstr "確認 Zulip 方案管理的電子郵件"
 
-#: templates/zerver/emails/remote_realm_billing_confirm_login.txt:1
+#: templates/zerver/emails/remote_realm_billing_confirm_login.txt
 #, python-format
 msgid ""
 "Click the link below to confirm your email and log in to Zulip plan "
@@ -3556,7 +3020,7 @@ msgstr ""
 "點擊下方連結以確認您的電子郵件並登入 %(remote_realm_host)s 的 Zulip 方案管"
 "理。"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:9
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
@@ -3565,7 +3029,7 @@ msgstr ""
 "您的 Zulip 贊助申請已獲核准！您的組織已升級至<a "
 "href=\"%(plans_link)s\">Zulip 社群方案</a>。"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.html:12
+#: templates/zerver/emails/sponsorship_approved_community_plan.html
 #, python-format
 msgid ""
 "If you could <a href=\"%(link_to_zulip)s\">list Zulip as a sponsor on your "
@@ -3574,37 +3038,37 @@ msgstr ""
 "如果您能在您的網站上<a href=\"%(link_to_zulip)s\">將 Zulip 列為贊助商</a>，我"
 "們將非常感謝！"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.subject.txt
 #, python-format
 msgid "Community plan sponsorship approved for %(billing_entity)s!"
 msgstr "%(billing_entity)s 的社群方案贊助已獲核准！"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:1
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "Your request for Zulip sponsorship has been approved! Your organization has "
 "been upgraded to the Zulip Community plan."
 msgstr "您的 Zulip 贊助申請已獲核准！您的組織已升級至 Zulip 社群方案。"
 
-#: templates/zerver/emails/sponsorship_approved_community_plan.txt:4
+#: templates/zerver/emails/sponsorship_approved_community_plan.txt
 msgid ""
 "If you could list Zulip as a sponsor on your website, we would really "
 "appreciate it!"
 msgstr "如果您能在您的網站上將 Zulip 列為贊助商，我們將非常感謝！"
 
-#: templates/zerver/find_account.html:4
+#: templates/zerver/find_account.html
 msgid "Find your accounts"
 msgstr "尋找您的帳戶"
 
-#: templates/zerver/find_account.html:12
+#: templates/zerver/find_account.html
 msgid "Find your Zulip accounts"
 msgstr "尋找您的Zulip帳號"
 
-#: templates/zerver/find_account.html:19
+#: templates/zerver/find_account.html
 msgid ""
 "Emails sent! The addresses entered on the previous page are listed below:"
 msgstr "電子郵件已寄出！在前一頁輸入的地址列於下方："
 
-#: templates/zerver/find_account.html:30
+#: templates/zerver/find_account.html
 #, python-format
 msgid ""
 "If you don't receive an email, you can <a href=\"%(current_url)s\">find "
@@ -3613,7 +3077,7 @@ msgstr ""
 "如果您沒有收到電子郵件，您可以 <a href=\"%(current_url)s\">尋找另一個電子郵件"
 "地址的帳戶</a>。"
 
-#: templates/zerver/find_account.html:42
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "Cloud organizations in which you have active accounts."
@@ -3621,7 +3085,7 @@ msgstr ""
 "輸入您的電子郵件地址以接收包含您擁有作用中帳戶的所有 Zulip Cloud 組織網址的電"
 "子郵件。"
 
-#: templates/zerver/find_account.html:44
+#: templates/zerver/find_account.html
 msgid ""
 "Enter your email address to receive an email with the URLs for all the Zulip "
 "organizations on this server in which you have active accounts."
@@ -3629,7 +3093,7 @@ msgstr ""
 "輸入您的電子郵件地址以接收包含您在此伺服器上擁有作用中帳戶的所有 Zulip 組織網"
 "址的電子郵件。"
 
-#: templates/zerver/find_account.html:46
+#: templates/zerver/find_account.html
 msgid ""
 "If you have also forgotten your password, you can <a href=\"/help/change-"
 "your-password\">reset it</a>."
@@ -3637,214 +3101,214 @@ msgstr ""
 "如果您也忘記了密碼，您可以<a href=\"/help/change-your-password\">重置密碼</"
 "a>。"
 
-#: templates/zerver/find_account.html:54
+#: templates/zerver/find_account.html
 msgid "Email address"
 msgstr "電子郵件地址"
 
-#: templates/zerver/find_account.html:56 templates/zerver/footer.html:19
+#: templates/zerver/find_account.html templates/zerver/footer.html
 msgid "Find accounts"
 msgstr "查詢帳號"
 
-#: templates/zerver/footer.html:6
+#: templates/zerver/footer.html
 msgid "Product"
 msgstr "產品"
 
-#: templates/zerver/footer.html:9
+#: templates/zerver/footer.html
 msgid "Why Zulip"
 msgstr "為什麼選擇 Zulip"
 
-#: templates/zerver/footer.html:10
+#: templates/zerver/footer.html
 msgid "Features"
 msgstr "功能"
 
-#: templates/zerver/footer.html:11
+#: templates/zerver/footer.html
 msgid "Plans & pricing"
 msgstr "方案與定價"
 
-#: templates/zerver/footer.html:12
+#: templates/zerver/footer.html
 msgid "Zulip Cloud"
 msgstr "Zulip Cloud"
 
-#: templates/zerver/footer.html:13
+#: templates/zerver/footer.html
 msgid "Self-hosting"
 msgstr "自託管"
 
-#: templates/zerver/footer.html:14
+#: templates/zerver/footer.html
 msgid "Security"
 msgstr "安全性"
 
-#: templates/zerver/footer.html:15
+#: templates/zerver/footer.html
 msgid "Integrations"
 msgstr "整合"
 
-#: templates/zerver/footer.html:16
+#: templates/zerver/footer.html
 msgid "Desktop & mobile apps"
 msgstr "桌面 & 行動裝置應用程式"
 
-#: templates/zerver/footer.html:17 templates/zerver/portico-header.html:53
+#: templates/zerver/footer.html templates/zerver/portico-header.html
 msgid "New organization"
 msgstr "新組織"
 
-#: templates/zerver/footer.html:24
+#: templates/zerver/footer.html
 msgid "Solutions"
 msgstr "解決方案"
 
-#: templates/zerver/footer.html:27
+#: templates/zerver/footer.html
 msgid "Business"
 msgstr "商務選購"
 
-#: templates/zerver/footer.html:28
+#: templates/zerver/footer.html
 msgid "Education"
 msgstr "教育"
 
-#: templates/zerver/footer.html:29
+#: templates/zerver/footer.html
 msgid "Research"
 msgstr "研究用途"
 
-#: templates/zerver/footer.html:30
+#: templates/zerver/footer.html
 msgid "Events & conferences"
 msgstr "活動與會議"
 
-#: templates/zerver/footer.html:31
+#: templates/zerver/footer.html
 msgid "Open source projects"
 msgstr "開源專案"
 
-#: templates/zerver/footer.html:32
+#: templates/zerver/footer.html
 msgid "Communities"
 msgstr "社群"
 
-#: templates/zerver/footer.html:33
+#: templates/zerver/footer.html
 msgid "Engineers"
 msgstr "工程師"
 
-#: templates/zerver/footer.html:34
+#: templates/zerver/footer.html
 msgid "Customer stories"
 msgstr "使用者回饋"
 
-#: templates/zerver/footer.html:35
+#: templates/zerver/footer.html
 msgid "Open communities"
 msgstr "開放社群"
 
-#: templates/zerver/footer.html:40
+#: templates/zerver/footer.html
 msgid "Resources"
 msgstr "資源"
 
-#: templates/zerver/footer.html:43
+#: templates/zerver/footer.html
 msgid "Getting started"
 msgstr "開始使用"
 
-#: templates/zerver/footer.html:44 templates/zerver/footer.html:119
+#: templates/zerver/footer.html
 msgid "Help center"
 msgstr "幫助中心"
 
-#: templates/zerver/footer.html:45
+#: templates/zerver/footer.html
 msgid "Community chat"
 msgstr "社群聊天"
 
-#: templates/zerver/footer.html:48
+#: templates/zerver/footer.html
 msgid "Partners"
 msgstr "夥伴"
 
-#: templates/zerver/footer.html:49
+#: templates/zerver/footer.html
 msgid "Zulip Cloud status"
 msgstr "Zulip Cloud 狀態"
 
-#: templates/zerver/footer.html:52
+#: templates/zerver/footer.html
 msgid "Moving to Zulip"
 msgstr "遷移至 Zulip"
 
-#: templates/zerver/footer.html:57
+#: templates/zerver/footer.html
 msgid "Installing a Zulip server"
 msgstr "安裝 Zulip 伺服器"
 
-#: templates/zerver/footer.html:62
+#: templates/zerver/footer.html
 msgid "Upgrading a Zulip server"
 msgstr "升級 Zulip 伺服器"
 
-#: templates/zerver/footer.html:69
+#: templates/zerver/footer.html
 msgid "Contributing"
 msgstr "貢獻"
 
-#: templates/zerver/footer.html:74
+#: templates/zerver/footer.html
 msgid "Contributing guide"
 msgstr "貢獻指南"
 
-#: templates/zerver/footer.html:77
+#: templates/zerver/footer.html
 msgid "Development community"
 msgstr "開發社群"
 
-#: templates/zerver/footer.html:80
+#: templates/zerver/footer.html
 msgid "Translation"
 msgstr "翻譯"
 
-#: templates/zerver/footer.html:84
+#: templates/zerver/footer.html
 msgid "GitHub"
 msgstr "GitHub"
 
-#: templates/zerver/footer.html:89
+#: templates/zerver/footer.html
 msgid "About us"
 msgstr "關於我們"
 
-#: templates/zerver/footer.html:93
+#: templates/zerver/footer.html
 msgid "Team"
 msgstr "團隊"
 
-#: templates/zerver/footer.html:95
+#: templates/zerver/footer.html
 msgid "History"
 msgstr "歷史"
 
-#: templates/zerver/footer.html:97
+#: templates/zerver/footer.html
 msgid "Values"
 msgstr "理念"
 
-#: templates/zerver/footer.html:98
+#: templates/zerver/footer.html
 msgid "Jobs"
 msgstr "工作機會"
 
-#: templates/zerver/footer.html:99
+#: templates/zerver/footer.html
 msgid "Blog"
 msgstr "部落格"
 
-#: templates/zerver/footer.html:100
+#: templates/zerver/footer.html
 msgid "Support Zulip"
 msgstr "支持 Zulip"
 
-#: templates/zerver/footer.html:103
+#: templates/zerver/footer.html
 msgid "Mastodon"
 msgstr "Mastodon"
 
-#: templates/zerver/footer.html:104
+#: templates/zerver/footer.html
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: templates/zerver/footer.html:105
+#: templates/zerver/footer.html
 #, fuzzy
 #| msgid "Bluesky handle"
 msgid "Bluesky"
 msgstr "Bluesky 帳號名稱"
 
-#: templates/zerver/footer.html:115
+#: templates/zerver/footer.html
 msgid "Powered by <a href=\"https://zulip.com\">Zulip</a>"
 msgstr "由 <a href=\"https://zulip.com\">Zulip</a> 提供支援"
 
-#: templates/zerver/footer.html:121
+#: templates/zerver/footer.html
 msgid "Terms of Service"
 msgstr "服務條款"
 
-#: templates/zerver/footer.html:122
+#: templates/zerver/footer.html
 msgid "Privacy policy"
 msgstr "隱私權方針"
 
-#: templates/zerver/footer.html:124
+#: templates/zerver/footer.html
 msgid "Website attributions"
 msgstr "網站歸屬"
 
-#: templates/zerver/integrations/catalog.html:22
+#: templates/zerver/integrations/catalog.html
 #, python-format
 msgid "Over %(integrations_count_display)s native integrations."
 msgstr "超過 %(integrations_count_display)s 個原生整合。"
 
-#: templates/zerver/integrations/catalog.html:26
+#: templates/zerver/integrations/catalog.html
 msgid ""
 "And hundreds more through <a href=\"/integrations/zapier\">Zapier</a> and <a "
 "href=\"/integrations/ifttt\">IFTTT</a>."
@@ -3852,51 +3316,47 @@ msgstr ""
 "以及透過 <a href=\"/integrations/zapier\">Zapier</a> 與 <a href=\"/"
 "integrations/ifttt\">IFTTT</a> 提供的數百種更多功能。"
 
-#: templates/zerver/integrations/catalog.html:39
+#: templates/zerver/integrations/catalog.html
 msgid "Search integrations"
 msgstr "搜尋整合"
 
-#: templates/zerver/integrations/catalog.html:62
-#: templates/zerver/integrations/catalog.html:86
+#: templates/zerver/integrations/catalog.html
 msgid "Custom integrations"
 msgstr "自訂整合"
 
-#: templates/zerver/integrations/catalog.html:64
-#: templates/zerver/integrations/catalog.html:88
+#: templates/zerver/integrations/catalog.html
 msgid "Incoming webhooks"
 msgstr "傳入 Webhooks"
 
-#: templates/zerver/integrations/catalog.html:67
-#: templates/zerver/integrations/catalog.html:91 zerver/lib/integrations.py:43
+#: templates/zerver/integrations/catalog.html zerver/lib/integrations.py
 msgid "Interactive bots"
 msgstr "互動機器人"
 
-#: templates/zerver/integrations/catalog.html:70
-#: templates/zerver/integrations/catalog.html:94
+#: templates/zerver/integrations/catalog.html
 msgid "REST API"
 msgstr "REST API"
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back to list"
 msgstr ""
 
-#: templates/zerver/integrations/doc.html:34
+#: templates/zerver/integrations/doc.html
 msgid "Back"
 msgstr ""
 
-#: templates/zerver/invalid_email.html:4 templates/zerver/invalid_email.html:13
+#: templates/zerver/invalid_email.html
 msgid "Invalid email"
 msgstr "無效的 email"
 
-#: templates/zerver/invalid_email.html:15
+#: templates/zerver/invalid_email.html
 msgid "Email not allowed"
 msgstr "不允許的電子郵件"
 
-#: templates/zerver/invalid_email.html:21
+#: templates/zerver/invalid_email.html
 msgid "The email address you are trying to sign up with is not valid."
 msgstr "您嘗試註冊的電子郵件地址無效。"
 
-#: templates/zerver/invalid_email.html:24
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3906,7 +3366,7 @@ msgstr ""
 "您嘗試加入的組織 <a href=\"%(realm_url)s\">%(realm_name)s</a> 不允許使用您的"
 "電子郵件網域進行註冊。"
 
-#: templates/zerver/invalid_email.html:27
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3916,7 +3376,7 @@ msgstr ""
 "您嘗試加入的組織 <a href=\"%(realm_url)s\">%(realm_name)s</a> 不允許使用臨時"
 "電子郵件地址進行註冊。"
 
-#: templates/zerver/invalid_email.html:30
+#: templates/zerver/invalid_email.html
 #, python-format
 msgid ""
 "The organization you are trying to join, <a "
@@ -3926,24 +3386,24 @@ msgstr ""
 "您嘗試加入的組織 <a href=\"%(realm_url)s\">%(realm_name)s</a> 不允許使用包含"
 "「+」符號的電子郵件進行註冊。"
 
-#: templates/zerver/invalid_email.html:33
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using a valid email address."
 msgstr "請使用有效的電子郵件地址進行註冊。"
 
-#: templates/zerver/invalid_email.html:35
+#: templates/zerver/invalid_email.html
 msgid "Please sign up using an allowed email address."
 msgstr "請使用合乎規範的電子郵件地址進行註冊。"
 
-#: templates/zerver/invalid_realm.html:4 templates/zerver/invalid_realm.html:12
+#: templates/zerver/invalid_realm.html
 msgid "No organization found"
 msgstr "找不到組織"
 
-#: templates/zerver/invalid_realm.html:17
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid "There is no Zulip organization at <b>%(current_url)s</b>."
 msgstr "在 <b>%(current_url)s</b> 沒有 Zulip 組織。"
 
-#: templates/zerver/invalid_realm.html:21
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3954,7 +3414,7 @@ msgstr ""
 "Zulip Cloud 帳戶清單</a>，或<a href=\"mailto:%(support_email)s\">聯絡 Zulip "
 "支援</a>。"
 
-#: templates/zerver/invalid_realm.html:23
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "Please try a different URL, <a href=\"%(root_domain_url)s/accounts/find/"
@@ -3965,7 +3425,7 @@ msgstr ""
 "服器上的帳戶清單</a>，或<a href=\"mailto:%(support_email)s\">聯絡此 Zulip 伺"
 "服器的管理員</a>。"
 
-#: templates/zerver/invalid_realm.html:28
+#: templates/zerver/invalid_realm.html
 #, python-format
 msgid ""
 "<a href=\"%(current_url)s/serverlogin/\">Click here</a> to access plan "
@@ -3974,57 +3434,57 @@ msgstr ""
 "<a href=\"%(current_url)s/serverlogin/\">點此</a>存取您的 Zulip 伺服器方案管"
 "理。"
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:4
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session"
 msgstr "無效或過期的登入工作階段"
 
-#: templates/zerver/log_into_subdomain_token_invalid.html:12
+#: templates/zerver/log_into_subdomain_token_invalid.html
 msgid "Invalid or expired login session."
 msgstr "無效或過期的 login session。"
 
-#: templates/zerver/login.html:18
+#: templates/zerver/login.html
 msgid "Log in to Zulip"
 msgstr "登入 Zulip"
 
-#: templates/zerver/login.html:54
+#: templates/zerver/login.html
 msgid "You've already registered with this email address. Please log in below."
 msgstr "您已用此 email 地址註冊。請在下方登入。"
 
-#: templates/zerver/login.html:82
+#: templates/zerver/login.html
 msgid "Email or username"
 msgstr "Email 或使用者名稱"
 
-#: templates/zerver/login.html:84
+#: templates/zerver/login.html
 msgid "Username"
 msgstr "使用者名稱"
 
-#: templates/zerver/login.html:101
+#: templates/zerver/login.html
 msgid "Forgot your password?"
 msgstr "忘記您的密碼？"
 
-#: templates/zerver/login.html:134
+#: templates/zerver/login.html
 #, python-format
 msgid "Log in with %(identity_provider)s"
 msgstr "用 %(identity_provider)s 登入"
 
-#: templates/zerver/login.html:154
+#: templates/zerver/login.html
 msgid "View without an account"
 msgstr "不需帳戶即可查看"
 
-#: templates/zerver/login.html:174
+#: templates/zerver/login.html
 msgid ""
 "Don't have an account yet? You need to be invited to join this organization."
 msgstr "還沒有帳戶嗎？您需要受邀才能加入此組織。"
 
-#: templates/zerver/no_spare_licenses.html:4
+#: templates/zerver/no_spare_licenses.html
 msgid "No licenses available"
 msgstr "沒有可用授權"
 
-#: templates/zerver/no_spare_licenses.html:12
+#: templates/zerver/no_spare_licenses.html
 msgid "Organization cannot accept new members right now"
 msgstr "組織目前無法接受新成員"
 
-#: templates/zerver/no_spare_licenses.html:16
+#: templates/zerver/no_spare_licenses.html
 #, python-format
 msgid ""
 "New members cannot currently join <a href=\"%(realm_url)s\">%(realm_name)s</"
@@ -4033,25 +3493,25 @@ msgstr ""
 "新成員目前無法加入 <a href=\"%(realm_url)s\">%(realm_name)s</a>，因為所有 "
 "Zulip Cloud 授權都在使用中。"
 
-#: templates/zerver/no_spare_licenses.html:19
+#: templates/zerver/no_spare_licenses.html
 msgid ""
 "Please contact the person who invited you and ask them to increase the "
 "number of licenses, then try again."
 msgstr "請聯絡邀請您的人員，要求他們增加授權數量，然後再試一次。"
 
-#: templates/zerver/portico-header.html:4
+#: templates/zerver/portico-header.html
 msgid "Skip to main content"
 msgstr "跳至主要內容"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:4
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain error"
 msgstr "認證子網域錯誤"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:11
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid "Authentication subdomain"
 msgstr "認證子網域"
 
-#: templates/zerver/portico_error_pages/auth_subdomain.html:13
+#: templates/zerver/portico_error_pages/auth_subdomain.html
 msgid ""
 "It appears you ended up here by accident. This site is meant to be an "
 "intermediate step in the authentication process and shouldn't be accessed "
@@ -4063,42 +3523,40 @@ msgstr ""
 "取。如果您是直接來到這裡， 您可能輸入了錯誤的網址。如果您在嘗試 登入時卡在這"
 "裡，這很可能是伺服器錯誤或設定問題。"
 
-#: templates/zerver/portico_error_pages/demo_creation_disabled.html:4
+#: templates/zerver/portico_error_pages/demo_creation_disabled.html
 msgid "Demo organizations disabled"
 msgstr "Demo 組織已停用"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:4
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:11
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Update required"
 msgstr "需要更新"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:13
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "You are using old version of the Zulip desktop app that is no longer "
 "supported."
 msgstr "您正在使用已不再支援的舊版 Zulip 桌面應用程式。"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:21
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid ""
 "The auto-update feature in this old version of Zulip desktop app no longer "
 "works."
 msgstr "此舊版 Zulip 桌面應用程式的 自動更新功能已無法使用。"
 
-#: templates/zerver/portico_error_pages/insecure_desktop_app.html:30
+#: templates/zerver/portico_error_pages/insecure_desktop_app.html
 msgid "Download the latest release."
 msgstr "下載最新發行版。"
 
-#: templates/zerver/portico_error_pages/rate_limit_exceeded.html:13
+#: templates/zerver/portico_error_pages/rate_limit_exceeded.html
 msgid ""
 "You have exceeded the limit for how often a user can perform this action."
 msgstr "您已超過使用者執行此操作的 頻率限制。"
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:4
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:11
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid "Organization creation link required"
 msgstr "需要組織建立連結"
 
-#: templates/zerver/portico_error_pages/realm_creation_disabled.html:13
+#: templates/zerver/portico_error_pages/realm_creation_disabled.html
 msgid ""
 "Creating a new organization on this server requires a valid organization "
 "creation link. Please see <a href=\"https://zulip.readthedocs.io/en/stable/"
@@ -4109,12 +3567,11 @@ msgstr ""
 "zulip.readthedocs.io/en/stable/production/multiple-organizations.html\">文件"
 "</a> 了解建立新組織的更多資訊。"
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:4
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:11
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid "Organization creation link expired or invalid"
 msgstr "組織建立連結已過期或無效"
 
-#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html:13
+#: templates/zerver/portico_error_pages/realm_creation_link_invalid.html
 msgid ""
 "Unfortunately, this is not a valid link for creating an organization. Please "
 "<a href=\"/new/\">obtain a new link</a> and try again."
@@ -4122,11 +3579,11 @@ msgstr ""
 "抱歉，此連結無法用於建立組織。請 <a href=\"/new/\">取得新的連結</a> 後再試一"
 "次。"
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:11
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 msgid "Unexpected Zulip server registration"
 msgstr "意外的 Zulip 伺服器註冊"
 
-#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html:13
+#: templates/zerver/portico_error_pages/remote_realm_server_mismatch_error.html
 #, python-format
 msgid ""
 "Your Zulip organization is registered as associated with a different Zulip "
@@ -4136,17 +3593,16 @@ msgstr ""
 "您的 Zulip 組織已註冊並關聯至不同的 Zulip 伺服器安裝環境。 請 <a "
 "href=\"mailto:%(support_email)s\">聯絡 Zulip 支援團隊</a> 協助解決此問題。"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:4
-#: templates/zerver/portico_error_pages/unsupported_browser.html:11
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 msgid "Unsupported browser"
 msgstr "不支援的瀏覽器"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:13
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid "%(browser_name)s is not supported by Zulip."
 msgstr "Zulip 不支援 %(browser_name)s。"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:18
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "Zulip supports <a href=\"%(supported_browsers_page_link)s\">modern browsers</"
@@ -4155,27 +3611,26 @@ msgstr ""
 "Zulip 支援 <a href=\"%(supported_browsers_page_link)s\">現代瀏覽器</a>， 如 "
 "Firefox、Chrome 和 Edge。"
 
-#: templates/zerver/portico_error_pages/unsupported_browser.html:24
+#: templates/zerver/portico_error_pages/unsupported_browser.html
 #, python-format
 msgid ""
 "You can also use the <a href=\"%(apps_page_link)s\">Zulip desktop app</a>."
 msgstr "您也可以使用 <a href=\"%(apps_page_link)s\">Zulip 桌面應用程式</a>。"
 
-#: templates/zerver/portico_error_pages/user_deactivated.html:4
-#: templates/zerver/portico_error_pages/user_deactivated.html:11
-#: zerver/lib/exceptions.py:372
+#: templates/zerver/portico_error_pages/user_deactivated.html
+#: zerver/lib/exceptions.py
 msgid "Account is deactivated"
 msgstr "帳號已被停用"
 
-#: templates/zerver/realm_import_post_process.html:5
+#: templates/zerver/realm_import_post_process.html
 msgid "Finalize organization import"
 msgstr "完成組織匯入"
 
-#: templates/zerver/realm_import_post_process.html:13
+#: templates/zerver/realm_import_post_process.html
 msgid "Organization import completed!"
 msgstr "組織匯入完成！"
 
-#: templates/zerver/realm_import_post_process.html:23
+#: templates/zerver/realm_import_post_process.html
 #, python-format
 msgid ""
 "No account in the imported data matched the email address you've verified "
@@ -4186,52 +3641,51 @@ msgstr ""
 "（<strong>%(verified_email)s</strong>）。請選擇一個帳號來關聯您的電子郵件地"
 "址。"
 
-#: templates/zerver/realm_import_post_process.html:31
+#: templates/zerver/realm_import_post_process.html
 msgid "Select your account"
 msgstr "選擇您的帳號"
 
-#: templates/zerver/realm_import_post_process.html:34
+#: templates/zerver/realm_import_post_process.html
 msgid "Create new account"
 msgstr "建立新的帳號"
 
-#: templates/zerver/realm_reactivation.html:4
+#: templates/zerver/realm_reactivation.html
 msgid "Organization successfully reactivated"
 msgstr "組織成功重新啟用"
 
-#: templates/zerver/realm_reactivation.html:13
+#: templates/zerver/realm_reactivation.html
 msgid "Your organization has been successfully reactivated."
 msgstr "您的組織已成功重新啟用。"
 
-#: templates/zerver/realm_reactivation_link_error.html:4
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "Organization reactivation link expired or invalid"
 msgstr "組織重新啟用連結已過期或無效"
 
-#: templates/zerver/realm_reactivation_link_error.html:13
+#: templates/zerver/realm_reactivation_link_error.html
 msgid "The organization reactivation link has expired or is not valid."
 msgstr "組織重新啟用連結已過期或無效。"
 
-#: templates/zerver/realm_redirect.html:4
-#: templates/zerver/realm_redirect.html:12
+#: templates/zerver/realm_redirect.html
 msgid "Log in to your organization"
 msgstr "登入您的組織"
 
-#: templates/zerver/realm_redirect.html:25
+#: templates/zerver/realm_redirect.html
 msgid "your-organization"
 msgstr "您的組織"
 
-#: templates/zerver/realm_redirect.html:37
+#: templates/zerver/realm_redirect.html
 msgid "Don't know your organization URL?"
 msgstr "不知道貴組織的網址嗎？"
 
-#: templates/zerver/realm_redirect.html:38
+#: templates/zerver/realm_redirect.html
 msgid "Find your organization."
 msgstr "查詢您的組織。"
 
-#: templates/zerver/realm_redirect.html:40
+#: templates/zerver/realm_redirect.html
 msgid "Next"
 msgstr "下一個"
 
-#: templates/zerver/realm_redirect.html:47
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "<a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4241,11 +3695,11 @@ msgstr ""
 "如果您還沒有組織，可以<a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(org_creation_link)s\">建立新組織</a>。"
 
-#: templates/zerver/realm_redirect.html:52
+#: templates/zerver/realm_redirect.html
 msgid "Self-hosting Zulip?"
 msgstr "自託管 Zulip？"
 
-#: templates/zerver/realm_redirect.html:53
+#: templates/zerver/realm_redirect.html
 #, python-format
 msgid ""
 "You can <a target=\"_blank\" rel=\"noopener noreferrer\" "
@@ -4254,71 +3708,71 @@ msgstr ""
 "您可以 <a target=\"_blank\" rel=\"noopener noreferrer\" "
 "href=\"%(self_hosted_login_help)s\">登入以管理方案與帳務。</a>"
 
-#: templates/zerver/reset.html:4 templates/zerver/reset.html:12
+#: templates/zerver/reset.html
 msgid "Reset your password"
 msgstr "重置您的密碼"
 
-#: templates/zerver/reset.html:17
+#: templates/zerver/reset.html
 msgid ""
 "Forgot your password? No problem, we'll send a link to reset your password "
 "to the email you signed up with."
 msgstr ""
 "忘記密碼了嗎？沒問題，我們會將重置密碼的連結發送到您註冊時使用的電子郵件。"
 
-#: templates/zerver/reset.html:34
+#: templates/zerver/reset.html
 msgid "Send reset link"
 msgstr "發送重置連結"
 
-#: templates/zerver/reset_confirm.html:5 templates/zerver/reset_confirm.html:13
+#: templates/zerver/reset_confirm.html
 msgid "Set a new password"
 msgstr "設定新密碼"
 
-#: templates/zerver/reset_confirm.html:45
+#: templates/zerver/reset_confirm.html
 msgid "Confirm password"
 msgstr "確認密碼"
 
-#: templates/zerver/reset_confirm.html:76
+#: templates/zerver/reset_confirm.html
 msgid "Sorry, the link you provided is invalid or has already been used."
 msgstr "抱歉，您提供的連結是無效的，或此連結已被使用。"
 
-#: templates/zerver/reset_done.html:4
+#: templates/zerver/reset_done.html
 msgid "New password successfully set"
 msgstr "新密碼設定成功"
 
-#: templates/zerver/reset_done.html:13
+#: templates/zerver/reset_done.html
 msgid "You've set a new password!"
 msgstr "您已設定新密碼！"
 
-#: templates/zerver/reset_done.html:17
+#: templates/zerver/reset_done.html
 #, python-format
 msgid "Please <a href=\"%(login_url)s\">log in</a> with your new password."
 msgstr "請用新密碼<a href=\"%(login_url)s\">登入</a>。"
 
-#: templates/zerver/reset_emailed.html:4
+#: templates/zerver/reset_emailed.html
 msgid "Password reset email sent"
 msgstr "密碼重置電子郵件已發送"
 
-#: templates/zerver/reset_emailed.html:13
+#: templates/zerver/reset_emailed.html
 msgid "Password reset sent!"
 msgstr "重置密碼已發送！"
 
-#: templates/zerver/reset_emailed.html:17
+#: templates/zerver/reset_emailed.html
 msgid "Check your email in a few minutes to finish the process."
 msgstr "請在幾分鐘內查看您的電子郵件以完成流程。"
 
-#: templates/zerver/slack_import.html:5 templates/zerver/slack_import.html:13
+#: templates/zerver/slack_import.html
 msgid "Import from Slack"
 msgstr "從 Slack 匯入"
 
-#: templates/zerver/slack_import.html:22
+#: templates/zerver/slack_import.html
 msgid "Import progress"
 msgstr "匯入進度"
 
-#: templates/zerver/slack_import.html:24
+#: templates/zerver/slack_import.html
 msgid "Checking import status…"
 msgstr "確認匯入狀態…"
 
-#: templates/zerver/slack_import.html:28
+#: templates/zerver/slack_import.html
 msgid ""
 "An unexpected error occurred during the import process. Please follow the "
 "instructions for the <a href=\"https://zulip.com/help/import-from-"
@@ -4326,7 +3780,7 @@ msgid ""
 "process </a> to complete your import."
 msgstr ""
 
-#: templates/zerver/slack_import.html:45
+#: templates/zerver/slack_import.html
 #, python-format
 msgid ""
 "Follow <a href=\"https://zulip.com/help//import-from-slack#export-your-slack-"
@@ -4339,15 +3793,15 @@ msgstr ""
 "rel=\"noopener noreferrer\" target=\"_blank\">這些說明</a>來取得<strong>Bot "
 "User OAuth Token</strong>。"
 
-#: templates/zerver/slack_import.html:51
+#: templates/zerver/slack_import.html
 msgid "Slack bot user OAuth token"
 msgstr "Slack Bot User OAuth Token"
 
-#: templates/zerver/slack_import.html:76
+#: templates/zerver/slack_import.html
 msgid "Upload your Slack export file"
 msgstr "上傳您的 Slack 匯出檔案"
 
-#: templates/zerver/slack_import.html:78
+#: templates/zerver/slack_import.html
 msgid ""
 "Follow <a href=\"https://zulip.com/help/import-from-slack#export-your-slack-"
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">these instructions</a> "
@@ -4357,19 +3811,19 @@ msgstr ""
 "data\" target=\"_blank\" rel=\"noopener noreferrer\">這些說明</a>來取得您的 "
 "Slack 訊息歷史匯出。"
 
-#: templates/zerver/slack_import.html:83
+#: templates/zerver/slack_import.html
 msgid "Start upload"
 msgstr "開始上傳"
 
-#: templates/zerver/slack_import.html:92
+#: templates/zerver/slack_import.html
 msgid "Uploaded export file"
 msgstr "已上傳的匯出檔案"
 
-#: templates/zerver/slack_import.html:101
+#: templates/zerver/slack_import.html
 msgid "Who will be allowed to see other users' email addresses?"
 msgstr "誰可以查看其他使用者的 Email 地址？"
 
-#: templates/zerver/slack_import.html:104
+#: templates/zerver/slack_import.html
 msgid ""
 "Users can <a href=\"https://zulip.com/help/configure-email-visibility\" "
 "target=\"_blank\">change</a> their email visibility configuration when they "
@@ -4378,11 +3832,11 @@ msgstr ""
 "使用者可以在登入時 <a href=\"https://zulip.com/help/configure-email-"
 "visibility\" target=\"_blank\">變更</a> 他們的電子郵件可見度設定。"
 
-#: templates/zerver/slack_import.html:117
+#: templates/zerver/slack_import.html
 msgid "Start import"
 msgstr "開始匯入"
 
-#: templates/zerver/slack_import.html:127
+#: templates/zerver/slack_import.html
 msgid ""
 "Feel free to step away. You can always come back to this page <br /> by "
 "clicking the <b>Complete registration</b> button in your email."
@@ -4390,7 +3844,7 @@ msgstr ""
 "您可以隨時稍作暫停。隨時都能透過點擊電子郵件中的 <br /> <b>完成註冊</b> 按鈕 "
 "回到此頁面。"
 
-#: templates/zerver/slack_import.html:141
+#: templates/zerver/slack_import.html
 msgid ""
 "Or <span id=\"cancel-slack-import\" tabindex=\"0\">create organization</"
 "span> without importing data."
@@ -4398,7 +3852,7 @@ msgstr ""
 "或是 <span id=\"cancel-slack-import\" tabindex=\"0\">建立組織</span> 而不匯入"
 "資料。"
 
-#: templates/zerver/slack_import_file_upload_instruction.html:3
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4409,7 +3863,7 @@ msgstr ""
 "行匯入的 <a href=\"/help/import-from-slack#import-your-data-into-zulip\" "
 "rel=\"noopener noreferrer\" target=\"_blank\">程序</a>。"
 
-#: templates/zerver/slack_import_file_upload_instruction.html:7
+#: templates/zerver/slack_import_file_upload_instruction.html
 #, python-format
 msgid ""
 "Maximum size: %(max_file_size)s MiB. For larger exports, follow the <a "
@@ -4420,20 +3874,20 @@ msgstr ""
 "href=\"/help/import-from-slack#import-your-data-into-zulip\" rel=\"noopener "
 "noreferrer\" target=\"_blank\">流程</a>操作，將您的資料匯入 Zulip。"
 
-#: templates/zerver/social_auth_select_email.html:4
+#: templates/zerver/social_auth_select_email.html
 msgid "Select account for authentication"
 msgstr "選擇帳號進行認證"
 
-#: templates/zerver/social_auth_select_email.html:10
+#: templates/zerver/social_auth_select_email.html
 msgid "<h1 class=\"get-started\">Select account</h1>"
 msgstr "<h1 class=\"get-started\">選擇帳號</h1>"
 
-#: templates/zerver/social_auth_select_email.html:67
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "Your GitHub account also has unverified email addresses associated with it."
 msgstr "您的 GitHub 帳號還有未驗證的電子郵件地址 與其關聯。"
 
-#: templates/zerver/social_auth_select_email.html:73
+#: templates/zerver/social_auth_select_email.html
 msgid ""
 "To use one of these to log in to Zulip, you must first <a href=\"https://"
 "github.com/settings/emails\">verify it with GitHub.</a>"
@@ -4441,21 +3895,21 @@ msgstr ""
 "要使用其中一個登入 Zulip，您必須先 <a href=\"https://github.com/settings/"
 "emails\">在 GitHub 進行驗證。</a>"
 
-#: templates/zerver/unsubscribe_link_error.html:4
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Error unsubscribing email"
 msgstr "取消訂閱電子郵件時發生錯誤"
 
-#: templates/zerver/unsubscribe_link_error.html:12
+#: templates/zerver/unsubscribe_link_error.html
 msgid "Unknown email unsubscribe request"
 msgstr "未知的電子郵件取消訂閱請求"
 
-#: templates/zerver/unsubscribe_link_error.html:16
+#: templates/zerver/unsubscribe_link_error.html
 msgid ""
 "Hi there! It looks like you tried to unsubscribe from something, but we "
 "don't recognize the URL."
 msgstr "您好！看起來您嘗試取消訂閱某些內容，但我們無法識別此網址。"
 
-#: templates/zerver/unsubscribe_link_error.html:19
+#: templates/zerver/unsubscribe_link_error.html
 #, python-format
 msgid ""
 "Please double-check that you have the full URL and try again, or <a "
@@ -4465,12 +3919,11 @@ msgstr ""
 "請再次檢查您是否有完整的網址並重新嘗試，或<a href=\"mailto:"
 "%(support_email)s\">傳送電子郵件給我們</a>，我們會為您解決！"
 
-#: templates/zerver/unsubscribe_success.html:4
-#: templates/zerver/unsubscribe_success.html:14
+#: templates/zerver/unsubscribe_success.html
 msgid "Email settings updated"
 msgstr "Email 設定已更新"
 
-#: templates/zerver/unsubscribe_success.html:19
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You've successfully unsubscribed from Zulip %(subscription_type)s emails for "
@@ -4479,7 +3932,7 @@ msgstr ""
 "您已成功取消訂閱 <a href=\"%(realm_url)s\">%(realm_name)s</a> 的 Zulip "
 "%(subscription_type)s 電子郵件。"
 
-#: templates/zerver/unsubscribe_success.html:27
+#: templates/zerver/unsubscribe_success.html
 #, python-format
 msgid ""
 "You can undo this change or review your preferences in your <a "
@@ -4488,113 +3941,111 @@ msgstr ""
 "您可以在<a href=\"%(realm_url)s/#settings/notifications\">通知設定</a>中 撤銷"
 "此變更或檢查您的偏好設定。"
 
-#: zerver/actions/channel_folders.py:57
-#: zerver/actions/custom_profile_fields.py:162
+#: zerver/actions/channel_folders.py zerver/actions/custom_profile_fields.py
 msgid "Invalid order mapping."
 msgstr "無效的順序對應。"
 
-#: zerver/actions/create_realm.py:346
+#: zerver/actions/create_realm.py
 msgid "Questions and discussion about using Zulip."
 msgstr "關於使用 Zulip 的問題和討論。"
 
-#: zerver/actions/create_realm.py:352
+#: zerver/actions/create_realm.py
 msgid "Experiment with Zulip here. :test_tube:"
 msgstr "在這裡試用 Zulip。:test_tube:"
 
-#: zerver/actions/create_realm.py:358
+#: zerver/actions/create_realm.py
 msgid "For team-wide conversations"
 msgstr "用於全團隊對話"
 
-#: zerver/actions/create_user.py:85
+#: zerver/actions/create_user.py
 msgid "signups"
 msgstr "註冊"
 
-#: zerver/actions/create_user.py:113
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} joined this organization."
 msgstr "{user} 加入了此組織。"
 
-#: zerver/actions/create_user.py:310
+#: zerver/actions/create_user.py
 #, python-brace-format
 msgid "{user} accepted your invitation to join Zulip!"
 msgstr "{user} 已同意您的邀請並加入了 Zulip！"
 
-#: zerver/actions/create_user.py:713
+#: zerver/actions/create_user.py
 msgid ""
 "Cannot activate a placeholder account; ask the user to sign up, instead."
 msgstr "無法啟用佔位符帳號；請要求使用者註冊。"
 
-#: zerver/actions/create_user.py:717
+#: zerver/actions/create_user.py
 #, fuzzy
 #| msgid "Cannot deactivate user group in use."
 msgid "Cannot reactivate a deleted user"
 msgstr "無法停用使用中的使用者群組。"
 
-#: zerver/actions/custom_profile_fields.py:272 zerver/lib/users.py:557
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
 msgid ""
 "You are not allowed to change this field. Contact an administrator to update "
 "it."
 msgstr "您不被允許變更此欄位。請聯絡管理員進行更新。"
 
-#: zerver/actions/custom_profile_fields.py:302 zerver/lib/users.py:552
-#: zerver/views/custom_profile_fields.py:239
-#: zerver/views/custom_profile_fields.py:264
+#: zerver/actions/custom_profile_fields.py zerver/lib/users.py
+#: zerver/views/custom_profile_fields.py
 #, python-brace-format
 msgid "Field id {id} not found."
 msgstr "找不到欄位 id {id}。"
 
-#: zerver/actions/default_streams.py:18
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group name '{group_name}'"
 msgstr "無效的預設頻道群組名稱「{group_name}」"
 
-#: zerver/actions/default_streams.py:22
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group name too long (limit: {max_length} characters)"
 msgstr "預設頻道群組名稱過長（限制：{max_length} 個字元）"
 
-#: zerver/actions/default_streams.py:30
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Default channel group name '{group_name}' contains NULL (0x00) characters."
 msgstr "預設頻道群組名稱「{group_name}」包含 NULL (0x00) 字元。"
 
-#: zerver/actions/default_streams.py:46
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Invalid default channel group {group_name}"
 msgstr "無效的預設頻道群組 {group_name}"
 
-#: zerver/actions/default_streams.py:94 zerver/actions/default_streams.py:121
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "'{channel_name}' is a default channel and cannot be added to '{group_name}'"
 msgstr "「{channel_name}」是預設頻道，無法加入到「{group_name}」"
 
-#: zerver/actions/default_streams.py:105 zerver/actions/default_streams.py:166
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "Default channel group '{group_name}' already exists"
 msgstr "預設頻道群組「{group_name}」已存在"
 
-#: zerver/actions/default_streams.py:127
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is already present in default channel group "
 "'{group_name}'"
 msgstr "頻道「{channel_name}」已存在於預設頻道群組「{group_name}」中"
 
-#: zerver/actions/default_streams.py:144
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid ""
 "Channel '{channel_name}' is not present in default channel group "
 "'{group_name}'"
 msgstr "頻道「{channel_name}」不存在於預設頻道群組「{group_name}」中"
 
-#: zerver/actions/default_streams.py:159
+#: zerver/actions/default_streams.py
 #, python-brace-format
 msgid "This default channel group is already named '{group_name}'"
 msgstr "此預設頻道群組已命名為「{group_name}」"
 
-#: zerver/actions/invites.py:147
+#: zerver/actions/invites.py
 msgid ""
 "To protect users, Zulip limits the number of invitations you can send in one "
 "day. Because you have reached the limit, no invitations were sent."
@@ -4602,7 +4053,7 @@ msgstr ""
 "為了保護使用者，Zulip 限制您每天可以發送的邀請數量。由於您已達到限制，因此未"
 "發送邀請。"
 
-#: zerver/actions/invites.py:226
+#: zerver/actions/invites.py
 msgid ""
 "Your account is too new to send invites for this organization. Ask an "
 "organization admin, or a more experienced user."
@@ -4610,75 +4061,75 @@ msgstr ""
 "您的帳號太新，以至於不能發送此組織的邀請。詢問組織管理者，或是更有經驗的使用"
 "者。"
 
-#: zerver/actions/invites.py:266
+#: zerver/actions/invites.py
 msgid "Some emails did not validate, so we didn't send any invitations."
 msgstr "部份 emails 尚未驗證，所以我們沒有送出邀請。"
 
-#: zerver/actions/invites.py:274
+#: zerver/actions/invites.py
 msgid "We weren't able to invite anyone."
 msgstr "我們無法邀請任何人。"
 
-#: zerver/actions/message_edit.py:138 zerver/views/scheduled_messages.py:78
+#: zerver/actions/message_edit.py zerver/views/scheduled_messages.py
 msgid "Nothing to change"
 msgstr "沒有任何變更"
 
-#: zerver/actions/message_edit.py:142
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot be moved to channels."
 msgstr "私人訊息無法移動到頻道。"
 
-#: zerver/actions/message_edit.py:144
+#: zerver/actions/message_edit.py
 msgid "Direct messages cannot have topics."
 msgstr "私人訊息無法有議題。"
 
-#: zerver/actions/message_edit.py:147
+#: zerver/actions/message_edit.py
 msgid "Invalid propagate_mode without topic edit"
 msgstr "無效的非議題編輯 propagate_mode"
 
-#: zerver/actions/message_edit.py:153
+#: zerver/actions/message_edit.py
 msgid "General chat cannot be marked as resolved"
 msgstr "一般聊天無法標記為解決"
 
-#: zerver/actions/message_edit.py:159
+#: zerver/actions/message_edit.py
 msgid "Cannot change message content while changing channel"
 msgstr "變更頻道時無法變更訊息內容"
 
-#: zerver/actions/message_edit.py:163
+#: zerver/actions/message_edit.py
 msgid "Widgets cannot be edited."
 msgstr "小工具無法編輯。"
 
-#: zerver/actions/message_edit.py:181
+#: zerver/actions/message_edit.py
 msgid "Your organization has turned off message editing"
 msgstr "您的組織關閉了訊息編輯"
 
-#: zerver/actions/message_edit.py:185 zerver/actions/message_edit.py:1634
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to edit this message"
 msgstr "您沒有權限編輯此訊息"
 
-#: zerver/actions/message_edit.py:190
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message has passed"
 msgstr "可編輯此訊息的時間已過"
 
-#: zerver/actions/message_edit.py:286
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as resolved."
 msgstr "{user} 已將此議題標記為 解決。"
 
-#: zerver/actions/message_edit.py:288
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "{user} has marked this topic as unresolved."
 msgstr "{user} 已將此議題標記為 未解決。"
 
-#: zerver/actions/message_edit.py:1356
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved to {new_location} by {user}."
 msgstr "此議題已被 {user} 移動到 {new_location}。"
 
-#: zerver/actions/message_edit.py:1360
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "A message was moved from this topic to {new_location} by {user}."
 msgstr "一則訊息已被 {user} 從此議題移動到 {new_location}。"
 
-#: zerver/actions/message_edit.py:1364
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved from this topic to "
@@ -4686,18 +4137,18 @@ msgid ""
 msgstr ""
 "{changed_messages_count} 則訊息已被 {user} 從此議題移動到 {new_location}。"
 
-#: zerver/actions/message_edit.py:1403
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid "This topic was moved here from {old_location} by {user}."
 msgstr "此議題已被 {user} 從 {old_location} 移動到這裡。"
 
-#: zerver/actions/message_edit.py:1408
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "[A message]({message_link}) was moved here from {old_location} by {user}."
 msgstr "[一則訊息]({message_link}) 已被 {user} 從 {old_location} 移動到這裡。"
 
-#: zerver/actions/message_edit.py:1412
+#: zerver/actions/message_edit.py
 #, python-brace-format
 msgid ""
 "{changed_messages_count} messages were moved here from {old_location} by "
@@ -4705,65 +4156,62 @@ msgid ""
 msgstr ""
 "{changed_messages_count} 則訊息已被 {user} 從 {old_location} 移動到這裡。"
 
-#: zerver/actions/message_edit.py:1628
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to resolve topics in this channel."
 msgstr "您沒有權限在此頻道中解決議題。"
 
-#: zerver/actions/message_edit.py:1647
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's topic has passed."
 msgstr "編輯此訊息議題的時間限制已過。"
 
-#: zerver/actions/message_edit.py:1758
+#: zerver/actions/message_edit.py
 msgid "You don't have permission to move this message"
 msgstr "您沒有權限移動此訊息"
 
-#: zerver/actions/message_edit.py:1777
+#: zerver/actions/message_edit.py
 msgid "The time limit for editing this message's channel has passed"
 msgstr "編輯此訊息頻道的時間限制已過"
 
-#: zerver/actions/message_flags.py:312
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid flag: '{flag}'"
 msgstr "無效的標誌：「{flag}」"
 
-#: zerver/actions/message_flags.py:314
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Flag not editable: '{flag}'"
 msgstr "標記無法編輯：「{flag}」"
 
-#: zerver/actions/message_flags.py:317
+#: zerver/actions/message_flags.py
 #, python-brace-format
 msgid "Invalid message flag operation: '{operation}'"
 msgstr "無效的訊息標記操作：「{operation}」"
 
-#: zerver/actions/message_flags.py:402 zerver/lib/message.py:423
-#: zerver/lib/message.py:438 zerver/lib/message.py:467
-#: zerver/lib/message.py:481
+#: zerver/actions/message_flags.py zerver/lib/message.py
 msgid "Invalid message(s)"
 msgstr "無效的訊息(s)"
 
-#: zerver/actions/message_send.py:192
+#: zerver/actions/message_send.py
 msgid "Unable to render message"
 msgstr "無法渲染訊息"
 
-#: zerver/actions/message_send.py:1356
+#: zerver/actions/message_send.py
 msgid "Expected exactly one channel"
 msgstr "期望只有一個頻道"
 
-#: zerver/actions/message_send.py:1367
+#: zerver/actions/message_send.py
 msgid "Invalid data type for channel"
 msgstr "頻道的資料類型無效"
 
-#: zerver/actions/message_send.py:1383 zerver/actions/message_send.py:1393
-#: zerver/lib/recipient_parsing.py:15
+#: zerver/actions/message_send.py zerver/lib/recipient_parsing.py
 msgid "Invalid data type for recipients"
 msgstr "無效的 recipients 資料類型"
 
-#: zerver/actions/message_send.py:1401 zerver/actions/message_send.py:1409
+#: zerver/actions/message_send.py
 msgid "Recipient lists may contain emails or user IDs, but not both."
 msgstr "接收者清單可包含 emails 或是使用者 IDs，但不能兩個同時存在。"
 
-#: zerver/actions/message_send.py:1565
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel ID {channel_id}, "
@@ -4772,7 +4220,7 @@ msgstr ""
 "您的機器人 {bot_identity} 試圖發送訊息到頻道 ID {channel_id}，但沒有該 ID 的"
 "頻道。"
 
-#: zerver/actions/message_send.py:1576
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}, "
@@ -4782,7 +4230,7 @@ msgstr ""
 "您的機器人 {bot_identity} 試圖發送訊息到頻道 {channel_name}，但該頻道不存在。"
 "點擊[這裡]({new_channel_link})建立它。"
 
-#: zerver/actions/message_send.py:1588
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "Your bot {bot_identity} tried to send a message to channel {channel_name}. "
@@ -4791,29 +4239,29 @@ msgstr ""
 "您的機器人 {bot_identity} 試圖發送訊息到頻道 {channel_name}。該頻道存在但沒有"
 "任何訂閱者。"
 
-#: zerver/actions/message_send.py:1679
+#: zerver/actions/message_send.py
 msgid "You do not have permission to access some of the recipients."
 msgstr "您沒有權限存取某些接收者。"
 
-#: zerver/actions/message_send.py:1895
+#: zerver/actions/message_send.py
 msgid "Widgets: API programmer sent invalid JSON content"
 msgstr "小工具：API 程式設計師發送了無效的 JSON 內容"
 
-#: zerver/actions/message_send.py:1901
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "Widgets: {error_msg}"
 msgstr "小工具：{error_msg}"
 
-#: zerver/actions/message_send.py:2261
+#: zerver/actions/message_send.py
 msgid "The following changes have been made to your account."
 msgstr "您的帳號已進行以下變更。"
 
-#: zerver/actions/message_send.py:2264
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid "{user} has made the following changes to your account."
 msgstr "{user} 對您的帳號進行了以下變更。"
 
-#: zerver/actions/message_send.py:2270
+#: zerver/actions/message_send.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -4824,102 +4272,100 @@ msgstr ""
 "- **舊的 {field_name}：** {old_value}\n"
 "- **新的 {field_name}：** {new_value}\n"
 
-#: zerver/actions/realm_emoji.py:35 zerver/views/realm_emoji.py:40
+#: zerver/actions/realm_emoji.py zerver/views/realm_emoji.py
 msgid "A custom emoji with this name already exists."
 msgstr "自定義表情符號名稱已存在。"
 
-#: zerver/actions/realm_emoji.py:41 zerver/lib/upload/__init__.py:442
-#: zerver/lib/upload/__init__.py:519 zerver/lib/upload/__init__.py:527
-#: zerver/lib/upload/__init__.py:555
+#: zerver/actions/realm_emoji.py zerver/lib/upload/__init__.py
 msgid "Invalid image format"
 msgstr "無效的圖片格式"
 
-#: zerver/actions/realm_linkifiers.py:196
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must not contain duplicated linkifiers"
 msgstr "有序清單不得包含重複的連結器"
 
-#: zerver/actions/realm_linkifiers.py:201
+#: zerver/actions/realm_linkifiers.py
 msgid "The ordered list must enumerate all existing linkifiers exactly once"
 msgstr "有序清單必須將所有現有連結器完全列舉一次"
 
-#: zerver/actions/realm_settings.py:361
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid ""
 "You need to upgrade to the {required_upgrade_plan_name} plan to use this "
 "authentication method."
 msgstr "您需要升級到 {required_upgrade_plan_name} 方案才能使用此認證方法。"
 
-#: zerver/actions/realm_settings.py:376
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Invalid authentication method: {name}. Valid methods are: {methods}"
 msgstr "無效的認證方法：{name}。有效的方法有：{methods}"
 
-#: zerver/actions/realm_settings.py:402
+#: zerver/actions/realm_settings.py
 #, python-brace-format
 msgid "Authentication method {name} is not available on your current plan."
 msgstr "認證方法 {name} 在您目前的方案中不可用。"
 
-#: zerver/actions/realm_settings.py:511 zerver/views/streams.py:369
+#: zerver/actions/realm_settings.py zerver/views/streams.py
 msgid "Moderation request channel must be private."
 msgstr "審核請求頻道必須是私人的。"
 
-#: zerver/actions/saved_snippets.py:54 zerver/actions/saved_snippets.py:87
+#: zerver/actions/saved_snippets.py
 msgid "Saved snippet does not exist."
 msgstr "儲存的文字片段不存在。"
 
-#: zerver/actions/scheduled_messages.py:179
+#: zerver/actions/scheduled_messages.py
 msgid "Scheduled message was already sent"
 msgstr "已排程訊息已經發送"
 
-#: zerver/actions/scheduled_messages.py:325
+#: zerver/actions/scheduled_messages.py
 #, fuzzy
 #| msgid "Reminder does not exist"
 msgid "Reminder could not be sent."
 msgstr "提醒不存在"
 
-#: zerver/actions/scheduled_messages.py:357
+#: zerver/actions/scheduled_messages.py
 msgid "Message could not be sent at the scheduled time."
 msgstr "訊息無法在排定的時間發送。"
 
-#: zerver/actions/scheduled_messages.py:407
+#: zerver/actions/scheduled_messages.py
 #, python-brace-format
 msgid ""
 "The message you scheduled for {delivery_datetime} was not sent because of "
 "the following error:"
 msgstr "您排定於 {delivery_datetime} 發送的訊息因為以下錯誤而未發送："
 
-#: zerver/actions/scheduled_messages.py:412
+#: zerver/actions/scheduled_messages.py
 msgid "[View scheduled messages](#scheduled)"
 msgstr "[查看已排定的訊息](#scheduled)"
 
-#: zerver/actions/streams.py:123
+#: zerver/actions/streams.py
 msgid "Channel is already deactivated"
 msgstr "頻道已停用"
 
-#: zerver/actions/streams.py:192
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been archived."
 msgstr "頻道 #**{channel_name}** 已封存。"
 
-#: zerver/actions/streams.py:233
+#: zerver/actions/streams.py
 msgid "Channel is not currently deactivated"
 msgstr "頻道目前未停用"
 
-#: zerver/actions/streams.py:239
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel named {channel_name} already exists"
 msgstr "名為 {channel_name} 的頻道已存在"
 
-#: zerver/actions/streams.py:242
+#: zerver/actions/streams.py
 msgid "Channel is private and have no subscribers"
 msgstr "頻道是私人的且沒有訂閱者"
 
-#: zerver/actions/streams.py:320
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Channel #**{channel_name}** has been unarchived."
 msgstr "頻道 #**{channel_name}** 已解除封存。"
 
-#: zerver/actions/streams.py:1254
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [access permissions]({help_link}) for this channel from "
@@ -4928,7 +4374,7 @@ msgstr ""
 "{user} 將此頻道的[存取權限]({help_link})從 **{old_policy}** 變更為 "
 "**{new_policy}**。"
 
-#: zerver/actions/streams.py:1477
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} changed the [posting permissions]({help_link}) for this channel:\n"
@@ -4941,51 +4387,49 @@ msgstr ""
 "* **舊設定**：{old_setting_description}\n"
 "* **新設定**：{new_setting_description}\n"
 
-#: zerver/actions/streams.py:1547
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user_name} renamed channel {old_channel_name} to {new_channel_name}."
 msgstr "{user_name} 將頻道 {old_channel_name} 重新命名為 {new_channel_name}。"
 
-#: zerver/actions/streams.py:1564 zerver/actions/streams.py:1566
-#: zerver/views/streams.py:1071
+#: zerver/actions/streams.py zerver/views/streams.py
 msgid "No description."
 msgstr "無敘述。"
 
-#: zerver/actions/streams.py:1569
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{user} changed the description for this channel."
 msgstr "{user} 變更了此頻道的描述。"
 
-#: zerver/actions/streams.py:1571
+#: zerver/actions/streams.py
 msgid "Old description"
 msgstr "舊描述"
 
-#: zerver/actions/streams.py:1575
+#: zerver/actions/streams.py
 msgid "New description"
 msgstr "新描述"
 
-#: zerver/actions/streams.py:1645 zerver/actions/streams.py:1652
+#: zerver/actions/streams.py
 msgid "Forever"
 msgstr "永遠"
 
-#: zerver/actions/streams.py:1646 zerver/actions/streams.py:1651
-#: zerver/actions/streams.py:1655 zerver/actions/streams.py:1656
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "{number_of_days} days"
 msgstr "{number_of_days} 天"
 
-#: zerver/actions/streams.py:1648 zerver/actions/streams.py:1658
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "Messages in this channel will now be automatically deleted {number_of_days} "
 "days after they are sent."
 msgstr "此頻道中的訊息現在將在發送後 {number_of_days} 天自動刪除。"
 
-#: zerver/actions/streams.py:1653
+#: zerver/actions/streams.py
 msgid "Messages in this channel will now be retained forever."
 msgstr "此頻道中的訊息現在將永久保留。"
 
-#: zerver/actions/streams.py:1661
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user} has changed the [message retention period]({help_link}) for this "
@@ -5001,26 +4445,26 @@ msgstr ""
 "\n"
 "{summary_line}"
 
-#: zerver/actions/streams.py:1757
+#: zerver/actions/streams.py
 msgid "Automatic"
 msgstr "自動"
 
-#: zerver/actions/streams.py:1759
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "*{empty_topic_display_name}* topic allowed"
 msgstr "允許 *{empty_topic_display_name}* 議題"
 
-#: zerver/actions/streams.py:1762
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "No *{empty_topic_display_name}* topic"
 msgstr "不允許 *{empty_topic_display_name}* 議題"
 
-#: zerver/actions/streams.py:1765
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid "Only *{empty_topic_display_name}* topic allowed"
 msgstr "只允許 *{empty_topic_display_name}* 議題"
 
-#: zerver/actions/streams.py:1771
+#: zerver/actions/streams.py
 #, python-brace-format
 msgid ""
 "{user_name} changed the \"Allow posting to the *general chat* topic?\" "
@@ -5029,135 +4473,124 @@ msgstr ""
 "{user_name} 將「允許發文到 *一般聊天* ？」設定從 {old_topics_policy} 更改為 "
 "{new_topics_policy}。"
 
-#: zerver/actions/submessage.py:37
+#: zerver/actions/submessage.py
 msgid "You cannot attach a submessage to this message."
 msgstr "您無法將子訊息附加到此訊息。"
 
-#: zerver/actions/typing.py:61 zerver/lib/addressee.py:36
+#: zerver/actions/typing.py zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid user ID {user_id}"
 msgstr "無效的使用者 ID {user_id}"
 
-#: zerver/actions/user_groups.py:255 zerver/actions/user_groups.py:291
+#: zerver/actions/user_groups.py
 #, python-brace-format
 msgid "User group '{group_name}' already exists."
 msgstr "使用者群組「{group_name}」已存在。"
 
-#: zerver/decorator.py:218 zerver/decorator.py:723 zerver/lib/streams.py:145
-#: zerver/lib/streams.py:241 zerver/lib/streams.py:243
-#: zerver/lib/streams.py:245 zerver/lib/streams.py:254
-#: zerver/lib/streams.py:1607 zerver/lib/streams.py:1663
-#: zerver/lib/user_groups.py:194 zerver/lib/user_groups.py:220
-#: zerver/lib/user_groups.py:396 zerver/lib/user_groups.py:494
-#: zerver/lib/users.py:217 zerver/lib/users.py:286 zerver/lib/users.py:315
-#: zerver/lib/users.py:319 zerver/views/invite.py:161
-#: zerver/views/invite.py:290 zerver/views/message_summary.py:31
-#: zerver/views/presence.py:56 zerver/views/realm_emoji.py:35
-#: zerver/views/streams.py:384 zerver/views/streams.py:387
-#: zerver/views/streams.py:396 zerver/views/streams.py:449
-#: zerver/views/streams.py:907
+#: zerver/decorator.py zerver/lib/streams.py zerver/lib/user_groups.py
+#: zerver/lib/users.py zerver/views/invite.py zerver/views/message_summary.py
+#: zerver/views/presence.py zerver/views/realm_emoji.py zerver/views/streams.py
 msgid "Insufficient permission"
 msgstr "權限不足"
 
-#: zerver/decorator.py:272
+#: zerver/decorator.py
 msgid "This API is not available to incoming webhook bots."
 msgstr "此 API 不適用於傳入的 webhook 機器人。"
 
-#: zerver/decorator.py:310
+#: zerver/decorator.py
 msgid "Account is not associated with this subdomain"
 msgstr "帳號沒被關聯至此子域名"
 
-#: zerver/decorator.py:571 zerver/decorator.py:704
+#: zerver/decorator.py
 msgid "This endpoint does not accept bot requests."
 msgstr "此端點不接受機器人請求。"
 
-#: zerver/decorator.py:664
+#: zerver/decorator.py
 msgid "Must be an server administrator"
 msgstr "必須是伺服器管理員"
 
-#: zerver/decorator.py:765
+#: zerver/decorator.py
 msgid "This endpoint requires HTTP basic authentication."
 msgstr "此端點需要 HTTP 基本認證。"
 
-#: zerver/decorator.py:772
+#: zerver/decorator.py
 msgid "Invalid authorization header for basic auth"
 msgstr "無效的 authorization header for basic auth"
 
-#: zerver/decorator.py:774
+#: zerver/decorator.py
 msgid "Missing authorization header for basic auth"
 msgstr "basic auth 缺少 authorization header"
 
-#: zerver/decorator.py:950
+#: zerver/decorator.py
 msgid "Webhook bots can only access webhooks"
 msgstr "Webhook 機器人只能存取 webhooks"
 
-#: zerver/forms.py:69
+#: zerver/forms.py
 msgid "Incorrect email or password."
 msgstr "電子郵件或密碼不正確。"
 
-#: zerver/forms.py:71
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your account {username} has been deactivated. Please contact your "
 "organization administrator to reactivate it."
 msgstr "您的帳號 {username} 已被停用。請聯絡您的組織管理員以重新啟用。"
 
-#: zerver/forms.py:74
+#: zerver/forms.py
 msgid "The password is too weak."
 msgstr "密碼太弱。"
 
-#: zerver/forms.py:88
+#: zerver/forms.py
 msgid "Subdomain needs to have length 3 or greater."
 msgstr "子域名需要長度至少為 3。"
 
-#: zerver/forms.py:89
+#: zerver/forms.py
 msgid "Subdomain cannot start or end with a '-'."
 msgstr "子域名不能開頭或結尾有 '-'。"
 
-#: zerver/forms.py:90
+#: zerver/forms.py
 msgid "Subdomain can only have lowercase letters, numbers, and '-'s."
 msgstr "子域名只能是英文字母、數字、'-'。"
 
-#: zerver/forms.py:91
+#: zerver/forms.py
 msgid "Subdomain is already in use. Please choose a different one."
 msgstr "子域名已被使用。請選擇不同的子域名。"
 
-#: zerver/forms.py:92
+#: zerver/forms.py
 msgid "Subdomain reserved. Please choose a different one."
 msgstr "子域名已被保留。請選擇不同的子域名。"
 
-#: zerver/forms.py:129 zerver/forms.py:316 zerver/lib/email_validation.py:111
-#: zilencer/views.py:253
+#: zerver/forms.py zerver/lib/email_validation.py zilencer/views.py
 msgid "Please use your real email address."
 msgstr "請使用您真正的 email 地址。"
 
-#: zerver/forms.py:289
+#: zerver/forms.py
 #, python-brace-format
 msgid "The organization you are trying to join using {email} does not exist."
 msgstr "您嘗試加入的組織使用的 {email} 不存在。"
 
-#: zerver/forms.py:298
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Please request an invite for {email} from the organization administrator."
 msgstr "請向組織管理員申請邀請 {email}。"
 
-#: zerver/forms.py:303
+#: zerver/forms.py
 msgid "Can't join the organization: password authentication is not enabled."
 msgstr "無法加入組織：未啟用密碼驗證。"
 
-#: zerver/forms.py:311
+#: zerver/forms.py
 #, python-brace-format
 msgid ""
 "Your email address, {email}, is not in one of the domains that are allowed "
 "to register for accounts in this organization."
 msgstr "您的 email 地址 {email}，並不在此組織允許註冊的域名範圍內。"
 
-#: zerver/forms.py:319
+#: zerver/forms.py
 msgid "Email addresses containing + are not allowed in this organization."
 msgstr "此組織不允許包含 + 的電子郵件地址。"
 
-#: zerver/forms.py:334
+#: zerver/forms.py
 msgid ""
 "New members cannot join this organization because all Zulip licenses are in "
 "use. Please contact the person who invited you and ask them to increase the "
@@ -5166,32 +4599,31 @@ msgstr ""
 "新成員無法加入此組織，因為所有 Zulip 授權都已使用。請聯絡邀請您的人員，要求他"
 "們增加授權數量，然後再試一次。"
 
-#: zerver/forms.py:389
+#: zerver/forms.py
 msgid "Verified that you're a human user!"
 msgstr "已驗證您是真實使用者！"
 
-#: zerver/forms.py:390
+#: zerver/forms.py
 msgid "Verifying that you're not a bot…"
 msgstr "正在驗證您不是機器人…"
 
-#: zerver/forms.py:398 zerver/views/antispam.py:29
+#: zerver/forms.py zerver/views/antispam.py
 msgid "Challenges are not enabled."
 msgstr "尚未啟用挑戰功能。"
 
-#: zerver/forms.py:404 zerver/forms.py:409 zerver/forms.py:416
-#: zerver/forms.py:441 zerver/forms.py:466
+#: zerver/forms.py
 msgid "Validation failed, please try again."
 msgstr "驗證失敗，請再試一次。"
 
-#: zerver/forms.py:476
+#: zerver/forms.py
 msgid "New password"
 msgstr "新密碼"
 
-#: zerver/forms.py:483
+#: zerver/forms.py
 msgid "New password confirmation"
 msgstr "確認新密碼"
 
-#: zerver/forms.py:636
+#: zerver/forms.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "You're making too many attempts to sign in. Try again in {seconds} "
@@ -5203,90 +4635,88 @@ msgstr ""
 "您嘗試登入的次數過多。請在 {seconds} 秒後再試一次，或聯絡您的組織管理員尋求協"
 "助。"
 
-#: zerver/forms.py:648
+#: zerver/forms.py
 msgid ""
 "Your password has been disabled because it is too weak. Reset your password "
 "to create a new one."
 msgstr "您的密碼因為太弱而被停用。請重置密碼以建立新密碼。"
 
-#: zerver/forms.py:696
+#: zerver/forms.py
 msgid "Token"
 msgstr "Token"
 
-#: zerver/forms.py:719
+#: zerver/forms.py
 msgid "Tip: You can enter multiple email addresses with commas between them."
 msgstr "提示：您可以輸入多個電子郵件地址，以逗號分隔。"
 
-#: zerver/forms.py:725
+#: zerver/forms.py
 msgid "Please enter at most 10 emails."
 msgstr "請輸入至多 10 個 emails。"
 
-#: zerver/forms.py:738
+#: zerver/forms.py
 msgid "We couldn't find that Zulip organization."
 msgstr "我們找不到該 Zulip 組織。"
 
-#: zerver/lib/addressee.py:25
+#: zerver/lib/addressee.py
 #, python-brace-format
 msgid "Invalid email '{email}'"
 msgstr "無效的電子郵件「{email}」"
 
-#: zerver/lib/addressee.py:64 zerver/lib/addressee.py:138
-#: zerver/views/typing.py:50
+#: zerver/lib/addressee.py zerver/views/typing.py
 msgid "Missing topic"
 msgstr "缺少議題"
 
-#: zerver/lib/addressee.py:123
+#: zerver/lib/addressee.py
 msgid "Cannot send to multiple channels"
 msgstr "無法發送到多個頻道"
 
-#: zerver/lib/addressee.py:135
+#: zerver/lib/addressee.py
 msgid "Missing channel"
 msgstr "頻道不存在"
 
-#: zerver/lib/addressee.py:146
+#: zerver/lib/addressee.py
 msgid "Message must have recipients"
 msgstr "訊息必須有接受者"
 
-#: zerver/lib/addressee.py:155 zerver/lib/outgoing_webhook.py:222
+#: zerver/lib/addressee.py zerver/lib/outgoing_webhook.py
 msgid "Invalid message type"
 msgstr "無效的訊息類型"
 
-#: zerver/lib/attachments.py:42 zerver/views/thumbnail.py:61
-#: zerver/views/thumbnail.py:66
+#: zerver/lib/attachments.py zerver/views/thumbnail.py
 msgid "Invalid attachment"
 msgstr "無效的附加檔案"
 
-#: zerver/lib/attachments.py:51
+#: zerver/lib/attachments.py
 msgid ""
 "An error occurred while deleting the attachment. Please try again later."
 msgstr "刪除附件時發生錯誤。請稍後再試。"
 
-#: zerver/lib/bot_lib.py:107
+#: zerver/lib/bot_lib.py
 msgid "Message must have recipients!"
 msgstr "訊息必須有接受者！"
 
-#: zerver/lib/channel_folders.py:27
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name can't be empty."
 msgstr "頻道資料夾名稱不能空白。"
 
-#: zerver/lib/channel_folders.py:32
+#: zerver/lib/channel_folders.py
 #, python-brace-format
 msgid "Invalid character in channel folder name, at position {position}."
 msgstr "頻道資料夾名稱中有無效字元，位置在 {position}。"
 
-#: zerver/lib/channel_folders.py:38
+#: zerver/lib/channel_folders.py
 msgid "Channel folder name already in use"
 msgstr "頻道資料夾名稱已被使用"
 
-#: zerver/lib/channel_folders.py:77
+#: zerver/lib/channel_folders.py
 msgid "Invalid channel folder ID"
 msgstr "頻道資料夾 ID 無效"
 
-#: zerver/lib/demo_organizations.py:35
+#: zerver/lib/demo_organizations.py
 msgid "Configure owner account email address."
 msgstr "確認擁有者的電子郵件地址。"
 
-#: zerver/lib/demo_organizations.py:60
+#: zerver/lib/demo_organizations.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "\n"
@@ -5306,72 +4736,72 @@ msgstr ""
 " {demo_conversion_deadline} 天後**自動刪除**，\n"
 "除非將其[轉換為永久組織]({convert_demo_organization_help_url})。\n"
 
-#: zerver/lib/devices.py:30
+#: zerver/lib/devices.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is not a date"
 msgid "{var_name} is not Base64 encoded"
 msgstr "{var_name} 不是 date"
 
-#: zerver/lib/devices.py:68
+#: zerver/lib/devices.py
 #, fuzzy
 #| msgid "Invalid emoji code."
 msgid "Invalid `device_id`"
 msgstr "無效的表情符號碼。"
 
-#: zerver/lib/digest.py:458
+#: zerver/lib/digest.py
 #, python-brace-format
 msgid "{service_name} digest"
 msgstr "{service_name} 摘要"
 
-#: zerver/lib/domains.py:9
+#: zerver/lib/domains.py
 msgid "Domain can't be empty."
 msgstr "域名不能為空。"
 
-#: zerver/lib/domains.py:11
+#: zerver/lib/domains.py
 msgid "Domain must have at least one dot (.)"
 msgstr "域名必須至少有一個 (.)"
 
-#: zerver/lib/domains.py:13
+#: zerver/lib/domains.py
 msgid "Domain is too long"
 msgstr "域名過長"
 
-#: zerver/lib/domains.py:15
+#: zerver/lib/domains.py
 msgid "Domain cannot start or end with a dot (.)"
 msgstr "域名不能開頭或結尾有 (.)"
 
-#: zerver/lib/domains.py:18
+#: zerver/lib/domains.py
 msgid "Consecutive '.' are not allowed."
 msgstr "不允許連續的 「‧」。"
 
-#: zerver/lib/domains.py:20
+#: zerver/lib/domains.py
 msgid "Subdomains cannot start or end with a '-'."
 msgstr "子域名不能開頭或結尾有 '-'。"
 
-#: zerver/lib/domains.py:22
+#: zerver/lib/domains.py
 msgid "Domain can only have letters, numbers, '.' and '-'s."
 msgstr "域名只能是英文字母、數字、'.' 和 '-'。"
 
-#: zerver/lib/drafts.py:64
+#: zerver/lib/drafts.py
 msgid "Timestamp must not be negative."
 msgstr "時間戳記不得為負數。"
 
-#: zerver/lib/drafts.py:73
+#: zerver/lib/drafts.py
 msgid "Topic must not contain null bytes"
 msgstr "議題不得包含空位元組"
 
-#: zerver/lib/drafts.py:75
+#: zerver/lib/drafts.py
 msgid "Must specify exactly 1 channel ID for channel messages"
 msgstr "頻道訊息必須準確指定 1 個頻道 ID"
 
-#: zerver/lib/drafts.py:105
+#: zerver/lib/drafts.py
 msgid "User has disabled synchronizing drafts."
 msgstr "使用者已停用同步草稿。"
 
-#: zerver/lib/drafts.py:149 zerver/lib/drafts.py:169
+#: zerver/lib/drafts.py
 msgid "Draft does not exist"
 msgstr "草稿不存在"
 
-#: zerver/lib/email_mirror.py:235
+#: zerver/lib/email_mirror.py
 #, python-brace-format
 msgid ""
 "Error sending message to channel {channel_name} via message notification "
@@ -5381,147 +4811,147 @@ msgstr ""
 "透過訊息通知電子郵件回覆發送訊息到頻道 {channel_name} 時發生錯誤：\n"
 "{error_message}"
 
-#: zerver/lib/email_mirror.py:469
+#: zerver/lib/email_mirror.py
 msgid "Email with no subject"
 msgstr "沒有主旨的電子郵件"
 
-#: zerver/lib/email_notifications.py:162 zerver/lib/email_notifications.py:184
+#: zerver/lib/email_notifications.py
 msgid "Open Zulip to see the spoiler content"
 msgstr "開啟 Zulip 來查看劇透內容"
 
-#: zerver/lib/email_notifications.py:630
+#: zerver/lib/email_notifications.py
 #, python-brace-format
 msgid "{service_name} notifications"
 msgstr "{service_name} 通知"
 
-#: zerver/lib/email_validation.py:104
+#: zerver/lib/email_validation.py
 msgid "Invalid address."
 msgstr "無效的地址。"
 
-#: zerver/lib/email_validation.py:109
+#: zerver/lib/email_validation.py
 msgid "Outside your domain."
 msgstr "超出您的域名之外。"
 
-#: zerver/lib/email_validation.py:113 zerver/views/users.py:927
+#: zerver/lib/email_validation.py zerver/views/users.py
 msgid "Email addresses containing + are not allowed."
 msgstr "不允許 Email 地址含有 +。"
 
-#: zerver/lib/email_validation.py:160
+#: zerver/lib/email_validation.py
 msgid "Reserved for system bots."
 msgstr "保留給系統機器人使用。"
 
-#: zerver/lib/email_validation.py:183
+#: zerver/lib/email_validation.py
 #, python-brace-format
 msgid "{email} already has an account"
 msgstr "{email} 已是帳號"
 
-#: zerver/lib/email_validation.py:185
+#: zerver/lib/email_validation.py
 msgid "Already has an account."
 msgstr "已有帳號。"
 
-#: zerver/lib/email_validation.py:187
+#: zerver/lib/email_validation.py
 msgid "Account has been deactivated."
 msgstr "帳號已被停用。"
 
-#: zerver/lib/emoji.py:87 zerver/views/realm_emoji.py:65
+#: zerver/lib/emoji.py zerver/views/realm_emoji.py
 #, python-brace-format
 msgid "Emoji '{emoji_name}' does not exist"
 msgstr "表情符號 '{emoji_name}' 不存在"
 
-#: zerver/lib/emoji.py:100
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji."
 msgstr "無效的自定義表情符號。"
 
-#: zerver/lib/emoji.py:102
+#: zerver/lib/emoji.py
 msgid "Invalid custom emoji name."
 msgstr "無效的自定義表情符號名稱。"
 
-#: zerver/lib/emoji.py:104
+#: zerver/lib/emoji.py
 msgid "This custom emoji has been deactivated."
 msgstr "此自定義表情符號已被停用。"
 
-#: zerver/lib/emoji.py:107 zerver/lib/emoji.py:112
+#: zerver/lib/emoji.py
 msgid "Invalid emoji code."
 msgstr "無效的表情符號碼。"
 
-#: zerver/lib/emoji.py:109 zerver/lib/emoji.py:114
+#: zerver/lib/emoji.py
 msgid "Invalid emoji name."
 msgstr "無效的表情符號名稱。"
 
-#: zerver/lib/emoji.py:117
+#: zerver/lib/emoji.py
 msgid "Invalid emoji type."
 msgstr "無效的表情符號類型。"
 
-#: zerver/lib/emoji.py:130
+#: zerver/lib/emoji.py
 msgid "Must be an organization administrator or emoji author"
 msgstr "必須是組織管理者或表情符號作者"
 
-#: zerver/lib/emoji.py:138
+#: zerver/lib/emoji.py
 msgid "Emoji names must end with either a letter or digit."
 msgstr "表情符號名稱必須以字母或數字結尾。"
 
-#: zerver/lib/emoji.py:141
+#: zerver/lib/emoji.py
 msgid ""
 "Emoji names must contain only lowercase English letters, digits, spaces, "
 "dashes, and underscores."
 msgstr "表情符號名稱只能包含小寫英文字母、數字、空格、連字號和底線。"
 
-#: zerver/lib/emoji.py:144
+#: zerver/lib/emoji.py
 msgid "Emoji name is missing"
 msgstr "缺少表情符號名稱"
 
-#: zerver/lib/events.py:2214
+#: zerver/lib/events.py
 msgid "Could not allocate event queue"
 msgstr "無法分配事件佇列"
 
-#: zerver/lib/exceptions.py:166
+#: zerver/lib/exceptions.py
 msgid "Not logged in: API authentication or user session required"
 msgstr "未登入：必須有 API 驗證或使用者會話"
 
-#: zerver/lib/exceptions.py:194
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{channel_name}' already exists"
 msgstr "頻道「{channel_name}」已存在"
 
-#: zerver/lib/exceptions.py:207
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel '{stream}' does not exist"
 msgstr "頻道 '{stream}' 不存在"
 
-#: zerver/lib/exceptions.py:220
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Channel with ID '{stream_id}' does not exist"
 msgstr "ID 為 '{stream_id}' 的頻道不存在"
 
-#: zerver/lib/exceptions.py:232
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unsupported parameter combination: {parameters}"
 msgstr "不支援的參數組合：{parameters}"
 
-#: zerver/lib/exceptions.py:245
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "{required_parameter} is required when {set_parameter} is set."
 msgstr ""
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "organization owner"
 msgstr "組織擁有者"
 
-#: zerver/lib/exceptions.py:254
+#: zerver/lib/exceptions.py
 msgid "user"
 msgstr "使用者"
 
-#: zerver/lib/exceptions.py:259
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Cannot deactivate the only {entity}."
 msgstr "無法停用唯一的{entity}。"
 
-#: zerver/lib/exceptions.py:272
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Invalid Markdown include statement: {include_statement}"
 msgstr "無效的 Markdown 語法：{include_statement}"
 
-#: zerver/lib/exceptions.py:286
+#: zerver/lib/exceptions.py
 msgid ""
 "API usage exceeded rate limit; see https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
@@ -5529,94 +4959,92 @@ msgstr ""
 "API 使用量已超過速率限制；請參閱 https://zulip.com/api/http-headers#rate-"
 "limiting-response-headers"
 
-#: zerver/lib/exceptions.py:313 zerver/lib/typed_endpoint.py:372
-#: zerver/lib/validator.py:736
+#: zerver/lib/exceptions.py zerver/lib/typed_endpoint.py
+#: zerver/lib/validator.py
 msgid "Malformed JSON"
 msgstr "JSON 格式錯誤"
 
-#: zerver/lib/exceptions.py:325 zerver/views/invite.py:54
-#: zerver/views/invite.py:181 zerver/views/invite.py:305
+#: zerver/lib/exceptions.py zerver/views/invite.py
 msgid "Must be an organization administrator"
 msgstr "必須是組織管理者"
 
-#: zerver/lib/exceptions.py:337
+#: zerver/lib/exceptions.py
 msgid "Must be an organization owner"
 msgstr "必須是組織擁有者"
 
-#: zerver/lib/exceptions.py:349
+#: zerver/lib/exceptions.py
 #, fuzzy
 #| msgid "Must be an organization owner"
 msgid "Must be a bot user"
 msgstr "必須是組織擁有者"
 
-#: zerver/lib/exceptions.py:363
+#: zerver/lib/exceptions.py
 msgid "Your username or password is incorrect"
 msgstr "您的使用者名稱或密碼不正確"
 
-#: zerver/lib/exceptions.py:381
+#: zerver/lib/exceptions.py
 msgid "This organization has been deactivated"
 msgstr "此組織已被停用"
 
-#: zerver/lib/exceptions.py:391
+#: zerver/lib/exceptions.py
 msgid ""
 "The mobile push notification service registration for your server has been "
 "deactivated"
 msgstr "您伺服器的行動推播通知服務註冊已被停用"
 
-#: zerver/lib/exceptions.py:401
+#: zerver/lib/exceptions.py
 msgid "Password authentication is disabled in this organization"
 msgstr "此組織已停用密碼驗證"
 
-#: zerver/lib/exceptions.py:410
+#: zerver/lib/exceptions.py
 msgid "Your password has been disabled and needs to be reset"
 msgstr "您的密碼已被停用，需要重設"
 
-#: zerver/lib/exceptions.py:427
+#: zerver/lib/exceptions.py
 msgid "Invalid API key"
 msgstr "無效的 API key"
 
-#: zerver/lib/exceptions.py:434
+#: zerver/lib/exceptions.py
 msgid "Malformed API key"
 msgstr "格式錯誤的 API Key"
 
-#: zerver/lib/exceptions.py:474
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "The '{event_type}' event isn't currently supported by the {webhook_name} "
 "webhook; ignoring"
 msgstr "'{event_type}' 事件目前不被 {webhook_name} webhook 支援；忽略"
 
-#: zerver/lib/exceptions.py:494
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Unable to parse request: Did {webhook_name} generate this event?"
 msgstr "無法解析請求：這個事件是由 {webhook_name} 產生的嗎？"
 
-#: zerver/lib/exceptions.py:521
+#: zerver/lib/exceptions.py
 msgid "User not authenticated"
 msgstr "使用者未驗證"
 
-#: zerver/lib/exceptions.py:534 zerver/views/auth.py:825
-#: zerver/views/auth.py:1184 zerver/views/auth.py:1250
+#: zerver/lib/exceptions.py zerver/views/auth.py
 msgid "Invalid subdomain"
 msgstr "無效的子域名"
 
-#: zerver/lib/exceptions.py:568
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to initiate direct message conversations."
 msgstr "您沒有權限發起私人訊息對話。"
 
-#: zerver/lib/exceptions.py:581
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "Sending messages to the {empty_topic_display_name} is not allowed in this "
 "channel."
 msgstr "不允許在此頻道中發送訊息到 {empty_topic_display_name}。"
 
-#: zerver/lib/exceptions.py:594
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "Only the {empty_topic_display_name} topic is allowed in this channel."
 msgstr "此頻道只允許 {empty_topic_display_name} 議題。"
 
-#: zerver/lib/exceptions.py:607
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "To enable this configuration, all messages in this channel must be in the "
@@ -5625,19 +5053,19 @@ msgstr ""
 "要啟用此設定，此頻道中的所有訊息都必須在 {empty_topic_display_name} 議題中。"
 "請考慮重新命名或刪除其他議題。"
 
-#: zerver/lib/exceptions.py:614
+#: zerver/lib/exceptions.py
 msgid "Direct messages are disabled in this organization."
 msgstr "此組織已停用私人訊息。"
 
-#: zerver/lib/exceptions.py:616
+#: zerver/lib/exceptions.py
 msgid "This conversation does not include any users who can authorize it."
 msgstr "此對話中沒有任何有核准權限的使用者。"
 
-#: zerver/lib/exceptions.py:629
+#: zerver/lib/exceptions.py
 msgid "Access denied"
 msgstr "存取被拒絕"
 
-#: zerver/lib/exceptions.py:669
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid ""
 "You only have permission to move the {total_messages_allowed_to_move}/"
@@ -5646,254 +5074,254 @@ msgstr ""
 "您只有權限移動此議題中最近的 {total_messages_allowed_to_move}/"
 "{total_messages_in_topic} 則訊息。"
 
-#: zerver/lib/exceptions.py:682
+#: zerver/lib/exceptions.py
 msgid "Reaction already exists."
 msgstr "已經有這個表情回應。"
 
-#: zerver/lib/exceptions.py:694
+#: zerver/lib/exceptions.py
 msgid "Reaction doesn't exist."
 msgstr "回應不存在。"
 
-#: zerver/lib/exceptions.py:719
+#: zerver/lib/exceptions.py
 msgid ""
 "Your organization is registered to a different Zulip server. Please contact "
 "Zulip support for assistance in resolving this issue."
 msgstr ""
 "您的組織已註冊到不同的 Zulip 伺服器。請聯絡 Zulip 支援團隊以協助解決此問題。"
 
-#: zerver/lib/exceptions.py:733
+#: zerver/lib/exceptions.py
 msgid "Organization not registered"
 msgstr "組織未註冊"
 
-#: zerver/lib/exceptions.py:745
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use channel wildcard mentions in this channel."
 msgstr "您沒有權限在此頻道中使用頻道萬用字元「@-提及」。"
 
-#: zerver/lib/exceptions.py:757
+#: zerver/lib/exceptions.py
 msgid ""
 "You do not have permission to use topic wildcard mentions in this topic."
 msgstr "您沒有權限在此議題中使用議題萬用字元「@-提及」。"
 
-#: zerver/lib/exceptions.py:770
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{field_name}' value does not match the expected value."
 msgstr "'{field_name}' 值與預期值不符。"
 
-#: zerver/lib/exceptions.py:795
+#: zerver/lib/exceptions.py
 #, python-brace-format
 msgid "'{setting_name}' must be a system user group."
 msgstr "'{setting_name}' 必須是系統使用者群組。"
 
-#: zerver/lib/exceptions.py:811
+#: zerver/lib/exceptions.py
 msgid "Cannot deactivate user group in use."
 msgstr "無法停用使用中的使用者群組。"
 
-#: zerver/lib/exceptions.py:821
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to administer this channel."
 msgstr "您沒有權限管理此頻道。"
 
-#: zerver/lib/exceptions.py:831
+#: zerver/lib/exceptions.py
 msgid "You do not have permission to change default channels."
 msgstr "您沒有權限變更預設頻道。"
 
-#: zerver/lib/exceptions.py:841
+#: zerver/lib/exceptions.py
 msgid "Email is already in use."
 msgstr "電子郵件已被使用。"
 
-#: zerver/lib/exceptions.py:851
+#: zerver/lib/exceptions.py
 msgid "Scheduled delivery time must be in the future."
 msgstr "排程傳送時間必須是未來時間。"
 
-#: zerver/lib/exceptions.py:874
+#: zerver/lib/exceptions.py
 msgid "Invalid bouncer_public_key"
 msgstr "無效的 bouncer_public_key"
 
-#: zerver/lib/exceptions.py:886
+#: zerver/lib/exceptions.py
 msgid "Request expired"
 msgstr "要求已過期"
 
-#: zerver/lib/exceptions.py:896
+#: zerver/lib/exceptions.py
 msgid "Invalid encrypted_push_registration"
 msgstr "無效的 encrypted_push_registration"
 
-#: zerver/lib/exceptions.py:908
+#: zerver/lib/exceptions.py
 msgid "Server is not configured to use push notification service."
 msgstr "伺服器未設定使用推播通知服務。"
 
-#: zerver/lib/external_accounts.py:39
+#: zerver/lib/external_accounts.py
 #, fuzzy
 #| msgid "Already has an account."
 msgid "Atlassian account ID"
 msgstr "已有帳號。"
 
-#: zerver/lib/external_accounts.py:45
+#: zerver/lib/external_accounts.py
 msgid "Behance username"
 msgstr "Behance 使用者名稱"
 
-#: zerver/lib/external_accounts.py:51
+#: zerver/lib/external_accounts.py
 msgid "Bitbucket username"
 msgstr "Bitbucket 使用者名稱"
 
-#: zerver/lib/external_accounts.py:57
+#: zerver/lib/external_accounts.py
 msgid "Bluesky handle"
 msgstr "Bluesky 帳號名稱"
 
-#: zerver/lib/external_accounts.py:63
+#: zerver/lib/external_accounts.py
 msgid "Codeberg username"
 msgstr "Codeberg 使用者名稱"
 
-#: zerver/lib/external_accounts.py:69
+#: zerver/lib/external_accounts.py
 msgid "Discord tag"
 msgstr "Discord 使用者名稱"
 
-#: zerver/lib/external_accounts.py:75
+#: zerver/lib/external_accounts.py
 msgid "Dribbble username"
 msgstr "Dribbble 使用者名稱"
 
-#: zerver/lib/external_accounts.py:81
+#: zerver/lib/external_accounts.py
 msgid "Facebook username"
 msgstr "Facebook 使用者名稱"
 
-#: zerver/lib/external_accounts.py:87
+#: zerver/lib/external_accounts.py
 msgid "GitHub username"
 msgstr "GitHub 使用者名稱"
 
-#: zerver/lib/external_accounts.py:93
+#: zerver/lib/external_accounts.py
 msgid "GitLab username"
 msgstr "GitLab 使用者名稱"
 
-#: zerver/lib/external_accounts.py:99
+#: zerver/lib/external_accounts.py
 msgid "Instagram username"
 msgstr "Instagram 使用者名稱"
 
-#: zerver/lib/external_accounts.py:105
+#: zerver/lib/external_accounts.py
 msgid "LinkedIn profile name"
 msgstr "LinkedIn 個人檔案名稱"
 
-#: zerver/lib/external_accounts.py:111
+#: zerver/lib/external_accounts.py
 msgid "Mastodon profile"
 msgstr "Mastodon 個人檔案"
 
-#: zerver/lib/external_accounts.py:117
+#: zerver/lib/external_accounts.py
 msgid "Medium username"
 msgstr "Medium 使用者名稱"
 
-#: zerver/lib/external_accounts.py:123
+#: zerver/lib/external_accounts.py
 msgid "Pinterest username"
 msgstr "Pinterest 使用者名稱"
 
-#: zerver/lib/external_accounts.py:129
+#: zerver/lib/external_accounts.py
 msgid "Reddit username"
 msgstr "Reddit 使用者名稱"
 
-#: zerver/lib/external_accounts.py:135
+#: zerver/lib/external_accounts.py
 msgid "Snapchat username"
 msgstr "Snapchat 使用者名稱"
 
-#: zerver/lib/external_accounts.py:141
+#: zerver/lib/external_accounts.py
 msgid "Threads username"
 msgstr "Threads 使用者名稱"
 
-#: zerver/lib/external_accounts.py:147
+#: zerver/lib/external_accounts.py
 msgid "TikTok username"
 msgstr "TikTok 使用者名稱"
 
-#: zerver/lib/external_accounts.py:153
+#: zerver/lib/external_accounts.py
 msgid "Twitch username"
 msgstr "Twitch 使用者名稱"
 
-#: zerver/lib/external_accounts.py:159
+#: zerver/lib/external_accounts.py
 msgid "X username"
 msgstr "X 使用者名稱"
 
-#: zerver/lib/external_accounts.py:165
+#: zerver/lib/external_accounts.py
 msgid "YouTube handle"
 msgstr "YouTube 帳號名稱"
 
-#: zerver/lib/external_accounts.py:192
+#: zerver/lib/external_accounts.py
 msgid "Invalid external account type"
 msgstr "無效的外部帳號類型"
 
-#: zerver/lib/integrations.py:42
+#: zerver/lib/integrations.py
 msgid "Integration frameworks"
 msgstr "第三方整合框架"
 
-#: zerver/lib/integrations.py:48
+#: zerver/lib/integrations.py
 msgid "Video calling"
 msgstr "視訊通話"
 
-#: zerver/lib/integrations.py:49
+#: zerver/lib/integrations.py
 msgid "Continuous integration"
 msgstr "持續整合"
 
-#: zerver/lib/integrations.py:50
+#: zerver/lib/integrations.py
 msgid "Customer support"
 msgstr "客戶支援"
 
-#: zerver/lib/integrations.py:51
+#: zerver/lib/integrations.py
 msgid "Deployment"
 msgstr "部署"
 
-#: zerver/lib/integrations.py:52
+#: zerver/lib/integrations.py
 msgid "Entertainment"
 msgstr "娛樂"
 
-#: zerver/lib/integrations.py:53
+#: zerver/lib/integrations.py
 msgid "Communication"
 msgstr "通訊"
 
-#: zerver/lib/integrations.py:54
+#: zerver/lib/integrations.py
 msgid "Financial"
 msgstr "金融"
 
-#: zerver/lib/integrations.py:55
+#: zerver/lib/integrations.py
 msgid "Human resources"
 msgstr "人力資源"
 
-#: zerver/lib/integrations.py:56
+#: zerver/lib/integrations.py
 msgid "Marketing"
 msgstr "市場"
 
-#: zerver/lib/integrations.py:57
+#: zerver/lib/integrations.py
 msgid "Miscellaneous"
 msgstr "其他"
 
-#: zerver/lib/integrations.py:58
+#: zerver/lib/integrations.py
 msgid "Monitoring"
 msgstr "監控"
 
-#: zerver/lib/integrations.py:59
+#: zerver/lib/integrations.py
 msgid "Project management"
 msgstr "專案管理"
 
-#: zerver/lib/integrations.py:60
+#: zerver/lib/integrations.py
 msgid "Productivity"
 msgstr "生產力"
 
-#: zerver/lib/integrations.py:61
+#: zerver/lib/integrations.py
 msgid "Version control"
 msgstr "版本控制"
 
-#: zerver/lib/message.py:212 zerver/views/welcome_bot_custom_message.py:32
+#: zerver/lib/message.py zerver/views/welcome_bot_custom_message.py
 msgid "Message must not be empty"
 msgstr "訊息不能為空"
 
-#: zerver/lib/message.py:214
+#: zerver/lib/message.py
 msgid "Message must not contain null bytes"
 msgstr "訊息不可包含 null bytes"
 
-#: zerver/lib/message.py:1525
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "You are not allowed to mention user group '{user_group_name}'."
 msgstr "您不被允許「@-提及」使用者群組 '{user_group_name}'。"
 
-#: zerver/lib/message.py:1755
+#: zerver/lib/message.py
 #, python-brace-format
 msgid "{other_users} and {last_user}"
 msgstr ""
 
-#: zerver/lib/message_report.py:51 zerver/lib/message_report.py:103
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid ""
 "{reporting_user_mention} reported a message sent by {reported_user_mention} "
@@ -5902,7 +5330,7 @@ msgstr ""
 "{reporting_user_mention} 檢舉了一則由 {reported_user_mention} 於 "
 "{reported_message_date_sent} 發送的訊息。"
 
-#: zerver/lib/message_report.py:69
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "{reporting_user_mention} reported a direct message sent by "
@@ -5915,7 +5343,7 @@ msgstr ""
 "{reporting_user_mention} 檢舉了一則由 {reported_user_mention} 於 "
 "{reported_message_date_sent} 發送給 {recipient_user} 的私訊。"
 
-#: zerver/lib/message_report.py:78
+#: zerver/lib/message_report.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "{reporting_user_mention} reported a direct message sent by "
@@ -5928,71 +5356,71 @@ msgstr ""
 "{reporting_user_mention} 檢舉了一則由 {reported_user_mention} 於 "
 "{reported_message_date_sent} 發送給 {recipient_user} 的私訊。"
 
-#: zerver/lib/message_report.py:114
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "Original message at {channel_message_link}"
 msgstr "位於 {channel_message_link} 的原始訊息"
 
-#: zerver/lib/message_report.py:125
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "[Original message]({direct_message_link})"
 msgstr "[原始訊息]({direct_message_link})"
 
-#: zerver/lib/message_report.py:149
+#: zerver/lib/message_report.py
 #, python-brace-format
 msgid "{fullname} moderation"
 msgstr "{fullname} 的審核請求"
 
-#: zerver/lib/narrow.py:214
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator: {desc}"
 msgstr "無效的範圍操作：{desc}"
 
-#: zerver/lib/narrow.py:227
+#: zerver/lib/narrow.py
 #, python-brace-format
 msgid "Invalid narrow operator combination: {desc}"
 msgstr "無效的篩選運算子組合：{desc}"
 
-#: zerver/lib/narrow.py:885
+#: zerver/lib/narrow.py
 msgid "Duplicate 'with' operators."
 msgstr "重複的 'with' 操作。"
 
-#: zerver/lib/narrow.py:895 zerver/lib/narrow.py:916
+#: zerver/lib/narrow.py
 msgid "Invalid 'with' operator"
 msgstr "無效的 'with' 操作"
 
-#: zerver/lib/narrow.py:1230
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor' argument."
 msgstr "缺少 'anchor' 參數。"
 
-#: zerver/lib/narrow.py:1233
+#: zerver/lib/narrow.py
 msgid "Missing 'anchor_date' argument."
 msgstr "缺少 'anchor_date' 參數。"
 
-#: zerver/lib/narrow.py:1267
+#: zerver/lib/narrow.py
 msgid "Invalid anchor"
 msgstr "無效的錨點"
 
-#: zerver/lib/narrow_predicate.py:22
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operator {operator} not supported."
 msgstr "不支援操作 {operator}。"
 
-#: zerver/lib/narrow_predicate.py:25
+#: zerver/lib/narrow_predicate.py
 #, python-brace-format
 msgid "Operand {operand} not supported."
 msgstr "不支援運算元 {operand}。"
 
-#: zerver/lib/navigation_views.py:20
+#: zerver/lib/navigation_views.py
 msgid "Navigation view does not exist."
 msgstr "導覽檢視不存在。"
 
-#: zerver/lib/onboarding.py:61
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid "A note from {admin_group_syntax}:"
 msgstr "來自 {admin_group_syntax} 的備註："
 
-#: zerver/lib/onboarding.py:93
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6003,7 +5431,7 @@ msgstr ""
 "想了解更多，請查看我們的[使用 Zulip 進行課程教學指南]"
 "({getting_started_url})！\n"
 
-#: zerver/lib/onboarding.py:97
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6013,7 +5441,7 @@ msgstr ""
 "\n"
 "想了解更多，請查看我們的[入門指南]({getting_started_url})！\n"
 
-#: zerver/lib/onboarding.py:105
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6023,7 +5451,7 @@ msgstr ""
 "\n"
 "我們也有[為課程設定 Zulip]({organization_setup_url}) 的指南。\n"
 
-#: zerver/lib/onboarding.py:109
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6033,7 +5461,7 @@ msgstr ""
 "\n"
 "我們也有[將您的組織遷移到 Zulip]({organization_setup_url}) 的指南。\n"
 
-#: zerver/lib/onboarding.py:120
+#: zerver/lib/onboarding.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "\n"
@@ -6054,7 +5482,7 @@ msgstr ""
 " {demo_conversion_deadline} 天後**自動刪除**，\n"
 "除非將其[轉換為永久組織]({convert_demo_organization_help_url})。\n"
 
-#: zerver/lib/onboarding.py:132
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "I've kicked off some conversations to help you get started. You can find\n"
@@ -6064,7 +5492,7 @@ msgstr ""
 "我已經預備了一些對話內容來協助您開始使用。您可以在\n"
 "[收件匣](/#inbox) 中找到它們。\n"
 
-#: zerver/lib/onboarding.py:137
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6075,7 +5503,7 @@ msgstr ""
 "您隨時可以回到[歡迎使用 Zulip 影片]({navigation_tour_video_url})來快速瀏覽應"
 "用程式。\n"
 
-#: zerver/lib/onboarding.py:148
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6099,7 +5527,7 @@ msgstr ""
 "{demo_organization_text}\n"
 "\n"
 
-#: zerver/lib/onboarding.py:218
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can [download](/apps/) the [mobile and desktop apps](/apps/).\n"
@@ -6109,7 +5537,7 @@ msgstr ""
 "您可以[下載](/apps/)[行動版和桌面版應用程式](/apps/)。\n"
 "Zulip 在瀏覽器中也運作得很好。\n"
 
-#: zerver/lib/onboarding.py:223
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Go to [Profile settings](#settings/profile) to add a [profile picture](/help/"
@@ -6121,7 +5549,7 @@ msgstr ""
 "profile-picture)\n"
 "並編輯您的[個人檔案資訊](/help/edit-your-profile)。\n"
 
-#: zerver/lib/onboarding.py:228
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can switch between [light and dark theme](/help/dark-theme), [pick your\n"
@@ -6138,7 +5566,7 @@ msgstr ""
 "[變更您的語言](/help/change-your-language)，\n"
 "並自定義您的 Zulip 體驗。\n"
 
-#: zerver/lib/onboarding.py:235
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6154,7 +5582,7 @@ msgstr ""
 "\n"
 "[瀏覽和訂閱頻道]({settings_link})。\n"
 
-#: zerver/lib/onboarding.py:242
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "[Topics](/help/introduction-to-topics) summarize what each conversation in "
@@ -6181,7 +5609,7 @@ msgstr ""
 "查看[最近的對話](#recent)以獲得正在討論的\n"
 "議題列表。\n"
 
-#: zerver/lib/onboarding.py:254
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Zulip's [keyboard shortcuts](#keyboard-shortcuts) let you navigate the app\n"
@@ -6195,7 +5623,7 @@ msgstr ""
 "\n"
 "隨時按「?」來查看[快捷鍵表](#keyboard-shortcuts)。\n"
 
-#: zerver/lib/onboarding.py:261
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can **format** *your* `message` using the handy formatting buttons, or "
@@ -6213,7 +5641,7 @@ msgstr ""
 "查看[快速參考](#message-formatting)來了解\n"
 "隱藏內容、全域時間等功能。\n"
 
-#: zerver/lib/onboarding.py:269
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6228,7 +5656,7 @@ msgstr ""
 "查看我們的 [新手上路指南](/help/getting-started-with-zulip)，\n"
 "或瀏覽 [說明中心](/help/) 以了解更多資訊！\n"
 
-#: zerver/lib/onboarding.py:276
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6239,7 +5667,7 @@ msgstr ""
 "您可以盡情與我聊天！要取得說明，\n"
 "請嘗試以下其中一個訊息：{bot_commands}\n"
 
-#: zerver/lib/onboarding.py:364
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6257,7 +5685,7 @@ msgstr ""
 "({move_content_another_topic_help_url}) 議題，\n"
 "甚至將議題 [移動至不同頻道]({move_content_another_channel_help_url}).\n"
 
-#: zerver/lib/onboarding.py:375
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try moving this message to another topic and back.\n"
@@ -6265,7 +5693,7 @@ msgstr ""
 "\n"
 ":point_right: 試著將此訊息移動到另一個議題，然後再移回來。\n"
 
-#: zerver/lib/onboarding.py:379
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6286,12 +5714,11 @@ msgstr ""
 "「{topic_name}」議題，\n"
 "如您在左側邊欄和上方所見。\n"
 
-#: zerver/lib/onboarding.py:388 zerver/lib/onboarding.py:440
-#: zerver/lib/onboarding.py:531
+#: zerver/lib/onboarding.py
 msgid "welcome to Zulip!"
 msgstr "歡迎使用 Zulip！"
 
-#: zerver/lib/onboarding.py:391
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "You can read Zulip one conversation at a time, seeing each message in "
@@ -6302,7 +5729,7 @@ msgstr ""
 "您可以一次閱讀一個對話，在上下文中看到每則訊息，\n"
 "不受其他對話數量影響。\n"
 
-#: zerver/lib/onboarding.py:396
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: When you're ready, check out your [Inbox](/#inbox) for other\n"
@@ -6312,7 +5739,7 @@ msgstr ""
 ":point_right: 當您準備好時，請查看您的[收件匣](/#inbox)中\n"
 "其他有未讀訊息的對話。\n"
 
-#: zerver/lib/onboarding.py:401
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "To kick off a new conversation, pick a channel in the left sidebar, and "
@@ -6323,7 +5750,7 @@ msgstr ""
 "要開始新對話，請在左側邊欄選擇一個頻道，\n"
 "然後點擊其名稱旁邊的「+」按鈕。\n"
 
-#: zerver/lib/onboarding.py:406
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "Label your conversation with a topic. Think about finishing the sentence: "
@@ -6334,7 +5761,7 @@ msgstr ""
 "為您的對話標記議題。請考慮完成這個句子：\n"
 "「嘿，我們可以談論…嗎？」\n"
 
-#: zerver/lib/onboarding.py:411
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Try starting a new conversation in this channel.\n"
@@ -6342,7 +5769,7 @@ msgstr ""
 "\n"
 ":point_right: 試著在這個頻道開始新的對話。\n"
 
-#: zerver/lib/onboarding.py:416
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6353,7 +5780,7 @@ msgstr ""
 ":point_right: 使用這個議題來試用 [Zulip 的訊息功能]"
 "({format_message_help_url})。\n"
 
-#: zerver/lib/onboarding.py:422
+#: zerver/lib/onboarding.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -6388,7 +5815,7 @@ msgstr ""
 "\n"
 "```\n"
 
-#: zerver/lib/onboarding.py:443
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 "This **greetings** topic is a great place to say “hi” :wave: to your "
@@ -6397,7 +5824,7 @@ msgstr ""
 "\n"
 "這個**問候**議題是向你的隊友說「嗨」:wave: 的好地方。\n"
 
-#: zerver/lib/onboarding.py:447
+#: zerver/lib/onboarding.py
 msgid ""
 "\n"
 ":point_right: Click on this message to start a new message in the same "
@@ -6406,142 +5833,140 @@ msgstr ""
 "\n"
 ":point_right: 點擊這個訊息，在同一個對話中開始新訊息。\n"
 
-#: zerver/lib/onboarding.py:467
+#: zerver/lib/onboarding.py
 msgid "moving messages"
 msgstr "移動訊息"
 
-#: zerver/lib/onboarding.py:484
+#: zerver/lib/onboarding.py
 msgid "experiments"
 msgstr "實驗"
 
-#: zerver/lib/onboarding.py:499
+#: zerver/lib/onboarding.py
 msgid "start a conversation"
 msgstr "開始對話"
 
-#: zerver/lib/onboarding.py:516
+#: zerver/lib/onboarding.py
 msgid "greetings"
 msgstr "問候"
 
-#: zerver/lib/outgoing_webhook.py:325
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid JSON in response"
 msgstr "回應中的 JSON 無效"
 
-#: zerver/lib/outgoing_webhook.py:334
+#: zerver/lib/outgoing_webhook.py
 msgid "Invalid response format"
 msgstr "回應格式無效"
 
-#: zerver/lib/push_notifications.py:102
+#: zerver/lib/push_notifications.py
 msgid "Empty or invalid length token"
 msgstr "空或長度無效的 token"
 
-#: zerver/lib/push_notifications.py:107
+#: zerver/lib/push_notifications.py
 msgid "Invalid APNS token"
 msgstr "無效的 APNS token"
 
-#: zerver/lib/push_notifications.py:445
+#: zerver/lib/push_notifications.py
 msgid "Invalid GCM option to bouncer: priority {priority!r}"
 msgstr "傳送至 bouncer 的 GCM 選項無效：priority 為 {priority!r}"
 
-#: zerver/lib/push_notifications.py:455
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "Invalid GCM options to bouncer: {options}"
 msgstr "傳送到 bouncer 的 GCM 選項無效：{options}"
 
 #. error
-#: zerver/lib/push_notifications.py:735 zilencer/views.py:705
+#: zerver/lib/push_notifications.py zilencer/views.py
 msgid "Token does not exist"
 msgstr "Token 不存在"
 
-#: zerver/lib/push_notifications.py:1106
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned @{user_group_name}:"
 msgstr "{full_name} 「@-提及」 @{user_group_name}："
 
-#: zerver/lib/push_notifications.py:1110
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned you:"
 msgstr "{full_name} 「@-提及」你："
 
-#: zerver/lib/push_notifications.py:1117
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "{full_name} mentioned everyone:"
 msgstr "{full_name} 「@-提及」所有人："
 
-#: zerver/lib/push_notifications.py:1371
+#: zerver/lib/push_notifications.py
 msgid "New message"
 msgstr "新的訊息"
 
-#: zerver/lib/push_notifications.py:1917
+#: zerver/lib/push_notifications.py
 msgid "Test notification"
 msgstr "通知測試"
 
-#: zerver/lib/push_notifications.py:1918
+#: zerver/lib/push_notifications.py
 #, python-brace-format
 msgid "This is a test notification from {realm_name} ({realm_url})."
 msgstr "這是來自 {realm_name} ({realm_url}) 的通知測試。"
 
-#: zerver/lib/push_notifications.py:2001
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized"
 msgstr "裝置無法識別"
 
-#: zerver/lib/push_notifications.py:2013
+#: zerver/lib/push_notifications.py
 msgid "Device not recognized by the push bouncer"
 msgstr "推送轉發器無法識別裝置"
 
-#: zerver/lib/push_notifications.py:2051
+#: zerver/lib/push_notifications.py
 msgid "No active registered push device"
 msgstr "沒有已註冊的推播裝置處於啟用狀態"
 
-#: zerver/lib/push_notifications.py:2064
+#: zerver/lib/push_notifications.py
 msgid "Network error while connecting to Zulip push notification service."
 msgstr "連線至 Zulip 推播通知服務時發生網路錯誤。"
 
-#: zerver/lib/push_notifications.py:2077
+#: zerver/lib/push_notifications.py
 msgid "Internal server error on Zulip push notification service, retry later."
 msgstr "Zulip 推播通知服務發生內部伺服器錯誤，請稍後再試。"
 
-#: zerver/lib/push_notifications.py:2091
+#: zerver/lib/push_notifications.py
 msgid ""
 "Push notification configuration issue on server, contact the server "
 "administrator or retry later."
 msgstr "伺服器上的推播通知設定有問題，請聯繫伺服器管理員或稍後再試。"
 
-#: zerver/lib/push_registration.py:210
+#: zerver/lib/push_registration.py
 msgid "Invalid `push_key`"
 msgstr "無效的 `push_key`"
 
-#: zerver/lib/rate_limiter.py:446
+#: zerver/lib/rate_limiter.py
 #, python-brace-format
 msgid "{secs}{nbsp}second"
 msgid_plural "{secs}{nbsp}seconds"
 msgstr[0] ""
 
-#: zerver/lib/recipient_parsing.py:9
+#: zerver/lib/recipient_parsing.py
 msgid "Invalid data type for channel ID"
 msgstr "頻道 ID 的資料類型無效"
 
-#: zerver/lib/recipient_users.py:35 zerver/lib/streams.py:659
-#: zerver/lib/streams.py:675 zerver/tornado/views.py:229
-#: zerver/views/events_register.py:73 zerver/views/message_send.py:171
-#: zerver/views/message_send.py:192
+#: zerver/lib/recipient_users.py zerver/lib/streams.py zerver/tornado/views.py
+#: zerver/views/events_register.py zerver/views/message_send.py
 msgid "User not authorized for this query"
 msgstr "使用者此查詢未授權"
 
-#: zerver/lib/recipient_users.py:75
+#: zerver/lib/recipient_users.py
 #, python-brace-format
 msgid "'{email}' is no longer using Zulip."
 msgstr "'{email}' 沒再使用 Zulip。"
 
-#: zerver/lib/recipient_users.py:82
+#: zerver/lib/recipient_users.py
 msgid "You can't send direct messages outside of your organization."
 msgstr "您不能傳送私人訊息給組織外的人員。"
 
-#: zerver/lib/reminders.py:29
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid "Maximum reminder note length: {max_length} characters"
 msgstr "提醒備註的最大長度：{max_length} 個字元"
 
-#: zerver/lib/reminders.py:78
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid ""
 #| "You requested a reminder for the following direct message. Note:\n"
@@ -6553,13 +5978,13 @@ msgstr ""
 "你已為以下的私人訊息設定提醒。備註：\n"
 " > {note}"
 
-#: zerver/lib/reminders.py:83
+#: zerver/lib/reminders.py
 #, fuzzy
 #| msgid "You requested a reminder for the following direct message."
 msgid "You requested a reminder for the following message."
 msgstr "您已為以下私人訊息設定了提醒。"
 
-#: zerver/lib/reminders.py:94
+#: zerver/lib/reminders.py
 #, python-brace-format
 msgid ""
 "You requested a reminder for the following direct message. Note:\n"
@@ -6568,11 +5993,11 @@ msgstr ""
 "你已為以下的私人訊息設定提醒。備註：\n"
 " > {note}"
 
-#: zerver/lib/reminders.py:99
+#: zerver/lib/reminders.py
 msgid "You requested a reminder for the following direct message."
 msgstr "您已為以下私人訊息設定了提醒。"
 
-#: zerver/lib/reminders.py:126
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{user_silent_mention} [sent]({conversation_url}) a todo list."
 msgid ""
@@ -6580,14 +6005,14 @@ msgid ""
 "{topic_pretty_link}."
 msgstr "{user_silent_mention} [發送了]({conversation_url})一個待辦清單。"
 
-#: zerver/lib/reminders.py:128
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{user_silent_mention} [said]({conversation_url}):"
 msgid ""
 "{user_silent_mention} [said]({conversation_url}) in {topic_pretty_link}:"
 msgstr "{user_silent_mention} [說]({conversation_url})："
 
-#: zerver/lib/reminders.py:132
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{user_silent_mention} [sent]({conversation_url}) a todo list."
 msgid ""
@@ -6595,7 +6020,7 @@ msgid ""
 "{list_of_recipient_mentions}."
 msgstr "{user_silent_mention} [發送了]({conversation_url})一個待辦清單。"
 
-#: zerver/lib/reminders.py:135
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{user_silent_mention} [said]({conversation_url}):"
 msgid ""
@@ -6603,700 +6028,684 @@ msgid ""
 "{list_of_recipient_mentions}:"
 msgstr "{user_silent_mention} [說]({conversation_url})："
 
-#: zerver/lib/reminders.py:139
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{user_silent_mention} [sent]({conversation_url}) a todo list."
 msgid "You [sent]({conversation_url}) yourself a {widget}."
 msgstr "{user_silent_mention} [發送了]({conversation_url})一個待辦清單。"
 
-#: zerver/lib/reminders.py:140
+#: zerver/lib/reminders.py
 #, fuzzy, python-brace-format
 #| msgid "{user_silent_mention} [sent]({conversation_url}) a todo list."
 msgid "You [sent]({conversation_url}) a note to yourself:"
 msgstr "{user_silent_mention} [發送了]({conversation_url})一個待辦清單。"
 
-#: zerver/lib/reminders.py:173
+#: zerver/lib/reminders.py
 msgid "Reminder does not exist"
 msgstr "提醒不存在"
 
-#: zerver/lib/remote_server.py:199
+#: zerver/lib/remote_server.py
 #, python-brace-format
 msgid "Push notifications bouncer error: {error}"
 msgstr "推送通知轉發器錯誤：{error}"
 
-#: zerver/lib/request.py:70
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Can't decide between '{var_name1}' and '{var_name2}' arguments"
 msgstr "不能從 '{var_name1}' 和 '{var_name2}' 之中決定參數"
 
-#: zerver/lib/request.py:83 zerver/lib/streams.py:762 zerver/views/typing.py:47
+#: zerver/lib/request.py zerver/lib/streams.py zerver/views/typing.py
 #, python-brace-format
 msgid "Missing '{var_name}' argument"
 msgstr "缺少 '{var_name}' 參數"
 
-#: zerver/lib/request.py:97
+#: zerver/lib/request.py
 #, python-brace-format
 msgid "Bad value for '{var_name}': {bad_value}"
 msgstr "'{var_name}' 的值無效：{bad_value}"
 
-#: zerver/lib/scheduled_messages.py:20
+#: zerver/lib/scheduled_messages.py
 msgid "Scheduled message does not exist"
 msgstr "排程訊息不存在"
 
-#: zerver/lib/send_email.py:83
+#: zerver/lib/send_email.py
 #, python-brace-format
 msgid "{service_name} account security"
 msgstr "{service_name} 帳戶安全"
 
-#: zerver/lib/streams.py:247 zerver/views/streams.py:365
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "A default channel cannot be private."
 msgstr "預設頻道不能是私人頻道。"
 
-#: zerver/lib/streams.py:250 zerver/views/streams.py:394
+#: zerver/lib/streams.py zerver/views/streams.py
 msgid "Web-public channels are not enabled."
 msgstr "網路公開頻道未啟用。"
 
-#: zerver/lib/streams.py:626
+#: zerver/lib/streams.py
 msgid "You do not have permission to post in this channel."
 msgstr "您沒有權限在此頻道發佈訊息。"
 
-#: zerver/lib/streams.py:666 zerver/lib/streams.py:712
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Not authorized to send to channel '{channel_name}'"
 msgstr "沒有傳送到頻道 '{channel_name}' 的授權"
 
-#: zerver/lib/streams.py:755
+#: zerver/lib/streams.py
 msgid "You do not have permission to create new topics in this channel."
 msgstr "您沒有權限在此頻道中建立新議題。"
 
-#: zerver/lib/streams.py:846 zerver/lib/streams.py:881
-#: zerver/lib/streams.py:1010 zerver/lib/streams.py:1083
-#: zerver/views/user_topics.py:107
+#: zerver/lib/streams.py zerver/views/user_topics.py
 msgid "Invalid channel ID"
 msgstr "頻道 ID 無效"
 
-#: zerver/lib/streams.py:1063 zerver/lib/streams.py:1211
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Invalid channel name '{channel_name}'"
 msgstr "頻道名稱 '{channel_name}' 無效"
 
-#: zerver/lib/streams.py:1680
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Channel(s) ({channel_names}) do not exist"
 msgstr "頻道 ({channel_names}) 不存在"
 
-#: zerver/lib/streams.py:1756
+#: zerver/lib/streams.py
 #, python-brace-format
 msgid "Default channel group with id '{group_id}' does not exist."
 msgstr "ID 為 '{group_id}' 的預設頻道群組不存在。"
 
-#: zerver/lib/string_validation.py:40
+#: zerver/lib/string_validation.py
 msgid "Channel name can't be empty."
 msgstr "頻道名稱不能為空。"
 
-#: zerver/lib/string_validation.py:44
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Channel name too long (limit: {max_length} characters)."
 msgstr "頻道名稱過長（限制：{max_length} 個字元）。"
 
-#: zerver/lib/string_validation.py:52
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in channel name, at position {position}."
 msgstr "頻道名稱中有無效字元，位置在 {position}。"
 
-#: zerver/lib/string_validation.py:62
+#: zerver/lib/string_validation.py
 #, python-brace-format
 msgid "Invalid character in topic, at position {position}!"
 msgstr "議題中有無效字元，位置在 {position}！"
 
-#: zerver/lib/subscription_info.py:548
+#: zerver/lib/subscription_info.py
 msgid "Subscriber data is not available for this channel"
 msgstr "此頻道無法取得訂閱者資料"
 
-#: zerver/lib/subscription_info.py:569
+#: zerver/lib/subscription_info.py
 msgid "Unable to retrieve subscribers for private channel"
 msgstr "無法擷取封閉頻道的訂閱者"
 
-#: zerver/lib/thumbnail.py:164
+#: zerver/lib/thumbnail.py
 msgid "Could not decode image; did you upload an image file?"
 msgstr "無法解碼圖片；您上傳的是圖片檔案嗎？"
 
-#: zerver/lib/thumbnail.py:175 zerver/lib/thumbnail.py:182
-#: zerver/lib/thumbnail.py:193
+#: zerver/lib/thumbnail.py
 msgid "Image size exceeds limit."
 msgstr "圖檔超過限制大小。"
 
-#: zerver/lib/thumbnail.py:199
+#: zerver/lib/thumbnail.py
 msgid "Image is corrupted or truncated"
 msgstr "圖片損壞或不完整"
 
-#: zerver/lib/typed_endpoint.py:317 zerver/lib/typed_endpoint.py:318
-#: zerver/lib/validator.py:186
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a boolean"
 msgstr "{var_name} 不是 boolean"
 
-#: zerver/lib/typed_endpoint.py:319
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} does not have the expected format"
 msgstr "{var_name} 格式不符合預期"
 
-#: zerver/lib/typed_endpoint.py:320 zerver/lib/typed_endpoint.py:321
-#: zerver/lib/validator.py:127 zerver/lib/validator.py:129
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a date"
 msgstr "{var_name} 不是 date"
 
-#: zerver/lib/typed_endpoint.py:322 zerver/lib/validator.py:250
-#: zerver/lib/validator.py:628
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a dict"
 msgstr "{var_name} 不是 dict"
 
-#: zerver/lib/typed_endpoint.py:323 zerver/lib/typed_endpoint.py:335
-#: zerver/lib/validator.py:71 zerver/lib/validator.py:159
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "Invalid {var_name}"
 msgstr "無效的 {var_name}"
 
-#: zerver/lib/typed_endpoint.py:324 zerver/lib/typed_endpoint.py:339
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Argument \"{argument}\" at {var_name} is unexpected"
 msgstr "在 {var_name} 中的參數 \"{argument}\" 不被預期"
 
-#: zerver/lib/typed_endpoint.py:325 zerver/lib/typed_endpoint.py:326
-#: zerver/lib/validator.py:180
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a float"
 msgstr "{var_name} 不是 float"
 
-#: zerver/lib/typed_endpoint.py:327 zerver/lib/typed_endpoint.py:328
-#: zerver/lib/validator.py:170
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too small"
 msgstr "{var_name} 太小"
 
-#: zerver/lib/typed_endpoint.py:329 zerver/lib/typed_endpoint.py:330
-#: zerver/lib/validator.py:146
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an integer"
 msgstr "{var_name} 不是 integer"
 
-#: zerver/lib/typed_endpoint.py:331 zerver/lib/typed_endpoint.py:332
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not valid JSON"
 msgstr "{var_name} 不是有效的 JSON"
 
-#: zerver/lib/typed_endpoint.py:333 zerver/lib/validator.py:172
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too large"
 msgstr "{var_name} 太大"
 
-#: zerver/lib/typed_endpoint.py:334 zerver/lib/validator.py:205
-#: zerver/lib/validator.py:625
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a list"
 msgstr "{var_name} 不是 list"
 
-#: zerver/lib/typed_endpoint.py:336 zerver/lib/validator.py:89
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is too long (limit: {max_length} characters)"
 msgstr "{var_name} 過長（限制：{max_length} 字元）"
 
-#: zerver/lib/typed_endpoint.py:337
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is too short."
 msgstr "{var_name} 太短。"
 
-#: zerver/lib/typed_endpoint.py:338 zerver/lib/validator.py:56
-#: zerver/lib/validator.py:124 zerver/lib/validator.py:135
+#: zerver/lib/typed_endpoint.py zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string"
 msgstr "{var_name} 不是個字串"
 
-#: zerver/lib/typed_endpoint.py:340
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} has invalid format"
 msgstr "{var_name} 格式無效"
 
-#: zerver/lib/typed_endpoint.py:341
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} is not length {length}"
 msgstr "{var_name} 長度不是 {length}"
 
-#: zerver/lib/typed_endpoint.py:342
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too long (limit: {max_length} items)"
 msgstr "{var_name} 過長（限制：{max_length} 字元）"
 
-#: zerver/lib/typed_endpoint.py:343
+#: zerver/lib/typed_endpoint.py
 #, fuzzy, python-brace-format
 #| msgid "{var_name} is too long (limit: {max_length} characters)"
 msgid "{var_name} is too short (minimum {min_length} items)"
 msgstr "{var_name} 過長（限制：{max_length} 字元）"
 
-#: zerver/lib/typed_endpoint.py:377
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} cannot be blank"
 msgstr "{var_name} 不能為空白"
 
-#: zerver/lib/typed_endpoint.py:380 zerver/lib/typed_endpoint.py:383
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "Invalid {var_name}: {msg}"
 msgstr "無效的 {var_name}：{msg}"
 
-#: zerver/lib/typed_endpoint.py:386
+#: zerver/lib/typed_endpoint.py
 #, python-brace-format
 msgid "{var_name} field is missing: {msg}"
 msgstr "{var_name} 欄位遺失：{msg}"
 
-#: zerver/lib/typed_endpoint.py:506 zerver/webhooks/ifttt/view.py:37
-#: zerver/webhooks/slack/view.py:219 zerver/webhooks/slack_incoming/view.py:67
+#: zerver/lib/typed_endpoint.py zerver/webhooks/ifttt/view.py
+#: zerver/webhooks/slack/view.py zerver/webhooks/slack_incoming/view.py
 msgid "Malformed payload"
 msgstr "無效的資料載荷格式"
 
-#: zerver/lib/typed_endpoint_validators.py:34
-#: zerver/lib/typed_endpoint_validators.py:40
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not in the list of possible values"
 msgstr "不在可能值的清單中"
 
-#: zerver/lib/typed_endpoint_validators.py:58
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a URL"
 msgstr "不是一個 URL"
 
-#: zerver/lib/typed_endpoint_validators.py:79
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a recognized time zone"
 msgstr "無法識別的時區"
 
-#: zerver/lib/typed_endpoint_validators.py:109
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "{var_name} is not a valid hex color code"
 msgstr "{var_name} 不是有效的 hex color code"
 
-#: zerver/lib/typed_endpoint_validators.py:124
+#: zerver/lib/typed_endpoint_validators.py
 #, python-brace-format
 msgid "Invalid {setting_name}"
 msgstr "無效的 {setting_name}"
 
-#: zerver/lib/typed_endpoint_validators.py:129
+#: zerver/lib/typed_endpoint_validators.py
 msgid "Not a valid unsigned 32-bit integer"
 msgstr ""
 
-#: zerver/lib/upload/__init__.py:57
+#: zerver/lib/upload/__init__.py
 msgid "Upload would exceed your organization's upload quota."
 msgstr "上傳將超過您組織的上傳配額。"
 
-#: zerver/lib/upload/__init__.py:569 zerver/lib/upload/__init__.py:571
+#: zerver/lib/upload/__init__.py
 msgid "Image size exceeds limit"
 msgstr "圖片大小超過限制"
 
-#: zerver/lib/user_groups.py:100 zerver/lib/user_groups.py:137
+#: zerver/lib/user_groups.py
 msgid "User group is deactivated."
 msgstr "使用者群組已停用。"
 
-#: zerver/lib/user_groups.py:140
+#: zerver/lib/user_groups.py
 msgid "Invalid user group"
 msgstr "無效的使用者群組"
 
-#: zerver/lib/user_groups.py:155
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {user_group_id}"
 msgstr "無效的使用者群組 ID：{user_group_id}"
 
-#: zerver/lib/user_groups.py:163
+#: zerver/lib/user_groups.py
 msgid "Invalid system group name."
 msgstr "無效的系統群組名稱。"
 
-#: zerver/lib/user_groups.py:387 zerver/lib/user_groups.py:485
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "Invalid user group ID: {group_id}"
 msgstr "無效的使用者群組 ID：{group_id}"
 
-#: zerver/lib/user_groups.py:418
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:internet' group."
 msgstr ""
 "「{setting_name}」設定無法指定為「所有網際網路使用者（role:internet）」群組。"
 
-#: zerver/lib/user_groups.py:428
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:nobody' group."
 msgstr "「{setting_name}」設定無法指定為「無人（role:nobody）」群組。"
 
-#: zerver/lib/user_groups.py:438
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to 'role:everyone' group."
 msgstr "「{setting_name}」設定無法指定為「所有人（role:everyone）」群組。"
 
-#: zerver/lib/user_groups.py:448
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "'{setting_name}' setting cannot be set to '{group_name}' group."
 msgstr "「{setting_name}」設定無法指定為「{group_name}」群組。"
 
-#: zerver/lib/user_groups.py:559
+#: zerver/lib/user_groups.py
 msgid "User group name can't be empty!"
 msgstr "使用者群組名稱不能為空！"
 
-#: zerver/lib/user_groups.py:563
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot exceed {max_length} characters."
 msgstr "使用者群組名稱不得超過 {max_length} 個字元。"
 
-#: zerver/lib/user_groups.py:571
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid "User group name cannot start with '{prefix}'."
 msgstr "使用者群組名稱不能以 '{prefix}' 開頭。"
 
-#: zerver/lib/user_groups.py:1371 zerver/lib/user_groups.py:1379
+#: zerver/lib/user_groups.py
 #, python-brace-format
 msgid ""
 "'{setting_name}' must be restricted to organization administrators for "
 "groups used in 'workplace_users_group'."
 msgstr ""
 
-#: zerver/lib/user_groups.py:1405
+#: zerver/lib/user_groups.py
 msgid ""
 "'can_manage_all_groups' must be restricted to organization administrators "
 "when 'workplace_users_group' includes user-defined groups."
 msgstr ""
 
-#: zerver/lib/user_status.py:162
+#: zerver/lib/user_status.py
 msgid "Client did not pass any new values."
 msgstr "客戶端沒有傳遞任何新值。"
 
-#: zerver/lib/user_status.py:185
+#: zerver/lib/user_status.py
 msgid ""
 "Client must pass emoji_name if they pass either emoji_code or reaction_type."
 msgstr "如果客戶端傳遞 emoji_code 或 reaction_type，就必須傳遞 emoji_name。"
 
-#: zerver/lib/users.py:61
+#: zerver/lib/users.py
 msgid "Name too long!"
 msgstr "名稱過長！"
 
-#: zerver/lib/users.py:63
+#: zerver/lib/users.py
 msgid "Name must not be empty!"
 msgstr "名字不能為空！"
 
-#: zerver/lib/users.py:67
+#: zerver/lib/users.py
 msgid "Invalid characters in name!"
 msgstr "無效的字元在名稱裡！"
 
-#: zerver/lib/users.py:73
+#: zerver/lib/users.py
 msgid "Invalid format!"
 msgstr "無效的格式！"
 
-#: zerver/lib/users.py:92
+#: zerver/lib/users.py
 msgid "Unique names required in this organization."
 msgstr "此組織需要唯一的名稱。"
 
-#: zerver/lib/users.py:114
+#: zerver/lib/users.py
 msgid "Name is already in use."
 msgstr "名稱已被使用。"
 
-#: zerver/lib/users.py:120 zerver/lib/users.py:132 zerver/views/users.py:683
-#: zerver/views/users.py:910
+#: zerver/lib/users.py zerver/views/users.py
 msgid "Bad name or username"
 msgstr "無效的名稱或使用者名稱"
 
-#: zerver/lib/users.py:152
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid integration '{integration_name}'."
 msgstr "無效的第三方整合「{integration_name}」。"
 
-#: zerver/lib/users.py:158
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Missing configuration parameters: {keys}"
 msgstr "缺少設定參數：{keys}"
 
-#: zerver/lib/users.py:168
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid {key} value {value} ({error})"
 msgstr "無效的 {key} 值 {value} ({error})"
 
-#: zerver/lib/users.py:186
+#: zerver/lib/users.py
 msgid "Invalid configuration data!"
 msgstr "無效的設定資料！"
 
-#: zerver/lib/users.py:222
+#: zerver/lib/users.py
 msgid "Invalid bot type"
 msgstr "無效的機器人類型"
 
-#: zerver/lib/users.py:227
+#: zerver/lib/users.py
 msgid "Invalid interface type"
 msgstr "無效的介面類型"
 
-#: zerver/lib/users.py:273
+#: zerver/lib/users.py
 #, python-brace-format
 msgid "Invalid user ID: {user_id}"
 msgstr "無效的使用者 ID：{user_id}"
 
-#: zerver/lib/users.py:282 zerver/lib/users.py:284
+#: zerver/lib/users.py
 msgid "No such bot"
 msgstr "無此機器人"
 
-#: zerver/lib/users.py:308 zerver/lib/users.py:339 zerver/lib/users.py:356
-#: zerver/lib/users.py:435 zerver/lib/users.py:461 zerver/lib/users.py:483
-#: zerver/views/presence.py:44
+#: zerver/lib/users.py zerver/views/presence.py
 msgid "No such user"
 msgstr "無此使用者"
 
-#: zerver/lib/users.py:310
+#: zerver/lib/users.py
 msgid "User is deactivated"
 msgstr "使用者已停用"
 
-#: zerver/lib/validator.py:63
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{item} cannot be blank."
 msgstr "{item} 不能是空白。"
 
-#: zerver/lib/validator.py:104
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} has incorrect length {length}; should be {target_length}"
 msgstr "{var_name} 是不正確的長度 {length}; 應為 {target_length}"
 
-#: zerver/lib/validator.py:140
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not an ISO 8601 datetime string"
 msgstr "{var_name} 不是 ISO 8601 日期時間字串"
 
-#: zerver/lib/validator.py:209
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{container} should have exactly {length} items"
 msgstr "{container} 應有 {length} items"
 
-#: zerver/lib/validator.py:258
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{key_name} key is missing from {var_name}"
 msgstr "在 {var_name} 裡缺少 key {key_name}"
 
-#: zerver/lib/validator.py:283
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "Unexpected arguments: {keys}"
 msgstr "非預期的參數：{keys}"
 
-#: zerver/lib/validator.py:316 zerver/views/realm.py:99
+#: zerver/lib/validator.py zerver/views/realm.py
 #, python-brace-format
 msgid "{var_name} is not an allowed_type"
 msgstr "{var_name} 不是 allowed_type"
 
-#: zerver/lib/validator.py:325
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{variable} != {expected_value} ({value} is wrong)"
 msgstr "{variable} != {expected_value} ({value} 是錯的)"
 
-#: zerver/lib/validator.py:352 zerver/lib/validator.py:366
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a URL"
 msgstr "{var_name} 不是 URL"
 
-#: zerver/lib/validator.py:379
+#: zerver/lib/validator.py
 #, python-format
 msgid "URL pattern must contain '%(username)s'."
 msgstr "URL 模式必須包含 '%(username)s'。"
 
-#: zerver/lib/validator.py:403
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{item}' cannot be blank."
 msgstr "'{item}' 不能是空白。"
 
-#: zerver/lib/validator.py:412
+#: zerver/lib/validator.py
 msgid "Field must not have duplicate choices."
 msgstr "欄位不能有重複的選項。"
 
-#: zerver/lib/validator.py:425
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "'{value}' is not a valid choice for '{field_name}'."
 msgstr "'{value}' 對於 '{field_name}' 不是有效的選擇。"
 
-#: zerver/lib/validator.py:577
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or an integer list"
 msgstr "{var_name} 不是 string 或 integer list"
 
-#: zerver/lib/validator.py:587
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is not a string or integer"
 msgstr "{var_name} 不是 string 或 integer"
 
-#: zerver/lib/validator.py:616
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} does not have a length"
 msgstr "{var_name} 沒有長度"
 
-#: zerver/lib/validator.py:676 zerver/lib/validator.py:698
+#: zerver/lib/validator.py
 #, python-brace-format
 msgid "{var_name} is missing"
 msgstr "{var_name} 遺失"
 
-#: zerver/lib/webhooks/common.py:112
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Unknown 'PresetUrlOption': {config}"
 msgstr "未知的 'PresetUrlOption'：{config}"
 
-#: zerver/lib/webhooks/common.py:143
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "Missing the HTTP event header '{header}'"
 msgstr "缺少 HTTP event header '{header}'"
 
-#: zerver/lib/webhooks/common.py:331
+#: zerver/lib/webhooks/common.py
 #, python-brace-format
 msgid "The algorithm '{algorithm}' is not supported."
 msgstr "不支援演算法 '{algorithm}'。"
 
-#: zerver/lib/webhooks/common.py:338
+#: zerver/lib/webhooks/common.py
 msgid ""
 "The webhook secret is missing. Please set the webhook_secret while "
 "generating the URL."
 msgstr "缺少 webhook secret。請在產生 URL 時設定 webhook_secret。"
 
-#: zerver/lib/webhooks/common.py:351
+#: zerver/lib/webhooks/common.py
 msgid "Webhook signature verification failed."
 msgstr "Webhook 簽章驗證失敗。"
 
-#: zerver/lib/workplace_users.py:49
+#: zerver/lib/workplace_users.py
 msgid ""
 "'workplace_users_group' must be a group whose membership can only be managed "
 "by organization administrators."
 msgstr ""
 
-#: zerver/lib/zcommand.py:29
+#: zerver/lib/zcommand.py
 msgid "There should be a leading slash in the zcommand."
 msgstr "在 zcommand 中應該有前置斜線。"
 
-#: zerver/lib/zcommand.py:78
+#: zerver/lib/zcommand.py
 #, python-brace-format
 msgid "No such command: {command}"
 msgstr "無此指令：{command}"
 
-#: zerver/lib/zulip_update_announcements.py:866
+#: zerver/lib/zulip_update_announcements.py
 msgid "`zulip_update_announcements_stream` is unexpectedly deactivated."
 msgstr "`zulip_update_announcements_stream` 意外地被停用。"
 
-#: zerver/middleware.py:472
+#: zerver/middleware.py
 #, python-brace-format
 msgid "CSRF error: {reason}"
 msgstr "CSRF 錯誤：{reason}"
 
-#: zerver/middleware.py:646
+#: zerver/middleware.py
 #, python-brace-format
 msgid "Reverse proxy misconfiguration: {proxy_reason}"
 msgstr "反向代理配置錯誤：{proxy_reason}"
 
-#: zerver/models/custom_profile_fields.py:45
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "Invalid user IDs: {invalid_ids}"
 msgstr "無效的使用者 ID：{invalid_ids}"
 
-#: zerver/models/custom_profile_fields.py:53
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is deactivated"
 msgstr "ID 為 {user_id} 的使用者已停用"
 
-#: zerver/models/custom_profile_fields.py:57
+#: zerver/models/custom_profile_fields.py
 #, python-brace-format
 msgid "User with ID {user_id} is a bot"
 msgstr "ID 為 {user_id} 的使用者是機器人"
 
-#: zerver/models/custom_profile_fields.py:105
+#: zerver/models/custom_profile_fields.py
 msgid "Dropdown"
 msgstr "下拉式選單"
 
-#: zerver/models/custom_profile_fields.py:120
+#: zerver/models/custom_profile_fields.py
 msgid "Short text"
 msgstr "短文字"
 
-#: zerver/models/custom_profile_fields.py:121
+#: zerver/models/custom_profile_fields.py
 msgid "Paragraph"
 msgstr "段落文字"
 
-#: zerver/models/custom_profile_fields.py:122
+#: zerver/models/custom_profile_fields.py
 msgid "Date"
 msgstr "日期"
 
-#: zerver/models/custom_profile_fields.py:126
+#: zerver/models/custom_profile_fields.py
 msgid "External account"
 msgstr "外部帳戶"
 
-#: zerver/models/custom_profile_fields.py:131
+#: zerver/models/custom_profile_fields.py
 msgid "Pronouns"
 msgstr "代名詞"
 
-#: zerver/models/groups.py:22 zerver/models/users.py:320
+#: zerver/models/groups.py zerver/models/users.py
 msgid "Nobody"
 msgstr "沒有人"
 
-#: zerver/models/groups.py:26
+#: zerver/models/groups.py
 msgid "Full members"
 msgstr "正式成員"
 
-#: zerver/models/groups.py:27
+#: zerver/models/groups.py
 msgid "Members"
 msgstr "成員"
 
-#: zerver/models/groups.py:29
+#: zerver/models/groups.py
 msgid "Everyone on the internet"
 msgstr "網路上的所有人"
 
-#: zerver/models/linkifiers.py:42
+#: zerver/models/linkifiers.py
 msgid "Invalid auto-conversion field: missing '}' character."
 msgstr ""
 
-#: zerver/models/linkifiers.py:45
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Invalid characters in emoji name"
 msgid "Invalid auto-conversion field: empty field name."
 msgstr "表情符號名稱中有無效的字元"
 
-#: zerver/models/linkifiers.py:49
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid ""
 "Group %(name)r in auto-conversion field is not present in linkifier pattern."
 msgstr "URL 範本中的群組 %(name)r 未出現在連結轉換器語法中。"
 
-#: zerver/models/linkifiers.py:74 zerver/models/linkifiers.py:77
+#: zerver/models/linkifiers.py
 #, python-brace-format
 msgid "Bad regular expression: {regex}"
 msgstr "無效的正規表達式：{regex}"
 
-#: zerver/models/linkifiers.py:79
+#: zerver/models/linkifiers.py
 msgid "Unknown regular expression error"
 msgstr "未知的正規表達式錯誤"
 
-#: zerver/models/linkifiers.py:87
+#: zerver/models/linkifiers.py
 msgid "Invalid URL template."
 msgstr "無效的 URL 範本。"
 
-#: zerver/models/linkifiers.py:137
+#: zerver/models/linkifiers.py
 #, fuzzy
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid "Example input does not match the linkifier pattern."
 msgstr "URL 範本中的群組 %(name)r 未出現在連結轉換器語法中。"
 
-#: zerver/models/linkifiers.py:141
+#: zerver/models/linkifiers.py
 msgid "Example text does not match auto-conversion field."
 msgstr ""
 
-#: zerver/models/linkifiers.py:157
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgstr "URL 範本中的群組 %(name)r 未出現在連結轉換器語法中。"
 
-#: zerver/models/linkifiers.py:169
+#: zerver/models/linkifiers.py
 #, python-format
 msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgstr "連結轉換器語法中的群組 %(name)r 未出現在 URL 範本中。"
 
-#: zerver/models/linkifiers.py:175
+#: zerver/models/linkifiers.py
 msgid "An alternative URL template cannot be the same as the URL template."
 msgstr ""
 
-#: zerver/models/linkifiers.py:179
+#: zerver/models/linkifiers.py
 msgid "Alternative URL templates must be unique."
 msgstr ""
 
-#: zerver/models/linkifiers.py:193
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in URL template is not present in linkifier pattern."
 msgid ""
@@ -7304,7 +6713,7 @@ msgid ""
 "pattern."
 msgstr "URL 範本中的群組 %(name)r 未出現在連結轉換器語法中。"
 
-#: zerver/models/linkifiers.py:203
+#: zerver/models/linkifiers.py
 #, fuzzy, python-format
 #| msgid "Group %(name)r in linkifier pattern is not present in URL template."
 msgid ""
@@ -7312,429 +6721,424 @@ msgid ""
 "template."
 msgstr "連結轉換器語法中的群組 %(name)r 未出現在 URL 範本中。"
 
-#: zerver/models/messages.py:380
+#: zerver/models/messages.py
 msgid "Unicode emoji"
 msgstr "Unicode 表情符號"
 
-#: zerver/models/messages.py:381
+#: zerver/models/messages.py
 msgid "Custom emoji"
 msgstr "自定義表情符號"
 
-#: zerver/models/messages.py:382
+#: zerver/models/messages.py
 msgid "Zulip extra emoji"
 msgstr "Zulip 額外的表情符號"
 
-#: zerver/models/realm_emoji.py:40
+#: zerver/models/realm_emoji.py
 msgid "Invalid characters in emoji name"
 msgstr "表情符號名稱中有無效的字元"
 
-#: zerver/models/realm_playgrounds.py:41
+#: zerver/models/realm_playgrounds.py
 msgid "Invalid characters in pygments language"
 msgstr "Pygments 語言中有無效的字元"
 
-#: zerver/models/realm_playgrounds.py:73
+#: zerver/models/realm_playgrounds.py
 msgid "Missing the required variable \"code\" in the URL template"
 msgstr "URL 範本中缺少必要的變數 \"code\""
 
-#: zerver/models/realm_playgrounds.py:78
+#: zerver/models/realm_playgrounds.py
 msgid "\"code\" should be the only variable present in the URL template"
 msgstr "\"code\" 應是 URL 範本中唯一的變數"
 
-#: zerver/models/realms.py:463
+#: zerver/models/realms.py
 msgid "sandbox"
 msgstr "沙盒"
 
-#: zerver/models/realms.py:464
+#: zerver/models/realms.py
 msgid "general"
 msgstr "一般"
 
-#: zerver/models/realms.py:465
+#: zerver/models/realms.py
 msgid "channel events"
 msgstr "頻道事件"
 
-#: zerver/models/realms.py:467
+#: zerver/models/realms.py
 msgid "Spam"
 msgstr "垃圾訊息"
 
-#: zerver/models/realms.py:468
+#: zerver/models/realms.py
 msgid "Harassment"
 msgstr "騷擾"
 
-#: zerver/models/realms.py:469
+#: zerver/models/realms.py
 msgid "Inappropriate content"
 msgstr "不當內容"
 
-#: zerver/models/realms.py:470
+#: zerver/models/realms.py
 msgid "Violates community norms"
 msgstr "違反社群規範"
 
-#: zerver/models/realms.py:471
+#: zerver/models/realms.py
 msgid "Other reason"
 msgstr "其他原因"
 
-#: zerver/models/realms.py:496
+#: zerver/models/realms.py
 msgid "Zulip updates"
 msgstr "Zulip 更新"
 
-#: zerver/models/realms.py:622
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Standard. Upgrade to access."
 msgstr "Zulip Cloud Standard 可用。升級以取得使用權限。"
 
-#: zerver/models/realms.py:623
+#: zerver/models/realms.py
 msgid "Available on Zulip Cloud Plus. Upgrade to access."
 msgstr "Zulip Cloud Plus 可用。升級以取得使用權限。"
 
-#: zerver/models/realms.py:695
+#: zerver/models/realms.py
 msgid "Disabled"
 msgstr ""
 
-#: zerver/models/realms.py:703
+#: zerver/models/realms.py
 msgid "Allow GIFs rated G (General audience)"
 msgstr "允許 G 級 GIF（一般觀眾）"
 
-#: zerver/models/realms.py:707
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG (Parental guidance)"
 msgstr "允許 PG 級 GIF（家長指導）"
 
-#: zerver/models/realms.py:711
+#: zerver/models/realms.py
 msgid "Allow GIFs rated PG-13 (Parental guidance - under 13)"
 msgstr "允許 PG-13 級 GIF（家長指導 - 13 歲以下）"
 
-#: zerver/models/realms.py:715
+#: zerver/models/realms.py
 msgid "Allow GIFs rated R (Restricted)"
 msgstr "允許 R 級 GIF（限制級）"
 
-#: zerver/models/streams.py:61
+#: zerver/models/streams.py
 msgid "Web-public"
 msgstr "網路公共"
 
-#: zerver/models/streams.py:67
+#: zerver/models/streams.py
 msgid "Public"
 msgstr "公開"
 
-#: zerver/models/streams.py:73
+#: zerver/models/streams.py
 msgid "Private, shared history"
 msgstr "封閉，共享歷史記錄"
 
-#: zerver/models/streams.py:79
+#: zerver/models/streams.py
 msgid "Private, protected history"
 msgstr "封閉，受保護歷史記錄"
 
-#: zerver/models/users.py:316
+#: zerver/models/users.py
 msgid "Admins, moderators, members and guests"
 msgstr "管理者、版主、成員和訪客"
 
-#: zerver/models/users.py:317
+#: zerver/models/users.py
 msgid "Admins, moderators and members"
 msgstr "管理者、版主和成員"
 
-#: zerver/models/users.py:318
+#: zerver/models/users.py
 msgid "Admins and moderators"
 msgstr "管理員和版主"
 
-#: zerver/models/users.py:319
+#: zerver/models/users.py
 msgid "Admins only"
 msgstr "只允許管理者"
 
-#: zerver/models/users.py:514
+#: zerver/models/users.py
 msgid "Unknown user"
 msgstr "未知的使用者"
 
-#: zerver/models/users.py:698
+#: zerver/models/users.py
 msgid "Organization owner"
 msgstr "組織擁有者"
 
-#: zerver/models/users.py:699
+#: zerver/models/users.py
 msgid "Organization administrator"
 msgstr "組織管理員"
 
-#: zerver/models/users.py:700
+#: zerver/models/users.py
 msgid "Moderator"
 msgstr "版主"
 
-#: zerver/models/users.py:701
+#: zerver/models/users.py
 msgid "Member"
 msgstr "成員"
 
-#: zerver/models/users.py:702
+#: zerver/models/users.py
 msgid "Guest"
 msgstr "訪客"
 
-#: zerver/signals.py:82
+#: zerver/signals.py
 msgid "Unknown IP address"
 msgstr "未知的 IP 地址"
 
-#: zerver/signals.py:83
+#: zerver/signals.py
 msgid "an unknown operating system"
 msgstr "未知的作業系統"
 
-#: zerver/signals.py:84
+#: zerver/signals.py
 msgid "An unknown browser"
 msgstr "未知的瀏覽器"
 
-#: zerver/tornado/event_queue.py:818
+#: zerver/tornado/event_queue.py
 msgid "Missing 'queue_id' argument"
 msgstr "缺少 'queue_id' 參數"
 
-#: zerver/tornado/event_queue.py:821
+#: zerver/tornado/event_queue.py
 msgid "Missing 'last_event_id' argument"
 msgstr "缺少 'last_event_id' 參數"
 
-#: zerver/tornado/event_queue.py:828
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "An event newer than {event_id} has already been pruned!"
 msgstr "比 {event_id} 更新的事件已被清除！"
 
-#: zerver/tornado/event_queue.py:838
+#: zerver/tornado/event_queue.py
 #, python-brace-format
 msgid "Event {event_id} was not in this queue"
 msgstr "事件 {event_id} 不在此佇列中"
 
-#: zerver/tornado/exceptions.py:17
+#: zerver/tornado/exceptions.py
 #, python-brace-format
 msgid "Bad event queue ID: {queue_id}"
 msgstr "無效的事件佇列 ID：{queue_id}"
 
-#: zerver/views/antispam.py:53
+#: zerver/views/antispam.py
 msgid "Failed to generate challenge"
 msgstr "生成驗證挑戰失敗"
 
-#: zerver/views/auth.py:615
+#: zerver/views/auth.py
 msgid "JWT authentication is not enabled for this organization"
 msgstr "此組織未啟用 JWT 身份驗證"
 
-#: zerver/views/auth.py:618
+#: zerver/views/auth.py
 msgid "No JSON web token passed in request"
 msgstr "請求中沒有傳遞 JSON 網路權杖"
 
-#: zerver/views/auth.py:625
+#: zerver/views/auth.py
 msgid "Bad JSON web token"
 msgstr "無效的 JSON 網路權杖"
 
-#: zerver/views/auth.py:629
+#: zerver/views/auth.py
 msgid "No email specified in JSON web token claims"
 msgstr "JSON 網路權杖聲明中未指定電子郵件"
 
-#: zerver/views/auth.py:1190
+#: zerver/views/auth.py
 msgid "Subdomain required"
 msgstr "需要子域名"
 
-#: zerver/views/auth.py:1254
+#: zerver/views/auth.py
 msgid "Password is incorrect."
 msgstr "密碼不正確。"
 
-#: zerver/views/channel_folders.py:98
+#: zerver/views/channel_folders.py
 msgid "You need to remove all the channels from this folder to archive it."
 msgstr "您需要從此資料夾中移除所有頻道才能封存它。"
 
-#: zerver/views/compatibility.py:18
+#: zerver/views/compatibility.py
 msgid "User-Agent header missing from request"
 msgstr "該請求缺少 User-Agent header"
 
-#: zerver/views/custom_profile_fields.py:44
+#: zerver/views/custom_profile_fields.py
 msgid "Label cannot be blank."
 msgstr "標籤不能為空白。"
 
-#: zerver/views/custom_profile_fields.py:58
+#: zerver/views/custom_profile_fields.py
 msgid "Field must have at least one choice."
 msgstr "欄位必須至少有一個選項。"
 
-#: zerver/views/custom_profile_fields.py:74
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for display in profile summary."
 msgstr "欄位類型不支援在個人檔案摘要中顯示。"
 
-#: zerver/views/custom_profile_fields.py:83
+#: zerver/views/custom_profile_fields.py
 msgid "Field type not supported for use for user matching."
 msgstr "此欄位類型不支援用於使用者比對。"
 
-#: zerver/views/custom_profile_fields.py:113
+#: zerver/views/custom_profile_fields.py
 msgid "Invalid field type."
 msgstr "無效的欄位類型。"
 
-#: zerver/views/custom_profile_fields.py:196
-#: zerver/views/custom_profile_fields.py:270
+#: zerver/views/custom_profile_fields.py
 msgid "Only 2 custom profile fields can be displayed in the profile summary."
 msgstr "個人檔案摘要中只能顯示 2 個自定義個人檔案欄位。"
 
-#: zerver/views/custom_profile_fields.py:229
-#: zerver/views/custom_profile_fields.py:304
+#: zerver/views/custom_profile_fields.py
 msgid "A field with that label already exists."
 msgstr "具有該標籤的欄位已存在。"
 
-#: zerver/views/custom_profile_fields.py:286
+#: zerver/views/custom_profile_fields.py
 msgid "Default custom field cannot be updated."
 msgstr "預設自定義欄位不能被更新。"
 
-#: zerver/views/development/dev_login.py:100
+#: zerver/views/development/dev_login.py
 msgid "Endpoint not available in production."
 msgstr "端點在生產環境中不可用。"
 
-#: zerver/views/development/dev_login.py:102
+#: zerver/views/development/dev_login.py
 msgid "DevAuthBackend not enabled."
 msgstr "DevAuthBackend 未啟用。"
 
-#: zerver/views/events_register.py:86 zerver/views/events_register.py:90
+#: zerver/views/events_register.py
 #, python-brace-format
 msgid "Invalid '{key}' parameter for anonymous request"
 msgstr "匿名請求的 '{key}' 參數無效"
 
-#: zerver/views/health.py:18
+#: zerver/views/health.py
 msgid "Database is empty"
 msgstr "資料庫是空的"
 
-#: zerver/views/health.py:22
+#: zerver/views/health.py
 msgid "Cannot query postgresql"
 msgstr "無法查詢 postgresql"
 
-#: zerver/views/health.py:29
+#: zerver/views/health.py
 msgid "Cannot connect to rabbitmq"
 msgstr "無法連線到 rabbitmq"
 
-#: zerver/views/health.py:35
+#: zerver/views/health.py
 msgid "Cannot query rabbitmq"
 msgstr "無法查詢 rabbitmq"
 
-#: zerver/views/health.py:42
+#: zerver/views/health.py
 msgid "Cannot query redis"
 msgstr "無法查詢 redis"
 
-#: zerver/views/health.py:52
+#: zerver/views/health.py
 msgid "Cannot write to memcached"
 msgstr "無法寫入 memcached"
 
-#: zerver/views/health.py:57
+#: zerver/views/health.py
 msgid "Cannot query memcached"
 msgstr "無法查詢 memcached"
 
-#: zerver/views/invite.py:61 zerver/views/invite.py:66
-#: zerver/views/invite.py:80 zerver/views/invite.py:83
+#: zerver/views/invite.py
 msgid "No such invitation"
 msgstr "無此邀請"
 
-#: zerver/views/invite.py:69
+#: zerver/views/invite.py
 #, fuzzy
 #| msgid "Invitation has already been revoked"
 msgid "Invitation already used or deactivated."
 msgstr "邀請已被撤銷"
 
-#: zerver/views/invite.py:89
+#: zerver/views/invite.py
 msgid "Invitation has already been revoked"
 msgstr "邀請已被撤銷"
 
-#: zerver/views/invite.py:101
+#: zerver/views/invite.py
 #, python-brace-format
 msgid "Invalid channel ID {channel_id}. No invites were sent."
 msgstr "無效的頻道 ID {channel_id}。沒有發送邀請。"
 
-#: zerver/views/invite.py:115
+#: zerver/views/invite.py
 msgid "You do not have permission to subscribe other users to channels."
 msgstr "您沒有讓其他使用者訂閱頻道的權限。"
 
-#: zerver/views/invite.py:173
+#: zerver/views/invite.py
 msgid "You must specify at least one email address."
 msgstr "您必須指定至少一個電子郵件地址。"
 
-#: zerver/views/invite.py:198
+#: zerver/views/invite.py
 msgid ""
 "Some of those addresses are already using Zulip, so we didn't send them an "
 "invitation. We did send invitations to everyone else!"
 msgstr ""
 "部份地址已經在 Zulip 使用，所以我們沒送出邀請。除此之外其他部份都已送出！"
 
-#: zerver/views/message_edit.py:126
+#: zerver/views/message_edit.py
 msgid "Message edit history is disabled in this organization"
 msgstr "此組織禁用訊息編輯歷史"
 
-#: zerver/views/message_edit.py:195 zerver/views/message_edit.py:199
-#: zerver/views/message_edit.py:206
+#: zerver/views/message_edit.py
 msgid "You don't have permission to delete this message"
 msgstr "您沒有刪除此訊息的權限"
 
-#: zerver/views/message_edit.py:214
+#: zerver/views/message_edit.py
 msgid "The time limit for deleting this message has passed"
 msgstr "刪除此訊息的時間限制已過"
 
-#: zerver/views/message_edit.py:235
+#: zerver/views/message_edit.py
 msgid "Message already deleted"
 msgstr "訊息已被刪除"
 
-#: zerver/views/message_fetch.py:157
+#: zerver/views/message_fetch.py
 #, python-brace-format
 msgid "Too many messages requested (maximum {max_messages})."
 msgstr "請求的訊息過多（最多 {max_messages} 則）。"
 
-#: zerver/views/message_fetch.py:162 zerver/views/message_flags.py:94
+#: zerver/views/message_fetch.py zerver/views/message_flags.py
 msgid "The anchor can only be excluded at an end of the range"
 msgstr "錨點只能在範圍的末端被排除"
 
-#: zerver/views/message_flags.py:184
+#: zerver/views/message_flags.py
 #, python-brace-format
 msgid "No such topic '{topic}'"
 msgstr "無此議題 '{topic}'"
 
-#: zerver/views/message_report.py:29
+#: zerver/views/message_report.py
 msgid "An explanation is required."
 msgstr "必須提供說明。"
 
-#: zerver/views/message_report.py:32
+#: zerver/views/message_report.py
 msgid "Message reporting is not enabled in this organization."
 msgstr "此組織未啟用訊息檢舉功能。"
 
-#: zerver/views/message_send.py:190
+#: zerver/views/message_send.py
 msgid "Missing sender"
 msgstr "缺少發送者"
 
-#: zerver/views/message_send.py:197
+#: zerver/views/message_send.py
 msgid "Mirroring not allowed with recipient user IDs"
 msgstr "不允許使用收件者使用者 ID 進行鏡像"
 
-#: zerver/views/message_send.py:209 zerver/views/message_send.py:214
+#: zerver/views/message_send.py
 msgid "Invalid mirrored message"
 msgstr "無效的鏡像訊息"
 
-#: zerver/views/message_summary.py:28
+#: zerver/views/message_summary.py
 msgid "AI features are not enabled on this server."
 msgstr "此伺服器未啟用 AI 功能。"
 
-#: zerver/views/message_summary.py:38
+#: zerver/views/message_summary.py
 msgid "Reached monthly limit for AI credits."
 msgstr "已達到 AI 點數的每月限制。"
 
-#: zerver/views/message_summary.py:42
+#: zerver/views/message_summary.py
 msgid "No messages in conversation to summarize"
 msgstr "對話中沒有可摘要的訊息"
 
-#: zerver/views/muted_users.py:16
+#: zerver/views/muted_users.py
 msgid "Cannot mute self"
 msgstr "不能靜音自己"
 
-#: zerver/views/muted_users.py:34
+#: zerver/views/muted_users.py
 msgid "User already muted"
 msgstr "使用者已靜音"
 
-#: zerver/views/muted_users.py:48
+#: zerver/views/muted_users.py
 msgid "User is not muted"
 msgstr "使用者未靜音"
 
-#: zerver/views/navigation_views.py:59 zerver/views/navigation_views.py:91
+#: zerver/views/navigation_views.py
 msgid "Built-in views cannot have a custom name."
 msgstr "內建檢視無法使用自訂名稱。"
 
-#: zerver/views/navigation_views.py:62
+#: zerver/views/navigation_views.py
 msgid "Custom views must have a valid name."
 msgstr "自訂檢視必須提供有效的名稱。"
 
-#: zerver/views/navigation_views.py:65 zerver/views/navigation_views.py:67
-#: zerver/views/navigation_views.py:93
+#: zerver/views/navigation_views.py
 msgid "Navigation view already exists."
 msgstr "導覽檢視已存在。"
 
-#: zerver/views/onboarding_steps.py:32
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid "Unknown onboarding_step: {onboarding_step}"
 msgstr "未知的 onboarding_step：{onboarding_step}"
 
-#: zerver/views/onboarding_steps.py:41
+#: zerver/views/onboarding_steps.py
 #, python-brace-format
 msgid ""
 "\n"
@@ -7745,215 +7149,215 @@ msgstr ""
 "你先前選擇稍後觀看 [歡迎使用 Zulip 影片]({navigation_tour_video_url})。現在方"
 "便觀看嗎？\n"
 
-#: zerver/views/presence.py:51
+#: zerver/views/presence.py
 msgid "Presence is not supported for bot users."
 msgstr "機器人不支援 Presence。"
 
-#: zerver/views/presence.py:74
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "No presence data for {user_id_or_email}"
 msgstr "沒有 {user_id_or_email} 的在線狀態資料"
 
-#: zerver/views/presence.py:200
+#: zerver/views/presence.py
 #, python-brace-format
 msgid "Invalid status: {status}"
 msgstr "無效的狀態：{status}"
 
-#: zerver/views/push_notifications.py:151
+#: zerver/views/push_notifications.py
 #, fuzzy
 #| msgid "You do not have permission to change default channels."
 msgid "You do not have permission to manage plans and billing."
 msgstr "您沒有權限變更預設頻道。"
 
-#: zerver/views/push_notifications.py:167
+#: zerver/views/push_notifications.py
 msgid "Server doesn't use the push notification service"
 msgstr "伺服器不使用推送通知服務"
 
-#: zerver/views/push_notifications.py:199
+#: zerver/views/push_notifications.py
 #, python-brace-format
 msgid "Error returned by the bouncer: {result}"
 msgstr "轉發器回傳錯誤：{result}"
 
-#: zerver/views/push_notifications.py:283
+#: zerver/views/push_notifications.py
 msgid "Verification secret not prepared"
 msgstr "驗證密鑰未準備就緒"
 
-#: zerver/views/push_notifications.py:349
+#: zerver/views/push_notifications.py
 msgid ""
 "Missing parameters: must provide either all push key fields, all token "
 "fields, or both."
 msgstr ""
 
-#: zerver/views/push_notifications.py:355
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate key for."
 msgstr ""
 
-#: zerver/views/push_notifications.py:365
+#: zerver/views/push_notifications.py
 msgid "A registration for the device already in progress."
 msgstr ""
 
-#: zerver/views/push_notifications.py:376
+#: zerver/views/push_notifications.py
 msgid "No push registration exists to rotate token for."
 msgstr ""
 
-#: zerver/views/reactions.py:48
+#: zerver/views/reactions.py
 msgid ""
 "At least one of the following arguments must be present: emoji_name, "
 "emoji_code"
 msgstr "以下參數至少必須存在一個：emoji_name, emoji_code"
 
-#: zerver/views/read_receipts.py:23
+#: zerver/views/read_receipts.py
 msgid "Read receipts are disabled in this organization."
 msgstr "此組織已停用已讀回條。"
 
-#: zerver/views/realm.py:242
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid language '{language}'"
 msgstr "無效的語言 '{language}'"
 
-#: zerver/views/realm.py:249
+#: zerver/views/realm.py
 msgid "At least one authentication method must be enabled."
 msgstr "至少必須啟用一種身份驗證方法。"
 
-#: zerver/views/realm.py:255
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid video_chat_provider {video_chat_provider}"
 msgstr "無效的 video_chat_provider：{video_chat_provider}"
 
-#: zerver/views/realm.py:263
+#: zerver/views/realm.py
 #, python-brace-format
 msgid "Invalid gif_rating_policy {gif_rating_policy}"
 msgstr "無效的 gif_rating_policy {gif_rating_policy}"
 
-#: zerver/views/realm.py:401
+#: zerver/views/realm.py
 msgid ""
 "Organization is not eligible for discounted pricing for non workplace users."
 msgstr ""
 
-#: zerver/views/realm.py:407
+#: zerver/views/realm.py
 msgid ""
 "Discounted pricing for workplace users cannot be enabled with current "
 "discounted plan."
 msgstr ""
 
-#: zerver/views/realm.py:568
+#: zerver/views/realm.py
 msgid "Must be a demo organization."
 msgstr "必須是試用組織。"
 
-#: zerver/views/realm.py:601 zerver/views/realm.py:608
+#: zerver/views/realm.py
 msgid "Invalid data deletion time for demo organization."
 msgstr "示範組織的資料刪除時間設定無效。"
 
-#: zerver/views/realm.py:624
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at most {max_allowed_days} days in the future."
 msgstr "資料刪除時間必須設定在未來 {max_allowed_days} 天以內。"
 
-#: zerver/views/realm.py:635
+#: zerver/views/realm.py
 #, python-brace-format
 msgid ""
 "Data deletion time must be at least {min_allowed_days} days in the future."
 msgstr "資料刪除時間至少必須是未來 {min_allowed_days} 天。"
 
-#: zerver/views/realm_domains.py:38
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "Invalid domain: {error}"
 msgstr "無效的域名：{error}"
 
-#: zerver/views/realm_domains.py:41
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "The domain {domain} is already a part of your organization."
 msgstr "該域名 {domain} 已經是您組織的一部分。"
 
-#: zerver/views/realm_domains.py:62 zerver/views/realm_domains.py:75
+#: zerver/views/realm_domains.py
 #, python-brace-format
 msgid "No entry found for domain {domain}."
 msgstr "找不到域名 {domain} 的進入點。"
 
-#: zerver/views/realm_emoji.py:42
+#: zerver/views/realm_emoji.py
 msgid "You must upload exactly one file."
 msgstr "您必須上傳一個檔案。"
 
-#: zerver/views/realm_emoji.py:44
+#: zerver/views/realm_emoji.py
 msgid "Only administrators can override default emoji."
 msgstr "只有管理員能覆蓋預設表情符號。"
 
-#: zerver/views/realm_emoji.py:50 zerver/views/realm_icon.py:27
-#: zerver/views/realm_logo.py:33 zerver/views/user_settings.py:562
+#: zerver/views/realm_emoji.py zerver/views/realm_icon.py
+#: zerver/views/realm_logo.py zerver/views/user_settings.py
 #, python-brace-format
 msgid "Uploaded file is larger than the allowed limit of {max_size} MiB"
 msgstr "上傳檔案大於允許的限制 {max_size} MiB"
 
-#: zerver/views/realm_export.py:44
+#: zerver/views/realm_export.py
 msgid ""
 "Exports of all public and private data are not enabled for this organization."
 msgstr "此組織尚未啟用所有公開與私人資料的匯出功能。"
 
-#: zerver/views/realm_export.py:70
+#: zerver/views/realm_export.py
 msgid "Exceeded rate limit."
 msgstr "超過速率限制。"
 
-#: zerver/views/realm_export.py:93
+#: zerver/views/realm_export.py
 #, python-brace-format
 msgid ""
 "The export you requested is too large for automatic processing. Please "
 "request a manual export by contacting {email}."
 msgstr "您要求的匯出資料量過大，無法自動處理。請聯繫 {email} 申請手動匯出。"
 
-#: zerver/views/realm_export.py:132
+#: zerver/views/realm_export.py
 msgid "Invalid data export ID"
 msgstr "無效的資料輸出 ID"
 
-#: zerver/views/realm_export.py:135
+#: zerver/views/realm_export.py
 msgid "Export already deleted"
 msgstr "匯出已被刪除"
 
-#: zerver/views/realm_export.py:137
+#: zerver/views/realm_export.py
 msgid "Export failed, nothing to delete"
 msgstr "匯出失敗，沒有可刪除的內容"
 
-#: zerver/views/realm_export.py:139
+#: zerver/views/realm_export.py
 msgid "Export still in progress"
 msgstr "匯出仍在進行中"
 
-#: zerver/views/realm_icon.py:20
+#: zerver/views/realm_icon.py
 msgid "You must upload exactly one icon."
 msgstr "您必須上傳至少一個圖示。"
 
-#: zerver/views/realm_linkifiers.py:60 zerver/views/realm_linkifiers.py:90
+#: zerver/views/realm_linkifiers.py
 msgid "Linkifier not found."
 msgstr "找不到連結轉換器。"
 
-#: zerver/views/realm_logo.py:27
+#: zerver/views/realm_logo.py
 msgid "You must upload exactly one logo."
 msgstr "您必須上傳一個且僅有一個標誌。"
 
-#: zerver/views/realm_playgrounds.py:29
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid characters in pygments language"
 msgid "Invalid character in language: {character}"
 msgstr "Pygments 語言中有無效的字元"
 
-#: zerver/views/realm_playgrounds.py:32
+#: zerver/views/realm_playgrounds.py
 #, fuzzy, python-brace-format
 #| msgid "Invalid language '{language}'"
 msgid "Language '{language}' is not allowed."
 msgstr "無效的語言 '{language}'"
 
-#: zerver/views/realm_playgrounds.py:40
+#: zerver/views/realm_playgrounds.py
 msgid "Invalid playground"
 msgstr "無效的程式碼測試場"
 
-#: zerver/views/registration.py:329
+#: zerver/views/registration.py
 msgid "Unable to cancel import once it has started."
 msgstr "匯入開始後無法取消。"
 
-#: zerver/views/registration.py:1121
+#: zerver/views/registration.py
 msgid "Unauthenticated"
 msgstr "未驗證"
 
-#: zerver/views/registration.py:1135
+#: zerver/views/registration.py
 msgid ""
 "Converting Slack data… This may take a while. If you close this tab, you can "
 "return here from the “Complete registration” link in your email."
@@ -7961,217 +7365,215 @@ msgstr ""
 "正在轉換 Slack 資料… 這可能需要一些時間。如果您關閉此分頁，可以透過電子郵件中"
 "的「完成註冊」連結回到這裡。"
 
-#: zerver/views/registration.py:1172
+#: zerver/views/registration.py
 msgid "Importing messages…"
 msgstr "正在匯入訊息…"
 
-#: zerver/views/registration.py:1175
+#: zerver/views/registration.py
 msgid "Importing attachment data…"
 msgstr "正在匯入附件資料…"
 
-#: zerver/views/registration.py:1178
+#: zerver/views/registration.py
 msgid "Importing converted Slack data…"
 msgstr "正在匯入轉換後的 Slack 資料…"
 
-#: zerver/views/registration.py:1184
+#: zerver/views/registration.py
 msgid "Finalizing import…"
 msgstr "正在完成匯入…"
 
-#: zerver/views/registration.py:1187
+#: zerver/views/registration.py
 msgid "Done!"
 msgstr "完成！"
 
-#: zerver/views/registration.py:1215
+#: zerver/views/registration.py
 msgid "No users matching provided email."
 msgstr "沒有符合提供電子郵件的使用者。"
 
-#: zerver/views/registration.py:1535
+#: zerver/views/registration.py
 msgid "Your name"
 msgstr "您的名字"
 
-#: zerver/views/scheduled_messages.py:83
+#: zerver/views/scheduled_messages.py
 msgid "Recipient required when updating type of scheduled message."
 msgstr "更新排程訊息類型時需要收件者。"
 
-#: zerver/views/scheduled_messages.py:94
+#: zerver/views/scheduled_messages.py
 msgid "Topic required when updating scheduled message type to channel."
 msgstr "將排程訊息類型更新為頻道時需要議題。"
 
-#: zerver/views/sentry.py:38
+#: zerver/views/sentry.py
 msgid "Invalid request format"
 msgstr "無效的請求格式"
 
-#: zerver/views/sentry.py:41
+#: zerver/views/sentry.py
 msgid "Invalid DSN"
 msgstr "無效的 DSN"
 
-#: zerver/views/streams.py:176
+#: zerver/views/streams.py
 msgid "Private channels cannot be made default."
 msgstr "封閉頻道不能設為預設。"
 
-#: zerver/views/streams.py:210
+#: zerver/views/streams.py
 msgid "You must pass \"new_description\" or \"new_group_name\"."
 msgstr "您必須傳遞 \"new_description\" 或 \"new_group_name\"。"
 
-#: zerver/views/streams.py:241
+#: zerver/views/streams.py
 msgid "Invalid value for \"op\". Specify one of \"add\" or \"remove\"."
 msgstr "\"op\" 值無效。請指定 \"add\" 或 \"remove\"。"
 
-#: zerver/views/streams.py:353 zerver/views/streams.py:357
-#: zerver/views/streams.py:361
+#: zerver/views/streams.py
 msgid "Invalid parameters"
 msgstr "無效參數"
 
-#: zerver/views/streams.py:377 zerver/views/streams.py:500
+#: zerver/views/streams.py
 msgid "Channel content access is required."
 msgstr "需要頻道內容存取權限。"
 
-#: zerver/views/streams.py:456
+#: zerver/views/streams.py
 msgid "Channel already has that name."
 msgstr "頻道已使用該名稱。"
 
-#: zerver/views/streams.py:580 zerver/views/user_groups.py:551
+#: zerver/views/streams.py zerver/views/user_groups.py
 msgid "Nothing to do. Specify at least one of \"add\" or \"delete\"."
 msgstr "沒有要做的事。請至少指定 \"add\" 或 \"delete\" 其中一個。"
 
-#: zerver/views/streams.py:657
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to {channel_name}."
 msgstr "{user_full_name} 已為您訂閱 {channel_name}。"
 
-#: zerver/views/streams.py:663
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_full_name} subscribed you to the following channels:"
 msgstr "{user_full_name} 已將你加入下列頻道："
 
-#: zerver/views/streams.py:902
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unable to access channel ({channel_name})."
 msgstr "無法存取頻道 ({channel_name})。"
 
-#: zerver/views/streams.py:1035
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created the following channels: {new_channels}."
 msgstr "{user_name} 建立了以下頻道：{new_channels}。"
 
-#: zerver/views/streams.py:1037
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{user_name} created a new channel {new_channels}."
 msgstr "{user_name} 建立了新頻道 {new_channels}。"
 
-#: zerver/views/streams.py:1038
+#: zerver/views/streams.py
 msgid "new channels"
 msgstr "新頻道"
 
-#: zerver/views/streams.py:1084
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Web-public** channel created by {user_name}. **Description:**"
 msgstr "由 {user_name} 建立的 **網路公共** 頻道。**描述：**"
 
-#: zerver/views/streams.py:1088
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "**Public** channel created by {user_name}. **Description:**"
 msgstr "由 {user_name} 建立的 **公開** 頻道。**描述：**"
 
-#: zerver/views/streams.py:1092
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, shared history** channel created by {user_name}. **Description:**"
 msgstr "由 {user_name} 建立的 **私人，分享過往訊息** 頻道。**描述：**"
 
-#: zerver/views/streams.py:1096
+#: zerver/views/streams.py
 #, python-brace-format
 msgid ""
 "**Private, protected history** channel created by {user_name}. **Description:"
 "**"
 msgstr "由 {user_name} 建立的 **私人，保護過往訊息** 頻道。**描述：**"
 
-#: zerver/views/streams.py:1338
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "{property} is not a boolean"
 msgstr "{property} 不是布林值"
 
-#: zerver/views/streams.py:1341
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Unknown subscription property: {property}"
 msgstr "未知的訂閱屬性：{property}"
 
-#: zerver/views/streams.py:1389
+#: zerver/views/streams.py
 #, python-brace-format
 msgid "Not subscribed to channel ID {channel_id}"
 msgstr "未訂閱頻道 ID {channel_id}"
 
-#: zerver/views/submessage.py:40
+#: zerver/views/submessage.py
 msgid "Invalid json for submessage"
 msgstr "無效的子訊息 json"
 
-#: zerver/views/tusd.py:110 zerver/views/upload.py:471
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than the maximum upload size ({max_size} MiB) allowed by your "
 "organization's plan."
 msgstr "檔案超過您組織方案允許的最大上傳大小上限（{max_size} MiB）。"
 
-#: zerver/views/tusd.py:119 zerver/views/upload.py:479
+#: zerver/views/tusd.py zerver/views/upload.py
 #, python-brace-format
 msgid ""
 "File is larger than this server's configured maximum upload size ({max_size} "
 "MiB)."
 msgstr "檔案大於此伺服器設定的最大上傳大小 ({max_size} MiB)。"
 
-#: zerver/views/tusd.py:273
+#: zerver/views/tusd.py
 #, python-brace-format
 msgid ""
 "Uploaded file exceeds the maximum file size for imports ({max_file_size} "
 "MiB)."
 msgstr "上傳的檔案超過檔案大小限制（{max_file_size} MiB）。"
 
-#: zerver/views/typing.py:53 zerver/views/typing.py:96
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for channel messages"
 msgstr "使用者已停用頻道訊息的輸入通知"
 
-#: zerver/views/typing.py:64
+#: zerver/views/typing.py
 msgid "Missing 'to' argument"
 msgstr "缺少 'to' 參數"
 
-#: zerver/views/typing.py:69
+#: zerver/views/typing.py
 msgid "Empty 'to' list"
 msgstr "'to' 清單為空"
 
-#: zerver/views/typing.py:72 zerver/views/typing.py:106
+#: zerver/views/typing.py
 msgid "User has disabled typing notifications for direct messages"
 msgstr "使用者已停用直接訊息的輸入通知"
 
-#: zerver/views/upload.py:275
+#: zerver/views/upload.py
 msgid "<p>This file does not exist or has been deleted.</p>"
 msgstr "<p>此檔案不存在或已被刪除。</p>"
 
-#: zerver/views/upload.py:285
+#: zerver/views/upload.py
 msgid "<p>You are not authorized to view this file.</p>"
 msgstr "<p>您無權查看此檔案。</p>"
 
-#: zerver/views/upload.py:408 zerver/views/upload.py:414
+#: zerver/views/upload.py
 msgid "Invalid token"
 msgstr "無效的憑證"
 
-#: zerver/views/upload.py:410
+#: zerver/views/upload.py
 msgid "Invalid filename"
 msgstr "無效的檔案名稱"
 
-#: zerver/views/upload.py:458
+#: zerver/views/upload.py
 msgid "You must specify a file to upload"
 msgstr "您必須指定要上傳的檔案"
 
-#: zerver/views/upload.py:460 zerver/views/users.py:581
-#: zerver/views/users.py:704
+#: zerver/views/upload.py zerver/views/users.py
 msgid "You may only upload one file at a time"
 msgstr "您一次只能上傳一個檔案"
 
-#: zerver/views/user_groups.py:161
+#: zerver/views/user_groups.py
 msgid "No new data supplied"
 msgstr "未提供新資料"
 
-#: zerver/views/user_groups.py:258
+#: zerver/views/user_groups.py
 msgid ""
 "Nothing to do. Specify at least one of \"add\", \"delete\", "
 "\"add_subgroups\" or \"delete_subgroups\"."
@@ -8179,134 +7581,134 @@ msgstr ""
 "沒有任何操作。請至少指定以下其中一項：\"add\"、\"delete\"、\"add_subgroups\" "
 "或 \"delete_subgroups\"。"
 
-#: zerver/views/user_groups.py:320
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} added you to the group {group_name}."
 msgstr "{user_full_name} 將您加入群組 {group_name}。"
 
-#: zerver/views/user_groups.py:325
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "{user_full_name} removed you from the group {group_name}."
 msgstr "{user_full_name} 將您從群組 {group_name} 移除。"
 
-#: zerver/views/user_groups.py:385
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User {user_id} is already a member of this group"
 msgstr "使用者 {user_id} 已是此群組的成員"
 
-#: zerver/views/user_groups.py:439
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "There is no member '{user_id}' in this user group"
 msgstr "此使用者群組中沒有成員 '{user_id}'"
 
-#: zerver/views/user_groups.py:468
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is already a subgroup of this group."
 msgstr "使用者群組 {group_id} 已是此群組的子群組。"
 
-#: zerver/views/user_groups.py:479
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid ""
 "User group {user_group_id} is already a subgroup of one of the passed "
 "subgroups."
 msgstr "使用者群組 {user_group_id} 已經是所提供子群組其中之一的子群組。"
 
-#: zerver/views/user_groups.py:499
+#: zerver/views/user_groups.py
 msgid ""
 "Subgroups of a group used for 'workplace_users_group' must allow only "
 "organization administrators to manage their membership."
 msgstr ""
 
-#: zerver/views/user_groups.py:527
+#: zerver/views/user_groups.py
 #, python-brace-format
 msgid "User group {group_id} is not a subgroup of this group."
 msgstr "使用者群組 {group_id} 不是此群組的子群組。"
 
-#: zerver/views/user_settings.py:82
+#: zerver/views/user_settings.py
 msgid "Avatar changes are disabled in this organization."
 msgstr "此組織已停用頭像變更功能。"
 
-#: zerver/views/user_settings.py:90
+#: zerver/views/user_settings.py
 msgid "Email address changes are disabled in this organization."
 msgstr "此組織已停用電子郵件地址變更功能。"
 
-#: zerver/views/user_settings.py:223
+#: zerver/views/user_settings.py
 msgid "Invalid default_language"
 msgstr "無效的預設語言"
 
-#: zerver/views/user_settings.py:231
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid notification sound '{notification_sound}'"
 msgstr "無效的通知音效 '{notification_sound}'"
 
-#: zerver/views/user_settings.py:242
+#: zerver/views/user_settings.py
 #, python-brace-format
 msgid "Invalid email batching period: {seconds} seconds"
 msgstr "無效的電子郵件批次處理週期：{seconds} 秒"
 
-#: zerver/views/user_settings.py:256
+#: zerver/views/user_settings.py
 msgid "Either user_ids or group_ids must be provided."
 msgstr "必須提供 user_ids 或 group_ids 其中之一。"
 
-#: zerver/views/user_settings.py:406 zerver/views/user_settings.py:410
+#: zerver/views/user_settings.py
 msgid "Cannot change this setting for other users."
 msgstr "無法為其他使用者變更此設定。"
 
-#: zerver/views/user_settings.py:475
+#: zerver/views/user_settings.py
 msgid "Your Zulip password is managed in LDAP"
 msgstr "您的 Zulip 密碼在 LDAP 中管理"
 
-#: zerver/views/user_settings.py:485
+#: zerver/views/user_settings.py
 msgid "Wrong password!"
 msgstr "密碼錯誤！"
 
-#: zerver/views/user_settings.py:491
+#: zerver/views/user_settings.py
 #, fuzzy, python-brace-format
 #| msgid "You're making too many attempts! Try again in {seconds} seconds."
 msgid "You're making too many attempts! Try again in {retry_after_string}."
 msgstr "您嘗試次數過多！請在 {seconds} 秒後再試。"
 
-#: zerver/views/user_settings.py:497
+#: zerver/views/user_settings.py
 msgid "New password is too weak!"
 msgstr "新密碼太弱！"
 
-#: zerver/views/user_settings.py:552
+#: zerver/views/user_settings.py
 msgid "You must upload exactly one avatar."
 msgstr "您必須上傳恰好一個頭像。"
 
-#: zerver/views/user_topics.py:52
+#: zerver/views/user_topics.py
 msgid "Topic is not muted"
 msgstr "議題未靜音"
 
-#: zerver/views/users.py:142
+#: zerver/views/users.py
 msgid "Cannot deactivate the only organization owner"
 msgstr "無法停用該組織唯一的擁有者"
 
-#: zerver/views/users.py:154
+#: zerver/views/users.py
 #, fuzzy
 #| msgid "Who will be allowed to see other users' email addresses?"
 msgid "User is not allowed to delete other user's messages."
 msgstr "誰可以查看其他使用者的 Email 地址？"
 
-#: zerver/views/users.py:297
+#: zerver/views/users.py
 msgid "User not authorized to change user emails"
 msgstr "使用者無權變更使用者電子郵件"
 
-#: zerver/views/users.py:311
+#: zerver/views/users.py
 msgid ""
 "The owner permission cannot be removed from the only organization owner."
 msgstr "不能從唯一的組織所有者移除擁有者權限。"
 
-#: zerver/views/users.py:357
+#: zerver/views/users.py
 msgid "Invalid new email address."
 msgstr "無效的新電子郵件地址。"
 
-#: zerver/views/users.py:366
+#: zerver/views/users.py
 #, python-brace-format
 msgid "New email value error: {message}"
 msgstr "新電子郵件值錯誤：{message}"
 
-#: zerver/views/users.py:499
+#: zerver/views/users.py
 msgid ""
 "Can't change bot email until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
@@ -8314,23 +7716,23 @@ msgstr ""
 "在正確設定 FAKE_EMAIL_DOMAIN 之前，無法更改機器人 Email。\n"
 "請聯絡您的伺服器管理員。"
 
-#: zerver/views/users.py:512
+#: zerver/views/users.py
 msgid "Email address already in use"
 msgstr "電子郵件已被使用"
 
-#: zerver/views/users.py:531
+#: zerver/views/users.py
 msgid "Failed to change owner, no such user"
 msgstr "變更擁有者失敗，無此使用者"
 
-#: zerver/views/users.py:533
+#: zerver/views/users.py
 msgid "Failed to change owner, user is deactivated"
 msgstr "變更擁有者失敗，使用者已停用"
 
-#: zerver/views/users.py:535
+#: zerver/views/users.py
 msgid "Failed to change owner, bots can't own other bots"
 msgstr "變更擁有者失敗，機器人不能擁有其他機器人"
 
-#: zerver/views/users.py:662
+#: zerver/views/users.py
 msgid ""
 "Can't create bots until FAKE_EMAIL_DOMAIN is correctly configured.\n"
 "Please contact your server administrator."
@@ -8338,208 +7740,208 @@ msgstr ""
 "在 FAKE_EMAIL_DOMAIN 正確設定前，無法建立機器人。\n"
 "請聯繫您的伺服器管理員。"
 
-#: zerver/views/users.py:675
+#: zerver/views/users.py
 msgid "Embedded bots are not enabled."
 msgstr "嵌入式機器人未啟用。"
 
-#: zerver/views/users.py:677
+#: zerver/views/users.py
 msgid "Invalid embedded bot name."
 msgstr "無效的嵌入式機器人名稱。"
 
-#: zerver/views/users.py:903
+#: zerver/views/users.py
 msgid "User not authorized to create users"
 msgstr "使用者無權建立使用者"
 
-#: zerver/views/users.py:920
+#: zerver/views/users.py
 #, python-brace-format
 msgid "Email '{email}' not allowed in this organization"
 msgstr "電子郵件 '{email}' 在此組織不被允許"
 
-#: zerver/views/users.py:925
+#: zerver/views/users.py
 msgid "Disposable email addresses are not allowed in this organization"
 msgstr "此組織不允許使用拋棄式電子郵件地址"
 
-#: zerver/views/video_calls.py:61
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} access token"
 msgstr "無效的 {provider_name} 存取憑證"
 
-#: zerver/views/video_calls.py:68
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Failed to create {provider_name} call"
 msgstr "建立 {provider_name} 通話失敗"
 
-#: zerver/views/video_calls.py:75
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "{provider_name} credentials have not been configured"
 msgstr "{provider_name} 憑證尚未設定"
 
-#: zerver/views/video_calls.py:84
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} credentials"
 msgstr "無效的 {provider_name} 憑證"
 
-#: zerver/views/video_calls.py:91
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error connecting to the BigBlueButton server."
 msgid "Error connecting to the {provider_name} server: {reason}"
 msgstr "連線 BigBlueButton 伺服器時發生錯誤。"
 
-#: zerver/views/video_calls.py:100
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Error authenticating to the BigBlueButton server."
 msgid "Error authenticating to the {provider_name} server"
 msgstr "向 BigBlueButton 伺服器驗證時發生錯誤。"
 
-#: zerver/views/video_calls.py:109
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "BigBlueButton server returned an unexpected error."
 msgid "{provider_name} server returned an unexpected error: {status}"
 msgstr "BigBlueButton 伺服器回傳未預期的錯誤。"
 
-#: zerver/views/video_calls.py:118
+#: zerver/views/video_calls.py
 #, python-brace-format
 msgid "Invalid {provider_name} session identifier"
 msgstr "無效的 {provider_name} 會話識別碼"
 
-#: zerver/views/video_calls.py:126
+#: zerver/views/video_calls.py
 msgid "Unknown Zoom user email"
 msgstr "未知的 Zoom 使用者電子郵件"
 
-#: zerver/views/video_calls.py:350
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "Failed to create {provider_name} call"
 msgid "Failed to create {provider_name} public room."
 msgstr "建立 {provider_name} 通話失敗"
 
-#: zerver/views/video_calls.py:623
+#: zerver/views/video_calls.py
 msgid "Invalid signature."
 msgstr "無效的簽章。"
 
-#: zerver/views/video_calls.py:697
+#: zerver/views/video_calls.py
 #, fuzzy, python-brace-format
 #| msgid "{full_name} mentioned you:"
 msgid "{full_name}'s Zulip room"
 msgstr "{full_name} 「@-提及」你："
 
-#: zerver/webhooks/circleci/view.py:86
+#: zerver/webhooks/circleci/view.py
 msgid "Projects using this version control system provider aren't supported"
 msgstr "不支援使用此版本控制系統提供者的專案"
 
-#: zerver/webhooks/freshstatus/view.py:104
-#: zerver/webhooks/uptimerobot/view.py:58 zerver/webhooks/zabbix/view.py:50
+#: zerver/webhooks/freshstatus/view.py zerver/webhooks/uptimerobot/view.py
+#: zerver/webhooks/zabbix/view.py
 msgid "Invalid payload"
 msgstr "無效的負載"
 
-#: zerver/webhooks/front/view.py:148
+#: zerver/webhooks/front/view.py
 msgid "Unknown webhook request"
 msgstr "未知的 webhook 請求"
 
-#: zerver/webhooks/ifttt/view.py:31 zerver/webhooks/zapier/view.py:42
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Topic can't be empty"
 msgstr "議題不可為空"
 
-#: zerver/webhooks/ifttt/view.py:34 zerver/webhooks/zapier/view.py:45
+#: zerver/webhooks/ifttt/view.py zerver/webhooks/zapier/view.py
 msgid "Content can't be empty"
 msgstr "內容不可為空"
 
-#: zerver/webhooks/jotform/view.py:152
+#: zerver/webhooks/jotform/view.py
 msgid "Unable to handle Jotform payload"
 msgstr "無法處理 Jotform 酬載"
 
-#: zerver/webhooks/librato/view.py:172
+#: zerver/webhooks/librato/view.py
 msgid "Malformed JSON input"
 msgstr "格式錯誤的 JSON 輸入"
 
-#: zerver/webhooks/papertrail/view.py:34
+#: zerver/webhooks/papertrail/view.py
 msgid "Events key is missing from payload"
 msgstr "酬載中缺少事件金鑰"
 
-#: zerver/webhooks/slack/view.py:153
+#: zerver/webhooks/slack/view.py
 msgid "Error: channels_map_to_topics parameter other than 0 or 1"
 msgstr "錯誤：channels_map_to_topics 參數必須是 0 或 1"
 
-#: zerver/webhooks/wordpress/view.py:39
+#: zerver/webhooks/wordpress/view.py
 #, python-brace-format
 msgid "Unknown WordPress webhook action: {hook}"
 msgstr "未知的 WordPress webhook 動作：{hook}"
 
-#: zerver/worker/deferred_work.py:152
+#: zerver/worker/deferred_work.py
 #, python-brace-format
 msgid ""
 "Your data export is complete. [View and download exports]"
 "({export_settings_link})."
 msgstr "您的資料匯出已完成。[查看與下載匯出檔案]({export_settings_link})。"
 
-#: zilencer/auth.py:61
+#: zilencer/auth.py
 msgid "The verification secret has expired"
 msgstr "驗證密鑰已過期"
 
-#: zilencer/auth.py:63
+#: zilencer/auth.py
 msgid "The verification secret is invalid"
 msgstr "驗證密鑰無效"
 
-#: zilencer/auth.py:65
+#: zilencer/auth.py
 msgid "The verification secret is malformed"
 msgstr "驗證密鑰格式錯誤"
 
-#: zilencer/auth.py:67
+#: zilencer/auth.py
 msgid "The verification secret is for a different hostname"
 msgstr "驗證密鑰適用於不同的主機名稱"
 
-#: zilencer/auth.py:128
+#: zilencer/auth.py
 msgid "Invalid subdomain for push notifications bouncer"
 msgstr "無效的推送通知 bouncer 子域名"
 
-#: zilencer/auth.py:147
+#: zilencer/auth.py
 msgid "Must validate with valid Zulip server API key"
 msgstr "必須使用有效的 Zulip 伺服器 API 金鑰進行驗證"
 
 #. error
-#: zilencer/views.py:128 zilencer/views.py:130
+#: zilencer/views.py
 msgid "Invalid UUID"
 msgstr "無效的 UUID"
 
 #. error
-#: zilencer/views.py:135
+#: zilencer/views.py
 msgid "Invalid token type"
 msgstr "無效的憑證類型"
 
-#: zilencer/views.py:172
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} contains invalid components (e.g., path, query, fragment)."
 msgstr "{hostname} 包含無效的組件（例如：路徑、查詢、片段）。"
 
-#: zilencer/views.py:179
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} is not a valid hostname"
 msgstr "{hostname} 不是有效的主機名稱"
 
-#: zilencer/views.py:192
+#: zilencer/views.py
 #, python-brace-format
 msgid "{hostname} not yet registered"
 msgstr "{hostname} 尚未註冊"
 
-#: zilencer/views.py:213
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid server administrator email address: {email_reason}"
 msgstr "伺服器管理員電子郵件地址無效：{email_reason}"
 
-#: zilencer/views.py:257
+#: zilencer/views.py
 msgid "example.com is not a valid email domain."
 msgstr "example.com 不是有效的電子郵件網域。"
 
-#: zilencer/views.py:273 zilencer/views.py:281
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} is invalid because it does not have any MX records"
 msgstr "{domain} 無效，因為它沒有任何 MX 記錄"
 
-#: zilencer/views.py:287
+#: zilencer/views.py
 #, python-brace-format
 msgid "{domain} does not exist"
 msgstr "{domain} 不存在"
 
-#: zilencer/views.py:390
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "The global limits on recent usage of this endpoint have been reached. Please "
@@ -8548,77 +7950,77 @@ msgstr ""
 "此端點的近期使用已達到全域限制。請稍後再試，或聯絡 {support_email} 以獲得協"
 "助。"
 
-#: zilencer/views.py:398
+#: zilencer/views.py
 msgid "Registration not found for this hostname"
 msgstr "找不到此主機名稱的註冊資訊"
 
-#: zilencer/views.py:409
+#: zilencer/views.py
 msgid "The host reported it has no verification secret."
 msgstr "主機回報它沒有驗證密鑰。"
 
-#: zilencer/views.py:413
+#: zilencer/views.py
 #, fuzzy, python-brace-format
 #| msgid "Error response received from the host: {status_code}"
 msgid "Unexpected status code received from the host: {status_code}"
 msgstr "從主機收到錯誤回應：{status_code}"
 
-#: zilencer/views.py:508
+#: zilencer/views.py
 msgid "Missing ios_app_id"
 msgstr "缺少 ios_app_id"
 
-#: zilencer/views.py:511
+#: zilencer/views.py
 msgid "Missing user_id or user_uuid"
 msgstr "缺少 user_id 或 user_uuid"
 
-#: zilencer/views.py:899
+#: zilencer/views.py
 #, python-brace-format
 msgid ""
 "Your plan doesn't allow sending push notifications. Reason provided by the "
 "server: {reason}"
 msgstr "您的方案不允許傳送推送通知。伺服器提供的原因：{reason}"
 
-#: zilencer/views.py:947
+#: zilencer/views.py
 msgid "Your plan doesn't allow sending push notifications."
 msgstr "您的方案不允許傳送推送通知。"
 
-#: zilencer/views.py:1162
+#: zilencer/views.py
 #, python-brace-format
 msgid "Invalid property {property}"
 msgstr "無效的屬性 {property}"
 
-#: zilencer/views.py:1165
+#: zilencer/views.py
 msgid "Invalid event type."
 msgstr "無效的事件類型。"
 
-#: zilencer/views.py:1172
+#: zilencer/views.py
 msgid "Data is out of order."
 msgstr "資料順序錯誤。"
 
-#: zilencer/views.py:1277
+#: zilencer/views.py
 msgid "Duplicate registration detected."
 msgstr "偵測到重複註冊。"
 
-#: zilencer/views.py:1695
+#: zilencer/views.py
 msgid "Malformed audit log data"
 msgstr "格式錯誤的稽核紀錄資料"
 
-#: zproject/backends.py:584
+#: zproject/backends.py
 msgid "You need to reset your password."
 msgstr "您需要重設密碼。"
 
-#: zproject/backends.py:3213
+#: zproject/backends.py
 msgid "Missing id_token parameter"
 msgstr "缺少 id_token 參數"
 
-#: zproject/backends.py:3993
+#: zproject/backends.py
 msgid "Missing idp param"
 msgstr "缺少 idp 參數"
 
-#: zproject/backends.py:4163
+#: zproject/backends.py
 msgid "Invalid OTP"
 msgstr "無效的 OTP"
 
-#: zproject/backends.py:4166
+#: zproject/backends.py
 msgid "Can't use both mobile_flow_otp and desktop_flow_otp together."
 msgstr "無法同時使用 mobile_flow_otp 和 desktop_flow_otp。"
 

--- a/zerver/management/commands/makemessages.py
+++ b/zerver/management/commands/makemessages.py
@@ -125,6 +125,7 @@ class Command(makemessages.Command):
             default="translations.json",
             help="Namespace of the frontend locale file",
         )
+        parser.set_defaults(add_location="file")
 
     @override
     def handle(self, *args: Any, **options: Any) -> None:


### PR DESCRIPTION
These line numbers go stale quickly, cause unnecessary churn in Git, and prevent us from automating the makemessages call.

[Discussion](https://chat.zulip.org/#narrow/channel/58-translation/topic/.22Go.20to.20mentions.22.20missing.20in.20translations.2Ejson/near/2440277).

Recommended review command: `git show --ignore-matching-lines='^#:'`